### PR TITLE
LDV costs for alternative techs are a markup on ICEs. Bugfix missing LDV category.

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '1047970'
+ValidationKey: '1067080'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "edgeTransport: Prepare EDGE Transport Data for the REMIND model",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "description": "<p>EDGE-T is a fork of the GCAM transport module https://jgcri.github.io/gcam-doc/energy.html#transportation with a high level of detail in its representation of technological and modal options. It is a partial equilibrium model with a nested multinomial logit structure and relies on the modified logit formulation. Most of the sources are not publicly available. PIK-internal users can find the sources in the distributed file system in the folder `/p/projects/rd3mod/inputdata/sources/EDGE-Transport-Standalone`.<\/p>",
   "creators": [
     {

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: edgeTransport
 Title: Prepare EDGE Transport Data for the REMIND model
-Version: 0.5.5
+Version: 0.5.6
 Authors@R: c(
     person("Alois", "Dirnaichner", email = "dirnaichner@pik-potsdam.de", role = c("aut", "cre")),
     person("Marianna", "Rottoli", email = "rottoli@pik-potsdam.de", role = "aut"))
@@ -13,7 +13,7 @@ Encoding: UTF-8
 LazyData: true
 RoxygenNote: 7.1.2
 VignetteBuilder: knitr
-Date: 2022-03-03
+Date: 2022-03-04
 Config/testthat/edition: 3
 Imports:
     edgeTrpLib,

--- a/R/lvl0_mergeDat.R
+++ b/R/lvl0_mergeDat.R
@@ -25,8 +25,8 @@ lvl0_mergeDat = function(UCD_output, EU_data, PSI_costs, altCosts, CHN_trucks, G
                          SSP_scen, years, REMIND2ISO_MAPPING){
   vkm.veh <- value <- variable <- conv_pkm_MJ <- conv_vkm_MJ <- ratio <- MJ_km <- sector_fuel <- subsector_L3 <- `.` <- NULL
   k <- subsector_L2 <- tech_output <- MJ <- region <- loadFactor <- vehicle_type <- iso <- univocal_name <- technology <- NULL
+  val <- markup <- NULL
   subsector_L1 <- vkm.veh <- tot_purchasecost <- aveval <- incentive_val <- unit <- demldv <- NULL
-
   logit_cat = copy(GCAM_data[["logit_category"]])
   logit_cat = rbind(logit_cat,
                     logit_cat[subsector_L1 == "trn_pass_road_LDV_4W" & technology == "BEV"][, technology := "Hybrid Electric"])
@@ -83,9 +83,40 @@ lvl0_mergeDat = function(UCD_output, EU_data, PSI_costs, altCosts, CHN_trucks, G
   eu_iso = unique(REMIND2ISO_MAPPING[region %in% c("DEU", "FRA", "UKI", "ECS", "ENC", "ESW", "EWN", "ESC", "ECE", "NEN", "NES"), iso])
   ## calculate PSI costs in terms of 2005$/pkm annualized
   PSI_c = copy(PSI_costs)
+  ## define markups on alternative techs based on the percentage difference we find in EU countries
+  PSI_c = rbind(PSI_c, PSI_c[year == 2040][, year := 2100])
+  ## in 2100, purchase price for BEVs is 0.8*purchase price, for Hybrid Electric is 0.7, for FCEVs is 0.9
+  decr = data.table(technology = c("BEV", "Hybrid Electric", "FCEV", "Liquids", "NG"), val = c(0.8, 0.7, 0.9, 1, 1))
+  PSI_c = merge(PSI_c, decr, by = "technology")
+  PSI_c[year == 2100, tot_purchasecost := tot_purchasecost[technology== "Liquids"]*val, by = "vehicle_type"]
+
+
+  ## add "Large Car"and "Light Truck and SUV" taking the same values as for "Large Car and SUV"
+  PSI_c = rbind(PSI_c,
+                PSI_c[vehicle_type == "Large Car and SUV",][, vehicle_type := "Light Truck and SUV"],
+                PSI_c[vehicle_type == "Large Car and SUV",][, vehicle_type := "Large Car"])
+
+  PSI_c = approx_dt(PSI_c,
+                       xdata = years,
+                       xcol = "year",
+                       ycol = "tot_purchasecost",
+                       idxcols = c("technology", "vehicle_type"),
+                       extrapolate = TRUE)
+
+  PSI_c[, val := NULL]
+  PSI_c[, markup := ifelse(technology %in% c("BEV", "Hybrid Electric", "FCEV"),
+                           tot_purchasecost[technology %in% c("FCEV", "BEV", "Hybrid Electric")]/
+                             tot_purchasecost[technology == "Liquids"],
+                           0), by = c("year")]
+
   PSI_c[, c("variable", "unit") := list("Capital costs (purchase)", "2005$/veh/yr")]
   PSI_c = merge(PSI_c, unique(AM[, c("iso", "year")]), by = "year", allow.cartesian=TRUE)
-  PSI_c = rbind(PSI_c[iso %in% eu_iso], PSI_c[!iso %in% eu_iso & technology %in% c("BEV", "FCEV", "Hybrid Electric")])
+
+  ## apply the markup to the respective technologies
+  PSI_c[!iso %in% eu_iso & year >= 2015, tot_purchasecost := ifelse(technology %in% c("BEV", "FCEV", "Hybrid Electric"),
+                                                                    tot_purchasecost[technology=="Liquids"]*markup,
+                                                                    tot_purchasecost), by = c("iso", "year", "vehicle_type")][, markup := NULL]
+
   setnames(PSI_c, old ="tot_purchasecost", new = "value")
   PSI_c = merge(PSI_c, logit_cat, by = c("vehicle_type", "technology"), all.x = T)[, univocal_name := NULL]
   ## calculate UCD costs for LDVs in terms of 2005$/pkm annualized

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Prepare EDGE Transport Data for the REMIND model
 
-R package **edgeTransport**, version **0.5.3**
+R package **edgeTransport**, version **0.5.6**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/edgeTransport)](https://cran.r-project.org/package=edgeTransport)  [![R build status](https://github.com/pik-piam/edgeTransport/workflows/check/badge.svg)](https://github.com/pik-piam/edgeTransport/actions) [![codecov](https://codecov.io/gh/pik-piam/edgeTransport/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/edgeTransport) [![r-universe](https://pik-piam.r-universe.dev/badges/edgeTransport)](https://pik-piam.r-universe.dev/ui#builds)
 
@@ -46,7 +46,7 @@ In case of questions / problems please contact Alois Dirnaichner <dirnaichner@pi
 
 To cite package **edgeTransport** in publications use:
 
-Dirnaichner A, Rottoli M (2022). _edgeTransport: Prepare EDGE Transport Data for the REMIND model_. R package version 0.5.3.
+Dirnaichner A, Rottoli M (2022). _edgeTransport: Prepare EDGE Transport Data for the REMIND model_. R package version 0.5.6.
 
 A BibTeX entry for LaTeX users is
 
@@ -55,6 +55,6 @@ A BibTeX entry for LaTeX users is
   title = {edgeTransport: Prepare EDGE Transport Data for the REMIND model},
   author = {Alois Dirnaichner and Marianna Rottoli},
   year = {2022},
-  note = {R package version 0.5.3},
+  note = {R package version 0.5.6},
 }
 ```


### PR DESCRIPTION
This PR contains the bugfix related to the missing LDV category in input costs. It also changes slightly the alternative costs calculation, expressed as a percentage variation wrt to ICE vehicles in the region following the discussion with @robertpietzcker .