### PR TITLE
have generateEDGEdata() and all contributing functions tracked by madrat

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -8,3 +8,4 @@
 ^\.pre-commit-config\.yaml$
 ^TAGS
 ^workflow$
+^\.git$

--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '1221312'
+ValidationKey: '1336090'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "edgeTransport: Prepare EDGE Transport Data for the REMIND model",
-  "version": "0.6.4",
+  "version": "0.7.0",
   "description": "<p>EDGE-T is a fork of the GCAM transport module https://jgcri.github.io/gcam-doc/energy.html#transportation with a high level of detail in its representation of technological and modal options. It is a partial equilibrium model with a nested multinomial logit structure and relies on the modified logit formulation. Most of the sources are not publicly available. PIK-internal users can find the sources in the distributed file system in the folder `/p/projects/rd3mod/inputdata/sources/EDGE-Transport-Standalone`.<\/p>",
   "creators": [
     {

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: edgeTransport
 Title: Prepare EDGE Transport Data for the REMIND model
-Version: 0.6.4
+Version: 0.7.0
 Authors@R: c(
     person("Alois", "Dirnaichner", email = "dirnaichner@pik-potsdam.de", role = c("aut", "cre")),
     person("Marianna", "Rottoli", email = "rottoli@pik-potsdam.de", role = "aut"))
@@ -13,7 +13,7 @@ Encoding: UTF-8
 LazyData: true
 RoxygenNote: 7.1.2
 VignetteBuilder: knitr
-Date: 2022-04-01
+Date: 2022-04-05
 Config/testthat/edition: 3
 Imports:
     edgeTrpLib,

--- a/EDGEtransport.Rproj
+++ b/EDGEtransport.Rproj
@@ -12,8 +12,10 @@ Encoding: UTF-8
 RnwWeave: Sweave
 LaTeX: pdfLaTeX
 
+AutoAppendNewline: Yes
+StripTrailingWhitespace: Yes
+
 BuildType: Package
 PackageUseDevtools: Yes
 PackageInstallArgs: --no-multiarch --with-keep.source
-AutoAppendNewline: Yes
-StripTrailingWhitespace: Yes
+PackageRoxygenize: rd,collate,namespace,vignette

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -2,6 +2,7 @@
 
 export(Update_Validation_Excel_tool)
 export(Update_sw_trend)
+export(calcgenerateEDGEdata)
 export(collectScens)
 export(compScenEDGET)
 export(generateEDGEdata)

--- a/R/generateEDGEdata.R
+++ b/R/generateEDGEdata.R
@@ -543,3 +543,41 @@ generateEDGEdata <- function(input_folder, output_folder, cache_folder = "cache"
   }
 
 }
+
+#' @export
+#' @rdname generateEDGEdata
+calcgenerateEDGEdata <- function(input_folder, output_folder,
+                                 cache_folder = "cache", SSP_scen = "SSP2",
+                                 tech_scen = "Mix", smartlifestyle = FALSE,
+                                 val_excel_input = FALSE, storeRDS = FALSE,
+                                 loadLvl0Cache = FALSE, gdxPath = NULL,
+                                 preftab = NULL, plot.report = FALSE,
+                                 mitab4W.path = NULL, mitab.path = NULL,
+                                 ssp_demreg.path = NULL,
+                                 regional_demreg.path = NULL) {
+  "!# @monitor edgeTransport:::generateEDGEdata"
+  "!# @monitor edgeTransport:::compScenEDGET"
+  "!# @monitor edgeTransport:::lvl0_GCAMraw"
+  "!# @monitor edgeTransport:::lvl0_incocost"
+  "!# @monitor edgeTransport:::lvl0_loadEU"
+  "!# @monitor edgeTransport:::lvl0_loadUCD"
+  "!# @monitor edgeTransport:::lvl0_mrremind"
+  "!# @monitor edgeTransport:::lvl1_calibrateEDGEinconv"
+  "!# @monitor edgeTransport:::lvl1_IEAharmonization"
+  "!# @monitor edgeTransport:::lvl2_createoutput"
+  "!# @monitor edgeTransport:::lvl2_demandReg"
+  "!# @monitor edgeTransport:::lvl2_demandRegNAVIGATEIntl"
+  "!# @monitor edgeTransport:::lvl2_REMINDdemand"
+  "!# @monitor edgeTransport:::vl1_preftrend"
+
+  return(list(
+    x = generateEDGEdata(input_folder, output_folder, cache_folder,  SSP_scen,
+                         tech_scen, smartlifestyle, val_excel_input, storeRDS,
+                         loadLvl0Cache, gdxPath, preftab, plot.report,
+                         mitab4W.path, mitab.path, ssp_demreg.path,
+                         regional_demreg.path),
+    class = 'data.table',
+    unit = NA,
+    description = NA))
+
+}

--- a/R/generateEDGEdata.R
+++ b/R/generateEDGEdata.R
@@ -1,6 +1,11 @@
 #' Generate EDGE-Transport Input Data for the REMIND model.
 #'
 #' Run this script to prepare the input data for EDGE in EDGE-friendly units and regional aggregation
+#'
+#' `calcgenerateEDGEdata()` is a wrapper for `generateEDGEdata()` to make use of
+#' madrat caching.
+#'
+#' @md
 #' @param input_folder folder hosting raw data
 #' @param output_folder folder hosting REMIND input files. If NULL, a list of magclass objects is returned (set this option in case of a REMIND preprocessing run)
 #' @param cache_folder folder hosting a "local" cache (this is not the mrremid cache, it is specific to EDGE-T). NOTE: the cache folder will be created in the output_folder if it does not exist.

--- a/R/madrat.R
+++ b/R/madrat.R
@@ -1,0 +1,9 @@
+.onAttach <- function(libname, pkgname) {
+  if ('try-error' != class(try(find.package('madrat'), TRUE)))
+    madrat::madratAttach(pkgname)
+}
+
+.onDetach <- function(libpath) {
+  if ('try-error' != class(try(find.package('madrat'), TRUE)))
+    madrat::madratDetach(libpath)
+}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Prepare EDGE Transport Data for the REMIND model
 
-R package **edgeTransport**, version **0.6.4**
+R package **edgeTransport**, version **0.7.0**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/edgeTransport)](https://cran.r-project.org/package=edgeTransport)    [![r-universe](https://pik-piam.r-universe.dev/badges/edgeTransport)](https://pik-piam.r-universe.dev/ui#builds)
 
@@ -46,7 +46,7 @@ In case of questions / problems please contact Alois Dirnaichner <dirnaichner@pi
 
 To cite package **edgeTransport** in publications use:
 
-Dirnaichner A, Rottoli M (2022). _edgeTransport: Prepare EDGE Transport Data for the REMIND model_. R package version 0.6.4.
+Dirnaichner A, Rottoli M (2022). _edgeTransport: Prepare EDGE Transport Data for the REMIND model_. R package version 0.7.0.
 
 A BibTeX entry for LaTeX users is
 
@@ -55,6 +55,6 @@ A BibTeX entry for LaTeX users is
   title = {edgeTransport: Prepare EDGE Transport Data for the REMIND model},
   author = {Alois Dirnaichner and Marianna Rottoli},
   year = {2022},
-  note = {R package version 0.6.4},
+  note = {R package version 0.7.0},
 }
 ```


### PR DESCRIPTION
- added a `calcgenerateEDGEdata()` wrapper for `generateEDGEdata()`, which will be tracked by `madrat` by virtue of bein called calcsomething
- added `"!# @monitor"` strings to `calcgenerateEDGEdata()` for all `edgeTransport` functions that (could) feed into `generateEDGEdata()` so that they are tracked, too
- added `.onAttach()` and `.onDetach()` functions triggering `madrat` _iff_ it is installed
- `mrremind::calcEDGETrData()` is modified to call `calcOutput('generateEDGEData')` in connected merge request pik-piam/mrremind#245
- this leaves `edgeTransport` as independent of `madrat` as it was while enabling required caching 