### PR TITLE
Bugfix: solve negative entries for SDP scenarios.

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '1008802'
+ValidationKey: '1028808'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "edgeTransport: Prepare EDGE Transport Data for the REMIND model",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "description": "<p>EDGE-T is a fork of the GCAM transport module https://jgcri.github.io/gcam-doc/energy.html#transportation with a high level of detail in its representation of technological and modal options. It is a partial equilibrium model with a nested multinomial logit structure and relies on the modified logit formulation. Most of the sources are not publicly available. PIK-internal users can find the sources in the distributed file system in the folder `/p/projects/rd3mod/inputdata/sources/EDGE-Transport-Standalone`.<\/p>",
   "creators": [
     {

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: edgeTransport
 Title: Prepare EDGE Transport Data for the REMIND model
-Version: 0.5.3
+Version: 0.5.4
 Authors@R: c(
     person("Alois", "Dirnaichner", email = "dirnaichner@pik-potsdam.de", role = c("aut", "cre")),
     person("Marianna", "Rottoli", email = "rottoli@pik-potsdam.de", role = "aut"))
@@ -13,7 +13,7 @@ Encoding: UTF-8
 LazyData: true
 RoxygenNote: 7.1.2
 VignetteBuilder: knitr
-Date: 2022-02-11
+Date: 2022-03-01
 Config/testthat/edition: 3
 Imports:
     edgeTrpLib,

--- a/R/lvl1_incotrend.R
+++ b/R/lvl1_incotrend.R
@@ -506,7 +506,8 @@ if (tech_scen %in% c("ElecEra", "HydrHype")) {
 
     SWS$VS1_final_pref[
           vehicle_type %in% c("Large Car", "SUV", "Van") & year >= 2020,
-          sw := sw[year==2020] * (1 + largeCarFactor * (year-2020) / (largeCarYear-2020))]
+          sw := max(sw[year==2020] * (1 + largeCarFactor * (year-2020) / (largeCarYear-2020)), 0), by = c("vehicle_type", "region", "year")]
+
     SWS$VS1_final_pref[
           subsector_L3 == "Domestic Aviation" & year >= 2020,
           sw := sw[year==2020] * (1 + domAvFactor * (year-2020) / (domAvYear-2020))]


### PR DESCRIPTION
In "smart lifestyle" scenarios, preference factors for vehicles were allowed to go below 0, leading to negative shares and negative demand. This PR should solve the issue