### PR TITLE
Provide a regression config for all regions

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '1163880'
+ValidationKey: '1182960'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "edgeTransport: Prepare EDGE Transport Data for the REMIND model",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "<p>EDGE-T is a fork of the GCAM transport module https://jgcri.github.io/gcam-doc/energy.html#transportation with a high level of detail in its representation of technological and modal options. It is a partial equilibrium model with a nested multinomial logit structure and relies on the modified logit formulation. Most of the sources are not publicly available. PIK-internal users can find the sources in the distributed file system in the folder `/p/projects/rd3mod/inputdata/sources/EDGE-Transport-Standalone`.<\/p>",
   "creators": [
     {

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: edgeTransport
 Title: Prepare EDGE Transport Data for the REMIND model
-Version: 0.6.1
+Version: 0.6.2
 Authors@R: c(
     person("Alois", "Dirnaichner", email = "dirnaichner@pik-potsdam.de", role = c("aut", "cre")),
     person("Marianna", "Rottoli", email = "rottoli@pik-potsdam.de", role = "aut"))

--- a/R/generateEDGEdata.R
+++ b/R/generateEDGEdata.R
@@ -345,7 +345,7 @@ generateEDGEdata <- function(input_folder, output_folder, cache_folder = "cache"
       reg_demreg_tab <- NULL
       if(is.null(regional_demreg.path)){
         print("No path to a file with region-specific tuning parameters for the regression provided. Using default file.")
-        regional_demreg.path <- system.file("regional_regression_factors.csv", package="edgeTransport")
+        regional_demreg.path <- system.file("extdata", "regional_regression_factors.csv", package="edgeTransport")
       }
       reg_demreg_tab <- fread(regional_demreg.path, header = TRUE)
       ## demand in million km

--- a/R/generateEDGEdata.R
+++ b/R/generateEDGEdata.R
@@ -343,9 +343,11 @@ generateEDGEdata <- function(input_folder, output_folder, cache_folder = "cache"
         ssp_demreg_tab <- fread(ssp_demreg.path, header = TRUE)
       }
       reg_demreg_tab <- NULL
-      if(!is.null(regional_demreg.path) && file.exists(regional_demreg.path)){
-        reg_demreg_tab <- fread(regional_demreg.path, header = TRUE)
+      if(is.null(regional_demreg.path)){
+        print("No path to a file with region-specific tuning parameters for the regression provided. Using default file.")
+        regional_demreg.path <- system.file("regional_regression_factors.csv", package="edgeTransport")
       }
+      reg_demreg_tab <- fread(regional_demreg.path, header = TRUE)
       ## demand in million km
       dem_regr = lvl2_demandReg(tech_output = REMINDdat$dem,
                                 price_baseline = prices$S3S,

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Prepare EDGE Transport Data for the REMIND model
 
-R package **edgeTransport**, version **0.6.1**
+R package **edgeTransport**, version **0.6.2**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/edgeTransport)](https://cran.r-project.org/package=edgeTransport)  [![R build status](https://github.com/pik-piam/edgeTransport/workflows/check/badge.svg)](https://github.com/pik-piam/edgeTransport/actions) [![codecov](https://codecov.io/gh/pik-piam/edgeTransport/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/edgeTransport) [![r-universe](https://pik-piam.r-universe.dev/badges/edgeTransport)](https://pik-piam.r-universe.dev/ui#builds)
 
@@ -46,7 +46,7 @@ In case of questions / problems please contact Alois Dirnaichner <dirnaichner@pi
 
 To cite package **edgeTransport** in publications use:
 
-Dirnaichner A, Rottoli M (2022). _edgeTransport: Prepare EDGE Transport Data for the REMIND model_. R package version 0.6.1.
+Dirnaichner A, Rottoli M (2022). _edgeTransport: Prepare EDGE Transport Data for the REMIND model_. R package version 0.6.2.
 
 A BibTeX entry for LaTeX users is
 
@@ -55,6 +55,6 @@ A BibTeX entry for LaTeX users is
   title = {edgeTransport: Prepare EDGE Transport Data for the REMIND model},
   author = {Alois Dirnaichner and Marianna Rottoli},
   year = {2022},
-  note = {R package version 0.6.1},
+  note = {R package version 0.6.2},
 }
 ```

--- a/inst/extdata/regional_regression_factors.csv
+++ b/inst/extdata/regional_regression_factors.csv
@@ -12,3 +12,14 @@ SSP2,SSA,income_elasticity_freight_lo,0,0.2,0.4,0
 SSP2,REF,income_elasticity_freight_lo,0,-0.4,-0.2,0
 SSP2,OAS,income_elasticity_freight_lo,0,-0.3,-0.2,0
 SSP2,CAZ,income_elasticity_freight_lo,0,0.5,0.3,0
+SSP2,ECS,income_elasticity_pass_lo,0,0.4,0.2,0
+SSP2,NES,income_elasticity_pass_lo,0,1,0.2,0
+SSP2,ECE,income_elasticity_pass_lo,0,1,0.2,0
+SSP2,EWN,income_elasticity_pass_lo,0,-0.3,-0.2,0
+SSP2,ESW,income_elasticity_freight_sm,0,-0.5,-0.2,0
+SSP2,ECE,income_elasticity_freight_sm,0,0,-0.4,-0.2
+SSP2,ECS,income_elasticity_freight_sm,0,0,-0.2,0
+SSP2,FRA,income_elasticity_freight_sm,0,0,0.2,0.1
+SSP2,EWN,income_elasticity_freight_lo,0,-0.3,-0.4,-0.3
+SSP2,NES,income_elasticity_freight_lo,0,2,2,0.8
+SSP2,NES,income_elasticity_pass_sm,0,0.6,0.5,0

--- a/inst/extdata/regional_regression_factors.csv
+++ b/inst/extdata/regional_regression_factors.csv
@@ -4,9 +4,11 @@ SSP2,IND,income_elasticity_pass_sm,0,-0.3,0,0
 SSP2,CHA,income_elasticity_pass_sm,0,-0.3,0.1,-0.5
 SSP2,OAS,income_elasticity_pass_lo,0,-0.3,-0.1,0
 SSP2,MEA,income_elasticity_pass_lo,0,-0.4,-0.2,0
+SSP2,UKI,income_elasticity_pass_lo,0,-0.2,-0.1,0
 SSP2,MEA,income_elasticity_freight_sm,0,0.8,0.4,0
 SSP2,REF,income_elasticity_freight_sm,0,-0.9,-0.2,0
 SSP2,CHA,income_elasticity_freight_sm,0,-0.7,-0.1,-0.2
+SSP2,UKI,income_elasticity_freight_sm,0,0.2,0.1,0
 SSP2,IND,income_elasticity_freight_lo,0,1.1,0.6,0
 SSP2,SSA,income_elasticity_freight_lo,0,0.2,0.4,0
 SSP2,REF,income_elasticity_freight_lo,0,-0.4,-0.2,0
@@ -16,10 +18,10 @@ SSP2,ECS,income_elasticity_pass_lo,0,0.4,0.2,0
 SSP2,NES,income_elasticity_pass_lo,0,1,0.2,0
 SSP2,ECE,income_elasticity_pass_lo,0,1,0.2,0
 SSP2,EWN,income_elasticity_pass_lo,0,-0.3,-0.2,0
+SSP2,NES,income_elasticity_pass_sm,0,0.6,0.5,0
 SSP2,ESW,income_elasticity_freight_sm,0,-0.5,-0.2,0
 SSP2,ECE,income_elasticity_freight_sm,0,0,-0.4,-0.2
 SSP2,ECS,income_elasticity_freight_sm,0,0,-0.2,0
 SSP2,FRA,income_elasticity_freight_sm,0,0,0.2,0.1
 SSP2,EWN,income_elasticity_freight_lo,0,-0.3,-0.4,-0.3
 SSP2,NES,income_elasticity_freight_lo,0,2,2,0.8
-SSP2,NES,income_elasticity_pass_sm,0,0.6,0.5,0

--- a/inst/extdata/regional_regression_factors.csv
+++ b/inst/extdata/regional_regression_factors.csv
@@ -1,0 +1,14 @@
+SSP_scenario,region,var,2020,2030,2050,2100
+SSP2,OAS,income_elasticity_pass_sm,0,0,-0.6,0
+SSP2,IND,income_elasticity_pass_sm,0,-0.3,0,0
+SSP2,CHA,income_elasticity_pass_sm,0,-0.3,0.1,-0.5
+SSP2,OAS,income_elasticity_pass_lo,0,-0.3,-0.1,0
+SSP2,MEA,income_elasticity_pass_lo,0,-0.4,-0.2,0
+SSP2,MEA,income_elasticity_freight_sm,0,0.8,0.4,0
+SSP2,REF,income_elasticity_freight_sm,0,-0.9,-0.2,0
+SSP2,CHA,income_elasticity_freight_sm,0,-0.7,-0.1,-0.2
+SSP2,IND,income_elasticity_freight_lo,0,1.1,0.6,0
+SSP2,SSA,income_elasticity_freight_lo,0,0.2,0.4,0
+SSP2,REF,income_elasticity_freight_lo,0,-0.4,-0.2,0
+SSP2,OAS,income_elasticity_freight_lo,0,-0.3,-0.2,0
+SSP2,CAZ,income_elasticity_freight_lo,0,0.5,0.3,0


### PR DESCRIPTION
The config is shipped in `inst/extdata` and used in case no path is provided to `generateEDGEdata`.