### PR TITLE
Shift the start year for which the regression factors affect the

### DIFF
--- a/R/lvl2_demandReg.R
+++ b/R/lvl2_demandReg.R
@@ -102,8 +102,8 @@ lvl2_demandReg <- function(tech_output, price_baseline, GDP_POP, smartlifestyle,
       melt(id.vars = "var", variable.name = "year", value.name = "SSP_factor") %>%
       .[, year := as.numeric(as.character(year))] %>%
       .[price_el, on=c("year", "var")] %>%
-      .[year < 2020, SSP_factor := 0] %>%
-      .[year >= 2020 & year <= 2100, SSP_factor := na.approx(SSP_factor, x=year),
+      .[year <= 2010, SSP_factor := 0] %>%
+      .[year >= 2010 & year <= 2100, SSP_factor := na.approx(SSP_factor, x=year),
         by=c("region", "var")] %>%
       .[year <= 2100 & is.na(SSP_factor), SSP_factor := 0]
     
@@ -118,8 +118,8 @@ lvl2_demandReg <- function(tech_output, price_baseline, GDP_POP, smartlifestyle,
       melt(id.vars = c("region", "var"), variable.name = "year", value.name = "region_factor") %>%
       .[, year := as.numeric(as.character(year))] %>%
       .[price_el, on=c("region", "year", "var")] %>%
-      .[year < 2020, region_factor := 0] %>%
-      .[year >= 2020 & year <= 2100, region_factor := na.approx(region_factor, x=year),
+      .[year <= 2010, region_factor := 0] %>%
+      .[year >= 2010 & year <= 2100, region_factor := na.approx(region_factor, x=year),
         by=c("region", "var")] %>%
       .[year <= 2100 & is.na(region_factor), region_factor := 0]
     

--- a/inst/extdata/regional_regression_factors.csv
+++ b/inst/extdata/regional_regression_factors.csv
@@ -1,7 +1,7 @@
 SSP_scenario,region,var,2020,2030,2050,2100
 SSP2,OAS,income_elasticity_pass_sm,0,0,-0.6,0
 SSP2,IND,income_elasticity_pass_sm,0,-0.3,0,0
-SSP2,CHA,income_elasticity_pass_sm,0,-0.3,0.1,-0.5
+SSP2,CHA,income_elasticity_pass_sm,-0.7,-0.3,0.1,-0.2
 SSP2,OAS,income_elasticity_pass_lo,0,-0.3,-0.1,0
 SSP2,MEA,income_elasticity_pass_lo,0,-0.4,-0.2,0
 SSP2,UKI,income_elasticity_pass_lo,0,-0.2,-0.1,0
@@ -27,7 +27,7 @@ SSP2,EWN,income_elasticity_freight_lo,0,-0.3,-0.4,-0.3
 SSP2,NES,income_elasticity_freight_lo,0,2,2,0.8
 SSP1,OAS,income_elasticity_pass_sm,0,0,-0.6,0
 SSP1,IND,income_elasticity_pass_sm,0,-0.3,0,0
-SSP1,CHA,income_elasticity_pass_sm,0,-0.3,0.1,-0.5
+SSP1,CHA,income_elasticity_pass_sm,-0.7,-0.3,0.1,-0.2
 SSP1,OAS,income_elasticity_pass_lo,0,-0.3,-0.1,0
 SSP1,MEA,income_elasticity_pass_lo,0,-0.4,-0.2,0
 SSP1,UKI,income_elasticity_pass_lo,0,-0.2,-0.1,0
@@ -53,7 +53,7 @@ SSP1,EWN,income_elasticity_freight_lo,0,-0.3,-0.4,-0.3
 SSP1,NES,income_elasticity_freight_lo,0,2,2,0.8
 SSP5,OAS,income_elasticity_pass_sm,0,0,-0.6,0
 SSP5,IND,income_elasticity_pass_sm,0,-0.3,0,0
-SSP5,CHA,income_elasticity_pass_sm,0,-0.3,0.1,-0.5
+SSP5,CHA,income_elasticity_pass_sm,-0.7,-0.3,0.1,-0.2
 SSP5,OAS,income_elasticity_pass_lo,0,-0.3,-0.1,0
 SSP5,MEA,income_elasticity_pass_lo,0,-0.4,-0.2,0
 SSP5,UKI,income_elasticity_pass_lo,0,-0.2,-0.1,0
@@ -79,7 +79,7 @@ SSP5,EWN,income_elasticity_freight_lo,0,-0.3,-0.4,-0.3
 SSP5,NES,income_elasticity_freight_lo,0,2,2,0.8
 SSP2EU,OAS,income_elasticity_pass_sm,0,0,-0.6,0
 SSP2EU,IND,income_elasticity_pass_sm,0,-0.3,0,0
-SSP2EU,CHA,income_elasticity_pass_sm,0,-0.3,0.1,-0.5
+SSP2EU,CHA,income_elasticity_pass_sm,-0.7,-0.3,0.1,-0.2
 SSP2EU,OAS,income_elasticity_pass_lo,0,-0.3,-0.1,0
 SSP2EU,MEA,income_elasticity_pass_lo,0,-0.4,-0.2,0
 SSP2EU,UKI,income_elasticity_pass_lo,0,-0.2,-0.1,0
@@ -105,7 +105,7 @@ SSP2EU,EWN,income_elasticity_freight_lo,0,-0.3,-0.4,-0.3
 SSP2EU,NES,income_elasticity_freight_lo,0,2,2,0.8
 SDP,OAS,income_elasticity_pass_sm,0,0,-0.6,0
 SDP,IND,income_elasticity_pass_sm,0,-0.3,0,0
-SDP,CHA,income_elasticity_pass_sm,0,-0.3,0.1,-0.5
+SDP,CHA,income_elasticity_pass_sm,-0.7,-0.3,0.1,-0.2
 SDP,OAS,income_elasticity_pass_lo,0,-0.3,-0.1,0
 SDP,MEA,income_elasticity_pass_lo,0,-0.4,-0.2,0
 SDP,UKI,income_elasticity_pass_lo,0,-0.2,-0.1,0
@@ -131,7 +131,7 @@ SDP,EWN,income_elasticity_freight_lo,0,-0.3,-0.4,-0.3
 SDP,NES,income_elasticity_freight_lo,0,2,2,0.8
 SDP_MC,OAS,income_elasticity_pass_sm,0,0,-0.6,0
 SDP_MC,IND,income_elasticity_pass_sm,0,-0.3,0,0
-SDP_MC,CHA,income_elasticity_pass_sm,0,-0.3,0.1,-0.5
+SDP_MC,CHA,income_elasticity_pass_sm,-0.7,-0.3,0.1,-0.2
 SDP_MC,OAS,income_elasticity_pass_lo,0,-0.3,-0.1,0
 SDP_MC,MEA,income_elasticity_pass_lo,0,-0.4,-0.2,0
 SDP_MC,UKI,income_elasticity_pass_lo,0,-0.2,-0.1,0
@@ -157,7 +157,7 @@ SDP_MC,EWN,income_elasticity_freight_lo,0,-0.3,-0.4,-0.3
 SDP_MC,NES,income_elasticity_freight_lo,0,2,2,0.8
 SDP_RC,OAS,income_elasticity_pass_sm,0,0,-0.6,0
 SDP_RC,IND,income_elasticity_pass_sm,0,-0.3,0,0
-SDP_RC,CHA,income_elasticity_pass_sm,0,-0.3,0.1,-0.5
+SDP_RC,CHA,income_elasticity_pass_sm,-0.7,-0.3,0.1,-0.2
 SDP_RC,OAS,income_elasticity_pass_lo,0,-0.3,-0.1,0
 SDP_RC,MEA,income_elasticity_pass_lo,0,-0.4,-0.2,0
 SDP_RC,UKI,income_elasticity_pass_lo,0,-0.2,-0.1,0
@@ -183,7 +183,7 @@ SDP_RC,EWN,income_elasticity_freight_lo,0,-0.3,-0.4,-0.3
 SDP_RC,NES,income_elasticity_freight_lo,0,2,2,0.8
 SDP_EI,OAS,income_elasticity_pass_sm,0,0,-0.6,0
 SDP_EI,IND,income_elasticity_pass_sm,0,-0.3,0,0
-SDP_EI,CHA,income_elasticity_pass_sm,0,-0.3,0.1,-0.5
+SDP_EI,CHA,income_elasticity_pass_sm,-0.7,-0.3,0.1,-0.2
 SDP_EI,OAS,income_elasticity_pass_lo,0,-0.3,-0.1,0
 SDP_EI,MEA,income_elasticity_pass_lo,0,-0.4,-0.2,0
 SDP_EI,UKI,income_elasticity_pass_lo,0,-0.2,-0.1,0


### PR DESCRIPTION
regression.

And reduce pass_sm demand in CHA considerably for 2020. This is intended to reduce the FE demand spike in 2020 in the current iteration of the validation.