### PR TITLE
Correct for changes in the output format of mrcommons

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '3096812'
+ValidationKey: '3116190'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "edgeTransport: Prepare EDGE Transport Data for the REMIND model",
-  "version": "0.1.64",
+  "version": "0.1.65",
   "description": "<p>EDGE-T is a fork of the GCAM transport module https://jgcri.github.io/gcam-doc/energy.html#transportation with a high level of detail in its representation of technological and modal options. It is a partial equilibrium model with a nested multinomial logit structure and relies on the modified logit formulation. Most of the sources are not publicly available. PIK-internal users can find the sources in the distributed file system in the folder `/p/projects/rd3mod/inputdata/sources/EDGE-Transport-Standalone`.<\/p>",
   "creators": [
     {

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: edgeTransport
 Title: Prepare EDGE Transport Data for the REMIND model
-Version: 0.1.64
+Version: 0.1.65
 Authors@R: c(
     person("Alois", "Dirnaichner", email = "dirnaichner@pik-potsdam.de", role = c("aut", "cre")),
     person("Marianna", "Rottoli", email = "rottoli@pik-potsdam.de", role = "aut"))
@@ -20,6 +20,6 @@ Suggests:
 License: GPL-3
 Encoding: UTF-8
 LazyData: true
-RoxygenNote: 7.1.1
+RoxygenNote: 7.1.2
 VignetteBuilder: knitr
-Date: 2021-09-13
+Date: 2021-09-16

--- a/R/generateEDGEdata.R
+++ b/R/generateEDGEdata.R
@@ -29,7 +29,7 @@ generateEDGEdata <- function(input_folder, output_folder,
   scenario <- scenario_name <- vehicle_type <- type <- `.` <- CountryCode <- RegionCode <- technology <- NULL
   non_fuel_price <- tot_price <- fuel_price_pkm <- subsector_L1 <- loadFactor <- ratio <- NULL
   Year <- value <- DP_cap <- POP_val <- GDP_cap <- region <- weight <- MJ <- variable.unit <- EJ <- grouping_value <- NULL
-  sector <- variable <- region <- logit.exponent <- NULL
+  period <- sector <- variable <- region <- logit.exponent <- NULL
   levelNpath <- function(fname, N){
     path <- file.path(output_folder, REMIND_scenario, EDGE_scenario, paste0("level_", N))
     if(!dir.exists(path)){
@@ -100,17 +100,15 @@ generateEDGEdata <- function(input_folder, output_folder,
   ## rearrange the columns and create regional values
   GDP_country = GDP_country[,,paste0("gdp_", REMIND_scenario)]
   GDP_country <- as.data.table(GDP_country)
-  GDP_country[, year := as.numeric(gsub("y", "", Year))][, Year := NULL]
-  setnames(GDP_country, old = "value", new = "weight")
-  GDP = merge(GDP_country, REMIND2ISO_MAPPING, by.x = "ISO3", by.y = "iso")
+  GDP_country[, year := as.numeric(gsub("y", "", period))][, period := NULL]
+  setnames(GDP_country, old = c("value", "region"), new = c("weight", "iso"))
+  GDP = merge(GDP_country, REMIND2ISO_MAPPING, by="iso")
   GDP = GDP[,.(weight = sum(weight)), by = c("region", "year")]
-  setnames(GDP_country, c("ISO3"), c("iso"))
 
   RatioPPP2MER_country = as.data.table(RatioPPP2MER_country)
   RatioPPP2MER_country = RatioPPP2MER_country[, c("year", "data") := NULL]
-  setnames(RatioPPP2MER_country, old = "value", new = "ratio")
-
-  GDP_MER_country = merge(GDP_country, RatioPPP2MER_country, by.x = "iso", by.y = "Region")
+  setnames(RatioPPP2MER_country, old = c("value", "Region"), new = c("ratio", "iso"))
+  GDP_MER_country = merge(GDP_country, RatioPPP2MER_country, by = "iso")
   GDP_MER_country[, weight := weight*ratio]
   GDP_MER_country[, ratio := NULL]
   GDP_MER = merge(GDP_MER_country, REMIND2ISO_MAPPING, by = "iso")
@@ -119,7 +117,8 @@ generateEDGEdata <- function(input_folder, output_folder,
   POP_country = POP_country[,,paste0("pop_", REMIND_scenario)]
   POP_country <- as.data.table(POP_country)
   POP_country[, year := as.numeric(gsub("y", "", year))]
-  POP = merge(POP_country, REMIND2ISO_MAPPING, by.x = "iso2c", by.y = "iso")
+  setnames(POP_country, "iso3c", "iso")
+  POP = merge(POP_country, REMIND2ISO_MAPPING, by = "iso")
   POP = POP[,.(value = sum(value)), by = c("region", "year")]
   setnames(POP_country, old = c("iso2c", "variable"), new = c("iso", "POP"),skip_absent=TRUE)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Prepare EDGE Transport Data for the REMIND model
 
-R package **edgeTransport**, version **0.1.64**
+R package **edgeTransport**, version **0.1.65**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/edgeTransport)](https://cran.r-project.org/package=edgeTransport)    
 
@@ -46,7 +46,7 @@ In case of questions / problems please contact Alois Dirnaichner <dirnaichner@pi
 
 To cite package **edgeTransport** in publications use:
 
-Dirnaichner A, Rottoli M (2021). _edgeTransport: Prepare EDGE Transport Data for the REMIND model_. R package version 0.1.64.
+Dirnaichner A, Rottoli M (2021). _edgeTransport: Prepare EDGE Transport Data for the REMIND model_. R package version 0.1.65.
 
 A BibTeX entry for LaTeX users is
 
@@ -55,7 +55,7 @@ A BibTeX entry for LaTeX users is
   title = {edgeTransport: Prepare EDGE Transport Data for the REMIND model},
   author = {Alois Dirnaichner and Marianna Rottoli},
   year = {2021},
-  note = {R package version 0.1.64},
+  note = {R package version 0.1.65},
 }
 ```
 


### PR DESCRIPTION
GDPppp and PPP2MER ratios supplied by `mrcommons` have different temporal and spatial dimension names. These have likely to be adjusted again once the *standardization* has taken place.