### PR TITLE
Removed references to local folders from reporting.

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '354426'
+ValidationKey: '2052050'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "edgeTransport: Prepare EDGE Transport Data for the REMIND model",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "description": "<p>EDGE-T is a fork of the GCAM transport module https://jgcri.github.io/gcam-doc/energy.html#transportation with a high level of detail in its representation of technological and modal options. It is a partial equilibrium model with a nested multinomial logit structure and relies on the modified logit formulation. Most of the sources are not publicly available. PIK-internal users can find the sources in the distributed file system in the folder `/p/projects/rd3mod/inputdata/sources/EDGE-Transport-Standalone`.<\/p>",
   "creators": [
     {

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: edgeTransport
 Title: Prepare EDGE Transport Data for the REMIND model
-Version: 0.1.9
+Version: 0.1.10
 Authors@R: c(
     person("Alois", "Dirnaichner", email = "dirnaichner@pik-potsdam.de", role = c("aut", "cre")),
     person("Marianna", "Rottoli", email = "rottoli@pik-potsdam.de", role = "aut"))
@@ -25,4 +25,4 @@ Encoding: UTF-8
 LazyData: true
 RoxygenNote: 7.1.1
 VignetteBuilder: knitr
-Date: 2021-01-27
+Date: 2021-01-28

--- a/inst/Rmd/report.Rmd
+++ b/inst/Rmd/report.Rmd
@@ -22,11 +22,6 @@ require(gridExtra)
 
 
 ```{r, echo=FALSE, warning=FALSE, message=FALSE}
-setConfig(cachefolder = "~/../Desktop/rd3mod_inputdata/cache/default_a/")
-setConfig(sourcefolder = "~/SVN_repository/r3d_mod_input_data/sources/")
-setConfig(forcecache=T)
-setConfig(outputfolder = "~/SVN_repository/r3d_mod_input_data/output/")
-setConfig(mappingfolder = "~/SVN_repository/r3d_mod_input_data/mappings/")
 setConfig(forcecache = TRUE)
 
 cols <- c("NG" = "#d11141",


### PR DESCRIPTION
Reporting markdown contained references to local directories by mistake.