### PR TITLE
Add mapping for TRACCS roadvehicles.

### DIFF
--- a/R/lvl0_EUdata.R
+++ b/R/lvl0_EUdata.R
@@ -19,7 +19,9 @@ lvl0_loadEU <- function(input_folder, EU_dir = "EU_data"){
     EU_folder <- file.path(input_folder, EU_dir)
 
     ## load mappings
-    mapping_TRACCS_roadf_categories = fread(file.path(EU_folder, "mapping_TRACCS_roadvehicles.csv"), skip = 0)
+    mapfile <- system.file("extdata", "mapping_TRACCS_roadvehicles.csv",
+                           package = "edgeTransport", mustWork = TRUE)
+    mapping_TRACCS_roadf_categories = fread(mapfile, skip = 0)
 
     ## conversion unit->million
     CONV_unit_million <- 1e-06

--- a/inst/extdata/mapping_TRACCS_roadvehicles.csv
+++ b/inst/extdata/mapping_TRACCS_roadvehicles.csv
@@ -1,0 +1,27 @@
+category_TRACCS;vehicle_type;EDGE_vehicle_type
+Light Commercial Veh.;N1;Truck (0-3.5t)
+Heavy Duty Trucks;>3,5 t;Truck (7.5t)
+Heavy Duty Trucks;Rigid <=7,5 t;Truck (7.5t)
+Heavy Duty Trucks;Rigid 7,5 - 12 t;Truck (7.5t)
+Heavy Duty Trucks;Rigid 12 - 14 t;Truck (18t)
+Heavy Duty Trucks;Rigid 14 - 20 t;Truck (18t)
+Heavy Duty Trucks;Rigid 20 - 26 t;Truck (26t)
+Heavy Duty Trucks;Rigid 26 - 28 t;Truck (26t)
+Heavy Duty Trucks;Rigid 28 - 32 t;Truck (26t)
+Heavy Duty Trucks;Rigid >32 t;Truck (26t)
+Heavy Duty Trucks;Articulated 14 - 20 t;Truck (18t)
+Heavy Duty Trucks;Articulated 20 - 28 t;Truck (26t)
+Heavy Duty Trucks;Articulated 28 - 34 t;Truck (26t)
+Heavy Duty Trucks;Articulated 34 - 40 t;Truck (40t)
+Heavy Duty Trucks;Articulated 40 - 50 t;Truck (40t)
+Heavy Duty Trucks;Articulated 50 - 60 t;Truck (40t)
+Mopeds;2-stroke;Moped
+Mopeds;4-stroke;Moped
+Motorcycles;2-stroke;Motorcycle (50-250cc)
+Motorcycles;4-stroke;Motorcycle (>250cc)
+Passenger cars;Small;Subcompact Car
+Passenger cars;Lower-Medium;Compact Car
+Passenger cars;Upper-Medium;Midsize Car
+Passenger cars;Executive;Large Car and SUV
+Buses;Urban;Bus_tmp_vehicletype
+Buses;Coaches;Bus_tmp_vehicletype


### PR DESCRIPTION
14-20 is now in the 18t category

and >3.5 goes to 7.5

because the 0-3.5 are now covered by light commercial