### PR TITLE
Hotfix: Ship a missing dataset from mrremind.

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '567360'
+ValidationKey: '586365'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "edgeTransport: Prepare EDGE Transport Data for the REMIND model",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "<p>EDGE-T is a fork of the GCAM transport module https://jgcri.github.io/gcam-doc/energy.html#transportation with a high level of detail in its representation of technological and modal options. It is a partial equilibrium model with a nested multinomial logit structure and relies on the modified logit formulation. Most of the sources are not publicly available. PIK-internal users can find the sources in the distributed file system in the folder `/p/projects/rd3mod/inputdata/sources/EDGE-Transport-Standalone`.<\/p>",
   "creators": [
     {

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: edgeTransport
 Title: Prepare EDGE Transport Data for the REMIND model
-Version: 0.3.0
+Version: 0.3.1
 Authors@R: c(
     person("Alois", "Dirnaichner", email = "dirnaichner@pik-potsdam.de", role = c("aut", "cre")),
     person("Marianna", "Rottoli", email = "rottoli@pik-potsdam.de", role = "aut"))
@@ -13,7 +13,7 @@ Encoding: UTF-8
 LazyData: true
 RoxygenNote: 7.1.2
 VignetteBuilder: knitr
-Date: 2021-10-12
+Date: 2021-10-15
 Config/testthat/edition: 3
 Imports:
     edgeTrpLib,

--- a/R/lvl0_mrremind.R
+++ b/R/lvl0_mrremind.R
@@ -79,7 +79,8 @@ lvl0_mrremind <- function(SSP_scen, REMIND2ISO_MAPPING, load_cache=FALSE, mrremi
     GDP=GDP,
     GDP_POP=GDP_POP,
     GDP_POP_MER=GDP_POP_MER,
-    IEAbal=IEAbal
+    IEAbal=IEAbal,
+    trsp_incent=trsp_incent
   ))
 
 }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Prepare EDGE Transport Data for the REMIND model
 
-R package **edgeTransport**, version **0.3.0**
+R package **edgeTransport**, version **0.3.1**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/edgeTransport)](https://cran.r-project.org/package=edgeTransport)  [![R build status](https://github.com/pik-piam/edgeTransport/workflows/check/badge.svg)](https://github.com/pik-piam/edgeTransport/actions) [![codecov](https://codecov.io/gh/pik-piam/edgeTransport/branch/master/graph/badge.svg)](https://codecov.io/gh/pik-piam/edgeTransport) [![r-universe](https://pik-piam.r-universe.dev/badges/edgeTransport)](https://pik-piam.r-universe.dev/ui#builds)
 
@@ -46,7 +46,7 @@ In case of questions / problems please contact Alois Dirnaichner <dirnaichner@pi
 
 To cite package **edgeTransport** in publications use:
 
-Dirnaichner A, Rottoli M (2021). _edgeTransport: Prepare EDGE Transport Data for the REMIND model_. R package version 0.3.0.
+Dirnaichner A, Rottoli M (2021). _edgeTransport: Prepare EDGE Transport Data for the REMIND model_. R package version 0.3.1.
 
 A BibTeX entry for LaTeX users is
 
@@ -55,7 +55,7 @@ A BibTeX entry for LaTeX users is
   title = {edgeTransport: Prepare EDGE Transport Data for the REMIND model},
   author = {Alois Dirnaichner and Marianna Rottoli},
   year = {2021},
-  note = {R package version 0.3.0},
+  note = {R package version 0.3.1},
 }
 ```
 


### PR DESCRIPTION
Led to the following error in the input data preparation reported by @pweigmann 
```
[1] "-- merge costs, LF, annual mileage from the various sources"
Error in names(data)[[3]] : subscript out of bounds
Calls: retrieveData ... generateEDGEdata -> lvl0_mergeDat -> magpie2dt -> unlist -> strsplit
In addition: There were 50 or more warnings (use warnings() to see the first 50)
~~~~ Exit calcOutput(type = "EDGETrData", aggregate = FALSE) in 55.91 seconds
```
The library tries to process a NULL object here.