### PR TITLE
Add timestamp to EDGE-T output folders to avoid overwriting previous results

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -4,3 +4,6 @@
 ^GDP*\.RDS$
 ^\.github$
 ^codecov\.yml$
+^\.Rproj\.user$
+^\.pre-commit-config\.yaml$
+^TAGS

--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '586365'
+ValidationKey: '606496'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "edgeTransport: Prepare EDGE Transport Data for the REMIND model",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "<p>EDGE-T is a fork of the GCAM transport module https://jgcri.github.io/gcam-doc/energy.html#transportation with a high level of detail in its representation of technological and modal options. It is a partial equilibrium model with a nested multinomial logit structure and relies on the modified logit formulation. Most of the sources are not publicly available. PIK-internal users can find the sources in the distributed file system in the folder `/p/projects/rd3mod/inputdata/sources/EDGE-Transport-Standalone`.<\/p>",
   "creators": [
     {

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: edgeTransport
 Title: Prepare EDGE Transport Data for the REMIND model
-Version: 0.3.1
+Version: 0.3.2
 Authors@R: c(
     person("Alois", "Dirnaichner", email = "dirnaichner@pik-potsdam.de", role = c("aut", "cre")),
     person("Marianna", "Rottoli", email = "rottoli@pik-potsdam.de", role = "aut"))
@@ -13,7 +13,7 @@ Encoding: UTF-8
 LazyData: true
 RoxygenNote: 7.1.2
 VignetteBuilder: knitr
-Date: 2021-10-15
+Date: 2021-11-22
 Config/testthat/edition: 3
 Imports:
     edgeTrpLib,

--- a/R/generateEDGEdata.R
+++ b/R/generateEDGEdata.R
@@ -31,9 +31,11 @@ generateEDGEdata <- function(input_folder, output_folder,
   }
 
   stopifnot(tech_scen %in% c("ConvCase", "Mix", "ElecEra", "HydrHype"))
+  EDGE_scenario <- if(smartlifestyle) paste0(tech_scen, "Wise") else tech_scen
+  folder <- paste0(SSP_scen, "-", EDGE_scenario, "_", format(Sys.time(), "%Y-%m-%d_%H.%M.%S"))
 
   levelNpath <- function(fname, N){
-    path <- file.path(output_folder, SSP_scen, EDGE_scenario, paste0("level_", N))
+    path <- file.path(output_folder, folder, paste0("level_", N))
     if(!dir.exists(path)){
       dir.create(path, recursive = T)
     }
@@ -64,7 +66,6 @@ generateEDGEdata <- function(input_folder, output_folder,
   EDGE2teESmap = fread(system.file("extdata", "mapping_EDGE_REMIND_transport_categories.csv", package = "edgeTransport"))
   EDGE2CESmap = fread(system.file("extdata", "mapping_CESnodes_EDGE.csv", package = "edgeTransport"))
 
-  EDGE_scenario <- if(smartlifestyle) paste0(tech_scen, "Wise") else tech_scen
   print(paste0("You selected the ", EDGE_scenario, " transport scenario."))
   print(paste0("You selected the ", SSP_scen, " socio-economic scenario."))
   print(paste0("You selected the option to include lifestyle changes to: ", smartlifestyle))

--- a/R/lvl0_mrremind.R
+++ b/R/lvl0_mrremind.R
@@ -22,7 +22,7 @@ lvl0_mrremind <- function(SSP_scen, REMIND2ISO_MAPPING, load_cache=FALSE, mrremi
   }else{
     IEAbal = madrat::calcOutput("IO", subtype = "IEA_output", aggregate = TRUE)
     GDP_country = {
-      x <- calcOutput("GDPppp", aggregate = F)
+      x <- calcOutput("GDP", aggregate = F)
       getSets(x)[1] <- "ISO3"
       getSets(x)[2] <- "Year"
       x

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Prepare EDGE Transport Data for the REMIND model
 
-R package **edgeTransport**, version **0.3.1**
+R package **edgeTransport**, version **0.3.2**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/edgeTransport)](https://cran.r-project.org/package=edgeTransport)  [![R build status](https://github.com/pik-piam/edgeTransport/workflows/check/badge.svg)](https://github.com/pik-piam/edgeTransport/actions) [![codecov](https://codecov.io/gh/pik-piam/edgeTransport/branch/master/graph/badge.svg)](https://codecov.io/gh/pik-piam/edgeTransport) [![r-universe](https://pik-piam.r-universe.dev/badges/edgeTransport)](https://pik-piam.r-universe.dev/ui#builds)
 
@@ -46,7 +46,7 @@ In case of questions / problems please contact Alois Dirnaichner <dirnaichner@pi
 
 To cite package **edgeTransport** in publications use:
 
-Dirnaichner A, Rottoli M (2021). _edgeTransport: Prepare EDGE Transport Data for the REMIND model_. R package version 0.3.1.
+Dirnaichner A, Rottoli M (2021). _edgeTransport: Prepare EDGE Transport Data for the REMIND model_. R package version 0.3.2.
 
 A BibTeX entry for LaTeX users is
 
@@ -55,7 +55,6 @@ A BibTeX entry for LaTeX users is
   title = {edgeTransport: Prepare EDGE Transport Data for the REMIND model},
   author = {Alois Dirnaichner and Marianna Rottoli},
   year = {2021},
-  note = {R package version 0.3.1},
+  note = {R package version 0.3.2},
 }
 ```
-


### PR DESCRIPTION
The script `generateEDGEdata` used to overwrite existing outputs in the same output folder for same scenarios. Now the folders have a timestamp and no overwriting should take place.

This is a cleaned-up version of @johannah-pik 's https://github.com/johannah-pik/edgeTransport/tree/change_foldername_compscen