### PR TITLE
Bugfix: avoid double counting LDV types across databases.

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '2379472'
+ValidationKey: '2400256'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "edgeTransport: Prepare EDGE Transport Data for the REMIND model",
-  "version": "0.1.27",
+  "version": "0.1.28",
   "description": "<p>EDGE-T is a fork of the GCAM transport module https://jgcri.github.io/gcam-doc/energy.html#transportation with a high level of detail in its representation of technological and modal options. It is a partial equilibrium model with a nested multinomial logit structure and relies on the modified logit formulation. Most of the sources are not publicly available. PIK-internal users can find the sources in the distributed file system in the folder `/p/projects/rd3mod/inputdata/sources/EDGE-Transport-Standalone`.<\/p>",
   "creators": [
     {

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: edgeTransport
 Title: Prepare EDGE Transport Data for the REMIND model
-Version: 0.1.27
+Version: 0.1.28
 Authors@R: c(
     person("Alois", "Dirnaichner", email = "dirnaichner@pik-potsdam.de", role = c("aut", "cre")),
     person("Marianna", "Rottoli", email = "rottoli@pik-potsdam.de", role = "aut"))
@@ -22,4 +22,4 @@ Encoding: UTF-8
 LazyData: true
 RoxygenNote: 7.1.1
 VignetteBuilder: knitr
-Date: 2021-04-19
+Date: 2021-05-05

--- a/R/lvl0_EUdata.R
+++ b/R/lvl0_EUdata.R
@@ -258,8 +258,14 @@ lvl0_prepareEU <- function(EU_data,
     dem_EU <- unique(dem_EU, by=c("iso", "technology", "vehicle_type", "year"))
   }
 
+  ## exclude LDVs from EU countries in OTHER
+  dem_OTHER = dem_OTHER[!(iso %in% unique(dem_EU$iso) & subsector_L1 == "trn_pass_road_LDV_4W")]
   ## select based on the combination of variables available in TRACCS
   dem_OTHER[dem_EU, on=.(iso, vehicle_type, technology, year), tech_output := i.tech_output]
+  ## merge dem_EU with full mapping
+  dem_EU = merge(dem_EU, unique(dem_OTHER[, c("vehicle_type", "subsector_L1", "subsector_L2", "subsector_L3", "sector")]), by = "vehicle_type")
+  ## re-introduce LDVs in OTHER
+  dem_OTHER = rbind(dem_OTHER, dem_EU[subsector_L1 == "trn_pass_road_LDV_4W"])
 
   dups <- duplicated(dem_OTHER, by=c("iso", "technology", "vehicle_type","year"))
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Prepare EDGE Transport Data for the REMIND model
 
-R package **edgeTransport**, version **0.1.27**
+R package **edgeTransport**, version **0.1.28**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/edgeTransport)](https://cran.r-project.org/package=edgeTransport)    
 
@@ -46,10 +46,9 @@ In case of questions / problems please contact Alois Dirnaichner <dirnaichner@pi
 
 To cite package **edgeTransport** in publications use:
 
-Dirnaichner A, Rottoli M (2021).
-_edgeTransport: Prepare EDGE Transport
-Data for the REMIND model_. R package
-version 0.1.27.
+Dirnaichner A, Rottoli M (2021). _edgeTransport: Prepare EDGE
+Transport Data for the REMIND model_. R package version
+0.1.28.
 
 A BibTeX entry for LaTeX users is
 
@@ -58,7 +57,7 @@ A BibTeX entry for LaTeX users is
   title = {edgeTransport: Prepare EDGE Transport Data for the REMIND model},
   author = {Alois Dirnaichner and Marianna Rottoli},
   year = {2021},
-  note = {R package version 0.1.27},
+  note = {R package version 0.1.28},
 }
 ```
 


### PR DESCRIPTION
Fancy data table merging was not removing LDV veh types from OTHER database, just substituting the ones present in both databases.