### PR TITLE
Reduce demand and LDV share for low-to-mid income regions

### DIFF
--- a/inst/extdata/regional_regression_factors.csv
+++ b/inst/extdata/regional_regression_factors.csv
@@ -1,5 +1,5 @@
 SSP_scenario,region,var,2020,2030,2050,2100
-SSP2,OAS,income_elasticity_pass_sm,0,0,-0.6,0
+SSP2,OAS,income_elasticity_pass_sm,-0.7,-0.3,-0.4,0
 SSP2,IND,income_elasticity_pass_sm,0,-0.3,0,0
 SSP2,CHA,income_elasticity_pass_sm,-0.7,-0.3,0.1,-0.2
 SSP2,OAS,income_elasticity_pass_lo,0,-0.3,-0.1,0

--- a/inst/extdata/sw_trends.csv
+++ b/inst/extdata/sw_trends.csv
@@ -38,18 +38,18 @@ SSP2,CAZ,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Fre
 SSP2,CAZ,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1,1,1,1,1
 SSP2,CAZ,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1,1,1,1,1
 SSP2,CAZ,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.119202922022118,0.35,0.491006895018954,0.491006895018954
-SSP2,CAZ,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.047425873177567,0.188258994958996,0.476287063411217,0.476287063411217
-SSP2,CAZ,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.047425873177567,0.188258994958996,0.476287063411217,0.476287063411217
-SSP2,CAZ,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.047425873177567,0.188258994958996,0.476287063411217,0.476287063411217
+SSP2,CAZ,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.047425873177567,0.188258994958997,0.476287063411217,0.476287063411217
+SSP2,CAZ,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.047425873177567,0.188258994958997,0.476287063411217,0.476287063411217
+SSP2,CAZ,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.047425873177567,0.188258994958997,0.476287063411217,0.476287063411217
 SSP2,CAZ,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.119202922022118,0.35,0.491006895018954,0.491006895018954
-SSP2,CAZ,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.012363115783175,0.017986209962092,0.0954351880334422,0.0954351880334422
+SSP2,CAZ,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.012363115783175,0.017986209962092,0.0954351880334419,0.0954351880334419
 SSP2,CAZ,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.033464254621425,0.047425873177567,0.146211715726001,0.146211715726001
 SSP2,CAZ,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.012363115783175,0.017986209962092,0.1,0.1
 SSP2,CAZ,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.012363115783175,0.017986209962092,0.1,0.1
 SSP2,CAZ,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.012363115783175,0.017986209962092,0.1,0.1
 SSP2,CAZ,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.033464254621425,0.047425873177567,0.146211715726001,0.146211715726001
 SSP2,CAZ,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0,8.31528027664132e-07,4.53978687024344e-05,0.119202922022118,0.119202922022118
-SSP2,CAZ,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1,1,1,0.954351880334422,0.954351880334422
+SSP2,CAZ,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1,1,1,0.954351880334419,0.954351880334419
 SSP2,CAZ,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1,1,1,1,1
 SSP2,CAZ,Liquids,Domestic Ship_tmp_vehicletype,Domestic Ship_tmp_subsector_L1,Domestic Ship_tmp_subsector_L2,Domestic Ship,trn_freight,FV,linear,1,1,1,1,1
 SSP2,CAZ,Liquids,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1,1,1,1,1
@@ -64,7 +64,7 @@ SSP2,CAZ,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_
 SSP2,CAZ,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,1,1,1,1
 SSP2,CAZ,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,1,1,1,1
 SSP2,CAZ,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,1,1,1,1
-SSP2,CAZ,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.031042108230522,0.056541000119193,0.107538783896534,0.199969502302122,0.199969502302122
+SSP2,CAZ,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.031042108230522,0.056541000119193,0.107538783896534,0.199969502302121,0.199969502302121
 SSP2,CAZ,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.026315789473684,0.078947368421053,0.184210526315789,0.184210526315789
 SSP2,CAZ,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.026315789473684,0.078947368421053,0.184210526315789,0.184210526315789
 SSP2,CAZ,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.026315789473684,0.078947368421053,0.184210526315789,0.184210526315789
@@ -81,7 +81,7 @@ SSP2,CHA,"","","","",Passenger Rail,trn_pass,S3S,linear,0.00546103419952829,0.00
 SSP2,CHA,"","","","",Walk,trn_pass,S3S,linear,0.877713076761744,1,1,1,1
 SSP2,CHA,"","","","",trn_freight_road,trn_freight,S3S,linear,1,1,1,1,1
 SSP2,CHA,"","","","",trn_pass_road,trn_pass,S3S,linear,1,0.455729794383114,0.227864897191557,0.0584268967157839,0.0584268967157839
-SSP2,CHA,"","","",Bus,trn_pass_road,trn_pass,S2S3,linear,0.254432114324843,0.191544432089459,0.170509316525779,0.189454796139754,0.189454796139754
+SSP2,CHA,"","","",Bus,trn_pass_road,trn_pass,S2S3,linear,0.381648171487265,0.191544432089459,0.170509316525779,0.189454796139754,0.189454796139754
 SSP2,CHA,"","","",trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1,1,1,1,1
 SSP2,CHA,"","",trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,0.01080602223644,0.009522807095863,0.006956376814708,0.001823516252399,0.001823516252399
 SSP2,CHA,"","",trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1,1,1,1,1
@@ -109,14 +109,14 @@ SSP2,CHA,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road
 SSP2,CHA,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.1,0.4,0.9,1,1
 SSP2,CHA,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.1,0.4,0.9,1,1
 SSP2,CHA,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0476811688088472,0.45,0.982013790037908,0.982013790037908
-SSP2,CHA,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.022253608409715,0.0668777976648958,0.0699858045578576,0.0699858045578576
+SSP2,CHA,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.022253608409715,0.0668777976648955,0.0699858045578576,0.0699858045578576
 SSP2,CHA,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.001338570184857,0.0284555239065402,0.146211715726001,0.146211715726001
 SSP2,CHA,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.000494524631327,0.0107917259772552,0.1,0.1
 SSP2,CHA,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.01,0.2,0.6,0.2,0.2
 SSP2,CHA,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.01,0.2,0.6,0.2,0.2
 SSP2,CHA,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.001338570184857,0.0284555239065402,0.146211715726001,0.146211715726001
 SSP2,CHA,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0,8.31528027664132e-07,4.53978687024344e-05,0.119202922022118,0.119202922022118
-SSP2,CHA,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1,1,0.743656365691809,0.349929022789288,0.349929022789288
+SSP2,CHA,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1,1,0.743656365691807,0.349929022789288,0.349929022789288
 SSP2,CHA,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1,1,1,1,1
 SSP2,CHA,Liquids,Domestic Ship_tmp_vehicletype,Domestic Ship_tmp_subsector_L1,Domestic Ship_tmp_subsector_L2,Domestic Ship,trn_freight,FV,linear,1,1,1,1,1
 SSP2,CHA,Liquids,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1,1,1,1,1
@@ -131,7 +131,7 @@ SSP2,CHA,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_
 SSP2,CHA,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,1,1,1,1
 SSP2,CHA,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,1,1,1,1
 SSP2,CHA,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,1,1,1,1
-SSP2,CHA,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.142120012637288,0.159432643883675,0.090195248368545,0.115174077598356,0.115174077598356
+SSP2,CHA,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.142120012637288,0.159432643883675,0.0901952483685446,0.115174077598355,0.115174077598355
 SSP2,CHA,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.8778097236668e-05,0.013188367964814,0.0553035143317804,0.0921307947813305,0.0921307947813305
 SSP2,CHA,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.0007853553299874,0.014432374877611,0.0569509829460257,0.093173070843404,0.093173070843404
 SSP2,CHA,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.3,0.5,0.7,0.5,0.5
@@ -172,16 +172,16 @@ SSP2,DEU,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Fre
 SSP2,DEU,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1,1,1,1,1
 SSP2,DEU,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1,1,1,1,1
 SSP2,DEU,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.298007305055295,0.675,0.982013790037908,0.982013790037908
-SSP2,DEU,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.118564682943918,0.363070918849493,0.952574126822433,0.952574126822433
-SSP2,DEU,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.118564682943918,0.363070918849493,0.952574126822433,0.952574126822433
-SSP2,DEU,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.118564682943918,0.363070918849493,0.952574126822433,0.952574126822433
+SSP2,DEU,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.118564682943917,0.363070918849493,0.952574126822433,0.952574126822433
+SSP2,DEU,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.118564682943917,0.363070918849493,0.952574126822433,0.952574126822433
+SSP2,DEU,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.118564682943917,0.363070918849493,0.952574126822433,0.952574126822433
 SSP2,DEU,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.298007305055295,0.675,0.982013790037908,0.982013790037908
 SSP2,DEU,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.002472623156635,0.017986209962092,0.05,0.05
-SSP2,DEU,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.08031421109142,0.331981112242969,0.219317573589002,0.219317573589002
+SSP2,DEU,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.08031421109142,0.331981112242969,0.219317573589001,0.219317573589001
 SSP2,DEU,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.02967147787962,0.125903469734644,0.15,0.15
 SSP2,DEU,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.02967147787962,0.125903469734644,0.15,0.15
 SSP2,DEU,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.02967147787962,0.125903469734644,0.15,0.15
-SSP2,DEU,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.08031421109142,0.331981112242969,0.219317573589002,0.219317573589002
+SSP2,DEU,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.08031421109142,0.331981112242969,0.219317573589001,0.219317573589001
 SSP2,DEU,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0,8.31528027664132e-07,4.53978687024344e-05,0.119202922022118,0.119202922022118
 SSP2,DEU,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1,1,1,1,1
 SSP2,DEU,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1,1,1,1,1
@@ -306,9 +306,9 @@ SSP2,ECS,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Fre
 SSP2,ECS,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1,1,1,1,1
 SSP2,ECS,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1,1,1,1,1
 SSP2,ECS,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.119202922022118,0.25,0.294604137011372,0.294604137011372
-SSP2,ECS,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.047425873177567,0.134470710684997,0.28577223804673,0.28577223804673
-SSP2,ECS,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.047425873177567,0.134470710684997,0.28577223804673,0.28577223804673
-SSP2,ECS,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.047425873177567,0.134470710684997,0.28577223804673,0.28577223804673
+SSP2,ECS,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.047425873177567,0.134470710684998,0.28577223804673,0.28577223804673
+SSP2,ECS,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.047425873177567,0.134470710684998,0.28577223804673,0.28577223804673
+SSP2,ECS,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.047425873177567,0.134470710684998,0.28577223804673,0.28577223804673
 SSP2,ECS,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.119202922022118,0.25,0.294604137011372,0.294604137011372
 SSP2,ECS,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.002472623156635,0.053958629886276,0.1,0.1
 SSP2,ECS,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.01338570184857,0.047425873177567,0.0731058578630005,0.0731058578630005
@@ -386,7 +386,7 @@ SSP2,ENC,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp
 SSP2,ENC,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.02472623156635,0.08993104981046,0.1,0.1
 SSP2,ENC,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.06692850924285,0.237129365887835,0.146211715726001,0.146211715726001
 SSP2,ENC,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0,8.31528027664132e-07,4.53978687024344e-05,0.119202922022118,0.119202922022118
-SSP2,ENC,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1,1,1,0.524893534183932,0.524893534183932
+SSP2,ENC,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1,1,1,0.524893534183931,0.524893534183931
 SSP2,ENC,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1,1,1,1,1
 SSP2,ENC,Liquids,Domestic Ship_tmp_vehicletype,Domestic Ship_tmp_subsector_L1,Domestic Ship_tmp_subsector_L2,Domestic Ship,trn_freight,FV,linear,1,1,1,1,1
 SSP2,ENC,Liquids,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,0.1341454314254,0.1341454314254,0.1341454314254,0.1341454314254,0.1341454314254
@@ -504,7 +504,7 @@ SSP2,ESW,"",Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_
 SSP2,ESW,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0,0,0,0,0
 SSP2,ESW,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0,0,0,0,0
 SSP2,ESW,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0,0,0,0,0
-SSP2,ESW,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.118564682943918,0.268941421369995,0.666801888775703,0.666801888775703
+SSP2,ESW,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.118564682943917,0.268941421369995,0.666801888775703,0.666801888775703
 SSP2,ESW,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,0.72951273091157,0.763323639547623,0.830945456819731,0.966189091363946,0.966189091363946
 SSP2,ESW,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1,1,1,1,1
 SSP2,ESW,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1,1,1,1,1
@@ -643,18 +643,18 @@ SSP2,FRA,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Fre
 SSP2,FRA,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1,1,1,1,1
 SSP2,FRA,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1,1,1,1,1
 SSP2,FRA,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.298007305055295,0.75,0.982013790037908,0.982013790037908
-SSP2,FRA,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.118564682943918,0.403412132054992,0.952574126822433,0.952574126822433
-SSP2,FRA,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.118564682943918,0.403412132054992,0.952574126822433,0.952574126822433
-SSP2,FRA,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.118564682943918,0.403412132054992,0.952574126822433,0.952574126822433
+SSP2,FRA,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.118564682943917,0.403412132054992,0.952574126822433,0.952574126822433
+SSP2,FRA,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.118564682943917,0.403412132054992,0.952574126822433,0.952574126822433
+SSP2,FRA,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.118564682943917,0.403412132054992,0.952574126822433,0.952574126822433
 SSP2,FRA,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.298007305055295,0.75,0.982013790037908,0.982013790037908
-SSP2,FRA,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.012363115783175,0.017986209962092,0.0954351880334422,0.0954351880334422
+SSP2,FRA,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.012363115783175,0.017986209962092,0.0954351880334419,0.0954351880334419
 SSP2,FRA,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.06692850924285,0.047425873177567,0.146211715726001,0.146211715726001
 SSP2,FRA,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.02472623156635,0.017986209962092,0.1,0.1
 SSP2,FRA,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.02472623156635,0.017986209962092,0.1,0.1
 SSP2,FRA,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.02472623156635,0.017986209962092,0.1,0.1
 SSP2,FRA,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.06692850924285,0.047425873177567,0.146211715726001,0.146211715726001
 SSP2,FRA,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0,8.31528027664132e-07,4.53978687024344e-05,0.119202922022118,0.119202922022118
-SSP2,FRA,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1,1,1,0.954351880334422,0.954351880334422
+SSP2,FRA,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1,1,1,0.954351880334419,0.954351880334419
 SSP2,FRA,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1,1,1,1,1
 SSP2,FRA,Liquids,Domestic Ship_tmp_vehicletype,Domestic Ship_tmp_subsector_L1,Domestic Ship_tmp_subsector_L2,Domestic Ship,trn_freight,FV,linear,1,1,1,1,1
 SSP2,FRA,Liquids,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,0.160770475713231,0.160770475713231,0.160770475713231,0.160770475713231,0.160770475713231
@@ -669,7 +669,7 @@ SSP2,FRA,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_
 SSP2,FRA,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,1,1,1,1
 SSP2,FRA,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,1,1,1,1
 SSP2,FRA,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,1,1,1,1
-SSP2,FRA,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.026315789473684,0.078947368421053,0.175801662166867,0.175801662166867
+SSP2,FRA,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.026315789473684,0.078947368421053,0.175801662166866,0.175801662166866
 SSP2,FRA,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.026315789473684,0.078947368421053,0.184210526315789,0.184210526315789
 SSP2,FRA,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.026315789473684,0.078947368421053,0.184210526315789,0.184210526315789
 SSP2,FRA,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.026315789473684,0.078947368421053,0.184210526315789,0.184210526315789
@@ -686,7 +686,7 @@ SSP2,IND,"","","","",Passenger Rail,trn_pass,S3S,linear,0.000684210526315789,8e-
 SSP2,IND,"","","","",Walk,trn_pass,S3S,linear,0.131578947368421,0.0945454545454544,0.181818181818182,1,1
 SSP2,IND,"","","","",trn_freight_road,trn_freight,S3S,linear,1,1,1,1,1
 SSP2,IND,"","","","",trn_pass_road,trn_pass,S3S,linear,1,1,1,1,1
-SSP2,IND,"","","",Bus,trn_pass_road,trn_pass,S2S3,linear,0.118824252562298,0.0625,0.0323053436653747,0.0323053436653747,0.0323053436653747
+SSP2,IND,"","","",Bus,trn_pass_road,trn_pass,S2S3,linear,0.118824252562298,0.0714285714285714,0.0323053436653747,0.0323053436653747,0.0323053436653747
 SSP2,IND,"","","",trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1,1,1,1,1
 SSP2,IND,"","",trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,0.003027158638145,0.002667683549865,0.001948733373306,0.000510833020187,0.000510833020187
 SSP2,IND,"","",trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1,1,1,1,1
@@ -766,7 +766,7 @@ SSP2,JPN,"",Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_
 SSP2,JPN,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0,0,0,0,0
 SSP2,JPN,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0,0,0,0,0
 SSP2,JPN,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0,0,0,0,0
-SSP2,JPN,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.109079508308404,0.17929428091333,0.381029650728973,0.381029650728973
+SSP2,JPN,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.109079508308404,0.17929428091333,0.381029650728972,0.381029650728972
 SSP2,JPN,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1,1,1,1,1
 SSP2,JPN,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1,1,1,1,1
 SSP2,JPN,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1,1,1,1,1
@@ -776,11 +776,11 @@ SSP2,JPN,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road
 SSP2,JPN,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,0.0636363636363636,0.133333333333333,0.833333333333333,0.833333333333333
 SSP2,JPN,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.125163068123224,0.352941176470588,0.81834482503159,0.81834482503159
 SSP2,JPN,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.061815578915875,0.131898873055341,0.1,0.1
-SSP2,JPN,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.110432040250703,0.251078152116531,0.304607741095835,0.304607741095835
+SSP2,JPN,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.110432040250702,0.251078152116531,0.304607741095835,0.304607741095835
 SSP2,JPN,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,1,1,0.416666666666667,0.416666666666667
 SSP2,JPN,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,1,1,0.416666666666667,0.416666666666667
 SSP2,JPN,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,1,1,0.416666666666667,0.416666666666667
-SSP2,JPN,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.110432040250703,0.251078152116531,0.304607741095835,0.304607741095835
+SSP2,JPN,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.110432040250702,0.251078152116531,0.304607741095835,0.304607741095835
 SSP2,JPN,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0,8.31528027664132e-07,4.53978687024344e-05,0.119202922022118,0.119202922022118
 SSP2,JPN,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1,1,1,1,1
 SSP2,JPN,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1,1,1,1,1
@@ -798,11 +798,11 @@ SSP2,JPN,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_
 SSP2,JPN,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,0.0606060606060606,0.188888888888889,1,1
 SSP2,JPN,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,1,1,1,1
 SSP2,JPN,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.0078947368421052,0.0157894736842106,0.0230263157894736,0.0230263157894736
-SSP2,JPN,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.013157894736842,0.0464396284829724,0.0460526315789472,0.0460526315789472
+SSP2,JPN,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.013157894736842,0.0464396284829724,0.0460526315789473,0.0460526315789473
 SSP2,JPN,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,0.0303030303030303,0.111111111111111,0.25,0.25
 SSP2,JPN,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,0.0303030303030303,0.111111111111111,0.25,0.25
 SSP2,JPN,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,0.0303030303030303,0.111111111111111,0.25,0.25
-SSP2,JPN,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.013157894736842,0.0464396284829724,0.0460526315789472,0.0460526315789472
+SSP2,JPN,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.013157894736842,0.0464396284829724,0.0460526315789473,0.0460526315789473
 SSP2,LAM,"","","","",Cycle,trn_pass,S3S,linear,0.00981212891217365,0.0185165853437172,0.0462914633592929,0.231457316796465,0.231457316796465
 SSP2,LAM,"","","","",Domestic Aviation,trn_pass,S3S,linear,0.00840668890350734,0.0105762418419885,0.0264406046049712,0.0198304534537284,0.0198304534537284
 SSP2,LAM,"","","","",Domestic Ship,trn_freight,S3S,linear,0.009523329319276,0.009523329319276,0.00865757210843273,0.00793610776606333,0.00793610776606333
@@ -814,7 +814,7 @@ SSP2,LAM,"","","","",Passenger Rail,trn_pass,S3S,linear,0.134842686357634,0.1272
 SSP2,LAM,"","","","",Walk,trn_pass,S3S,linear,0.899323352244677,0.848561904989659,0.848561904989659,0.848561904989659,0.848561904989659
 SSP2,LAM,"","","","",trn_freight_road,trn_freight,S3S,linear,1,1,1,1,1
 SSP2,LAM,"","","","",trn_pass_road,trn_pass,S3S,linear,1,1,1,1,1
-SSP2,LAM,"","","",Bus,trn_pass_road,trn_pass,S2S3,linear,0.138594539617622,0.086621587261014,0.086621587261014,0.086621587261014,0.086621587261014
+SSP2,LAM,"","","",Bus,trn_pass_road,trn_pass,S2S3,linear,0.173243174522027,0.108276984076267,0.086621587261014,0.086621587261014,0.086621587261014
 SSP2,LAM,"","","",trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1,1,1,1,1
 SSP2,LAM,"","",trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,0.137734442638184,0.137734442638184,0.137734442638184,0.137734442638184,0.137734442638184
 SSP2,LAM,"","",trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1,1,1,1,1
@@ -837,23 +837,23 @@ SSP2,LAM,"",Van,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS
 SSP2,LAM,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0,0,0,0,0
 SSP2,LAM,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0,0,0,0,0
 SSP2,LAM,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0,0,0,0,0
-SSP2,LAM,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.118564682943918,0.53788284273999,1,1
+SSP2,LAM,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.118564682943917,0.53788284273999,1,1
 SSP2,LAM,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,0.0681034247188,0.18459049662895,0.41756464044925,0.88351292808985,0.88351292808985
 SSP2,LAM,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1,1,1,1,1
 SSP2,LAM,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1,1,1,1,1
 SSP2,LAM,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.079468614681412,0.2,0.2400478153426,0.2400478153426
-SSP2,LAM,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0316172487850447,0.107576568547998,0.232851453223261,0.232851453223261
-SSP2,LAM,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0316172487850447,0.107576568547998,0.232851453223261,0.232851453223261
-SSP2,LAM,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0316172487850447,0.107576568547998,0.232851453223261,0.232851453223261
+SSP2,LAM,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0316172487850447,0.107576568547998,0.232851453223262,0.232851453223262
+SSP2,LAM,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0316172487850447,0.107576568547998,0.232851453223262,0.232851453223262
+SSP2,LAM,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0316172487850447,0.107576568547998,0.232851453223262,0.232851453223262
 SSP2,LAM,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.079468614681412,0.2,0.2400478153426,0.2400478153426
-SSP2,LAM,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.002472623156635,0.017986209962092,0.0656116917729915,0.0656116917729915
-SSP2,LAM,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.00892380123238,0.0569110478130804,0.0812287309588894,0.0812287309588894
+SSP2,LAM,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.002472623156635,0.017986209962092,0.0656116917729916,0.0656116917729916
+SSP2,LAM,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.00892380123238,0.0569110478130804,0.0812287309588893,0.0812287309588893
 SSP2,LAM,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.00329683087551333,0.0215834519545104,0.0555555555555556,0.0555555555555556
 SSP2,LAM,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.00329683087551333,0.0215834519545104,0.0555555555555556,0.0555555555555556
 SSP2,LAM,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.00329683087551333,0.0215834519545104,0.0555555555555556,0.0555555555555556
-SSP2,LAM,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.00892380123238,0.0569110478130804,0.0812287309588894,0.0812287309588894
+SSP2,LAM,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.00892380123238,0.0569110478130804,0.0812287309588893,0.0812287309588893
 SSP2,LAM,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0,8.31528027664132e-07,4.53978687024344e-05,0.119202922022118,0.119202922022118
-SSP2,LAM,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1,1,1,0.721728609502907,0.721728609502907
+SSP2,LAM,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1,1,1,0.721728609502908,0.721728609502908
 SSP2,LAM,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1,1,1,1,1
 SSP2,LAM,Liquids,Domestic Ship_tmp_vehicletype,Domestic Ship_tmp_subsector_L1,Domestic Ship_tmp_subsector_L2,Domestic Ship,trn_freight,FV,linear,1,1,1,1,1
 SSP2,LAM,Liquids,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1,1,1,1,1
@@ -869,11 +869,11 @@ SSP2,LAM,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_
 SSP2,LAM,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,1,1,1,1
 SSP2,LAM,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,1,1,1,1
 SSP2,LAM,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.026893682222235,0.0472515688947483,0.10371786520469,0.135258574225718,0.135258574225718
-SSP2,LAM,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0175438596491227,0.0315789473684212,0.0614035087719297,0.0614035087719297
-SSP2,LAM,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0175438596491227,0.0315789473684212,0.0614035087719297,0.0614035087719297
-SSP2,LAM,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0175438596491227,0.0315789473684212,0.0614035087719297,0.0614035087719297
-SSP2,LAM,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0175438596491227,0.0315789473684212,0.0614035087719297,0.0614035087719297
-SSP2,LAM,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0175438596491227,0.0315789473684212,0.0614035087719297,0.0614035087719297
+SSP2,LAM,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0175438596491227,0.0315789473684212,0.0614035087719296,0.0614035087719296
+SSP2,LAM,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0175438596491227,0.0315789473684212,0.0614035087719296,0.0614035087719296
+SSP2,LAM,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0175438596491227,0.0315789473684212,0.0614035087719296,0.0614035087719296
+SSP2,LAM,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0175438596491227,0.0315789473684212,0.0614035087719296,0.0614035087719296
+SSP2,LAM,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0175438596491227,0.0315789473684212,0.0614035087719296,0.0614035087719296
 SSP2,MEA,"","","","",Cycle,trn_pass,S3S,linear,0.0165975108305109,0.0165975108305109,0.0165975108305109,0.0414937770762773,0.0414937770762773
 SSP2,MEA,"","","","",Domestic Aviation,trn_pass,S3S,linear,0.0089294530094782,0.00595296867298547,0.0178589060189564,0.0238118746919419,0.0238118746919419
 SSP2,MEA,"","","","",Domestic Ship,trn_freight,S3S,linear,0.002022051343562,0.002022051343562,0.002022051343562,0.002022051343562,0.002022051343562
@@ -885,7 +885,7 @@ SSP2,MEA,"","","","",Passenger Rail,trn_pass,S3S,linear,0.000556730785330985,0.0
 SSP2,MEA,"","","","",Walk,trn_pass,S3S,linear,1,1,1,1,1
 SSP2,MEA,"","","","",trn_freight_road,trn_freight,S3S,linear,1,1,1,1,1
 SSP2,MEA,"","","","",trn_pass_road,trn_pass,S3S,linear,0.639480996474237,0.71967693403545,0.71967693403545,0.71967693403545,0.71967693403545
-SSP2,MEA,"","","",Bus,trn_pass_road,trn_pass,S2S3,linear,0.183919217151252,0.122612811434168,0.0613064057170841,0.0490451245736673,0.0490451245736673
+SSP2,MEA,"","","",Bus,trn_pass_road,trn_pass,S2S3,linear,0.262741738787503,0.122612811434168,0.0613064057170841,0.0490451245736673,0.0490451245736673
 SSP2,MEA,"","","",trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1,1,1,1,1
 SSP2,MEA,"","",trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,0.007508394761241,0.007508394761241,0.007508394761241,0.007508394761241,0.007508394761241
 SSP2,MEA,"","",trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1,1,1,1,1
@@ -902,12 +902,12 @@ SSP2,MEA,"",Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_
 SSP2,MEA,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1,1,1,1,1
 SSP2,MEA,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0,0,0,0,0
 SSP2,MEA,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1,1,1,1,1
-SSP2,MEA,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.047425873177567,0.295835563506995,0.654894712190423,0.654894712190423
+SSP2,MEA,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.047425873177567,0.295835563506994,0.654894712190425,0.654894712190425
 SSP2,MEA,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,0.402051171672381,0.476794775213334,0.626281982295238,0.925256396459048,0.925256396459048
 SSP2,MEA,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1,1,1,1,1
 SSP2,MEA,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1,1,1,1,1
 SSP2,MEA,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.059601461011059,0.1,0.14028768429113,0.14028768429113
-SSP2,MEA,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0237129365887835,0.053788284273999,0.13608201811749,0.13608201811749
+SSP2,MEA,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0237129365887835,0.053788284273999,0.136082018117491,0.136082018117491
 SSP2,MEA,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,0.142857142857143,0.2,0.142857142857143,0.142857142857143
 SSP2,MEA,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,0.142857142857143,0.2,0.142857142857143,0.142857142857143
 SSP2,MEA,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.059601461011059,0.1,0.14028768429113,0.14028768429113
@@ -1019,7 +1019,7 @@ SSP2,NES,"","","","",Passenger Rail,trn_pass,S3S,linear,0.00160675014597331,0.00
 SSP2,NES,"","","","",Walk,trn_pass,S3S,linear,1,1,1,1,1
 SSP2,NES,"","","","",trn_freight_road,trn_freight,S3S,linear,1,1,1,1,1
 SSP2,NES,"","","","",trn_pass_road,trn_pass,S3S,linear,0.925821312685462,0.717579145423199,0.456641274360218,0.25115270089812,0.25115270089812
-SSP2,NES,"","","",Bus,trn_pass_road,trn_pass,S2S3,linear,0.021994137000963,0.0183284475008025,0.0109970685004815,0.0109970685004815,0.0109970685004815
+SSP2,NES,"","","",Bus,trn_pass_road,trn_pass,S2S3,linear,0.0549853425024075,0.021994137000963,0.0109970685004815,0.0109970685004815,0.0109970685004815
 SSP2,NES,"","","",trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1,1,1,1,1
 SSP2,NES,"","",trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,0.004922521505832,0.004922521505832,0.004922521505832,0.004922521505832,0.004922521505832
 SSP2,NES,"","",trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1,1,1,1,1
@@ -1088,7 +1088,7 @@ SSP2,OAS,"","","","",Passenger Rail,trn_pass,S3S,linear,0.00077008869031218,0.00
 SSP2,OAS,"","","","",Walk,trn_pass,S3S,linear,1,0.689328623982319,0.689328623982319,0.689328623982319,0.689328623982319
 SSP2,OAS,"","","","",trn_freight_road,trn_freight,S3S,linear,1,1,1,1,1
 SSP2,OAS,"","","","",trn_pass_road,trn_pass,S3S,linear,0.87209012211972,1,1,1,1
-SSP2,OAS,"","","",Bus,trn_pass_road,trn_pass,S2S3,linear,0.160206681607861,0.110191151172767,0.0550955755863836,0.0550955755863836,0.0550955755863836
+SSP2,OAS,"","","",Bus,trn_pass_road,trn_pass,S2S3,linear,0.240310022411792,0.140243283310795,0.0550955755863836,0.0550955755863836,0.0550955755863836
 SSP2,OAS,"","","",trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1,1,1,1,1
 SSP2,OAS,"","",trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,0.025341509717687,0.022332205438712,0.016313596880761,0.00427637976486,0.00427637976486
 SSP2,OAS,"","",trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1,1,1,1,1
@@ -1116,18 +1116,18 @@ SSP2,OAS,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Fre
 SSP2,OAS,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1,1,1,1,1
 SSP2,OAS,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,0.352966479972375,0.433845669975828,0.595604049982734,0.919120809996547,0.919120809996547
 SSP2,OAS,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.039734307340706,0.0625,0.0785611032030326,0.0785611032030326
-SSP2,OAS,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0158086243925223,0.0336176776712494,0.0762059301457946,0.0762059301457946
-SSP2,OAS,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0158086243925223,0.0336176776712494,0.0762059301457946,0.0762059301457946
-SSP2,OAS,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0158086243925223,0.0336176776712494,0.0762059301457946,0.0762059301457946
+SSP2,OAS,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0158086243925223,0.0336176776712495,0.0762059301457946,0.0762059301457946
+SSP2,OAS,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0158086243925223,0.0336176776712495,0.0762059301457946,0.0762059301457946
+SSP2,OAS,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0158086243925223,0.0336176776712495,0.0762059301457946,0.0762059301457946
 SSP2,OAS,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.039734307340706,0.0625,0.0785611032030326,0.0785611032030326
-SSP2,OAS,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.002472623156635,0.017986209962092,0.0656116917729915,0.0656116917729915
+SSP2,OAS,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.002472623156635,0.017986209962092,0.0656116917729916,0.0656116917729916
 SSP2,OAS,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.011154751540475,0.0118564682943918,0.0292423431452002,0.0292423431452002
 SSP2,OAS,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.00412103859439167,0.004496552490523,0.02,0.02
 SSP2,OAS,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.00412103859439167,0.004496552490523,0.02,0.02
 SSP2,OAS,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.00412103859439167,0.004496552490523,0.02,0.02
 SSP2,OAS,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.011154751540475,0.0118564682943918,0.0292423431452002,0.0292423431452002
 SSP2,OAS,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0,8.31528027664132e-07,4.53978687024344e-05,0.119202922022118,0.119202922022118
-SSP2,OAS,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1,1,1,0.656116917729915,0.656116917729915
+SSP2,OAS,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1,1,1,0.656116917729916,0.656116917729916
 SSP2,OAS,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1,1,1,1,1
 SSP2,OAS,Liquids,Domestic Ship_tmp_vehicletype,Domestic Ship_tmp_subsector_L1,Domestic Ship_tmp_subsector_L2,Domestic Ship,trn_freight,FV,linear,1,1,1,1,1
 SSP2,OAS,Liquids,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1,1,1,1,1
@@ -1159,7 +1159,7 @@ SSP2,REF,"","","","",Passenger Rail,trn_pass,S3S,linear,0.00236561326843326,0.00
 SSP2,REF,"","","","",Walk,trn_pass,S3S,linear,0.317883555031073,0.317883555031073,0.317883555031073,1,1
 SSP2,REF,"","","","",trn_freight_road,trn_freight,S3S,linear,1,1,1,1,1
 SSP2,REF,"","","","",trn_pass_road,trn_pass,S3S,linear,1,1,1,0.943741804984768,0.943741804984768
-SSP2,REF,"","","",Bus,trn_pass_road,trn_pass,S2S3,linear,0.106725224568562,0.0914787639159102,0.0762323032632585,0.0609858426106068,0.0609858426106068
+SSP2,REF,"","","",Bus,trn_pass_road,trn_pass,S2S3,linear,0.118583582853958,0.0914787639159102,0.0762323032632585,0.0609858426106068,0.0609858426106068
 SSP2,REF,"","","",trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1,1,1,1,1
 SSP2,REF,"","",trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,0.369757606378564,0.369757606378564,0.369757606378564,0.369757606378564,0.369757606378564
 SSP2,REF,"","",trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1,1,1,1,1
@@ -1216,18 +1216,18 @@ SSP2,REF,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_s
 SSP2,REF,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.063108879885637,0.087763909362331,0.137073968315718,0.188555268977994,0.188555268977994
 SSP2,REF,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.030480218828266,0.055993897280154,0.107021254183929,0.167260774393184,0.167260774393184
 SSP2,REF,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.026315789473684,0.078947368421053,0.147368421052631,0.147368421052631
-SSP2,SSA,"","","","",Cycle,trn_pass,S3S,linear,0.013878678157857,0.0179527662940391,0.0291452241314997,0.0327883771479372,0.0327883771479372
-SSP2,SSA,"","","","",Domestic Aviation,trn_pass,S3S,linear,0.00901317336217352,0.0509980791548766,0.0413961398176937,0.00620942097265405,0.00620942097265405
+SSP2,SSA,"","","","",Cycle,trn_pass,S3S,linear,0.013878678157857,0.017952766294039,0.0291452241314997,0.0327883771479372,0.0327883771479372
+SSP2,SSA,"","","","",Domestic Aviation,trn_pass,S3S,linear,0.00901317336217352,0.0509980791548764,0.0413961398176937,0.00620942097265405,0.00620942097265405
 SSP2,SSA,"","","","",Domestic Ship,trn_freight,S3S,linear,0.001467441828354,0.001467441828354,0.001467441828354,0.001467441828354,0.001467441828354
 SSP2,SSA,"","","","",Freight Rail,trn_freight,S3S,linear,0.01634165332484,0.01634165332484,0.01634165332484,0.01634165332484,0.01634165332484
-SSP2,SSA,"","","","",HSR,trn_pass,S3S,linear,1.47506311523337e-05,2.00316440897408e-05,0.0650403115771387,0.0097560467365708,0.0097560467365708
+SSP2,SSA,"","","","",HSR,trn_pass,S3S,linear,1.47506311523337e-05,2.00316440897407e-05,0.0650403115771387,0.0097560467365708,0.0097560467365708
 SSP2,SSA,"","","","",International Aviation,trn_aviation_intl,S3S,linear,1,1,1,1,1
 SSP2,SSA,"","","","",International Ship,trn_shipping_intl,S3S,linear,1,1,1,1,1
-SSP2,SSA,"","","","",Passenger Rail,trn_pass,S3S,linear,0.000602417147703971,0.00155851359059413,0.00253015202035668,0.000569284204580253,0.000569284204580253
-SSP2,SSA,"","","","",Walk,trn_pass,S3S,linear,1,0.903431854876908,1,1,1
+SSP2,SSA,"","","","",Passenger Rail,trn_pass,S3S,linear,0.000602417147703971,0.00155851359059412,0.00253015202035668,0.000569284204580253,0.000569284204580253
+SSP2,SSA,"","","","",Walk,trn_pass,S3S,linear,1,0.903431854876905,1,1,1
 SSP2,SSA,"","","","",trn_freight_road,trn_freight,S3S,linear,1,1,1,1,1
-SSP2,SSA,"","","","",trn_pass_road,trn_pass,S3S,linear,0.890164318010016,1,0.974063506007212,0.0974063506007212,0.0974063506007212
-SSP2,SSA,"","","",Bus,trn_pass_road,trn_pass,S2S3,linear,0.206400000437543,0.105846154070534,0.0732781066642163,0.0952615386634812,0.0952615386634812
+SSP2,SSA,"","","","",trn_pass_road,trn_pass,S3S,linear,0.890164318010017,1,0.974063506007213,0.0974063506007212,0.0974063506007212
+SSP2,SSA,"","","",Bus,trn_pass_road,trn_pass,S2S3,linear,0.247680000525051,0.127015384884641,0.0732781066642163,0.0952615386634812,0.0952615386634812
 SSP2,SSA,"","","",trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1,1,1,1,1
 SSP2,SSA,"","",trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,0.039283595822529,0.039283595822529,0.039283595822529,0.039283595822529,0.039283595822529
 SSP2,SSA,"","",trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1,1,1,1,1
@@ -1257,11 +1257,11 @@ SSP2,SSA,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road
 SSP2,SSA,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0094851746355134,0.053788284273999,0.14654986566499,0.14654986566499
 SSP2,SSA,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0238405844044236,0.1,0.151079044621217,0.151079044621217
 SSP2,SSA,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.002472623156635,0.017986209962092,0.075,0.075
-SSP2,SSA,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.006692850924285,0.047425873177567,0.0281176376396156,0.0281176376396156
+SSP2,SSA,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.006692850924285,0.047425873177567,0.0281176376396155,0.0281176376396155
 SSP2,SSA,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.002472623156635,0.017986209962092,0.0192307692307692,0.0192307692307692
 SSP2,SSA,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.002472623156635,0.017986209962092,0.0192307692307692,0.0192307692307692
 SSP2,SSA,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.002472623156635,0.017986209962092,0.0192307692307692,0.0192307692307692
-SSP2,SSA,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.006692850924285,0.047425873177567,0.0281176376396156,0.0281176376396156
+SSP2,SSA,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.006692850924285,0.047425873177567,0.0281176376396155,0.0281176376396155
 SSP2,SSA,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0,8.31528027664132e-07,4.53978687024344e-05,0.119202922022118,0.119202922022118
 SSP2,SSA,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1,1,1,1,1
 SSP2,SSA,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1,1,1,1,1
@@ -1316,14 +1316,14 @@ SSP2,UKI,"",Van,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS
 SSP2,UKI,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0,0,0,0,0
 SSP2,UKI,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0,0,0,0,0
 SSP2,UKI,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0,0,0,0,0
-SSP2,UKI,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.118564682943918,0.322729705643994,0.85731671414019,0.85731671414019
+SSP2,UKI,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.118564682943917,0.322729705643994,0.85731671414019,0.85731671414019
 SSP2,UKI,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,0.826003073674058,0.847752689464801,0.891251921046287,0.978250384209257,0.978250384209257
 SSP2,UKI,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1,1,1,1,1
 SSP2,UKI,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1,1,1,1,1
 SSP2,UKI,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.238405844044236,0.55,0.883812411034117,0.883812411034117
-SSP2,UKI,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.094851746355134,0.295835563506995,0.85731671414019,0.85731671414019
-SSP2,UKI,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.094851746355134,0.295835563506995,0.85731671414019,0.85731671414019
-SSP2,UKI,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.094851746355134,0.295835563506995,0.85731671414019,0.85731671414019
+SSP2,UKI,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.094851746355134,0.295835563506994,0.85731671414019,0.85731671414019
+SSP2,UKI,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.094851746355134,0.295835563506994,0.85731671414019,0.85731671414019
+SSP2,UKI,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.094851746355134,0.295835563506994,0.85731671414019,0.85731671414019
 SSP2,UKI,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.238405844044236,0.55,0.883812411034117,0.883812411034117
 SSP2,UKI,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.012363115783175,0.017986209962092,0.1,0.1
 SSP2,UKI,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.06692850924285,0.189703492710268,0.146211715726001,0.146211715726001
@@ -1388,7 +1388,7 @@ SSP2,USA,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Fre
 SSP2,USA,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1,1,1,1,1
 SSP2,USA,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1,1,1,1,1
 SSP2,USA,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0298007305055295,0.25,0.785611032030326,0.785611032030326
-SSP2,USA,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0118564682943918,0.134470710684997,0.762059301457946,0.762059301457946
+SSP2,USA,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0118564682943918,0.134470710684998,0.762059301457946,0.762059301457946
 SSP2,USA,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.03,0.25,0.5,0.8,0.8
 SSP2,USA,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.03,0.25,0.5,0.8,0.8
 SSP2,USA,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0298007305055295,0.25,0.785611032030326,0.785611032030326
@@ -1459,18 +1459,18 @@ SSP1,CAZ,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Fre
 SSP1,CAZ,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1,1,1,1,1
 SSP1,CAZ,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1,1,1,1,1
 SSP1,CAZ,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.119202922022118,0.35,0.491006895018954,0.491006895018954
-SSP1,CAZ,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.047425873177567,0.188258994958996,0.476287063411217,0.476287063411217
-SSP1,CAZ,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.047425873177567,0.188258994958996,0.476287063411217,0.476287063411217
-SSP1,CAZ,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.047425873177567,0.188258994958996,0.476287063411217,0.476287063411217
+SSP1,CAZ,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.047425873177567,0.188258994958997,0.476287063411217,0.476287063411217
+SSP1,CAZ,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.047425873177567,0.188258994958997,0.476287063411217,0.476287063411217
+SSP1,CAZ,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.047425873177567,0.188258994958997,0.476287063411217,0.476287063411217
 SSP1,CAZ,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.119202922022118,0.35,0.491006895018954,0.491006895018954
-SSP1,CAZ,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.012363115783175,0.017986209962092,0.0954351880334422,0.0954351880334422
+SSP1,CAZ,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.012363115783175,0.017986209962092,0.0954351880334419,0.0954351880334419
 SSP1,CAZ,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.033464254621425,0.047425873177567,0.146211715726001,0.146211715726001
 SSP1,CAZ,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.012363115783175,0.017986209962092,0.1,0.1
 SSP1,CAZ,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.012363115783175,0.017986209962092,0.1,0.1
 SSP1,CAZ,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.012363115783175,0.017986209962092,0.1,0.1
 SSP1,CAZ,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.033464254621425,0.047425873177567,0.146211715726001,0.146211715726001
 SSP1,CAZ,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0,8.31528027664132e-07,4.53978687024344e-05,0.119202922022118,0.119202922022118
-SSP1,CAZ,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1,1,1,0.954351880334422,0.954351880334422
+SSP1,CAZ,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1,1,1,0.954351880334419,0.954351880334419
 SSP1,CAZ,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1,1,1,1,1
 SSP1,CAZ,Liquids,Domestic Ship_tmp_vehicletype,Domestic Ship_tmp_subsector_L1,Domestic Ship_tmp_subsector_L2,Domestic Ship,trn_freight,FV,linear,1,1,1,1,1
 SSP1,CAZ,Liquids,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1,1,1,1,1
@@ -1485,7 +1485,7 @@ SSP1,CAZ,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_
 SSP1,CAZ,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,1,1,1,1
 SSP1,CAZ,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,1,1,1,1
 SSP1,CAZ,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,1,1,1,1
-SSP1,CAZ,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.031042108230522,0.056541000119193,0.107538783896534,0.199969502302122,0.199969502302122
+SSP1,CAZ,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.031042108230522,0.056541000119193,0.107538783896534,0.199969502302121,0.199969502302121
 SSP1,CAZ,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.026315789473684,0.078947368421053,0.184210526315789,0.184210526315789
 SSP1,CAZ,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.026315789473684,0.078947368421053,0.184210526315789,0.184210526315789
 SSP1,CAZ,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.026315789473684,0.078947368421053,0.184210526315789,0.184210526315789
@@ -1502,7 +1502,7 @@ SSP1,CHA,"","","","",Passenger Rail,trn_pass,S3S,linear,0.00546103419952829,0.00
 SSP1,CHA,"","","","",Walk,trn_pass,S3S,linear,0.877713076761744,1,1,1,1
 SSP1,CHA,"","","","",trn_freight_road,trn_freight,S3S,linear,1,1,1,1,1
 SSP1,CHA,"","","","",trn_pass_road,trn_pass,S3S,linear,1,0.455729794383114,0.227864897191557,0.0584268967157839,0.0584268967157839
-SSP1,CHA,"","","",Bus,trn_pass_road,trn_pass,S2S3,linear,0.254432114324843,0.191544432089459,0.170509316525779,0.189454796139754,0.189454796139754
+SSP1,CHA,"","","",Bus,trn_pass_road,trn_pass,S2S3,linear,0.381648171487265,0.191544432089459,0.170509316525779,0.189454796139754,0.189454796139754
 SSP1,CHA,"","","",trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1,1,1,1,1
 SSP1,CHA,"","",trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,0.01080602223644,0.009522807095863,0.006956376814708,0.001823516252399,0.001823516252399
 SSP1,CHA,"","",trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1,1,1,1,1
@@ -1530,14 +1530,14 @@ SSP1,CHA,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road
 SSP1,CHA,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.1,0.4,0.9,1,1
 SSP1,CHA,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.1,0.4,0.9,1,1
 SSP1,CHA,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0476811688088472,0.45,0.982013790037908,0.982013790037908
-SSP1,CHA,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.022253608409715,0.0668777976648958,0.0699858045578576,0.0699858045578576
+SSP1,CHA,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.022253608409715,0.0668777976648955,0.0699858045578576,0.0699858045578576
 SSP1,CHA,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.001338570184857,0.0284555239065402,0.146211715726001,0.146211715726001
 SSP1,CHA,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.000494524631327,0.0107917259772552,0.1,0.1
 SSP1,CHA,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.01,0.2,0.6,0.2,0.2
 SSP1,CHA,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.01,0.2,0.6,0.2,0.2
 SSP1,CHA,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.001338570184857,0.0284555239065402,0.146211715726001,0.146211715726001
 SSP1,CHA,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0,8.31528027664132e-07,4.53978687024344e-05,0.119202922022118,0.119202922022118
-SSP1,CHA,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1,1,0.743656365691809,0.349929022789288,0.349929022789288
+SSP1,CHA,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1,1,0.743656365691807,0.349929022789288,0.349929022789288
 SSP1,CHA,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1,1,1,1,1
 SSP1,CHA,Liquids,Domestic Ship_tmp_vehicletype,Domestic Ship_tmp_subsector_L1,Domestic Ship_tmp_subsector_L2,Domestic Ship,trn_freight,FV,linear,1,1,1,1,1
 SSP1,CHA,Liquids,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1,1,1,1,1
@@ -1552,7 +1552,7 @@ SSP1,CHA,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_
 SSP1,CHA,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,1,1,1,1
 SSP1,CHA,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,1,1,1,1
 SSP1,CHA,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,1,1,1,1
-SSP1,CHA,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.142120012637288,0.159432643883675,0.090195248368545,0.115174077598356,0.115174077598356
+SSP1,CHA,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.142120012637288,0.159432643883675,0.0901952483685446,0.115174077598355,0.115174077598355
 SSP1,CHA,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.8778097236668e-05,0.013188367964814,0.0553035143317804,0.0921307947813305,0.0921307947813305
 SSP1,CHA,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.0007853553299874,0.014432374877611,0.0569509829460257,0.093173070843404,0.093173070843404
 SSP1,CHA,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.3,0.5,0.7,0.5,0.5
@@ -1593,16 +1593,16 @@ SSP1,DEU,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Fre
 SSP1,DEU,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1,1,1,1,1
 SSP1,DEU,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1,1,1,1,1
 SSP1,DEU,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.298007305055295,0.675,0.982013790037908,0.982013790037908
-SSP1,DEU,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.118564682943918,0.363070918849493,0.952574126822433,0.952574126822433
-SSP1,DEU,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.118564682943918,0.363070918849493,0.952574126822433,0.952574126822433
-SSP1,DEU,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.118564682943918,0.363070918849493,0.952574126822433,0.952574126822433
+SSP1,DEU,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.118564682943917,0.363070918849493,0.952574126822433,0.952574126822433
+SSP1,DEU,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.118564682943917,0.363070918849493,0.952574126822433,0.952574126822433
+SSP1,DEU,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.118564682943917,0.363070918849493,0.952574126822433,0.952574126822433
 SSP1,DEU,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.298007305055295,0.675,0.982013790037908,0.982013790037908
 SSP1,DEU,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.002472623156635,0.017986209962092,0.05,0.05
-SSP1,DEU,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.08031421109142,0.331981112242969,0.219317573589002,0.219317573589002
+SSP1,DEU,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.08031421109142,0.331981112242969,0.219317573589001,0.219317573589001
 SSP1,DEU,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.02967147787962,0.125903469734644,0.15,0.15
 SSP1,DEU,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.02967147787962,0.125903469734644,0.15,0.15
 SSP1,DEU,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.02967147787962,0.125903469734644,0.15,0.15
-SSP1,DEU,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.08031421109142,0.331981112242969,0.219317573589002,0.219317573589002
+SSP1,DEU,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.08031421109142,0.331981112242969,0.219317573589001,0.219317573589001
 SSP1,DEU,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0,8.31528027664132e-07,4.53978687024344e-05,0.119202922022118,0.119202922022118
 SSP1,DEU,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1,1,1,1,1
 SSP1,DEU,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1,1,1,1,1
@@ -1727,9 +1727,9 @@ SSP1,ECS,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Fre
 SSP1,ECS,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1,1,1,1,1
 SSP1,ECS,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1,1,1,1,1
 SSP1,ECS,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.119202922022118,0.25,0.294604137011372,0.294604137011372
-SSP1,ECS,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.047425873177567,0.134470710684997,0.28577223804673,0.28577223804673
-SSP1,ECS,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.047425873177567,0.134470710684997,0.28577223804673,0.28577223804673
-SSP1,ECS,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.047425873177567,0.134470710684997,0.28577223804673,0.28577223804673
+SSP1,ECS,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.047425873177567,0.134470710684998,0.28577223804673,0.28577223804673
+SSP1,ECS,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.047425873177567,0.134470710684998,0.28577223804673,0.28577223804673
+SSP1,ECS,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.047425873177567,0.134470710684998,0.28577223804673,0.28577223804673
 SSP1,ECS,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.119202922022118,0.25,0.294604137011372,0.294604137011372
 SSP1,ECS,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.002472623156635,0.053958629886276,0.1,0.1
 SSP1,ECS,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.01338570184857,0.047425873177567,0.0731058578630005,0.0731058578630005
@@ -1807,7 +1807,7 @@ SSP1,ENC,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp
 SSP1,ENC,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.02472623156635,0.08993104981046,0.1,0.1
 SSP1,ENC,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.06692850924285,0.237129365887835,0.146211715726001,0.146211715726001
 SSP1,ENC,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0,8.31528027664132e-07,4.53978687024344e-05,0.119202922022118,0.119202922022118
-SSP1,ENC,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1,1,1,0.524893534183932,0.524893534183932
+SSP1,ENC,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1,1,1,0.524893534183931,0.524893534183931
 SSP1,ENC,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1,1,1,1,1
 SSP1,ENC,Liquids,Domestic Ship_tmp_vehicletype,Domestic Ship_tmp_subsector_L1,Domestic Ship_tmp_subsector_L2,Domestic Ship,trn_freight,FV,linear,1,1,1,1,1
 SSP1,ENC,Liquids,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,0.1341454314254,0.1341454314254,0.1341454314254,0.1341454314254,0.1341454314254
@@ -1925,7 +1925,7 @@ SSP1,ESW,"",Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_
 SSP1,ESW,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0,0,0,0,0
 SSP1,ESW,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0,0,0,0,0
 SSP1,ESW,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0,0,0,0,0
-SSP1,ESW,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.118564682943918,0.268941421369995,0.666801888775703,0.666801888775703
+SSP1,ESW,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.118564682943917,0.268941421369995,0.666801888775703,0.666801888775703
 SSP1,ESW,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,0.72951273091157,0.763323639547623,0.830945456819731,0.966189091363946,0.966189091363946
 SSP1,ESW,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1,1,1,1,1
 SSP1,ESW,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1,1,1,1,1
@@ -2064,18 +2064,18 @@ SSP1,FRA,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Fre
 SSP1,FRA,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1,1,1,1,1
 SSP1,FRA,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1,1,1,1,1
 SSP1,FRA,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.298007305055295,0.75,0.982013790037908,0.982013790037908
-SSP1,FRA,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.118564682943918,0.403412132054992,0.952574126822433,0.952574126822433
-SSP1,FRA,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.118564682943918,0.403412132054992,0.952574126822433,0.952574126822433
-SSP1,FRA,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.118564682943918,0.403412132054992,0.952574126822433,0.952574126822433
+SSP1,FRA,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.118564682943917,0.403412132054992,0.952574126822433,0.952574126822433
+SSP1,FRA,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.118564682943917,0.403412132054992,0.952574126822433,0.952574126822433
+SSP1,FRA,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.118564682943917,0.403412132054992,0.952574126822433,0.952574126822433
 SSP1,FRA,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.298007305055295,0.75,0.982013790037908,0.982013790037908
-SSP1,FRA,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.012363115783175,0.017986209962092,0.0954351880334422,0.0954351880334422
+SSP1,FRA,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.012363115783175,0.017986209962092,0.0954351880334419,0.0954351880334419
 SSP1,FRA,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.06692850924285,0.047425873177567,0.146211715726001,0.146211715726001
 SSP1,FRA,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.02472623156635,0.017986209962092,0.1,0.1
 SSP1,FRA,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.02472623156635,0.017986209962092,0.1,0.1
 SSP1,FRA,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.02472623156635,0.017986209962092,0.1,0.1
 SSP1,FRA,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.06692850924285,0.047425873177567,0.146211715726001,0.146211715726001
 SSP1,FRA,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0,8.31528027664132e-07,4.53978687024344e-05,0.119202922022118,0.119202922022118
-SSP1,FRA,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1,1,1,0.954351880334422,0.954351880334422
+SSP1,FRA,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1,1,1,0.954351880334419,0.954351880334419
 SSP1,FRA,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1,1,1,1,1
 SSP1,FRA,Liquids,Domestic Ship_tmp_vehicletype,Domestic Ship_tmp_subsector_L1,Domestic Ship_tmp_subsector_L2,Domestic Ship,trn_freight,FV,linear,1,1,1,1,1
 SSP1,FRA,Liquids,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,0.160770475713231,0.160770475713231,0.160770475713231,0.160770475713231,0.160770475713231
@@ -2090,7 +2090,7 @@ SSP1,FRA,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_
 SSP1,FRA,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,1,1,1,1
 SSP1,FRA,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,1,1,1,1
 SSP1,FRA,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,1,1,1,1
-SSP1,FRA,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.026315789473684,0.078947368421053,0.175801662166867,0.175801662166867
+SSP1,FRA,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.026315789473684,0.078947368421053,0.175801662166866,0.175801662166866
 SSP1,FRA,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.026315789473684,0.078947368421053,0.184210526315789,0.184210526315789
 SSP1,FRA,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.026315789473684,0.078947368421053,0.184210526315789,0.184210526315789
 SSP1,FRA,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.026315789473684,0.078947368421053,0.184210526315789,0.184210526315789
@@ -2107,7 +2107,7 @@ SSP1,IND,"","","","",Passenger Rail,trn_pass,S3S,linear,0.000684210526315789,8e-
 SSP1,IND,"","","","",Walk,trn_pass,S3S,linear,0.131578947368421,0.0945454545454544,0.181818181818182,1,1
 SSP1,IND,"","","","",trn_freight_road,trn_freight,S3S,linear,1,1,1,1,1
 SSP1,IND,"","","","",trn_pass_road,trn_pass,S3S,linear,1,1,1,1,1
-SSP1,IND,"","","",Bus,trn_pass_road,trn_pass,S2S3,linear,0.118824252562298,0.0625,0.0323053436653747,0.0323053436653747,0.0323053436653747
+SSP1,IND,"","","",Bus,trn_pass_road,trn_pass,S2S3,linear,0.118824252562298,0.0714285714285714,0.0323053436653747,0.0323053436653747,0.0323053436653747
 SSP1,IND,"","","",trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1,1,1,1,1
 SSP1,IND,"","",trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,0.003027158638145,0.002667683549865,0.001948733373306,0.000510833020187,0.000510833020187
 SSP1,IND,"","",trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1,1,1,1,1
@@ -2187,7 +2187,7 @@ SSP1,JPN,"",Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_
 SSP1,JPN,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0,0,0,0,0
 SSP1,JPN,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0,0,0,0,0
 SSP1,JPN,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0,0,0,0,0
-SSP1,JPN,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.109079508308404,0.17929428091333,0.381029650728973,0.381029650728973
+SSP1,JPN,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.109079508308404,0.17929428091333,0.381029650728972,0.381029650728972
 SSP1,JPN,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1,1,1,1,1
 SSP1,JPN,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1,1,1,1,1
 SSP1,JPN,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1,1,1,1,1
@@ -2197,11 +2197,11 @@ SSP1,JPN,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road
 SSP1,JPN,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,0.0636363636363636,0.133333333333333,0.833333333333333,0.833333333333333
 SSP1,JPN,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.125163068123224,0.352941176470588,0.81834482503159,0.81834482503159
 SSP1,JPN,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.061815578915875,0.131898873055341,0.1,0.1
-SSP1,JPN,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.110432040250703,0.251078152116531,0.304607741095835,0.304607741095835
+SSP1,JPN,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.110432040250702,0.251078152116531,0.304607741095835,0.304607741095835
 SSP1,JPN,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,1,1,0.416666666666667,0.416666666666667
 SSP1,JPN,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,1,1,0.416666666666667,0.416666666666667
 SSP1,JPN,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,1,1,0.416666666666667,0.416666666666667
-SSP1,JPN,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.110432040250703,0.251078152116531,0.304607741095835,0.304607741095835
+SSP1,JPN,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.110432040250702,0.251078152116531,0.304607741095835,0.304607741095835
 SSP1,JPN,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0,8.31528027664132e-07,4.53978687024344e-05,0.119202922022118,0.119202922022118
 SSP1,JPN,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1,1,1,1,1
 SSP1,JPN,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1,1,1,1,1
@@ -2219,11 +2219,11 @@ SSP1,JPN,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_
 SSP1,JPN,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,0.0606060606060606,0.188888888888889,1,1
 SSP1,JPN,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,1,1,1,1
 SSP1,JPN,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.0078947368421052,0.0157894736842106,0.0230263157894736,0.0230263157894736
-SSP1,JPN,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.013157894736842,0.0464396284829724,0.0460526315789472,0.0460526315789472
+SSP1,JPN,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.013157894736842,0.0464396284829724,0.0460526315789473,0.0460526315789473
 SSP1,JPN,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,0.0303030303030303,0.111111111111111,0.25,0.25
 SSP1,JPN,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,0.0303030303030303,0.111111111111111,0.25,0.25
 SSP1,JPN,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,0.0303030303030303,0.111111111111111,0.25,0.25
-SSP1,JPN,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.013157894736842,0.0464396284829724,0.0460526315789472,0.0460526315789472
+SSP1,JPN,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.013157894736842,0.0464396284829724,0.0460526315789473,0.0460526315789473
 SSP1,LAM,"","","","",Cycle,trn_pass,S3S,linear,0.00981212891217365,0.0185165853437172,0.0462914633592929,0.231457316796465,0.231457316796465
 SSP1,LAM,"","","","",Domestic Aviation,trn_pass,S3S,linear,0.00840668890350734,0.0105762418419885,0.0264406046049712,0.0198304534537284,0.0198304534537284
 SSP1,LAM,"","","","",Domestic Ship,trn_freight,S3S,linear,0.009523329319276,0.009523329319276,0.00865757210843273,0.00793610776606333,0.00793610776606333
@@ -2235,7 +2235,7 @@ SSP1,LAM,"","","","",Passenger Rail,trn_pass,S3S,linear,0.134842686357634,0.1272
 SSP1,LAM,"","","","",Walk,trn_pass,S3S,linear,0.899323352244677,0.848561904989659,0.848561904989659,0.848561904989659,0.848561904989659
 SSP1,LAM,"","","","",trn_freight_road,trn_freight,S3S,linear,1,1,1,1,1
 SSP1,LAM,"","","","",trn_pass_road,trn_pass,S3S,linear,1,1,1,1,1
-SSP1,LAM,"","","",Bus,trn_pass_road,trn_pass,S2S3,linear,0.138594539617622,0.086621587261014,0.086621587261014,0.086621587261014,0.086621587261014
+SSP1,LAM,"","","",Bus,trn_pass_road,trn_pass,S2S3,linear,0.173243174522027,0.108276984076267,0.086621587261014,0.086621587261014,0.086621587261014
 SSP1,LAM,"","","",trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1,1,1,1,1
 SSP1,LAM,"","",trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,0.137734442638184,0.137734442638184,0.137734442638184,0.137734442638184,0.137734442638184
 SSP1,LAM,"","",trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1,1,1,1,1
@@ -2258,23 +2258,23 @@ SSP1,LAM,"",Van,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS
 SSP1,LAM,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0,0,0,0,0
 SSP1,LAM,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0,0,0,0,0
 SSP1,LAM,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0,0,0,0,0
-SSP1,LAM,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.118564682943918,0.53788284273999,1,1
+SSP1,LAM,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.118564682943917,0.53788284273999,1,1
 SSP1,LAM,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,0.0681034247188,0.18459049662895,0.41756464044925,0.88351292808985,0.88351292808985
 SSP1,LAM,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1,1,1,1,1
 SSP1,LAM,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1,1,1,1,1
 SSP1,LAM,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.079468614681412,0.2,0.2400478153426,0.2400478153426
-SSP1,LAM,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0316172487850447,0.107576568547998,0.232851453223261,0.232851453223261
-SSP1,LAM,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0316172487850447,0.107576568547998,0.232851453223261,0.232851453223261
-SSP1,LAM,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0316172487850447,0.107576568547998,0.232851453223261,0.232851453223261
+SSP1,LAM,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0316172487850447,0.107576568547998,0.232851453223262,0.232851453223262
+SSP1,LAM,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0316172487850447,0.107576568547998,0.232851453223262,0.232851453223262
+SSP1,LAM,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0316172487850447,0.107576568547998,0.232851453223262,0.232851453223262
 SSP1,LAM,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.079468614681412,0.2,0.2400478153426,0.2400478153426
-SSP1,LAM,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.002472623156635,0.017986209962092,0.0656116917729915,0.0656116917729915
-SSP1,LAM,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.00892380123238,0.0569110478130804,0.0812287309588894,0.0812287309588894
+SSP1,LAM,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.002472623156635,0.017986209962092,0.0656116917729916,0.0656116917729916
+SSP1,LAM,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.00892380123238,0.0569110478130804,0.0812287309588893,0.0812287309588893
 SSP1,LAM,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.00329683087551333,0.0215834519545104,0.0555555555555556,0.0555555555555556
 SSP1,LAM,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.00329683087551333,0.0215834519545104,0.0555555555555556,0.0555555555555556
 SSP1,LAM,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.00329683087551333,0.0215834519545104,0.0555555555555556,0.0555555555555556
-SSP1,LAM,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.00892380123238,0.0569110478130804,0.0812287309588894,0.0812287309588894
+SSP1,LAM,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.00892380123238,0.0569110478130804,0.0812287309588893,0.0812287309588893
 SSP1,LAM,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0,8.31528027664132e-07,4.53978687024344e-05,0.119202922022118,0.119202922022118
-SSP1,LAM,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1,1,1,0.721728609502907,0.721728609502907
+SSP1,LAM,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1,1,1,0.721728609502908,0.721728609502908
 SSP1,LAM,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1,1,1,1,1
 SSP1,LAM,Liquids,Domestic Ship_tmp_vehicletype,Domestic Ship_tmp_subsector_L1,Domestic Ship_tmp_subsector_L2,Domestic Ship,trn_freight,FV,linear,1,1,1,1,1
 SSP1,LAM,Liquids,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1,1,1,1,1
@@ -2290,11 +2290,11 @@ SSP1,LAM,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_
 SSP1,LAM,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,1,1,1,1
 SSP1,LAM,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,1,1,1,1
 SSP1,LAM,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.026893682222235,0.0472515688947483,0.10371786520469,0.135258574225718,0.135258574225718
-SSP1,LAM,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0175438596491227,0.0315789473684212,0.0614035087719297,0.0614035087719297
-SSP1,LAM,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0175438596491227,0.0315789473684212,0.0614035087719297,0.0614035087719297
-SSP1,LAM,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0175438596491227,0.0315789473684212,0.0614035087719297,0.0614035087719297
-SSP1,LAM,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0175438596491227,0.0315789473684212,0.0614035087719297,0.0614035087719297
-SSP1,LAM,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0175438596491227,0.0315789473684212,0.0614035087719297,0.0614035087719297
+SSP1,LAM,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0175438596491227,0.0315789473684212,0.0614035087719296,0.0614035087719296
+SSP1,LAM,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0175438596491227,0.0315789473684212,0.0614035087719296,0.0614035087719296
+SSP1,LAM,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0175438596491227,0.0315789473684212,0.0614035087719296,0.0614035087719296
+SSP1,LAM,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0175438596491227,0.0315789473684212,0.0614035087719296,0.0614035087719296
+SSP1,LAM,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0175438596491227,0.0315789473684212,0.0614035087719296,0.0614035087719296
 SSP1,MEA,"","","","",Cycle,trn_pass,S3S,linear,0.0165975108305109,0.0165975108305109,0.0165975108305109,0.0414937770762773,0.0414937770762773
 SSP1,MEA,"","","","",Domestic Aviation,trn_pass,S3S,linear,0.0089294530094782,0.00595296867298547,0.0178589060189564,0.0238118746919419,0.0238118746919419
 SSP1,MEA,"","","","",Domestic Ship,trn_freight,S3S,linear,0.002022051343562,0.002022051343562,0.002022051343562,0.002022051343562,0.002022051343562
@@ -2306,7 +2306,7 @@ SSP1,MEA,"","","","",Passenger Rail,trn_pass,S3S,linear,0.000556730785330985,0.0
 SSP1,MEA,"","","","",Walk,trn_pass,S3S,linear,1,1,1,1,1
 SSP1,MEA,"","","","",trn_freight_road,trn_freight,S3S,linear,1,1,1,1,1
 SSP1,MEA,"","","","",trn_pass_road,trn_pass,S3S,linear,0.639480996474237,0.71967693403545,0.71967693403545,0.71967693403545,0.71967693403545
-SSP1,MEA,"","","",Bus,trn_pass_road,trn_pass,S2S3,linear,0.183919217151252,0.122612811434168,0.0613064057170841,0.0490451245736673,0.0490451245736673
+SSP1,MEA,"","","",Bus,trn_pass_road,trn_pass,S2S3,linear,0.262741738787503,0.122612811434168,0.0613064057170841,0.0490451245736673,0.0490451245736673
 SSP1,MEA,"","","",trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1,1,1,1,1
 SSP1,MEA,"","",trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,0.007508394761241,0.007508394761241,0.007508394761241,0.007508394761241,0.007508394761241
 SSP1,MEA,"","",trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1,1,1,1,1
@@ -2323,12 +2323,12 @@ SSP1,MEA,"",Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_
 SSP1,MEA,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1,1,1,1,1
 SSP1,MEA,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0,0,0,0,0
 SSP1,MEA,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1,1,1,1,1
-SSP1,MEA,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.047425873177567,0.295835563506995,0.654894712190423,0.654894712190423
+SSP1,MEA,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.047425873177567,0.295835563506994,0.654894712190425,0.654894712190425
 SSP1,MEA,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,0.402051171672381,0.476794775213334,0.626281982295238,0.925256396459048,0.925256396459048
 SSP1,MEA,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1,1,1,1,1
 SSP1,MEA,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1,1,1,1,1
 SSP1,MEA,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.059601461011059,0.1,0.14028768429113,0.14028768429113
-SSP1,MEA,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0237129365887835,0.053788284273999,0.13608201811749,0.13608201811749
+SSP1,MEA,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0237129365887835,0.053788284273999,0.136082018117491,0.136082018117491
 SSP1,MEA,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,0.142857142857143,0.2,0.142857142857143,0.142857142857143
 SSP1,MEA,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,0.142857142857143,0.2,0.142857142857143,0.142857142857143
 SSP1,MEA,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.059601461011059,0.1,0.14028768429113,0.14028768429113
@@ -2440,7 +2440,7 @@ SSP1,NES,"","","","",Passenger Rail,trn_pass,S3S,linear,0.00160675014597331,0.00
 SSP1,NES,"","","","",Walk,trn_pass,S3S,linear,1,1,1,1,1
 SSP1,NES,"","","","",trn_freight_road,trn_freight,S3S,linear,1,1,1,1,1
 SSP1,NES,"","","","",trn_pass_road,trn_pass,S3S,linear,0.925821312685462,0.717579145423199,0.456641274360218,0.25115270089812,0.25115270089812
-SSP1,NES,"","","",Bus,trn_pass_road,trn_pass,S2S3,linear,0.021994137000963,0.0183284475008025,0.0109970685004815,0.0109970685004815,0.0109970685004815
+SSP1,NES,"","","",Bus,trn_pass_road,trn_pass,S2S3,linear,0.0549853425024075,0.021994137000963,0.0109970685004815,0.0109970685004815,0.0109970685004815
 SSP1,NES,"","","",trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1,1,1,1,1
 SSP1,NES,"","",trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,0.004922521505832,0.004922521505832,0.004922521505832,0.004922521505832,0.004922521505832
 SSP1,NES,"","",trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1,1,1,1,1
@@ -2509,7 +2509,7 @@ SSP1,OAS,"","","","",Passenger Rail,trn_pass,S3S,linear,0.00077008869031218,0.00
 SSP1,OAS,"","","","",Walk,trn_pass,S3S,linear,1,0.689328623982319,0.689328623982319,0.689328623982319,0.689328623982319
 SSP1,OAS,"","","","",trn_freight_road,trn_freight,S3S,linear,1,1,1,1,1
 SSP1,OAS,"","","","",trn_pass_road,trn_pass,S3S,linear,0.87209012211972,1,1,1,1
-SSP1,OAS,"","","",Bus,trn_pass_road,trn_pass,S2S3,linear,0.160206681607861,0.110191151172767,0.0550955755863836,0.0550955755863836,0.0550955755863836
+SSP1,OAS,"","","",Bus,trn_pass_road,trn_pass,S2S3,linear,0.240310022411792,0.140243283310795,0.0550955755863836,0.0550955755863836,0.0550955755863836
 SSP1,OAS,"","","",trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1,1,1,1,1
 SSP1,OAS,"","",trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,0.025341509717687,0.022332205438712,0.016313596880761,0.00427637976486,0.00427637976486
 SSP1,OAS,"","",trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1,1,1,1,1
@@ -2537,18 +2537,18 @@ SSP1,OAS,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Fre
 SSP1,OAS,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1,1,1,1,1
 SSP1,OAS,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,0.352966479972375,0.433845669975828,0.595604049982734,0.919120809996547,0.919120809996547
 SSP1,OAS,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.039734307340706,0.0625,0.0785611032030326,0.0785611032030326
-SSP1,OAS,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0158086243925223,0.0336176776712494,0.0762059301457946,0.0762059301457946
-SSP1,OAS,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0158086243925223,0.0336176776712494,0.0762059301457946,0.0762059301457946
-SSP1,OAS,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0158086243925223,0.0336176776712494,0.0762059301457946,0.0762059301457946
+SSP1,OAS,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0158086243925223,0.0336176776712495,0.0762059301457946,0.0762059301457946
+SSP1,OAS,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0158086243925223,0.0336176776712495,0.0762059301457946,0.0762059301457946
+SSP1,OAS,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0158086243925223,0.0336176776712495,0.0762059301457946,0.0762059301457946
 SSP1,OAS,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.039734307340706,0.0625,0.0785611032030326,0.0785611032030326
-SSP1,OAS,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.002472623156635,0.017986209962092,0.0656116917729915,0.0656116917729915
+SSP1,OAS,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.002472623156635,0.017986209962092,0.0656116917729916,0.0656116917729916
 SSP1,OAS,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.011154751540475,0.0118564682943918,0.0292423431452002,0.0292423431452002
 SSP1,OAS,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.00412103859439167,0.004496552490523,0.02,0.02
 SSP1,OAS,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.00412103859439167,0.004496552490523,0.02,0.02
 SSP1,OAS,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.00412103859439167,0.004496552490523,0.02,0.02
 SSP1,OAS,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.011154751540475,0.0118564682943918,0.0292423431452002,0.0292423431452002
 SSP1,OAS,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0,8.31528027664132e-07,4.53978687024344e-05,0.119202922022118,0.119202922022118
-SSP1,OAS,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1,1,1,0.656116917729915,0.656116917729915
+SSP1,OAS,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1,1,1,0.656116917729916,0.656116917729916
 SSP1,OAS,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1,1,1,1,1
 SSP1,OAS,Liquids,Domestic Ship_tmp_vehicletype,Domestic Ship_tmp_subsector_L1,Domestic Ship_tmp_subsector_L2,Domestic Ship,trn_freight,FV,linear,1,1,1,1,1
 SSP1,OAS,Liquids,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1,1,1,1,1
@@ -2580,7 +2580,7 @@ SSP1,REF,"","","","",Passenger Rail,trn_pass,S3S,linear,0.00236561326843326,0.00
 SSP1,REF,"","","","",Walk,trn_pass,S3S,linear,0.317883555031073,0.317883555031073,0.317883555031073,1,1
 SSP1,REF,"","","","",trn_freight_road,trn_freight,S3S,linear,1,1,1,1,1
 SSP1,REF,"","","","",trn_pass_road,trn_pass,S3S,linear,1,1,1,0.943741804984768,0.943741804984768
-SSP1,REF,"","","",Bus,trn_pass_road,trn_pass,S2S3,linear,0.106725224568562,0.0914787639159102,0.0762323032632585,0.0609858426106068,0.0609858426106068
+SSP1,REF,"","","",Bus,trn_pass_road,trn_pass,S2S3,linear,0.118583582853958,0.0914787639159102,0.0762323032632585,0.0609858426106068,0.0609858426106068
 SSP1,REF,"","","",trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1,1,1,1,1
 SSP1,REF,"","",trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,0.369757606378564,0.369757606378564,0.369757606378564,0.369757606378564,0.369757606378564
 SSP1,REF,"","",trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1,1,1,1,1
@@ -2637,18 +2637,18 @@ SSP1,REF,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_s
 SSP1,REF,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.063108879885637,0.087763909362331,0.137073968315718,0.188555268977994,0.188555268977994
 SSP1,REF,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.030480218828266,0.055993897280154,0.107021254183929,0.167260774393184,0.167260774393184
 SSP1,REF,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.026315789473684,0.078947368421053,0.147368421052631,0.147368421052631
-SSP1,SSA,"","","","",Cycle,trn_pass,S3S,linear,0.013878678157857,0.0179527662940391,0.0291452241314997,0.0327883771479372,0.0327883771479372
-SSP1,SSA,"","","","",Domestic Aviation,trn_pass,S3S,linear,0.00901317336217352,0.0509980791548766,0.0413961398176937,0.00620942097265405,0.00620942097265405
+SSP1,SSA,"","","","",Cycle,trn_pass,S3S,linear,0.013878678157857,0.017952766294039,0.0291452241314997,0.0327883771479372,0.0327883771479372
+SSP1,SSA,"","","","",Domestic Aviation,trn_pass,S3S,linear,0.00901317336217352,0.0509980791548764,0.0413961398176937,0.00620942097265405,0.00620942097265405
 SSP1,SSA,"","","","",Domestic Ship,trn_freight,S3S,linear,0.001467441828354,0.001467441828354,0.001467441828354,0.001467441828354,0.001467441828354
 SSP1,SSA,"","","","",Freight Rail,trn_freight,S3S,linear,0.01634165332484,0.01634165332484,0.01634165332484,0.01634165332484,0.01634165332484
-SSP1,SSA,"","","","",HSR,trn_pass,S3S,linear,1.47506311523337e-05,2.00316440897408e-05,0.0650403115771387,0.0097560467365708,0.0097560467365708
+SSP1,SSA,"","","","",HSR,trn_pass,S3S,linear,1.47506311523337e-05,2.00316440897407e-05,0.0650403115771387,0.0097560467365708,0.0097560467365708
 SSP1,SSA,"","","","",International Aviation,trn_aviation_intl,S3S,linear,1,1,1,1,1
 SSP1,SSA,"","","","",International Ship,trn_shipping_intl,S3S,linear,1,1,1,1,1
-SSP1,SSA,"","","","",Passenger Rail,trn_pass,S3S,linear,0.000602417147703971,0.00155851359059413,0.00253015202035668,0.000569284204580253,0.000569284204580253
-SSP1,SSA,"","","","",Walk,trn_pass,S3S,linear,1,0.903431854876908,1,1,1
+SSP1,SSA,"","","","",Passenger Rail,trn_pass,S3S,linear,0.000602417147703971,0.00155851359059412,0.00253015202035668,0.000569284204580253,0.000569284204580253
+SSP1,SSA,"","","","",Walk,trn_pass,S3S,linear,1,0.903431854876905,1,1,1
 SSP1,SSA,"","","","",trn_freight_road,trn_freight,S3S,linear,1,1,1,1,1
-SSP1,SSA,"","","","",trn_pass_road,trn_pass,S3S,linear,0.890164318010016,1,0.974063506007212,0.0974063506007212,0.0974063506007212
-SSP1,SSA,"","","",Bus,trn_pass_road,trn_pass,S2S3,linear,0.206400000437543,0.105846154070534,0.0732781066642163,0.0952615386634812,0.0952615386634812
+SSP1,SSA,"","","","",trn_pass_road,trn_pass,S3S,linear,0.890164318010017,1,0.974063506007213,0.0974063506007212,0.0974063506007212
+SSP1,SSA,"","","",Bus,trn_pass_road,trn_pass,S2S3,linear,0.247680000525051,0.127015384884641,0.0732781066642163,0.0952615386634812,0.0952615386634812
 SSP1,SSA,"","","",trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1,1,1,1,1
 SSP1,SSA,"","",trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,0.039283595822529,0.039283595822529,0.039283595822529,0.039283595822529,0.039283595822529
 SSP1,SSA,"","",trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1,1,1,1,1
@@ -2678,11 +2678,11 @@ SSP1,SSA,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road
 SSP1,SSA,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0094851746355134,0.053788284273999,0.14654986566499,0.14654986566499
 SSP1,SSA,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0238405844044236,0.1,0.151079044621217,0.151079044621217
 SSP1,SSA,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.002472623156635,0.017986209962092,0.075,0.075
-SSP1,SSA,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.006692850924285,0.047425873177567,0.0281176376396156,0.0281176376396156
+SSP1,SSA,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.006692850924285,0.047425873177567,0.0281176376396155,0.0281176376396155
 SSP1,SSA,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.002472623156635,0.017986209962092,0.0192307692307692,0.0192307692307692
 SSP1,SSA,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.002472623156635,0.017986209962092,0.0192307692307692,0.0192307692307692
 SSP1,SSA,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.002472623156635,0.017986209962092,0.0192307692307692,0.0192307692307692
-SSP1,SSA,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.006692850924285,0.047425873177567,0.0281176376396156,0.0281176376396156
+SSP1,SSA,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.006692850924285,0.047425873177567,0.0281176376396155,0.0281176376396155
 SSP1,SSA,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0,8.31528027664132e-07,4.53978687024344e-05,0.119202922022118,0.119202922022118
 SSP1,SSA,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1,1,1,1,1
 SSP1,SSA,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1,1,1,1,1
@@ -2737,14 +2737,14 @@ SSP1,UKI,"",Van,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS
 SSP1,UKI,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0,0,0,0,0
 SSP1,UKI,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0,0,0,0,0
 SSP1,UKI,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0,0,0,0,0
-SSP1,UKI,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.118564682943918,0.322729705643994,0.85731671414019,0.85731671414019
+SSP1,UKI,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.118564682943917,0.322729705643994,0.85731671414019,0.85731671414019
 SSP1,UKI,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,0.826003073674058,0.847752689464801,0.891251921046287,0.978250384209257,0.978250384209257
 SSP1,UKI,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1,1,1,1,1
 SSP1,UKI,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1,1,1,1,1
 SSP1,UKI,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.238405844044236,0.55,0.883812411034117,0.883812411034117
-SSP1,UKI,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.094851746355134,0.295835563506995,0.85731671414019,0.85731671414019
-SSP1,UKI,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.094851746355134,0.295835563506995,0.85731671414019,0.85731671414019
-SSP1,UKI,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.094851746355134,0.295835563506995,0.85731671414019,0.85731671414019
+SSP1,UKI,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.094851746355134,0.295835563506994,0.85731671414019,0.85731671414019
+SSP1,UKI,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.094851746355134,0.295835563506994,0.85731671414019,0.85731671414019
+SSP1,UKI,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.094851746355134,0.295835563506994,0.85731671414019,0.85731671414019
 SSP1,UKI,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.238405844044236,0.55,0.883812411034117,0.883812411034117
 SSP1,UKI,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.012363115783175,0.017986209962092,0.1,0.1
 SSP1,UKI,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.06692850924285,0.189703492710268,0.146211715726001,0.146211715726001
@@ -2809,7 +2809,7 @@ SSP1,USA,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Fre
 SSP1,USA,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1,1,1,1,1
 SSP1,USA,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1,1,1,1,1
 SSP1,USA,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0298007305055295,0.25,0.785611032030326,0.785611032030326
-SSP1,USA,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0118564682943918,0.134470710684997,0.762059301457946,0.762059301457946
+SSP1,USA,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0118564682943918,0.134470710684998,0.762059301457946,0.762059301457946
 SSP1,USA,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.03,0.25,0.5,0.8,0.8
 SSP1,USA,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.03,0.25,0.5,0.8,0.8
 SSP1,USA,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0298007305055295,0.25,0.785611032030326,0.785611032030326
@@ -2880,18 +2880,18 @@ SSP5,CAZ,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Fre
 SSP5,CAZ,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1,1,1,1,1
 SSP5,CAZ,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1,1,1,1,1
 SSP5,CAZ,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.119202922022118,0.35,0.491006895018954,0.491006895018954
-SSP5,CAZ,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.047425873177567,0.188258994958996,0.476287063411217,0.476287063411217
-SSP5,CAZ,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.047425873177567,0.188258994958996,0.476287063411217,0.476287063411217
-SSP5,CAZ,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.047425873177567,0.188258994958996,0.476287063411217,0.476287063411217
+SSP5,CAZ,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.047425873177567,0.188258994958997,0.476287063411217,0.476287063411217
+SSP5,CAZ,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.047425873177567,0.188258994958997,0.476287063411217,0.476287063411217
+SSP5,CAZ,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.047425873177567,0.188258994958997,0.476287063411217,0.476287063411217
 SSP5,CAZ,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.119202922022118,0.35,0.491006895018954,0.491006895018954
-SSP5,CAZ,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.012363115783175,0.017986209962092,0.0954351880334422,0.0954351880334422
+SSP5,CAZ,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.012363115783175,0.017986209962092,0.0954351880334419,0.0954351880334419
 SSP5,CAZ,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.033464254621425,0.047425873177567,0.146211715726001,0.146211715726001
 SSP5,CAZ,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.012363115783175,0.017986209962092,0.1,0.1
 SSP5,CAZ,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.012363115783175,0.017986209962092,0.1,0.1
 SSP5,CAZ,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.012363115783175,0.017986209962092,0.1,0.1
 SSP5,CAZ,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.033464254621425,0.047425873177567,0.146211715726001,0.146211715726001
 SSP5,CAZ,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0,8.31528027664132e-07,4.53978687024344e-05,0.119202922022118,0.119202922022118
-SSP5,CAZ,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1,1,1,0.954351880334422,0.954351880334422
+SSP5,CAZ,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1,1,1,0.954351880334419,0.954351880334419
 SSP5,CAZ,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1,1,1,1,1
 SSP5,CAZ,Liquids,Domestic Ship_tmp_vehicletype,Domestic Ship_tmp_subsector_L1,Domestic Ship_tmp_subsector_L2,Domestic Ship,trn_freight,FV,linear,1,1,1,1,1
 SSP5,CAZ,Liquids,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1,1,1,1,1
@@ -2906,7 +2906,7 @@ SSP5,CAZ,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_
 SSP5,CAZ,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,1,1,1,1
 SSP5,CAZ,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,1,1,1,1
 SSP5,CAZ,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,1,1,1,1
-SSP5,CAZ,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.031042108230522,0.056541000119193,0.107538783896534,0.199969502302122,0.199969502302122
+SSP5,CAZ,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.031042108230522,0.056541000119193,0.107538783896534,0.199969502302121,0.199969502302121
 SSP5,CAZ,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.026315789473684,0.078947368421053,0.184210526315789,0.184210526315789
 SSP5,CAZ,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.026315789473684,0.078947368421053,0.184210526315789,0.184210526315789
 SSP5,CAZ,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.026315789473684,0.078947368421053,0.184210526315789,0.184210526315789
@@ -2923,7 +2923,7 @@ SSP5,CHA,"","","","",Passenger Rail,trn_pass,S3S,linear,0.00546103419952829,0.00
 SSP5,CHA,"","","","",Walk,trn_pass,S3S,linear,0.877713076761744,1,1,1,1
 SSP5,CHA,"","","","",trn_freight_road,trn_freight,S3S,linear,1,1,1,1,1
 SSP5,CHA,"","","","",trn_pass_road,trn_pass,S3S,linear,1,0.455729794383114,0.227864897191557,0.0584268967157839,0.0584268967157839
-SSP5,CHA,"","","",Bus,trn_pass_road,trn_pass,S2S3,linear,0.254432114324843,0.191544432089459,0.170509316525779,0.189454796139754,0.189454796139754
+SSP5,CHA,"","","",Bus,trn_pass_road,trn_pass,S2S3,linear,0.381648171487265,0.191544432089459,0.170509316525779,0.189454796139754,0.189454796139754
 SSP5,CHA,"","","",trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1,1,1,1,1
 SSP5,CHA,"","",trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,0.01080602223644,0.009522807095863,0.006956376814708,0.001823516252399,0.001823516252399
 SSP5,CHA,"","",trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1,1,1,1,1
@@ -2951,14 +2951,14 @@ SSP5,CHA,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road
 SSP5,CHA,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.1,0.4,0.9,1,1
 SSP5,CHA,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.1,0.4,0.9,1,1
 SSP5,CHA,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0476811688088472,0.45,0.982013790037908,0.982013790037908
-SSP5,CHA,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.022253608409715,0.0668777976648958,0.0699858045578576,0.0699858045578576
+SSP5,CHA,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.022253608409715,0.0668777976648955,0.0699858045578576,0.0699858045578576
 SSP5,CHA,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.001338570184857,0.0284555239065402,0.146211715726001,0.146211715726001
 SSP5,CHA,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.000494524631327,0.0107917259772552,0.1,0.1
 SSP5,CHA,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.01,0.2,0.6,0.2,0.2
 SSP5,CHA,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.01,0.2,0.6,0.2,0.2
 SSP5,CHA,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.001338570184857,0.0284555239065402,0.146211715726001,0.146211715726001
 SSP5,CHA,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0,8.31528027664132e-07,4.53978687024344e-05,0.119202922022118,0.119202922022118
-SSP5,CHA,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1,1,0.743656365691809,0.349929022789288,0.349929022789288
+SSP5,CHA,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1,1,0.743656365691807,0.349929022789288,0.349929022789288
 SSP5,CHA,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1,1,1,1,1
 SSP5,CHA,Liquids,Domestic Ship_tmp_vehicletype,Domestic Ship_tmp_subsector_L1,Domestic Ship_tmp_subsector_L2,Domestic Ship,trn_freight,FV,linear,1,1,1,1,1
 SSP5,CHA,Liquids,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1,1,1,1,1
@@ -2973,7 +2973,7 @@ SSP5,CHA,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_
 SSP5,CHA,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,1,1,1,1
 SSP5,CHA,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,1,1,1,1
 SSP5,CHA,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,1,1,1,1
-SSP5,CHA,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.142120012637288,0.159432643883675,0.090195248368545,0.115174077598356,0.115174077598356
+SSP5,CHA,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.142120012637288,0.159432643883675,0.0901952483685446,0.115174077598355,0.115174077598355
 SSP5,CHA,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.8778097236668e-05,0.013188367964814,0.0553035143317804,0.0921307947813305,0.0921307947813305
 SSP5,CHA,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.0007853553299874,0.014432374877611,0.0569509829460257,0.093173070843404,0.093173070843404
 SSP5,CHA,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.3,0.5,0.7,0.5,0.5
@@ -3014,16 +3014,16 @@ SSP5,DEU,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Fre
 SSP5,DEU,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1,1,1,1,1
 SSP5,DEU,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1,1,1,1,1
 SSP5,DEU,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.298007305055295,0.675,0.982013790037908,0.982013790037908
-SSP5,DEU,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.118564682943918,0.363070918849493,0.952574126822433,0.952574126822433
-SSP5,DEU,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.118564682943918,0.363070918849493,0.952574126822433,0.952574126822433
-SSP5,DEU,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.118564682943918,0.363070918849493,0.952574126822433,0.952574126822433
+SSP5,DEU,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.118564682943917,0.363070918849493,0.952574126822433,0.952574126822433
+SSP5,DEU,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.118564682943917,0.363070918849493,0.952574126822433,0.952574126822433
+SSP5,DEU,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.118564682943917,0.363070918849493,0.952574126822433,0.952574126822433
 SSP5,DEU,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.298007305055295,0.675,0.982013790037908,0.982013790037908
 SSP5,DEU,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.002472623156635,0.017986209962092,0.05,0.05
-SSP5,DEU,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.08031421109142,0.331981112242969,0.219317573589002,0.219317573589002
+SSP5,DEU,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.08031421109142,0.331981112242969,0.219317573589001,0.219317573589001
 SSP5,DEU,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.02967147787962,0.125903469734644,0.15,0.15
 SSP5,DEU,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.02967147787962,0.125903469734644,0.15,0.15
 SSP5,DEU,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.02967147787962,0.125903469734644,0.15,0.15
-SSP5,DEU,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.08031421109142,0.331981112242969,0.219317573589002,0.219317573589002
+SSP5,DEU,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.08031421109142,0.331981112242969,0.219317573589001,0.219317573589001
 SSP5,DEU,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0,8.31528027664132e-07,4.53978687024344e-05,0.119202922022118,0.119202922022118
 SSP5,DEU,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1,1,1,1,1
 SSP5,DEU,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1,1,1,1,1
@@ -3148,9 +3148,9 @@ SSP5,ECS,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Fre
 SSP5,ECS,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1,1,1,1,1
 SSP5,ECS,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1,1,1,1,1
 SSP5,ECS,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.119202922022118,0.25,0.294604137011372,0.294604137011372
-SSP5,ECS,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.047425873177567,0.134470710684997,0.28577223804673,0.28577223804673
-SSP5,ECS,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.047425873177567,0.134470710684997,0.28577223804673,0.28577223804673
-SSP5,ECS,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.047425873177567,0.134470710684997,0.28577223804673,0.28577223804673
+SSP5,ECS,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.047425873177567,0.134470710684998,0.28577223804673,0.28577223804673
+SSP5,ECS,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.047425873177567,0.134470710684998,0.28577223804673,0.28577223804673
+SSP5,ECS,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.047425873177567,0.134470710684998,0.28577223804673,0.28577223804673
 SSP5,ECS,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.119202922022118,0.25,0.294604137011372,0.294604137011372
 SSP5,ECS,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.002472623156635,0.053958629886276,0.1,0.1
 SSP5,ECS,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.01338570184857,0.047425873177567,0.0731058578630005,0.0731058578630005
@@ -3228,7 +3228,7 @@ SSP5,ENC,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp
 SSP5,ENC,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.02472623156635,0.08993104981046,0.1,0.1
 SSP5,ENC,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.06692850924285,0.237129365887835,0.146211715726001,0.146211715726001
 SSP5,ENC,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0,8.31528027664132e-07,4.53978687024344e-05,0.119202922022118,0.119202922022118
-SSP5,ENC,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1,1,1,0.524893534183932,0.524893534183932
+SSP5,ENC,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1,1,1,0.524893534183931,0.524893534183931
 SSP5,ENC,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1,1,1,1,1
 SSP5,ENC,Liquids,Domestic Ship_tmp_vehicletype,Domestic Ship_tmp_subsector_L1,Domestic Ship_tmp_subsector_L2,Domestic Ship,trn_freight,FV,linear,1,1,1,1,1
 SSP5,ENC,Liquids,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,0.1341454314254,0.1341454314254,0.1341454314254,0.1341454314254,0.1341454314254
@@ -3346,7 +3346,7 @@ SSP5,ESW,"",Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_
 SSP5,ESW,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0,0,0,0,0
 SSP5,ESW,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0,0,0,0,0
 SSP5,ESW,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0,0,0,0,0
-SSP5,ESW,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.118564682943918,0.268941421369995,0.666801888775703,0.666801888775703
+SSP5,ESW,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.118564682943917,0.268941421369995,0.666801888775703,0.666801888775703
 SSP5,ESW,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,0.72951273091157,0.763323639547623,0.830945456819731,0.966189091363946,0.966189091363946
 SSP5,ESW,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1,1,1,1,1
 SSP5,ESW,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1,1,1,1,1
@@ -3485,18 +3485,18 @@ SSP5,FRA,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Fre
 SSP5,FRA,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1,1,1,1,1
 SSP5,FRA,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1,1,1,1,1
 SSP5,FRA,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.298007305055295,0.75,0.982013790037908,0.982013790037908
-SSP5,FRA,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.118564682943918,0.403412132054992,0.952574126822433,0.952574126822433
-SSP5,FRA,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.118564682943918,0.403412132054992,0.952574126822433,0.952574126822433
-SSP5,FRA,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.118564682943918,0.403412132054992,0.952574126822433,0.952574126822433
+SSP5,FRA,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.118564682943917,0.403412132054992,0.952574126822433,0.952574126822433
+SSP5,FRA,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.118564682943917,0.403412132054992,0.952574126822433,0.952574126822433
+SSP5,FRA,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.118564682943917,0.403412132054992,0.952574126822433,0.952574126822433
 SSP5,FRA,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.298007305055295,0.75,0.982013790037908,0.982013790037908
-SSP5,FRA,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.012363115783175,0.017986209962092,0.0954351880334422,0.0954351880334422
+SSP5,FRA,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.012363115783175,0.017986209962092,0.0954351880334419,0.0954351880334419
 SSP5,FRA,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.06692850924285,0.047425873177567,0.146211715726001,0.146211715726001
 SSP5,FRA,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.02472623156635,0.017986209962092,0.1,0.1
 SSP5,FRA,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.02472623156635,0.017986209962092,0.1,0.1
 SSP5,FRA,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.02472623156635,0.017986209962092,0.1,0.1
 SSP5,FRA,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.06692850924285,0.047425873177567,0.146211715726001,0.146211715726001
 SSP5,FRA,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0,8.31528027664132e-07,4.53978687024344e-05,0.119202922022118,0.119202922022118
-SSP5,FRA,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1,1,1,0.954351880334422,0.954351880334422
+SSP5,FRA,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1,1,1,0.954351880334419,0.954351880334419
 SSP5,FRA,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1,1,1,1,1
 SSP5,FRA,Liquids,Domestic Ship_tmp_vehicletype,Domestic Ship_tmp_subsector_L1,Domestic Ship_tmp_subsector_L2,Domestic Ship,trn_freight,FV,linear,1,1,1,1,1
 SSP5,FRA,Liquids,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,0.160770475713231,0.160770475713231,0.160770475713231,0.160770475713231,0.160770475713231
@@ -3511,7 +3511,7 @@ SSP5,FRA,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_
 SSP5,FRA,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,1,1,1,1
 SSP5,FRA,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,1,1,1,1
 SSP5,FRA,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,1,1,1,1
-SSP5,FRA,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.026315789473684,0.078947368421053,0.175801662166867,0.175801662166867
+SSP5,FRA,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.026315789473684,0.078947368421053,0.175801662166866,0.175801662166866
 SSP5,FRA,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.026315789473684,0.078947368421053,0.184210526315789,0.184210526315789
 SSP5,FRA,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.026315789473684,0.078947368421053,0.184210526315789,0.184210526315789
 SSP5,FRA,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.026315789473684,0.078947368421053,0.184210526315789,0.184210526315789
@@ -3528,7 +3528,7 @@ SSP5,IND,"","","","",Passenger Rail,trn_pass,S3S,linear,0.000684210526315789,8e-
 SSP5,IND,"","","","",Walk,trn_pass,S3S,linear,0.131578947368421,0.0945454545454544,0.181818181818182,1,1
 SSP5,IND,"","","","",trn_freight_road,trn_freight,S3S,linear,1,1,1,1,1
 SSP5,IND,"","","","",trn_pass_road,trn_pass,S3S,linear,1,1,1,1,1
-SSP5,IND,"","","",Bus,trn_pass_road,trn_pass,S2S3,linear,0.118824252562298,0.0625,0.0323053436653747,0.0323053436653747,0.0323053436653747
+SSP5,IND,"","","",Bus,trn_pass_road,trn_pass,S2S3,linear,0.118824252562298,0.0714285714285714,0.0323053436653747,0.0323053436653747,0.0323053436653747
 SSP5,IND,"","","",trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1,1,1,1,1
 SSP5,IND,"","",trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,0.003027158638145,0.002667683549865,0.001948733373306,0.000510833020187,0.000510833020187
 SSP5,IND,"","",trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1,1,1,1,1
@@ -3608,7 +3608,7 @@ SSP5,JPN,"",Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_
 SSP5,JPN,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0,0,0,0,0
 SSP5,JPN,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0,0,0,0,0
 SSP5,JPN,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0,0,0,0,0
-SSP5,JPN,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.109079508308404,0.17929428091333,0.381029650728973,0.381029650728973
+SSP5,JPN,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.109079508308404,0.17929428091333,0.381029650728972,0.381029650728972
 SSP5,JPN,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1,1,1,1,1
 SSP5,JPN,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1,1,1,1,1
 SSP5,JPN,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1,1,1,1,1
@@ -3618,11 +3618,11 @@ SSP5,JPN,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road
 SSP5,JPN,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,0.0636363636363636,0.133333333333333,0.833333333333333,0.833333333333333
 SSP5,JPN,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.125163068123224,0.352941176470588,0.81834482503159,0.81834482503159
 SSP5,JPN,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.061815578915875,0.131898873055341,0.1,0.1
-SSP5,JPN,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.110432040250703,0.251078152116531,0.304607741095835,0.304607741095835
+SSP5,JPN,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.110432040250702,0.251078152116531,0.304607741095835,0.304607741095835
 SSP5,JPN,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,1,1,0.416666666666667,0.416666666666667
 SSP5,JPN,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,1,1,0.416666666666667,0.416666666666667
 SSP5,JPN,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,1,1,0.416666666666667,0.416666666666667
-SSP5,JPN,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.110432040250703,0.251078152116531,0.304607741095835,0.304607741095835
+SSP5,JPN,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.110432040250702,0.251078152116531,0.304607741095835,0.304607741095835
 SSP5,JPN,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0,8.31528027664132e-07,4.53978687024344e-05,0.119202922022118,0.119202922022118
 SSP5,JPN,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1,1,1,1,1
 SSP5,JPN,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1,1,1,1,1
@@ -3640,11 +3640,11 @@ SSP5,JPN,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_
 SSP5,JPN,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,0.0606060606060606,0.188888888888889,1,1
 SSP5,JPN,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,1,1,1,1
 SSP5,JPN,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.0078947368421052,0.0157894736842106,0.0230263157894736,0.0230263157894736
-SSP5,JPN,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.013157894736842,0.0464396284829724,0.0460526315789472,0.0460526315789472
+SSP5,JPN,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.013157894736842,0.0464396284829724,0.0460526315789473,0.0460526315789473
 SSP5,JPN,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,0.0303030303030303,0.111111111111111,0.25,0.25
 SSP5,JPN,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,0.0303030303030303,0.111111111111111,0.25,0.25
 SSP5,JPN,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,0.0303030303030303,0.111111111111111,0.25,0.25
-SSP5,JPN,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.013157894736842,0.0464396284829724,0.0460526315789472,0.0460526315789472
+SSP5,JPN,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.013157894736842,0.0464396284829724,0.0460526315789473,0.0460526315789473
 SSP5,LAM,"","","","",Cycle,trn_pass,S3S,linear,0.00981212891217365,0.0185165853437172,0.0462914633592929,0.231457316796465,0.231457316796465
 SSP5,LAM,"","","","",Domestic Aviation,trn_pass,S3S,linear,0.00840668890350734,0.0105762418419885,0.0264406046049712,0.0198304534537284,0.0198304534537284
 SSP5,LAM,"","","","",Domestic Ship,trn_freight,S3S,linear,0.009523329319276,0.009523329319276,0.00865757210843273,0.00793610776606333,0.00793610776606333
@@ -3656,7 +3656,7 @@ SSP5,LAM,"","","","",Passenger Rail,trn_pass,S3S,linear,0.134842686357634,0.1272
 SSP5,LAM,"","","","",Walk,trn_pass,S3S,linear,0.899323352244677,0.848561904989659,0.848561904989659,0.848561904989659,0.848561904989659
 SSP5,LAM,"","","","",trn_freight_road,trn_freight,S3S,linear,1,1,1,1,1
 SSP5,LAM,"","","","",trn_pass_road,trn_pass,S3S,linear,1,1,1,1,1
-SSP5,LAM,"","","",Bus,trn_pass_road,trn_pass,S2S3,linear,0.138594539617622,0.086621587261014,0.086621587261014,0.086621587261014,0.086621587261014
+SSP5,LAM,"","","",Bus,trn_pass_road,trn_pass,S2S3,linear,0.173243174522027,0.108276984076267,0.086621587261014,0.086621587261014,0.086621587261014
 SSP5,LAM,"","","",trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1,1,1,1,1
 SSP5,LAM,"","",trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,0.137734442638184,0.137734442638184,0.137734442638184,0.137734442638184,0.137734442638184
 SSP5,LAM,"","",trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1,1,1,1,1
@@ -3679,23 +3679,23 @@ SSP5,LAM,"",Van,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS
 SSP5,LAM,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0,0,0,0,0
 SSP5,LAM,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0,0,0,0,0
 SSP5,LAM,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0,0,0,0,0
-SSP5,LAM,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.118564682943918,0.53788284273999,1,1
+SSP5,LAM,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.118564682943917,0.53788284273999,1,1
 SSP5,LAM,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,0.0681034247188,0.18459049662895,0.41756464044925,0.88351292808985,0.88351292808985
 SSP5,LAM,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1,1,1,1,1
 SSP5,LAM,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1,1,1,1,1
 SSP5,LAM,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.079468614681412,0.2,0.2400478153426,0.2400478153426
-SSP5,LAM,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0316172487850447,0.107576568547998,0.232851453223261,0.232851453223261
-SSP5,LAM,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0316172487850447,0.107576568547998,0.232851453223261,0.232851453223261
-SSP5,LAM,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0316172487850447,0.107576568547998,0.232851453223261,0.232851453223261
+SSP5,LAM,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0316172487850447,0.107576568547998,0.232851453223262,0.232851453223262
+SSP5,LAM,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0316172487850447,0.107576568547998,0.232851453223262,0.232851453223262
+SSP5,LAM,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0316172487850447,0.107576568547998,0.232851453223262,0.232851453223262
 SSP5,LAM,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.079468614681412,0.2,0.2400478153426,0.2400478153426
-SSP5,LAM,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.002472623156635,0.017986209962092,0.0656116917729915,0.0656116917729915
-SSP5,LAM,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.00892380123238,0.0569110478130804,0.0812287309588894,0.0812287309588894
+SSP5,LAM,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.002472623156635,0.017986209962092,0.0656116917729916,0.0656116917729916
+SSP5,LAM,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.00892380123238,0.0569110478130804,0.0812287309588893,0.0812287309588893
 SSP5,LAM,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.00329683087551333,0.0215834519545104,0.0555555555555556,0.0555555555555556
 SSP5,LAM,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.00329683087551333,0.0215834519545104,0.0555555555555556,0.0555555555555556
 SSP5,LAM,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.00329683087551333,0.0215834519545104,0.0555555555555556,0.0555555555555556
-SSP5,LAM,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.00892380123238,0.0569110478130804,0.0812287309588894,0.0812287309588894
+SSP5,LAM,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.00892380123238,0.0569110478130804,0.0812287309588893,0.0812287309588893
 SSP5,LAM,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0,8.31528027664132e-07,4.53978687024344e-05,0.119202922022118,0.119202922022118
-SSP5,LAM,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1,1,1,0.721728609502907,0.721728609502907
+SSP5,LAM,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1,1,1,0.721728609502908,0.721728609502908
 SSP5,LAM,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1,1,1,1,1
 SSP5,LAM,Liquids,Domestic Ship_tmp_vehicletype,Domestic Ship_tmp_subsector_L1,Domestic Ship_tmp_subsector_L2,Domestic Ship,trn_freight,FV,linear,1,1,1,1,1
 SSP5,LAM,Liquids,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1,1,1,1,1
@@ -3711,11 +3711,11 @@ SSP5,LAM,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_
 SSP5,LAM,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,1,1,1,1
 SSP5,LAM,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,1,1,1,1
 SSP5,LAM,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.026893682222235,0.0472515688947483,0.10371786520469,0.135258574225718,0.135258574225718
-SSP5,LAM,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0175438596491227,0.0315789473684212,0.0614035087719297,0.0614035087719297
-SSP5,LAM,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0175438596491227,0.0315789473684212,0.0614035087719297,0.0614035087719297
-SSP5,LAM,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0175438596491227,0.0315789473684212,0.0614035087719297,0.0614035087719297
-SSP5,LAM,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0175438596491227,0.0315789473684212,0.0614035087719297,0.0614035087719297
-SSP5,LAM,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0175438596491227,0.0315789473684212,0.0614035087719297,0.0614035087719297
+SSP5,LAM,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0175438596491227,0.0315789473684212,0.0614035087719296,0.0614035087719296
+SSP5,LAM,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0175438596491227,0.0315789473684212,0.0614035087719296,0.0614035087719296
+SSP5,LAM,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0175438596491227,0.0315789473684212,0.0614035087719296,0.0614035087719296
+SSP5,LAM,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0175438596491227,0.0315789473684212,0.0614035087719296,0.0614035087719296
+SSP5,LAM,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0175438596491227,0.0315789473684212,0.0614035087719296,0.0614035087719296
 SSP5,MEA,"","","","",Cycle,trn_pass,S3S,linear,0.0165975108305109,0.0165975108305109,0.0165975108305109,0.0414937770762773,0.0414937770762773
 SSP5,MEA,"","","","",Domestic Aviation,trn_pass,S3S,linear,0.0089294530094782,0.00595296867298547,0.0178589060189564,0.0238118746919419,0.0238118746919419
 SSP5,MEA,"","","","",Domestic Ship,trn_freight,S3S,linear,0.002022051343562,0.002022051343562,0.002022051343562,0.002022051343562,0.002022051343562
@@ -3727,7 +3727,7 @@ SSP5,MEA,"","","","",Passenger Rail,trn_pass,S3S,linear,0.000556730785330985,0.0
 SSP5,MEA,"","","","",Walk,trn_pass,S3S,linear,1,1,1,1,1
 SSP5,MEA,"","","","",trn_freight_road,trn_freight,S3S,linear,1,1,1,1,1
 SSP5,MEA,"","","","",trn_pass_road,trn_pass,S3S,linear,0.639480996474237,0.71967693403545,0.71967693403545,0.71967693403545,0.71967693403545
-SSP5,MEA,"","","",Bus,trn_pass_road,trn_pass,S2S3,linear,0.183919217151252,0.122612811434168,0.0613064057170841,0.0490451245736673,0.0490451245736673
+SSP5,MEA,"","","",Bus,trn_pass_road,trn_pass,S2S3,linear,0.262741738787503,0.122612811434168,0.0613064057170841,0.0490451245736673,0.0490451245736673
 SSP5,MEA,"","","",trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1,1,1,1,1
 SSP5,MEA,"","",trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,0.007508394761241,0.007508394761241,0.007508394761241,0.007508394761241,0.007508394761241
 SSP5,MEA,"","",trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1,1,1,1,1
@@ -3744,12 +3744,12 @@ SSP5,MEA,"",Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_
 SSP5,MEA,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1,1,1,1,1
 SSP5,MEA,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0,0,0,0,0
 SSP5,MEA,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1,1,1,1,1
-SSP5,MEA,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.047425873177567,0.295835563506995,0.654894712190423,0.654894712190423
+SSP5,MEA,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.047425873177567,0.295835563506994,0.654894712190425,0.654894712190425
 SSP5,MEA,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,0.402051171672381,0.476794775213334,0.626281982295238,0.925256396459048,0.925256396459048
 SSP5,MEA,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1,1,1,1,1
 SSP5,MEA,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1,1,1,1,1
 SSP5,MEA,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.059601461011059,0.1,0.14028768429113,0.14028768429113
-SSP5,MEA,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0237129365887835,0.053788284273999,0.13608201811749,0.13608201811749
+SSP5,MEA,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0237129365887835,0.053788284273999,0.136082018117491,0.136082018117491
 SSP5,MEA,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,0.142857142857143,0.2,0.142857142857143,0.142857142857143
 SSP5,MEA,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,0.142857142857143,0.2,0.142857142857143,0.142857142857143
 SSP5,MEA,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.059601461011059,0.1,0.14028768429113,0.14028768429113
@@ -3861,7 +3861,7 @@ SSP5,NES,"","","","",Passenger Rail,trn_pass,S3S,linear,0.00160675014597331,0.00
 SSP5,NES,"","","","",Walk,trn_pass,S3S,linear,1,1,1,1,1
 SSP5,NES,"","","","",trn_freight_road,trn_freight,S3S,linear,1,1,1,1,1
 SSP5,NES,"","","","",trn_pass_road,trn_pass,S3S,linear,0.925821312685462,0.717579145423199,0.456641274360218,0.25115270089812,0.25115270089812
-SSP5,NES,"","","",Bus,trn_pass_road,trn_pass,S2S3,linear,0.021994137000963,0.0183284475008025,0.0109970685004815,0.0109970685004815,0.0109970685004815
+SSP5,NES,"","","",Bus,trn_pass_road,trn_pass,S2S3,linear,0.0549853425024075,0.021994137000963,0.0109970685004815,0.0109970685004815,0.0109970685004815
 SSP5,NES,"","","",trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1,1,1,1,1
 SSP5,NES,"","",trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,0.004922521505832,0.004922521505832,0.004922521505832,0.004922521505832,0.004922521505832
 SSP5,NES,"","",trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1,1,1,1,1
@@ -3930,7 +3930,7 @@ SSP5,OAS,"","","","",Passenger Rail,trn_pass,S3S,linear,0.00077008869031218,0.00
 SSP5,OAS,"","","","",Walk,trn_pass,S3S,linear,1,0.689328623982319,0.689328623982319,0.689328623982319,0.689328623982319
 SSP5,OAS,"","","","",trn_freight_road,trn_freight,S3S,linear,1,1,1,1,1
 SSP5,OAS,"","","","",trn_pass_road,trn_pass,S3S,linear,0.87209012211972,1,1,1,1
-SSP5,OAS,"","","",Bus,trn_pass_road,trn_pass,S2S3,linear,0.160206681607861,0.110191151172767,0.0550955755863836,0.0550955755863836,0.0550955755863836
+SSP5,OAS,"","","",Bus,trn_pass_road,trn_pass,S2S3,linear,0.240310022411792,0.140243283310795,0.0550955755863836,0.0550955755863836,0.0550955755863836
 SSP5,OAS,"","","",trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1,1,1,1,1
 SSP5,OAS,"","",trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,0.025341509717687,0.022332205438712,0.016313596880761,0.00427637976486,0.00427637976486
 SSP5,OAS,"","",trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1,1,1,1,1
@@ -3958,18 +3958,18 @@ SSP5,OAS,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Fre
 SSP5,OAS,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1,1,1,1,1
 SSP5,OAS,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,0.352966479972375,0.433845669975828,0.595604049982734,0.919120809996547,0.919120809996547
 SSP5,OAS,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.039734307340706,0.0625,0.0785611032030326,0.0785611032030326
-SSP5,OAS,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0158086243925223,0.0336176776712494,0.0762059301457946,0.0762059301457946
-SSP5,OAS,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0158086243925223,0.0336176776712494,0.0762059301457946,0.0762059301457946
-SSP5,OAS,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0158086243925223,0.0336176776712494,0.0762059301457946,0.0762059301457946
+SSP5,OAS,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0158086243925223,0.0336176776712495,0.0762059301457946,0.0762059301457946
+SSP5,OAS,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0158086243925223,0.0336176776712495,0.0762059301457946,0.0762059301457946
+SSP5,OAS,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0158086243925223,0.0336176776712495,0.0762059301457946,0.0762059301457946
 SSP5,OAS,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.039734307340706,0.0625,0.0785611032030326,0.0785611032030326
-SSP5,OAS,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.002472623156635,0.017986209962092,0.0656116917729915,0.0656116917729915
+SSP5,OAS,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.002472623156635,0.017986209962092,0.0656116917729916,0.0656116917729916
 SSP5,OAS,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.011154751540475,0.0118564682943918,0.0292423431452002,0.0292423431452002
 SSP5,OAS,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.00412103859439167,0.004496552490523,0.02,0.02
 SSP5,OAS,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.00412103859439167,0.004496552490523,0.02,0.02
 SSP5,OAS,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.00412103859439167,0.004496552490523,0.02,0.02
 SSP5,OAS,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.011154751540475,0.0118564682943918,0.0292423431452002,0.0292423431452002
 SSP5,OAS,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0,8.31528027664132e-07,4.53978687024344e-05,0.119202922022118,0.119202922022118
-SSP5,OAS,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1,1,1,0.656116917729915,0.656116917729915
+SSP5,OAS,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1,1,1,0.656116917729916,0.656116917729916
 SSP5,OAS,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1,1,1,1,1
 SSP5,OAS,Liquids,Domestic Ship_tmp_vehicletype,Domestic Ship_tmp_subsector_L1,Domestic Ship_tmp_subsector_L2,Domestic Ship,trn_freight,FV,linear,1,1,1,1,1
 SSP5,OAS,Liquids,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1,1,1,1,1
@@ -4001,7 +4001,7 @@ SSP5,REF,"","","","",Passenger Rail,trn_pass,S3S,linear,0.00236561326843326,0.00
 SSP5,REF,"","","","",Walk,trn_pass,S3S,linear,0.317883555031073,0.317883555031073,0.317883555031073,1,1
 SSP5,REF,"","","","",trn_freight_road,trn_freight,S3S,linear,1,1,1,1,1
 SSP5,REF,"","","","",trn_pass_road,trn_pass,S3S,linear,1,1,1,0.943741804984768,0.943741804984768
-SSP5,REF,"","","",Bus,trn_pass_road,trn_pass,S2S3,linear,0.106725224568562,0.0914787639159102,0.0762323032632585,0.0609858426106068,0.0609858426106068
+SSP5,REF,"","","",Bus,trn_pass_road,trn_pass,S2S3,linear,0.118583582853958,0.0914787639159102,0.0762323032632585,0.0609858426106068,0.0609858426106068
 SSP5,REF,"","","",trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1,1,1,1,1
 SSP5,REF,"","",trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,0.369757606378564,0.369757606378564,0.369757606378564,0.369757606378564,0.369757606378564
 SSP5,REF,"","",trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1,1,1,1,1
@@ -4058,18 +4058,18 @@ SSP5,REF,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_s
 SSP5,REF,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.063108879885637,0.087763909362331,0.137073968315718,0.188555268977994,0.188555268977994
 SSP5,REF,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.030480218828266,0.055993897280154,0.107021254183929,0.167260774393184,0.167260774393184
 SSP5,REF,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.026315789473684,0.078947368421053,0.147368421052631,0.147368421052631
-SSP5,SSA,"","","","",Cycle,trn_pass,S3S,linear,0.013878678157857,0.0179527662940391,0.0291452241314997,0.0327883771479372,0.0327883771479372
-SSP5,SSA,"","","","",Domestic Aviation,trn_pass,S3S,linear,0.00901317336217352,0.0509980791548766,0.0413961398176937,0.00620942097265405,0.00620942097265405
+SSP5,SSA,"","","","",Cycle,trn_pass,S3S,linear,0.013878678157857,0.017952766294039,0.0291452241314997,0.0327883771479372,0.0327883771479372
+SSP5,SSA,"","","","",Domestic Aviation,trn_pass,S3S,linear,0.00901317336217352,0.0509980791548764,0.0413961398176937,0.00620942097265405,0.00620942097265405
 SSP5,SSA,"","","","",Domestic Ship,trn_freight,S3S,linear,0.001467441828354,0.001467441828354,0.001467441828354,0.001467441828354,0.001467441828354
 SSP5,SSA,"","","","",Freight Rail,trn_freight,S3S,linear,0.01634165332484,0.01634165332484,0.01634165332484,0.01634165332484,0.01634165332484
-SSP5,SSA,"","","","",HSR,trn_pass,S3S,linear,1.47506311523337e-05,2.00316440897408e-05,0.0650403115771387,0.0097560467365708,0.0097560467365708
+SSP5,SSA,"","","","",HSR,trn_pass,S3S,linear,1.47506311523337e-05,2.00316440897407e-05,0.0650403115771387,0.0097560467365708,0.0097560467365708
 SSP5,SSA,"","","","",International Aviation,trn_aviation_intl,S3S,linear,1,1,1,1,1
 SSP5,SSA,"","","","",International Ship,trn_shipping_intl,S3S,linear,1,1,1,1,1
-SSP5,SSA,"","","","",Passenger Rail,trn_pass,S3S,linear,0.000602417147703971,0.00155851359059413,0.00253015202035668,0.000569284204580253,0.000569284204580253
-SSP5,SSA,"","","","",Walk,trn_pass,S3S,linear,1,0.903431854876908,1,1,1
+SSP5,SSA,"","","","",Passenger Rail,trn_pass,S3S,linear,0.000602417147703971,0.00155851359059412,0.00253015202035668,0.000569284204580253,0.000569284204580253
+SSP5,SSA,"","","","",Walk,trn_pass,S3S,linear,1,0.903431854876905,1,1,1
 SSP5,SSA,"","","","",trn_freight_road,trn_freight,S3S,linear,1,1,1,1,1
-SSP5,SSA,"","","","",trn_pass_road,trn_pass,S3S,linear,0.890164318010016,1,0.974063506007212,0.0974063506007212,0.0974063506007212
-SSP5,SSA,"","","",Bus,trn_pass_road,trn_pass,S2S3,linear,0.206400000437543,0.105846154070534,0.0732781066642163,0.0952615386634812,0.0952615386634812
+SSP5,SSA,"","","","",trn_pass_road,trn_pass,S3S,linear,0.890164318010017,1,0.974063506007213,0.0974063506007212,0.0974063506007212
+SSP5,SSA,"","","",Bus,trn_pass_road,trn_pass,S2S3,linear,0.247680000525051,0.127015384884641,0.0732781066642163,0.0952615386634812,0.0952615386634812
 SSP5,SSA,"","","",trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1,1,1,1,1
 SSP5,SSA,"","",trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,0.039283595822529,0.039283595822529,0.039283595822529,0.039283595822529,0.039283595822529
 SSP5,SSA,"","",trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1,1,1,1,1
@@ -4099,11 +4099,11 @@ SSP5,SSA,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road
 SSP5,SSA,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0094851746355134,0.053788284273999,0.14654986566499,0.14654986566499
 SSP5,SSA,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0238405844044236,0.1,0.151079044621217,0.151079044621217
 SSP5,SSA,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.002472623156635,0.017986209962092,0.075,0.075
-SSP5,SSA,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.006692850924285,0.047425873177567,0.0281176376396156,0.0281176376396156
+SSP5,SSA,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.006692850924285,0.047425873177567,0.0281176376396155,0.0281176376396155
 SSP5,SSA,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.002472623156635,0.017986209962092,0.0192307692307692,0.0192307692307692
 SSP5,SSA,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.002472623156635,0.017986209962092,0.0192307692307692,0.0192307692307692
 SSP5,SSA,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.002472623156635,0.017986209962092,0.0192307692307692,0.0192307692307692
-SSP5,SSA,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.006692850924285,0.047425873177567,0.0281176376396156,0.0281176376396156
+SSP5,SSA,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.006692850924285,0.047425873177567,0.0281176376396155,0.0281176376396155
 SSP5,SSA,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0,8.31528027664132e-07,4.53978687024344e-05,0.119202922022118,0.119202922022118
 SSP5,SSA,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1,1,1,1,1
 SSP5,SSA,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1,1,1,1,1
@@ -4158,14 +4158,14 @@ SSP5,UKI,"",Van,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS
 SSP5,UKI,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0,0,0,0,0
 SSP5,UKI,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0,0,0,0,0
 SSP5,UKI,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0,0,0,0,0
-SSP5,UKI,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.118564682943918,0.322729705643994,0.85731671414019,0.85731671414019
+SSP5,UKI,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.118564682943917,0.322729705643994,0.85731671414019,0.85731671414019
 SSP5,UKI,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,0.826003073674058,0.847752689464801,0.891251921046287,0.978250384209257,0.978250384209257
 SSP5,UKI,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1,1,1,1,1
 SSP5,UKI,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1,1,1,1,1
 SSP5,UKI,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.238405844044236,0.55,0.883812411034117,0.883812411034117
-SSP5,UKI,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.094851746355134,0.295835563506995,0.85731671414019,0.85731671414019
-SSP5,UKI,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.094851746355134,0.295835563506995,0.85731671414019,0.85731671414019
-SSP5,UKI,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.094851746355134,0.295835563506995,0.85731671414019,0.85731671414019
+SSP5,UKI,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.094851746355134,0.295835563506994,0.85731671414019,0.85731671414019
+SSP5,UKI,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.094851746355134,0.295835563506994,0.85731671414019,0.85731671414019
+SSP5,UKI,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.094851746355134,0.295835563506994,0.85731671414019,0.85731671414019
 SSP5,UKI,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.238405844044236,0.55,0.883812411034117,0.883812411034117
 SSP5,UKI,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.012363115783175,0.017986209962092,0.1,0.1
 SSP5,UKI,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.06692850924285,0.189703492710268,0.146211715726001,0.146211715726001
@@ -4230,7 +4230,7 @@ SSP5,USA,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Fre
 SSP5,USA,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1,1,1,1,1
 SSP5,USA,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1,1,1,1,1
 SSP5,USA,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0298007305055295,0.25,0.785611032030326,0.785611032030326
-SSP5,USA,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0118564682943918,0.134470710684997,0.762059301457946,0.762059301457946
+SSP5,USA,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0118564682943918,0.134470710684998,0.762059301457946,0.762059301457946
 SSP5,USA,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.03,0.25,0.5,0.8,0.8
 SSP5,USA,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.03,0.25,0.5,0.8,0.8
 SSP5,USA,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0298007305055295,0.25,0.785611032030326,0.785611032030326
@@ -4301,18 +4301,18 @@ SSP2EU,CAZ,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,F
 SSP2EU,CAZ,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1,1,1,1,1
 SSP2EU,CAZ,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1,1,1,1,1
 SSP2EU,CAZ,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.119202922022118,0.35,0.491006895018954,0.491006895018954
-SSP2EU,CAZ,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.047425873177567,0.188258994958996,0.476287063411217,0.476287063411217
-SSP2EU,CAZ,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.047425873177567,0.188258994958996,0.476287063411217,0.476287063411217
-SSP2EU,CAZ,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.047425873177567,0.188258994958996,0.476287063411217,0.476287063411217
+SSP2EU,CAZ,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.047425873177567,0.188258994958997,0.476287063411217,0.476287063411217
+SSP2EU,CAZ,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.047425873177567,0.188258994958997,0.476287063411217,0.476287063411217
+SSP2EU,CAZ,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.047425873177567,0.188258994958997,0.476287063411217,0.476287063411217
 SSP2EU,CAZ,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.119202922022118,0.35,0.491006895018954,0.491006895018954
-SSP2EU,CAZ,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.012363115783175,0.017986209962092,0.0954351880334422,0.0954351880334422
+SSP2EU,CAZ,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.012363115783175,0.017986209962092,0.0954351880334419,0.0954351880334419
 SSP2EU,CAZ,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.033464254621425,0.047425873177567,0.146211715726001,0.146211715726001
 SSP2EU,CAZ,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.012363115783175,0.017986209962092,0.1,0.1
 SSP2EU,CAZ,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.012363115783175,0.017986209962092,0.1,0.1
 SSP2EU,CAZ,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.012363115783175,0.017986209962092,0.1,0.1
 SSP2EU,CAZ,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.033464254621425,0.047425873177567,0.146211715726001,0.146211715726001
 SSP2EU,CAZ,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0,8.31528027664132e-07,4.53978687024344e-05,0.119202922022118,0.119202922022118
-SSP2EU,CAZ,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1,1,1,0.954351880334422,0.954351880334422
+SSP2EU,CAZ,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1,1,1,0.954351880334419,0.954351880334419
 SSP2EU,CAZ,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1,1,1,1,1
 SSP2EU,CAZ,Liquids,Domestic Ship_tmp_vehicletype,Domestic Ship_tmp_subsector_L1,Domestic Ship_tmp_subsector_L2,Domestic Ship,trn_freight,FV,linear,1,1,1,1,1
 SSP2EU,CAZ,Liquids,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1,1,1,1,1
@@ -4327,7 +4327,7 @@ SSP2EU,CAZ,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_roa
 SSP2EU,CAZ,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,1,1,1,1
 SSP2EU,CAZ,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,1,1,1,1
 SSP2EU,CAZ,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,1,1,1,1
-SSP2EU,CAZ,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.031042108230522,0.056541000119193,0.107538783896534,0.199969502302122,0.199969502302122
+SSP2EU,CAZ,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.031042108230522,0.056541000119193,0.107538783896534,0.199969502302121,0.199969502302121
 SSP2EU,CAZ,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.026315789473684,0.078947368421053,0.184210526315789,0.184210526315789
 SSP2EU,CAZ,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.026315789473684,0.078947368421053,0.184210526315789,0.184210526315789
 SSP2EU,CAZ,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.026315789473684,0.078947368421053,0.184210526315789,0.184210526315789
@@ -4344,7 +4344,7 @@ SSP2EU,CHA,"","","","",Passenger Rail,trn_pass,S3S,linear,0.00546103419952829,0.
 SSP2EU,CHA,"","","","",Walk,trn_pass,S3S,linear,0.877713076761744,1,1,1,1
 SSP2EU,CHA,"","","","",trn_freight_road,trn_freight,S3S,linear,1,1,1,1,1
 SSP2EU,CHA,"","","","",trn_pass_road,trn_pass,S3S,linear,1,0.455729794383114,0.227864897191557,0.0584268967157839,0.0584268967157839
-SSP2EU,CHA,"","","",Bus,trn_pass_road,trn_pass,S2S3,linear,0.254432114324843,0.191544432089459,0.170509316525779,0.189454796139754,0.189454796139754
+SSP2EU,CHA,"","","",Bus,trn_pass_road,trn_pass,S2S3,linear,0.381648171487265,0.191544432089459,0.170509316525779,0.189454796139754,0.189454796139754
 SSP2EU,CHA,"","","",trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1,1,1,1,1
 SSP2EU,CHA,"","",trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,0.01080602223644,0.009522807095863,0.006956376814708,0.001823516252399,0.001823516252399
 SSP2EU,CHA,"","",trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1,1,1,1,1
@@ -4372,14 +4372,14 @@ SSP2EU,CHA,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_ro
 SSP2EU,CHA,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.1,0.4,0.9,1,1
 SSP2EU,CHA,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.1,0.4,0.9,1,1
 SSP2EU,CHA,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0476811688088472,0.45,0.982013790037908,0.982013790037908
-SSP2EU,CHA,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.022253608409715,0.0668777976648958,0.0699858045578576,0.0699858045578576
+SSP2EU,CHA,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.022253608409715,0.0668777976648955,0.0699858045578576,0.0699858045578576
 SSP2EU,CHA,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.001338570184857,0.0284555239065402,0.146211715726001,0.146211715726001
 SSP2EU,CHA,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.000494524631327,0.0107917259772552,0.1,0.1
 SSP2EU,CHA,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.01,0.2,0.6,0.2,0.2
 SSP2EU,CHA,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.01,0.2,0.6,0.2,0.2
 SSP2EU,CHA,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.001338570184857,0.0284555239065402,0.146211715726001,0.146211715726001
 SSP2EU,CHA,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0,8.31528027664132e-07,4.53978687024344e-05,0.119202922022118,0.119202922022118
-SSP2EU,CHA,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1,1,0.743656365691809,0.349929022789288,0.349929022789288
+SSP2EU,CHA,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1,1,0.743656365691807,0.349929022789288,0.349929022789288
 SSP2EU,CHA,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1,1,1,1,1
 SSP2EU,CHA,Liquids,Domestic Ship_tmp_vehicletype,Domestic Ship_tmp_subsector_L1,Domestic Ship_tmp_subsector_L2,Domestic Ship,trn_freight,FV,linear,1,1,1,1,1
 SSP2EU,CHA,Liquids,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1,1,1,1,1
@@ -4394,7 +4394,7 @@ SSP2EU,CHA,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_roa
 SSP2EU,CHA,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,1,1,1,1
 SSP2EU,CHA,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,1,1,1,1
 SSP2EU,CHA,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,1,1,1,1
-SSP2EU,CHA,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.142120012637288,0.159432643883675,0.090195248368545,0.115174077598356,0.115174077598356
+SSP2EU,CHA,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.142120012637288,0.159432643883675,0.0901952483685446,0.115174077598355,0.115174077598355
 SSP2EU,CHA,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.8778097236668e-05,0.013188367964814,0.0553035143317804,0.0921307947813305,0.0921307947813305
 SSP2EU,CHA,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.0007853553299874,0.014432374877611,0.0569509829460257,0.093173070843404,0.093173070843404
 SSP2EU,CHA,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.3,0.5,0.7,0.5,0.5
@@ -4435,16 +4435,16 @@ SSP2EU,DEU,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,F
 SSP2EU,DEU,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1,1,1,1,1
 SSP2EU,DEU,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1,1,1,1,1
 SSP2EU,DEU,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.298007305055295,0.675,0.982013790037908,0.982013790037908
-SSP2EU,DEU,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.118564682943918,0.363070918849493,0.952574126822433,0.952574126822433
-SSP2EU,DEU,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.118564682943918,0.363070918849493,0.952574126822433,0.952574126822433
-SSP2EU,DEU,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.118564682943918,0.363070918849493,0.952574126822433,0.952574126822433
+SSP2EU,DEU,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.118564682943917,0.363070918849493,0.952574126822433,0.952574126822433
+SSP2EU,DEU,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.118564682943917,0.363070918849493,0.952574126822433,0.952574126822433
+SSP2EU,DEU,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.118564682943917,0.363070918849493,0.952574126822433,0.952574126822433
 SSP2EU,DEU,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.298007305055295,0.675,0.982013790037908,0.982013790037908
 SSP2EU,DEU,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.002472623156635,0.017986209962092,0.05,0.05
-SSP2EU,DEU,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.08031421109142,0.331981112242969,0.219317573589002,0.219317573589002
+SSP2EU,DEU,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.08031421109142,0.331981112242969,0.219317573589001,0.219317573589001
 SSP2EU,DEU,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.02967147787962,0.125903469734644,0.15,0.15
 SSP2EU,DEU,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.02967147787962,0.125903469734644,0.15,0.15
 SSP2EU,DEU,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.02967147787962,0.125903469734644,0.15,0.15
-SSP2EU,DEU,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.08031421109142,0.331981112242969,0.219317573589002,0.219317573589002
+SSP2EU,DEU,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.08031421109142,0.331981112242969,0.219317573589001,0.219317573589001
 SSP2EU,DEU,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0,8.31528027664132e-07,4.53978687024344e-05,0.119202922022118,0.119202922022118
 SSP2EU,DEU,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1,1,1,1,1
 SSP2EU,DEU,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1,1,1,1,1
@@ -4569,9 +4569,9 @@ SSP2EU,ECS,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,F
 SSP2EU,ECS,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1,1,1,1,1
 SSP2EU,ECS,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1,1,1,1,1
 SSP2EU,ECS,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.119202922022118,0.25,0.294604137011372,0.294604137011372
-SSP2EU,ECS,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.047425873177567,0.134470710684997,0.28577223804673,0.28577223804673
-SSP2EU,ECS,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.047425873177567,0.134470710684997,0.28577223804673,0.28577223804673
-SSP2EU,ECS,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.047425873177567,0.134470710684997,0.28577223804673,0.28577223804673
+SSP2EU,ECS,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.047425873177567,0.134470710684998,0.28577223804673,0.28577223804673
+SSP2EU,ECS,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.047425873177567,0.134470710684998,0.28577223804673,0.28577223804673
+SSP2EU,ECS,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.047425873177567,0.134470710684998,0.28577223804673,0.28577223804673
 SSP2EU,ECS,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.119202922022118,0.25,0.294604137011372,0.294604137011372
 SSP2EU,ECS,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.002472623156635,0.053958629886276,0.1,0.1
 SSP2EU,ECS,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.01338570184857,0.047425873177567,0.0731058578630005,0.0731058578630005
@@ -4649,7 +4649,7 @@ SSP2EU,ENC,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_t
 SSP2EU,ENC,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.02472623156635,0.08993104981046,0.1,0.1
 SSP2EU,ENC,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.06692850924285,0.237129365887835,0.146211715726001,0.146211715726001
 SSP2EU,ENC,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0,8.31528027664132e-07,4.53978687024344e-05,0.119202922022118,0.119202922022118
-SSP2EU,ENC,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1,1,1,0.524893534183932,0.524893534183932
+SSP2EU,ENC,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1,1,1,0.524893534183931,0.524893534183931
 SSP2EU,ENC,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1,1,1,1,1
 SSP2EU,ENC,Liquids,Domestic Ship_tmp_vehicletype,Domestic Ship_tmp_subsector_L1,Domestic Ship_tmp_subsector_L2,Domestic Ship,trn_freight,FV,linear,1,1,1,1,1
 SSP2EU,ENC,Liquids,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,0.1341454314254,0.1341454314254,0.1341454314254,0.1341454314254,0.1341454314254
@@ -4767,7 +4767,7 @@ SSP2EU,ESW,"",Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tm
 SSP2EU,ESW,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0,0,0,0,0
 SSP2EU,ESW,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0,0,0,0,0
 SSP2EU,ESW,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0,0,0,0,0
-SSP2EU,ESW,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.118564682943918,0.268941421369995,0.666801888775703,0.666801888775703
+SSP2EU,ESW,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.118564682943917,0.268941421369995,0.666801888775703,0.666801888775703
 SSP2EU,ESW,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,0.72951273091157,0.763323639547623,0.830945456819731,0.966189091363946,0.966189091363946
 SSP2EU,ESW,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1,1,1,1,1
 SSP2EU,ESW,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1,1,1,1,1
@@ -4906,18 +4906,18 @@ SSP2EU,FRA,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,F
 SSP2EU,FRA,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1,1,1,1,1
 SSP2EU,FRA,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1,1,1,1,1
 SSP2EU,FRA,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.298007305055295,0.75,0.982013790037908,0.982013790037908
-SSP2EU,FRA,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.118564682943918,0.403412132054992,0.952574126822433,0.952574126822433
-SSP2EU,FRA,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.118564682943918,0.403412132054992,0.952574126822433,0.952574126822433
-SSP2EU,FRA,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.118564682943918,0.403412132054992,0.952574126822433,0.952574126822433
+SSP2EU,FRA,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.118564682943917,0.403412132054992,0.952574126822433,0.952574126822433
+SSP2EU,FRA,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.118564682943917,0.403412132054992,0.952574126822433,0.952574126822433
+SSP2EU,FRA,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.118564682943917,0.403412132054992,0.952574126822433,0.952574126822433
 SSP2EU,FRA,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.298007305055295,0.75,0.982013790037908,0.982013790037908
-SSP2EU,FRA,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.012363115783175,0.017986209962092,0.0954351880334422,0.0954351880334422
+SSP2EU,FRA,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.012363115783175,0.017986209962092,0.0954351880334419,0.0954351880334419
 SSP2EU,FRA,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.06692850924285,0.047425873177567,0.146211715726001,0.146211715726001
 SSP2EU,FRA,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.02472623156635,0.017986209962092,0.1,0.1
 SSP2EU,FRA,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.02472623156635,0.017986209962092,0.1,0.1
 SSP2EU,FRA,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.02472623156635,0.017986209962092,0.1,0.1
 SSP2EU,FRA,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.06692850924285,0.047425873177567,0.146211715726001,0.146211715726001
 SSP2EU,FRA,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0,8.31528027664132e-07,4.53978687024344e-05,0.119202922022118,0.119202922022118
-SSP2EU,FRA,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1,1,1,0.954351880334422,0.954351880334422
+SSP2EU,FRA,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1,1,1,0.954351880334419,0.954351880334419
 SSP2EU,FRA,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1,1,1,1,1
 SSP2EU,FRA,Liquids,Domestic Ship_tmp_vehicletype,Domestic Ship_tmp_subsector_L1,Domestic Ship_tmp_subsector_L2,Domestic Ship,trn_freight,FV,linear,1,1,1,1,1
 SSP2EU,FRA,Liquids,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,0.160770475713231,0.160770475713231,0.160770475713231,0.160770475713231,0.160770475713231
@@ -4932,7 +4932,7 @@ SSP2EU,FRA,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_roa
 SSP2EU,FRA,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,1,1,1,1
 SSP2EU,FRA,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,1,1,1,1
 SSP2EU,FRA,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,1,1,1,1
-SSP2EU,FRA,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.026315789473684,0.078947368421053,0.175801662166867,0.175801662166867
+SSP2EU,FRA,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.026315789473684,0.078947368421053,0.175801662166866,0.175801662166866
 SSP2EU,FRA,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.026315789473684,0.078947368421053,0.184210526315789,0.184210526315789
 SSP2EU,FRA,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.026315789473684,0.078947368421053,0.184210526315789,0.184210526315789
 SSP2EU,FRA,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.026315789473684,0.078947368421053,0.184210526315789,0.184210526315789
@@ -4949,7 +4949,7 @@ SSP2EU,IND,"","","","",Passenger Rail,trn_pass,S3S,linear,0.000684210526315789,8
 SSP2EU,IND,"","","","",Walk,trn_pass,S3S,linear,0.131578947368421,0.0945454545454544,0.181818181818182,1,1
 SSP2EU,IND,"","","","",trn_freight_road,trn_freight,S3S,linear,1,1,1,1,1
 SSP2EU,IND,"","","","",trn_pass_road,trn_pass,S3S,linear,1,1,1,1,1
-SSP2EU,IND,"","","",Bus,trn_pass_road,trn_pass,S2S3,linear,0.118824252562298,0.0625,0.0323053436653747,0.0323053436653747,0.0323053436653747
+SSP2EU,IND,"","","",Bus,trn_pass_road,trn_pass,S2S3,linear,0.118824252562298,0.0714285714285714,0.0323053436653747,0.0323053436653747,0.0323053436653747
 SSP2EU,IND,"","","",trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1,1,1,1,1
 SSP2EU,IND,"","",trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,0.003027158638145,0.002667683549865,0.001948733373306,0.000510833020187,0.000510833020187
 SSP2EU,IND,"","",trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1,1,1,1,1
@@ -5029,7 +5029,7 @@ SSP2EU,JPN,"",Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tm
 SSP2EU,JPN,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0,0,0,0,0
 SSP2EU,JPN,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0,0,0,0,0
 SSP2EU,JPN,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0,0,0,0,0
-SSP2EU,JPN,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.109079508308404,0.17929428091333,0.381029650728973,0.381029650728973
+SSP2EU,JPN,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.109079508308404,0.17929428091333,0.381029650728972,0.381029650728972
 SSP2EU,JPN,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1,1,1,1,1
 SSP2EU,JPN,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1,1,1,1,1
 SSP2EU,JPN,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1,1,1,1,1
@@ -5039,11 +5039,11 @@ SSP2EU,JPN,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_ro
 SSP2EU,JPN,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,0.0636363636363636,0.133333333333333,0.833333333333333,0.833333333333333
 SSP2EU,JPN,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.125163068123224,0.352941176470588,0.81834482503159,0.81834482503159
 SSP2EU,JPN,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.061815578915875,0.131898873055341,0.1,0.1
-SSP2EU,JPN,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.110432040250703,0.251078152116531,0.304607741095835,0.304607741095835
+SSP2EU,JPN,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.110432040250702,0.251078152116531,0.304607741095835,0.304607741095835
 SSP2EU,JPN,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,1,1,0.416666666666667,0.416666666666667
 SSP2EU,JPN,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,1,1,0.416666666666667,0.416666666666667
 SSP2EU,JPN,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,1,1,0.416666666666667,0.416666666666667
-SSP2EU,JPN,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.110432040250703,0.251078152116531,0.304607741095835,0.304607741095835
+SSP2EU,JPN,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.110432040250702,0.251078152116531,0.304607741095835,0.304607741095835
 SSP2EU,JPN,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0,8.31528027664132e-07,4.53978687024344e-05,0.119202922022118,0.119202922022118
 SSP2EU,JPN,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1,1,1,1,1
 SSP2EU,JPN,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1,1,1,1,1
@@ -5061,11 +5061,11 @@ SSP2EU,JPN,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_roa
 SSP2EU,JPN,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,0.0606060606060606,0.188888888888889,1,1
 SSP2EU,JPN,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,1,1,1,1
 SSP2EU,JPN,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.0078947368421052,0.0157894736842106,0.0230263157894736,0.0230263157894736
-SSP2EU,JPN,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.013157894736842,0.0464396284829724,0.0460526315789472,0.0460526315789472
+SSP2EU,JPN,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.013157894736842,0.0464396284829724,0.0460526315789473,0.0460526315789473
 SSP2EU,JPN,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,0.0303030303030303,0.111111111111111,0.25,0.25
 SSP2EU,JPN,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,0.0303030303030303,0.111111111111111,0.25,0.25
 SSP2EU,JPN,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,0.0303030303030303,0.111111111111111,0.25,0.25
-SSP2EU,JPN,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.013157894736842,0.0464396284829724,0.0460526315789472,0.0460526315789472
+SSP2EU,JPN,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.013157894736842,0.0464396284829724,0.0460526315789473,0.0460526315789473
 SSP2EU,LAM,"","","","",Cycle,trn_pass,S3S,linear,0.00981212891217365,0.0185165853437172,0.0462914633592929,0.231457316796465,0.231457316796465
 SSP2EU,LAM,"","","","",Domestic Aviation,trn_pass,S3S,linear,0.00840668890350734,0.0105762418419885,0.0264406046049712,0.0198304534537284,0.0198304534537284
 SSP2EU,LAM,"","","","",Domestic Ship,trn_freight,S3S,linear,0.009523329319276,0.009523329319276,0.00865757210843273,0.00793610776606333,0.00793610776606333
@@ -5077,7 +5077,7 @@ SSP2EU,LAM,"","","","",Passenger Rail,trn_pass,S3S,linear,0.134842686357634,0.12
 SSP2EU,LAM,"","","","",Walk,trn_pass,S3S,linear,0.899323352244677,0.848561904989659,0.848561904989659,0.848561904989659,0.848561904989659
 SSP2EU,LAM,"","","","",trn_freight_road,trn_freight,S3S,linear,1,1,1,1,1
 SSP2EU,LAM,"","","","",trn_pass_road,trn_pass,S3S,linear,1,1,1,1,1
-SSP2EU,LAM,"","","",Bus,trn_pass_road,trn_pass,S2S3,linear,0.138594539617622,0.086621587261014,0.086621587261014,0.086621587261014,0.086621587261014
+SSP2EU,LAM,"","","",Bus,trn_pass_road,trn_pass,S2S3,linear,0.173243174522027,0.108276984076267,0.086621587261014,0.086621587261014,0.086621587261014
 SSP2EU,LAM,"","","",trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1,1,1,1,1
 SSP2EU,LAM,"","",trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,0.137734442638184,0.137734442638184,0.137734442638184,0.137734442638184,0.137734442638184
 SSP2EU,LAM,"","",trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1,1,1,1,1
@@ -5100,23 +5100,23 @@ SSP2EU,LAM,"",Van,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,
 SSP2EU,LAM,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0,0,0,0,0
 SSP2EU,LAM,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0,0,0,0,0
 SSP2EU,LAM,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0,0,0,0,0
-SSP2EU,LAM,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.118564682943918,0.53788284273999,1,1
+SSP2EU,LAM,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.118564682943917,0.53788284273999,1,1
 SSP2EU,LAM,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,0.0681034247188,0.18459049662895,0.41756464044925,0.88351292808985,0.88351292808985
 SSP2EU,LAM,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1,1,1,1,1
 SSP2EU,LAM,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1,1,1,1,1
 SSP2EU,LAM,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.079468614681412,0.2,0.2400478153426,0.2400478153426
-SSP2EU,LAM,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0316172487850447,0.107576568547998,0.232851453223261,0.232851453223261
-SSP2EU,LAM,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0316172487850447,0.107576568547998,0.232851453223261,0.232851453223261
-SSP2EU,LAM,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0316172487850447,0.107576568547998,0.232851453223261,0.232851453223261
+SSP2EU,LAM,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0316172487850447,0.107576568547998,0.232851453223262,0.232851453223262
+SSP2EU,LAM,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0316172487850447,0.107576568547998,0.232851453223262,0.232851453223262
+SSP2EU,LAM,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0316172487850447,0.107576568547998,0.232851453223262,0.232851453223262
 SSP2EU,LAM,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.079468614681412,0.2,0.2400478153426,0.2400478153426
-SSP2EU,LAM,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.002472623156635,0.017986209962092,0.0656116917729915,0.0656116917729915
-SSP2EU,LAM,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.00892380123238,0.0569110478130804,0.0812287309588894,0.0812287309588894
+SSP2EU,LAM,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.002472623156635,0.017986209962092,0.0656116917729916,0.0656116917729916
+SSP2EU,LAM,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.00892380123238,0.0569110478130804,0.0812287309588893,0.0812287309588893
 SSP2EU,LAM,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.00329683087551333,0.0215834519545104,0.0555555555555556,0.0555555555555556
 SSP2EU,LAM,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.00329683087551333,0.0215834519545104,0.0555555555555556,0.0555555555555556
 SSP2EU,LAM,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.00329683087551333,0.0215834519545104,0.0555555555555556,0.0555555555555556
-SSP2EU,LAM,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.00892380123238,0.0569110478130804,0.0812287309588894,0.0812287309588894
+SSP2EU,LAM,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.00892380123238,0.0569110478130804,0.0812287309588893,0.0812287309588893
 SSP2EU,LAM,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0,8.31528027664132e-07,4.53978687024344e-05,0.119202922022118,0.119202922022118
-SSP2EU,LAM,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1,1,1,0.721728609502907,0.721728609502907
+SSP2EU,LAM,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1,1,1,0.721728609502908,0.721728609502908
 SSP2EU,LAM,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1,1,1,1,1
 SSP2EU,LAM,Liquids,Domestic Ship_tmp_vehicletype,Domestic Ship_tmp_subsector_L1,Domestic Ship_tmp_subsector_L2,Domestic Ship,trn_freight,FV,linear,1,1,1,1,1
 SSP2EU,LAM,Liquids,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1,1,1,1,1
@@ -5132,11 +5132,11 @@ SSP2EU,LAM,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_roa
 SSP2EU,LAM,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,1,1,1,1
 SSP2EU,LAM,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,1,1,1,1
 SSP2EU,LAM,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.026893682222235,0.0472515688947483,0.10371786520469,0.135258574225718,0.135258574225718
-SSP2EU,LAM,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0175438596491227,0.0315789473684212,0.0614035087719297,0.0614035087719297
-SSP2EU,LAM,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0175438596491227,0.0315789473684212,0.0614035087719297,0.0614035087719297
-SSP2EU,LAM,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0175438596491227,0.0315789473684212,0.0614035087719297,0.0614035087719297
-SSP2EU,LAM,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0175438596491227,0.0315789473684212,0.0614035087719297,0.0614035087719297
-SSP2EU,LAM,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0175438596491227,0.0315789473684212,0.0614035087719297,0.0614035087719297
+SSP2EU,LAM,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0175438596491227,0.0315789473684212,0.0614035087719296,0.0614035087719296
+SSP2EU,LAM,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0175438596491227,0.0315789473684212,0.0614035087719296,0.0614035087719296
+SSP2EU,LAM,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0175438596491227,0.0315789473684212,0.0614035087719296,0.0614035087719296
+SSP2EU,LAM,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0175438596491227,0.0315789473684212,0.0614035087719296,0.0614035087719296
+SSP2EU,LAM,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0175438596491227,0.0315789473684212,0.0614035087719296,0.0614035087719296
 SSP2EU,MEA,"","","","",Cycle,trn_pass,S3S,linear,0.0165975108305109,0.0165975108305109,0.0165975108305109,0.0414937770762773,0.0414937770762773
 SSP2EU,MEA,"","","","",Domestic Aviation,trn_pass,S3S,linear,0.0089294530094782,0.00595296867298547,0.0178589060189564,0.0238118746919419,0.0238118746919419
 SSP2EU,MEA,"","","","",Domestic Ship,trn_freight,S3S,linear,0.002022051343562,0.002022051343562,0.002022051343562,0.002022051343562,0.002022051343562
@@ -5148,7 +5148,7 @@ SSP2EU,MEA,"","","","",Passenger Rail,trn_pass,S3S,linear,0.000556730785330985,0
 SSP2EU,MEA,"","","","",Walk,trn_pass,S3S,linear,1,1,1,1,1
 SSP2EU,MEA,"","","","",trn_freight_road,trn_freight,S3S,linear,1,1,1,1,1
 SSP2EU,MEA,"","","","",trn_pass_road,trn_pass,S3S,linear,0.639480996474237,0.71967693403545,0.71967693403545,0.71967693403545,0.71967693403545
-SSP2EU,MEA,"","","",Bus,trn_pass_road,trn_pass,S2S3,linear,0.183919217151252,0.122612811434168,0.0613064057170841,0.0490451245736673,0.0490451245736673
+SSP2EU,MEA,"","","",Bus,trn_pass_road,trn_pass,S2S3,linear,0.262741738787503,0.122612811434168,0.0613064057170841,0.0490451245736673,0.0490451245736673
 SSP2EU,MEA,"","","",trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1,1,1,1,1
 SSP2EU,MEA,"","",trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,0.007508394761241,0.007508394761241,0.007508394761241,0.007508394761241,0.007508394761241
 SSP2EU,MEA,"","",trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1,1,1,1,1
@@ -5165,12 +5165,12 @@ SSP2EU,MEA,"",Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tm
 SSP2EU,MEA,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1,1,1,1,1
 SSP2EU,MEA,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0,0,0,0,0
 SSP2EU,MEA,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1,1,1,1,1
-SSP2EU,MEA,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.047425873177567,0.295835563506995,0.654894712190423,0.654894712190423
+SSP2EU,MEA,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.047425873177567,0.295835563506994,0.654894712190425,0.654894712190425
 SSP2EU,MEA,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,0.402051171672381,0.476794775213334,0.626281982295238,0.925256396459048,0.925256396459048
 SSP2EU,MEA,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1,1,1,1,1
 SSP2EU,MEA,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1,1,1,1,1
 SSP2EU,MEA,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.059601461011059,0.1,0.14028768429113,0.14028768429113
-SSP2EU,MEA,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0237129365887835,0.053788284273999,0.13608201811749,0.13608201811749
+SSP2EU,MEA,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0237129365887835,0.053788284273999,0.136082018117491,0.136082018117491
 SSP2EU,MEA,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,0.142857142857143,0.2,0.142857142857143,0.142857142857143
 SSP2EU,MEA,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,0.142857142857143,0.2,0.142857142857143,0.142857142857143
 SSP2EU,MEA,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.059601461011059,0.1,0.14028768429113,0.14028768429113
@@ -5282,7 +5282,7 @@ SSP2EU,NES,"","","","",Passenger Rail,trn_pass,S3S,linear,0.00160675014597331,0.
 SSP2EU,NES,"","","","",Walk,trn_pass,S3S,linear,1,1,1,1,1
 SSP2EU,NES,"","","","",trn_freight_road,trn_freight,S3S,linear,1,1,1,1,1
 SSP2EU,NES,"","","","",trn_pass_road,trn_pass,S3S,linear,0.925821312685462,0.717579145423199,0.456641274360218,0.25115270089812,0.25115270089812
-SSP2EU,NES,"","","",Bus,trn_pass_road,trn_pass,S2S3,linear,0.021994137000963,0.0183284475008025,0.0109970685004815,0.0109970685004815,0.0109970685004815
+SSP2EU,NES,"","","",Bus,trn_pass_road,trn_pass,S2S3,linear,0.0549853425024075,0.021994137000963,0.0109970685004815,0.0109970685004815,0.0109970685004815
 SSP2EU,NES,"","","",trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1,1,1,1,1
 SSP2EU,NES,"","",trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,0.004922521505832,0.004922521505832,0.004922521505832,0.004922521505832,0.004922521505832
 SSP2EU,NES,"","",trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1,1,1,1,1
@@ -5351,7 +5351,7 @@ SSP2EU,OAS,"","","","",Passenger Rail,trn_pass,S3S,linear,0.00077008869031218,0.
 SSP2EU,OAS,"","","","",Walk,trn_pass,S3S,linear,1,0.689328623982319,0.689328623982319,0.689328623982319,0.689328623982319
 SSP2EU,OAS,"","","","",trn_freight_road,trn_freight,S3S,linear,1,1,1,1,1
 SSP2EU,OAS,"","","","",trn_pass_road,trn_pass,S3S,linear,0.87209012211972,1,1,1,1
-SSP2EU,OAS,"","","",Bus,trn_pass_road,trn_pass,S2S3,linear,0.160206681607861,0.110191151172767,0.0550955755863836,0.0550955755863836,0.0550955755863836
+SSP2EU,OAS,"","","",Bus,trn_pass_road,trn_pass,S2S3,linear,0.240310022411792,0.140243283310795,0.0550955755863836,0.0550955755863836,0.0550955755863836
 SSP2EU,OAS,"","","",trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1,1,1,1,1
 SSP2EU,OAS,"","",trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,0.025341509717687,0.022332205438712,0.016313596880761,0.00427637976486,0.00427637976486
 SSP2EU,OAS,"","",trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1,1,1,1,1
@@ -5379,18 +5379,18 @@ SSP2EU,OAS,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,F
 SSP2EU,OAS,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1,1,1,1,1
 SSP2EU,OAS,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,0.352966479972375,0.433845669975828,0.595604049982734,0.919120809996547,0.919120809996547
 SSP2EU,OAS,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.039734307340706,0.0625,0.0785611032030326,0.0785611032030326
-SSP2EU,OAS,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0158086243925223,0.0336176776712494,0.0762059301457946,0.0762059301457946
-SSP2EU,OAS,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0158086243925223,0.0336176776712494,0.0762059301457946,0.0762059301457946
-SSP2EU,OAS,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0158086243925223,0.0336176776712494,0.0762059301457946,0.0762059301457946
+SSP2EU,OAS,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0158086243925223,0.0336176776712495,0.0762059301457946,0.0762059301457946
+SSP2EU,OAS,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0158086243925223,0.0336176776712495,0.0762059301457946,0.0762059301457946
+SSP2EU,OAS,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0158086243925223,0.0336176776712495,0.0762059301457946,0.0762059301457946
 SSP2EU,OAS,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.039734307340706,0.0625,0.0785611032030326,0.0785611032030326
-SSP2EU,OAS,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.002472623156635,0.017986209962092,0.0656116917729915,0.0656116917729915
+SSP2EU,OAS,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.002472623156635,0.017986209962092,0.0656116917729916,0.0656116917729916
 SSP2EU,OAS,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.011154751540475,0.0118564682943918,0.0292423431452002,0.0292423431452002
 SSP2EU,OAS,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.00412103859439167,0.004496552490523,0.02,0.02
 SSP2EU,OAS,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.00412103859439167,0.004496552490523,0.02,0.02
 SSP2EU,OAS,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.00412103859439167,0.004496552490523,0.02,0.02
 SSP2EU,OAS,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.011154751540475,0.0118564682943918,0.0292423431452002,0.0292423431452002
 SSP2EU,OAS,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0,8.31528027664132e-07,4.53978687024344e-05,0.119202922022118,0.119202922022118
-SSP2EU,OAS,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1,1,1,0.656116917729915,0.656116917729915
+SSP2EU,OAS,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1,1,1,0.656116917729916,0.656116917729916
 SSP2EU,OAS,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1,1,1,1,1
 SSP2EU,OAS,Liquids,Domestic Ship_tmp_vehicletype,Domestic Ship_tmp_subsector_L1,Domestic Ship_tmp_subsector_L2,Domestic Ship,trn_freight,FV,linear,1,1,1,1,1
 SSP2EU,OAS,Liquids,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1,1,1,1,1
@@ -5422,7 +5422,7 @@ SSP2EU,REF,"","","","",Passenger Rail,trn_pass,S3S,linear,0.00236561326843326,0.
 SSP2EU,REF,"","","","",Walk,trn_pass,S3S,linear,0.317883555031073,0.317883555031073,0.317883555031073,1,1
 SSP2EU,REF,"","","","",trn_freight_road,trn_freight,S3S,linear,1,1,1,1,1
 SSP2EU,REF,"","","","",trn_pass_road,trn_pass,S3S,linear,1,1,1,0.943741804984768,0.943741804984768
-SSP2EU,REF,"","","",Bus,trn_pass_road,trn_pass,S2S3,linear,0.106725224568562,0.0914787639159102,0.0762323032632585,0.0609858426106068,0.0609858426106068
+SSP2EU,REF,"","","",Bus,trn_pass_road,trn_pass,S2S3,linear,0.118583582853958,0.0914787639159102,0.0762323032632585,0.0609858426106068,0.0609858426106068
 SSP2EU,REF,"","","",trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1,1,1,1,1
 SSP2EU,REF,"","",trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,0.369757606378564,0.369757606378564,0.369757606378564,0.369757606378564,0.369757606378564
 SSP2EU,REF,"","",trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1,1,1,1,1
@@ -5479,18 +5479,18 @@ SSP2EU,REF,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp
 SSP2EU,REF,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.063108879885637,0.087763909362331,0.137073968315718,0.188555268977994,0.188555268977994
 SSP2EU,REF,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.030480218828266,0.055993897280154,0.107021254183929,0.167260774393184,0.167260774393184
 SSP2EU,REF,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.026315789473684,0.078947368421053,0.147368421052631,0.147368421052631
-SSP2EU,SSA,"","","","",Cycle,trn_pass,S3S,linear,0.013878678157857,0.0179527662940391,0.0291452241314997,0.0327883771479372,0.0327883771479372
-SSP2EU,SSA,"","","","",Domestic Aviation,trn_pass,S3S,linear,0.00901317336217352,0.0509980791548766,0.0413961398176937,0.00620942097265405,0.00620942097265405
+SSP2EU,SSA,"","","","",Cycle,trn_pass,S3S,linear,0.013878678157857,0.017952766294039,0.0291452241314997,0.0327883771479372,0.0327883771479372
+SSP2EU,SSA,"","","","",Domestic Aviation,trn_pass,S3S,linear,0.00901317336217352,0.0509980791548764,0.0413961398176937,0.00620942097265405,0.00620942097265405
 SSP2EU,SSA,"","","","",Domestic Ship,trn_freight,S3S,linear,0.001467441828354,0.001467441828354,0.001467441828354,0.001467441828354,0.001467441828354
 SSP2EU,SSA,"","","","",Freight Rail,trn_freight,S3S,linear,0.01634165332484,0.01634165332484,0.01634165332484,0.01634165332484,0.01634165332484
-SSP2EU,SSA,"","","","",HSR,trn_pass,S3S,linear,1.47506311523337e-05,2.00316440897408e-05,0.0650403115771387,0.0097560467365708,0.0097560467365708
+SSP2EU,SSA,"","","","",HSR,trn_pass,S3S,linear,1.47506311523337e-05,2.00316440897407e-05,0.0650403115771387,0.0097560467365708,0.0097560467365708
 SSP2EU,SSA,"","","","",International Aviation,trn_aviation_intl,S3S,linear,1,1,1,1,1
 SSP2EU,SSA,"","","","",International Ship,trn_shipping_intl,S3S,linear,1,1,1,1,1
-SSP2EU,SSA,"","","","",Passenger Rail,trn_pass,S3S,linear,0.000602417147703971,0.00155851359059413,0.00253015202035668,0.000569284204580253,0.000569284204580253
-SSP2EU,SSA,"","","","",Walk,trn_pass,S3S,linear,1,0.903431854876908,1,1,1
+SSP2EU,SSA,"","","","",Passenger Rail,trn_pass,S3S,linear,0.000602417147703971,0.00155851359059412,0.00253015202035668,0.000569284204580253,0.000569284204580253
+SSP2EU,SSA,"","","","",Walk,trn_pass,S3S,linear,1,0.903431854876905,1,1,1
 SSP2EU,SSA,"","","","",trn_freight_road,trn_freight,S3S,linear,1,1,1,1,1
-SSP2EU,SSA,"","","","",trn_pass_road,trn_pass,S3S,linear,0.890164318010016,1,0.974063506007212,0.0974063506007212,0.0974063506007212
-SSP2EU,SSA,"","","",Bus,trn_pass_road,trn_pass,S2S3,linear,0.206400000437543,0.105846154070534,0.0732781066642163,0.0952615386634812,0.0952615386634812
+SSP2EU,SSA,"","","","",trn_pass_road,trn_pass,S3S,linear,0.890164318010017,1,0.974063506007213,0.0974063506007212,0.0974063506007212
+SSP2EU,SSA,"","","",Bus,trn_pass_road,trn_pass,S2S3,linear,0.247680000525051,0.127015384884641,0.0732781066642163,0.0952615386634812,0.0952615386634812
 SSP2EU,SSA,"","","",trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1,1,1,1,1
 SSP2EU,SSA,"","",trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,0.039283595822529,0.039283595822529,0.039283595822529,0.039283595822529,0.039283595822529
 SSP2EU,SSA,"","",trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1,1,1,1,1
@@ -5520,11 +5520,11 @@ SSP2EU,SSA,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_ro
 SSP2EU,SSA,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0094851746355134,0.053788284273999,0.14654986566499,0.14654986566499
 SSP2EU,SSA,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0238405844044236,0.1,0.151079044621217,0.151079044621217
 SSP2EU,SSA,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.002472623156635,0.017986209962092,0.075,0.075
-SSP2EU,SSA,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.006692850924285,0.047425873177567,0.0281176376396156,0.0281176376396156
+SSP2EU,SSA,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.006692850924285,0.047425873177567,0.0281176376396155,0.0281176376396155
 SSP2EU,SSA,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.002472623156635,0.017986209962092,0.0192307692307692,0.0192307692307692
 SSP2EU,SSA,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.002472623156635,0.017986209962092,0.0192307692307692,0.0192307692307692
 SSP2EU,SSA,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.002472623156635,0.017986209962092,0.0192307692307692,0.0192307692307692
-SSP2EU,SSA,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.006692850924285,0.047425873177567,0.0281176376396156,0.0281176376396156
+SSP2EU,SSA,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.006692850924285,0.047425873177567,0.0281176376396155,0.0281176376396155
 SSP2EU,SSA,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0,8.31528027664132e-07,4.53978687024344e-05,0.119202922022118,0.119202922022118
 SSP2EU,SSA,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1,1,1,1,1
 SSP2EU,SSA,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1,1,1,1,1
@@ -5579,14 +5579,14 @@ SSP2EU,UKI,"",Van,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,
 SSP2EU,UKI,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0,0,0,0,0
 SSP2EU,UKI,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0,0,0,0,0
 SSP2EU,UKI,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0,0,0,0,0
-SSP2EU,UKI,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.118564682943918,0.322729705643994,0.85731671414019,0.85731671414019
+SSP2EU,UKI,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.118564682943917,0.322729705643994,0.85731671414019,0.85731671414019
 SSP2EU,UKI,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,0.826003073674058,0.847752689464801,0.891251921046287,0.978250384209257,0.978250384209257
 SSP2EU,UKI,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1,1,1,1,1
 SSP2EU,UKI,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1,1,1,1,1
 SSP2EU,UKI,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.238405844044236,0.55,0.883812411034117,0.883812411034117
-SSP2EU,UKI,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.094851746355134,0.295835563506995,0.85731671414019,0.85731671414019
-SSP2EU,UKI,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.094851746355134,0.295835563506995,0.85731671414019,0.85731671414019
-SSP2EU,UKI,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.094851746355134,0.295835563506995,0.85731671414019,0.85731671414019
+SSP2EU,UKI,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.094851746355134,0.295835563506994,0.85731671414019,0.85731671414019
+SSP2EU,UKI,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.094851746355134,0.295835563506994,0.85731671414019,0.85731671414019
+SSP2EU,UKI,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.094851746355134,0.295835563506994,0.85731671414019,0.85731671414019
 SSP2EU,UKI,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.238405844044236,0.55,0.883812411034117,0.883812411034117
 SSP2EU,UKI,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.012363115783175,0.017986209962092,0.1,0.1
 SSP2EU,UKI,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.06692850924285,0.189703492710268,0.146211715726001,0.146211715726001
@@ -5651,7 +5651,7 @@ SSP2EU,USA,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,F
 SSP2EU,USA,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1,1,1,1,1
 SSP2EU,USA,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1,1,1,1,1
 SSP2EU,USA,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0298007305055295,0.25,0.785611032030326,0.785611032030326
-SSP2EU,USA,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0118564682943918,0.134470710684997,0.762059301457946,0.762059301457946
+SSP2EU,USA,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0118564682943918,0.134470710684998,0.762059301457946,0.762059301457946
 SSP2EU,USA,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.03,0.25,0.5,0.8,0.8
 SSP2EU,USA,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.03,0.25,0.5,0.8,0.8
 SSP2EU,USA,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0298007305055295,0.25,0.785611032030326,0.785611032030326
@@ -5722,18 +5722,18 @@ SDP,CAZ,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Frei
 SDP,CAZ,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1,1,1,1,1
 SDP,CAZ,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1,1,1,1,1
 SDP,CAZ,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.119202922022118,0.35,0.491006895018954,0.491006895018954
-SDP,CAZ,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.047425873177567,0.188258994958996,0.476287063411217,0.476287063411217
-SDP,CAZ,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.047425873177567,0.188258994958996,0.476287063411217,0.476287063411217
-SDP,CAZ,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.047425873177567,0.188258994958996,0.476287063411217,0.476287063411217
+SDP,CAZ,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.047425873177567,0.188258994958997,0.476287063411217,0.476287063411217
+SDP,CAZ,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.047425873177567,0.188258994958997,0.476287063411217,0.476287063411217
+SDP,CAZ,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.047425873177567,0.188258994958997,0.476287063411217,0.476287063411217
 SDP,CAZ,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.119202922022118,0.35,0.491006895018954,0.491006895018954
-SDP,CAZ,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.012363115783175,0.017986209962092,0.0954351880334422,0.0954351880334422
+SDP,CAZ,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.012363115783175,0.017986209962092,0.0954351880334419,0.0954351880334419
 SDP,CAZ,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.033464254621425,0.047425873177567,0.146211715726001,0.146211715726001
 SDP,CAZ,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.012363115783175,0.017986209962092,0.1,0.1
 SDP,CAZ,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.012363115783175,0.017986209962092,0.1,0.1
 SDP,CAZ,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.012363115783175,0.017986209962092,0.1,0.1
 SDP,CAZ,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.033464254621425,0.047425873177567,0.146211715726001,0.146211715726001
 SDP,CAZ,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0,8.31528027664132e-07,4.53978687024344e-05,0.119202922022118,0.119202922022118
-SDP,CAZ,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1,1,1,0.954351880334422,0.954351880334422
+SDP,CAZ,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1,1,1,0.954351880334419,0.954351880334419
 SDP,CAZ,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1,1,1,1,1
 SDP,CAZ,Liquids,Domestic Ship_tmp_vehicletype,Domestic Ship_tmp_subsector_L1,Domestic Ship_tmp_subsector_L2,Domestic Ship,trn_freight,FV,linear,1,1,1,1,1
 SDP,CAZ,Liquids,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1,1,1,1,1
@@ -5748,7 +5748,7 @@ SDP,CAZ,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_t
 SDP,CAZ,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,1,1,1,1
 SDP,CAZ,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,1,1,1,1
 SDP,CAZ,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,1,1,1,1
-SDP,CAZ,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.031042108230522,0.056541000119193,0.107538783896534,0.199969502302122,0.199969502302122
+SDP,CAZ,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.031042108230522,0.056541000119193,0.107538783896534,0.199969502302121,0.199969502302121
 SDP,CAZ,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.026315789473684,0.078947368421053,0.184210526315789,0.184210526315789
 SDP,CAZ,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.026315789473684,0.078947368421053,0.184210526315789,0.184210526315789
 SDP,CAZ,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.026315789473684,0.078947368421053,0.184210526315789,0.184210526315789
@@ -5765,7 +5765,7 @@ SDP,CHA,"","","","",Passenger Rail,trn_pass,S3S,linear,0.00546103419952829,0.003
 SDP,CHA,"","","","",Walk,trn_pass,S3S,linear,0.877713076761744,1,1,1,1
 SDP,CHA,"","","","",trn_freight_road,trn_freight,S3S,linear,1,1,1,1,1
 SDP,CHA,"","","","",trn_pass_road,trn_pass,S3S,linear,1,0.455729794383114,0.227864897191557,0.0584268967157839,0.0584268967157839
-SDP,CHA,"","","",Bus,trn_pass_road,trn_pass,S2S3,linear,0.254432114324843,0.191544432089459,0.170509316525779,0.189454796139754,0.189454796139754
+SDP,CHA,"","","",Bus,trn_pass_road,trn_pass,S2S3,linear,0.381648171487265,0.191544432089459,0.170509316525779,0.189454796139754,0.189454796139754
 SDP,CHA,"","","",trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1,1,1,1,1
 SDP,CHA,"","",trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,0.01080602223644,0.009522807095863,0.006956376814708,0.001823516252399,0.001823516252399
 SDP,CHA,"","",trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1,1,1,1,1
@@ -5793,14 +5793,14 @@ SDP,CHA,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_
 SDP,CHA,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.1,0.4,0.9,1,1
 SDP,CHA,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.1,0.4,0.9,1,1
 SDP,CHA,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0476811688088472,0.45,0.982013790037908,0.982013790037908
-SDP,CHA,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.022253608409715,0.0668777976648958,0.0699858045578576,0.0699858045578576
+SDP,CHA,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.022253608409715,0.0668777976648955,0.0699858045578576,0.0699858045578576
 SDP,CHA,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.001338570184857,0.0284555239065402,0.146211715726001,0.146211715726001
 SDP,CHA,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.000494524631327,0.0107917259772552,0.1,0.1
 SDP,CHA,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.01,0.2,0.6,0.2,0.2
 SDP,CHA,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.01,0.2,0.6,0.2,0.2
 SDP,CHA,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.001338570184857,0.0284555239065402,0.146211715726001,0.146211715726001
 SDP,CHA,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0,8.31528027664132e-07,4.53978687024344e-05,0.119202922022118,0.119202922022118
-SDP,CHA,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1,1,0.743656365691809,0.349929022789288,0.349929022789288
+SDP,CHA,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1,1,0.743656365691807,0.349929022789288,0.349929022789288
 SDP,CHA,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1,1,1,1,1
 SDP,CHA,Liquids,Domestic Ship_tmp_vehicletype,Domestic Ship_tmp_subsector_L1,Domestic Ship_tmp_subsector_L2,Domestic Ship,trn_freight,FV,linear,1,1,1,1,1
 SDP,CHA,Liquids,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1,1,1,1,1
@@ -5815,7 +5815,7 @@ SDP,CHA,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_t
 SDP,CHA,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,1,1,1,1
 SDP,CHA,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,1,1,1,1
 SDP,CHA,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,1,1,1,1
-SDP,CHA,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.142120012637288,0.159432643883675,0.090195248368545,0.115174077598356,0.115174077598356
+SDP,CHA,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.142120012637288,0.159432643883675,0.0901952483685446,0.115174077598355,0.115174077598355
 SDP,CHA,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.8778097236668e-05,0.013188367964814,0.0553035143317804,0.0921307947813305,0.0921307947813305
 SDP,CHA,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.0007853553299874,0.014432374877611,0.0569509829460257,0.093173070843404,0.093173070843404
 SDP,CHA,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.3,0.5,0.7,0.5,0.5
@@ -5856,16 +5856,16 @@ SDP,DEU,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Frei
 SDP,DEU,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1,1,1,1,1
 SDP,DEU,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1,1,1,1,1
 SDP,DEU,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.298007305055295,0.675,0.982013790037908,0.982013790037908
-SDP,DEU,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.118564682943918,0.363070918849493,0.952574126822433,0.952574126822433
-SDP,DEU,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.118564682943918,0.363070918849493,0.952574126822433,0.952574126822433
-SDP,DEU,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.118564682943918,0.363070918849493,0.952574126822433,0.952574126822433
+SDP,DEU,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.118564682943917,0.363070918849493,0.952574126822433,0.952574126822433
+SDP,DEU,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.118564682943917,0.363070918849493,0.952574126822433,0.952574126822433
+SDP,DEU,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.118564682943917,0.363070918849493,0.952574126822433,0.952574126822433
 SDP,DEU,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.298007305055295,0.675,0.982013790037908,0.982013790037908
 SDP,DEU,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.002472623156635,0.017986209962092,0.05,0.05
-SDP,DEU,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.08031421109142,0.331981112242969,0.219317573589002,0.219317573589002
+SDP,DEU,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.08031421109142,0.331981112242969,0.219317573589001,0.219317573589001
 SDP,DEU,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.02967147787962,0.125903469734644,0.15,0.15
 SDP,DEU,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.02967147787962,0.125903469734644,0.15,0.15
 SDP,DEU,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.02967147787962,0.125903469734644,0.15,0.15
-SDP,DEU,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.08031421109142,0.331981112242969,0.219317573589002,0.219317573589002
+SDP,DEU,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.08031421109142,0.331981112242969,0.219317573589001,0.219317573589001
 SDP,DEU,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0,8.31528027664132e-07,4.53978687024344e-05,0.119202922022118,0.119202922022118
 SDP,DEU,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1,1,1,1,1
 SDP,DEU,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1,1,1,1,1
@@ -5990,9 +5990,9 @@ SDP,ECS,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Frei
 SDP,ECS,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1,1,1,1,1
 SDP,ECS,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1,1,1,1,1
 SDP,ECS,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.119202922022118,0.25,0.294604137011372,0.294604137011372
-SDP,ECS,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.047425873177567,0.134470710684997,0.28577223804673,0.28577223804673
-SDP,ECS,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.047425873177567,0.134470710684997,0.28577223804673,0.28577223804673
-SDP,ECS,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.047425873177567,0.134470710684997,0.28577223804673,0.28577223804673
+SDP,ECS,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.047425873177567,0.134470710684998,0.28577223804673,0.28577223804673
+SDP,ECS,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.047425873177567,0.134470710684998,0.28577223804673,0.28577223804673
+SDP,ECS,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.047425873177567,0.134470710684998,0.28577223804673,0.28577223804673
 SDP,ECS,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.119202922022118,0.25,0.294604137011372,0.294604137011372
 SDP,ECS,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.002472623156635,0.053958629886276,0.1,0.1
 SDP,ECS,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.01338570184857,0.047425873177567,0.0731058578630005,0.0731058578630005
@@ -6070,7 +6070,7 @@ SDP,ENC,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_
 SDP,ENC,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.02472623156635,0.08993104981046,0.1,0.1
 SDP,ENC,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.06692850924285,0.237129365887835,0.146211715726001,0.146211715726001
 SDP,ENC,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0,8.31528027664132e-07,4.53978687024344e-05,0.119202922022118,0.119202922022118
-SDP,ENC,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1,1,1,0.524893534183932,0.524893534183932
+SDP,ENC,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1,1,1,0.524893534183931,0.524893534183931
 SDP,ENC,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1,1,1,1,1
 SDP,ENC,Liquids,Domestic Ship_tmp_vehicletype,Domestic Ship_tmp_subsector_L1,Domestic Ship_tmp_subsector_L2,Domestic Ship,trn_freight,FV,linear,1,1,1,1,1
 SDP,ENC,Liquids,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,0.1341454314254,0.1341454314254,0.1341454314254,0.1341454314254,0.1341454314254
@@ -6188,7 +6188,7 @@ SDP,ESW,"",Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_s
 SDP,ESW,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0,0,0,0,0
 SDP,ESW,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0,0,0,0,0
 SDP,ESW,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0,0,0,0,0
-SDP,ESW,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.118564682943918,0.268941421369995,0.666801888775703,0.666801888775703
+SDP,ESW,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.118564682943917,0.268941421369995,0.666801888775703,0.666801888775703
 SDP,ESW,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,0.72951273091157,0.763323639547623,0.830945456819731,0.966189091363946,0.966189091363946
 SDP,ESW,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1,1,1,1,1
 SDP,ESW,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1,1,1,1,1
@@ -6327,18 +6327,18 @@ SDP,FRA,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Frei
 SDP,FRA,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1,1,1,1,1
 SDP,FRA,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1,1,1,1,1
 SDP,FRA,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.298007305055295,0.75,0.982013790037908,0.982013790037908
-SDP,FRA,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.118564682943918,0.403412132054992,0.952574126822433,0.952574126822433
-SDP,FRA,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.118564682943918,0.403412132054992,0.952574126822433,0.952574126822433
-SDP,FRA,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.118564682943918,0.403412132054992,0.952574126822433,0.952574126822433
+SDP,FRA,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.118564682943917,0.403412132054992,0.952574126822433,0.952574126822433
+SDP,FRA,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.118564682943917,0.403412132054992,0.952574126822433,0.952574126822433
+SDP,FRA,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.118564682943917,0.403412132054992,0.952574126822433,0.952574126822433
 SDP,FRA,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.298007305055295,0.75,0.982013790037908,0.982013790037908
-SDP,FRA,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.012363115783175,0.017986209962092,0.0954351880334422,0.0954351880334422
+SDP,FRA,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.012363115783175,0.017986209962092,0.0954351880334419,0.0954351880334419
 SDP,FRA,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.06692850924285,0.047425873177567,0.146211715726001,0.146211715726001
 SDP,FRA,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.02472623156635,0.017986209962092,0.1,0.1
 SDP,FRA,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.02472623156635,0.017986209962092,0.1,0.1
 SDP,FRA,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.02472623156635,0.017986209962092,0.1,0.1
 SDP,FRA,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.06692850924285,0.047425873177567,0.146211715726001,0.146211715726001
 SDP,FRA,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0,8.31528027664132e-07,4.53978687024344e-05,0.119202922022118,0.119202922022118
-SDP,FRA,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1,1,1,0.954351880334422,0.954351880334422
+SDP,FRA,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1,1,1,0.954351880334419,0.954351880334419
 SDP,FRA,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1,1,1,1,1
 SDP,FRA,Liquids,Domestic Ship_tmp_vehicletype,Domestic Ship_tmp_subsector_L1,Domestic Ship_tmp_subsector_L2,Domestic Ship,trn_freight,FV,linear,1,1,1,1,1
 SDP,FRA,Liquids,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,0.160770475713231,0.160770475713231,0.160770475713231,0.160770475713231,0.160770475713231
@@ -6353,7 +6353,7 @@ SDP,FRA,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_t
 SDP,FRA,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,1,1,1,1
 SDP,FRA,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,1,1,1,1
 SDP,FRA,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,1,1,1,1
-SDP,FRA,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.026315789473684,0.078947368421053,0.175801662166867,0.175801662166867
+SDP,FRA,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.026315789473684,0.078947368421053,0.175801662166866,0.175801662166866
 SDP,FRA,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.026315789473684,0.078947368421053,0.184210526315789,0.184210526315789
 SDP,FRA,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.026315789473684,0.078947368421053,0.184210526315789,0.184210526315789
 SDP,FRA,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.026315789473684,0.078947368421053,0.184210526315789,0.184210526315789
@@ -6370,7 +6370,7 @@ SDP,IND,"","","","",Passenger Rail,trn_pass,S3S,linear,0.000684210526315789,8e-0
 SDP,IND,"","","","",Walk,trn_pass,S3S,linear,0.131578947368421,0.0945454545454544,0.181818181818182,1,1
 SDP,IND,"","","","",trn_freight_road,trn_freight,S3S,linear,1,1,1,1,1
 SDP,IND,"","","","",trn_pass_road,trn_pass,S3S,linear,1,1,1,1,1
-SDP,IND,"","","",Bus,trn_pass_road,trn_pass,S2S3,linear,0.118824252562298,0.0625,0.0323053436653747,0.0323053436653747,0.0323053436653747
+SDP,IND,"","","",Bus,trn_pass_road,trn_pass,S2S3,linear,0.118824252562298,0.0714285714285714,0.0323053436653747,0.0323053436653747,0.0323053436653747
 SDP,IND,"","","",trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1,1,1,1,1
 SDP,IND,"","",trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,0.003027158638145,0.002667683549865,0.001948733373306,0.000510833020187,0.000510833020187
 SDP,IND,"","",trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1,1,1,1,1
@@ -6450,7 +6450,7 @@ SDP,JPN,"",Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_s
 SDP,JPN,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0,0,0,0,0
 SDP,JPN,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0,0,0,0,0
 SDP,JPN,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0,0,0,0,0
-SDP,JPN,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.109079508308404,0.17929428091333,0.381029650728973,0.381029650728973
+SDP,JPN,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.109079508308404,0.17929428091333,0.381029650728972,0.381029650728972
 SDP,JPN,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1,1,1,1,1
 SDP,JPN,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1,1,1,1,1
 SDP,JPN,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1,1,1,1,1
@@ -6460,11 +6460,11 @@ SDP,JPN,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_
 SDP,JPN,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,0.0636363636363636,0.133333333333333,0.833333333333333,0.833333333333333
 SDP,JPN,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.125163068123224,0.352941176470588,0.81834482503159,0.81834482503159
 SDP,JPN,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.061815578915875,0.131898873055341,0.1,0.1
-SDP,JPN,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.110432040250703,0.251078152116531,0.304607741095835,0.304607741095835
+SDP,JPN,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.110432040250702,0.251078152116531,0.304607741095835,0.304607741095835
 SDP,JPN,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,1,1,0.416666666666667,0.416666666666667
 SDP,JPN,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,1,1,0.416666666666667,0.416666666666667
 SDP,JPN,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,1,1,0.416666666666667,0.416666666666667
-SDP,JPN,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.110432040250703,0.251078152116531,0.304607741095835,0.304607741095835
+SDP,JPN,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.110432040250702,0.251078152116531,0.304607741095835,0.304607741095835
 SDP,JPN,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0,8.31528027664132e-07,4.53978687024344e-05,0.119202922022118,0.119202922022118
 SDP,JPN,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1,1,1,1,1
 SDP,JPN,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1,1,1,1,1
@@ -6482,11 +6482,11 @@ SDP,JPN,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_t
 SDP,JPN,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,0.0606060606060606,0.188888888888889,1,1
 SDP,JPN,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,1,1,1,1
 SDP,JPN,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.0078947368421052,0.0157894736842106,0.0230263157894736,0.0230263157894736
-SDP,JPN,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.013157894736842,0.0464396284829724,0.0460526315789472,0.0460526315789472
+SDP,JPN,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.013157894736842,0.0464396284829724,0.0460526315789473,0.0460526315789473
 SDP,JPN,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,0.0303030303030303,0.111111111111111,0.25,0.25
 SDP,JPN,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,0.0303030303030303,0.111111111111111,0.25,0.25
 SDP,JPN,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,0.0303030303030303,0.111111111111111,0.25,0.25
-SDP,JPN,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.013157894736842,0.0464396284829724,0.0460526315789472,0.0460526315789472
+SDP,JPN,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.013157894736842,0.0464396284829724,0.0460526315789473,0.0460526315789473
 SDP,LAM,"","","","",Cycle,trn_pass,S3S,linear,0.00981212891217365,0.0185165853437172,0.0462914633592929,0.231457316796465,0.231457316796465
 SDP,LAM,"","","","",Domestic Aviation,trn_pass,S3S,linear,0.00840668890350734,0.0105762418419885,0.0264406046049712,0.0198304534537284,0.0198304534537284
 SDP,LAM,"","","","",Domestic Ship,trn_freight,S3S,linear,0.009523329319276,0.009523329319276,0.00865757210843273,0.00793610776606333,0.00793610776606333
@@ -6498,7 +6498,7 @@ SDP,LAM,"","","","",Passenger Rail,trn_pass,S3S,linear,0.134842686357634,0.12723
 SDP,LAM,"","","","",Walk,trn_pass,S3S,linear,0.899323352244677,0.848561904989659,0.848561904989659,0.848561904989659,0.848561904989659
 SDP,LAM,"","","","",trn_freight_road,trn_freight,S3S,linear,1,1,1,1,1
 SDP,LAM,"","","","",trn_pass_road,trn_pass,S3S,linear,1,1,1,1,1
-SDP,LAM,"","","",Bus,trn_pass_road,trn_pass,S2S3,linear,0.138594539617622,0.086621587261014,0.086621587261014,0.086621587261014,0.086621587261014
+SDP,LAM,"","","",Bus,trn_pass_road,trn_pass,S2S3,linear,0.173243174522027,0.108276984076267,0.086621587261014,0.086621587261014,0.086621587261014
 SDP,LAM,"","","",trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1,1,1,1,1
 SDP,LAM,"","",trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,0.137734442638184,0.137734442638184,0.137734442638184,0.137734442638184,0.137734442638184
 SDP,LAM,"","",trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1,1,1,1,1
@@ -6521,23 +6521,23 @@ SDP,LAM,"",Van,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1
 SDP,LAM,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0,0,0,0,0
 SDP,LAM,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0,0,0,0,0
 SDP,LAM,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0,0,0,0,0
-SDP,LAM,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.118564682943918,0.53788284273999,1,1
+SDP,LAM,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.118564682943917,0.53788284273999,1,1
 SDP,LAM,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,0.0681034247188,0.18459049662895,0.41756464044925,0.88351292808985,0.88351292808985
 SDP,LAM,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1,1,1,1,1
 SDP,LAM,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1,1,1,1,1
 SDP,LAM,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.079468614681412,0.2,0.2400478153426,0.2400478153426
-SDP,LAM,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0316172487850447,0.107576568547998,0.232851453223261,0.232851453223261
-SDP,LAM,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0316172487850447,0.107576568547998,0.232851453223261,0.232851453223261
-SDP,LAM,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0316172487850447,0.107576568547998,0.232851453223261,0.232851453223261
+SDP,LAM,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0316172487850447,0.107576568547998,0.232851453223262,0.232851453223262
+SDP,LAM,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0316172487850447,0.107576568547998,0.232851453223262,0.232851453223262
+SDP,LAM,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0316172487850447,0.107576568547998,0.232851453223262,0.232851453223262
 SDP,LAM,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.079468614681412,0.2,0.2400478153426,0.2400478153426
-SDP,LAM,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.002472623156635,0.017986209962092,0.0656116917729915,0.0656116917729915
-SDP,LAM,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.00892380123238,0.0569110478130804,0.0812287309588894,0.0812287309588894
+SDP,LAM,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.002472623156635,0.017986209962092,0.0656116917729916,0.0656116917729916
+SDP,LAM,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.00892380123238,0.0569110478130804,0.0812287309588893,0.0812287309588893
 SDP,LAM,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.00329683087551333,0.0215834519545104,0.0555555555555556,0.0555555555555556
 SDP,LAM,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.00329683087551333,0.0215834519545104,0.0555555555555556,0.0555555555555556
 SDP,LAM,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.00329683087551333,0.0215834519545104,0.0555555555555556,0.0555555555555556
-SDP,LAM,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.00892380123238,0.0569110478130804,0.0812287309588894,0.0812287309588894
+SDP,LAM,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.00892380123238,0.0569110478130804,0.0812287309588893,0.0812287309588893
 SDP,LAM,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0,8.31528027664132e-07,4.53978687024344e-05,0.119202922022118,0.119202922022118
-SDP,LAM,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1,1,1,0.721728609502907,0.721728609502907
+SDP,LAM,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1,1,1,0.721728609502908,0.721728609502908
 SDP,LAM,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1,1,1,1,1
 SDP,LAM,Liquids,Domestic Ship_tmp_vehicletype,Domestic Ship_tmp_subsector_L1,Domestic Ship_tmp_subsector_L2,Domestic Ship,trn_freight,FV,linear,1,1,1,1,1
 SDP,LAM,Liquids,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1,1,1,1,1
@@ -6553,11 +6553,11 @@ SDP,LAM,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_t
 SDP,LAM,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,1,1,1,1
 SDP,LAM,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,1,1,1,1
 SDP,LAM,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.026893682222235,0.0472515688947483,0.10371786520469,0.135258574225718,0.135258574225718
-SDP,LAM,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0175438596491227,0.0315789473684212,0.0614035087719297,0.0614035087719297
-SDP,LAM,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0175438596491227,0.0315789473684212,0.0614035087719297,0.0614035087719297
-SDP,LAM,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0175438596491227,0.0315789473684212,0.0614035087719297,0.0614035087719297
-SDP,LAM,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0175438596491227,0.0315789473684212,0.0614035087719297,0.0614035087719297
-SDP,LAM,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0175438596491227,0.0315789473684212,0.0614035087719297,0.0614035087719297
+SDP,LAM,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0175438596491227,0.0315789473684212,0.0614035087719296,0.0614035087719296
+SDP,LAM,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0175438596491227,0.0315789473684212,0.0614035087719296,0.0614035087719296
+SDP,LAM,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0175438596491227,0.0315789473684212,0.0614035087719296,0.0614035087719296
+SDP,LAM,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0175438596491227,0.0315789473684212,0.0614035087719296,0.0614035087719296
+SDP,LAM,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0175438596491227,0.0315789473684212,0.0614035087719296,0.0614035087719296
 SDP,MEA,"","","","",Cycle,trn_pass,S3S,linear,0.0165975108305109,0.0165975108305109,0.0165975108305109,0.0414937770762773,0.0414937770762773
 SDP,MEA,"","","","",Domestic Aviation,trn_pass,S3S,linear,0.0089294530094782,0.00595296867298547,0.0178589060189564,0.0238118746919419,0.0238118746919419
 SDP,MEA,"","","","",Domestic Ship,trn_freight,S3S,linear,0.002022051343562,0.002022051343562,0.002022051343562,0.002022051343562,0.002022051343562
@@ -6569,7 +6569,7 @@ SDP,MEA,"","","","",Passenger Rail,trn_pass,S3S,linear,0.000556730785330985,0.00
 SDP,MEA,"","","","",Walk,trn_pass,S3S,linear,1,1,1,1,1
 SDP,MEA,"","","","",trn_freight_road,trn_freight,S3S,linear,1,1,1,1,1
 SDP,MEA,"","","","",trn_pass_road,trn_pass,S3S,linear,0.639480996474237,0.71967693403545,0.71967693403545,0.71967693403545,0.71967693403545
-SDP,MEA,"","","",Bus,trn_pass_road,trn_pass,S2S3,linear,0.183919217151252,0.122612811434168,0.0613064057170841,0.0490451245736673,0.0490451245736673
+SDP,MEA,"","","",Bus,trn_pass_road,trn_pass,S2S3,linear,0.262741738787503,0.122612811434168,0.0613064057170841,0.0490451245736673,0.0490451245736673
 SDP,MEA,"","","",trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1,1,1,1,1
 SDP,MEA,"","",trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,0.007508394761241,0.007508394761241,0.007508394761241,0.007508394761241,0.007508394761241
 SDP,MEA,"","",trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1,1,1,1,1
@@ -6586,12 +6586,12 @@ SDP,MEA,"",Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_s
 SDP,MEA,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1,1,1,1,1
 SDP,MEA,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0,0,0,0,0
 SDP,MEA,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1,1,1,1,1
-SDP,MEA,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.047425873177567,0.295835563506995,0.654894712190423,0.654894712190423
+SDP,MEA,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.047425873177567,0.295835563506994,0.654894712190425,0.654894712190425
 SDP,MEA,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,0.402051171672381,0.476794775213334,0.626281982295238,0.925256396459048,0.925256396459048
 SDP,MEA,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1,1,1,1,1
 SDP,MEA,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1,1,1,1,1
 SDP,MEA,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.059601461011059,0.1,0.14028768429113,0.14028768429113
-SDP,MEA,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0237129365887835,0.053788284273999,0.13608201811749,0.13608201811749
+SDP,MEA,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0237129365887835,0.053788284273999,0.136082018117491,0.136082018117491
 SDP,MEA,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,0.142857142857143,0.2,0.142857142857143,0.142857142857143
 SDP,MEA,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,0.142857142857143,0.2,0.142857142857143,0.142857142857143
 SDP,MEA,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.059601461011059,0.1,0.14028768429113,0.14028768429113
@@ -6703,7 +6703,7 @@ SDP,NES,"","","","",Passenger Rail,trn_pass,S3S,linear,0.00160675014597331,0.001
 SDP,NES,"","","","",Walk,trn_pass,S3S,linear,1,1,1,1,1
 SDP,NES,"","","","",trn_freight_road,trn_freight,S3S,linear,1,1,1,1,1
 SDP,NES,"","","","",trn_pass_road,trn_pass,S3S,linear,0.925821312685462,0.717579145423199,0.456641274360218,0.25115270089812,0.25115270089812
-SDP,NES,"","","",Bus,trn_pass_road,trn_pass,S2S3,linear,0.021994137000963,0.0183284475008025,0.0109970685004815,0.0109970685004815,0.0109970685004815
+SDP,NES,"","","",Bus,trn_pass_road,trn_pass,S2S3,linear,0.0549853425024075,0.021994137000963,0.0109970685004815,0.0109970685004815,0.0109970685004815
 SDP,NES,"","","",trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1,1,1,1,1
 SDP,NES,"","",trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,0.004922521505832,0.004922521505832,0.004922521505832,0.004922521505832,0.004922521505832
 SDP,NES,"","",trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1,1,1,1,1
@@ -6772,7 +6772,7 @@ SDP,OAS,"","","","",Passenger Rail,trn_pass,S3S,linear,0.00077008869031218,0.000
 SDP,OAS,"","","","",Walk,trn_pass,S3S,linear,1,0.689328623982319,0.689328623982319,0.689328623982319,0.689328623982319
 SDP,OAS,"","","","",trn_freight_road,trn_freight,S3S,linear,1,1,1,1,1
 SDP,OAS,"","","","",trn_pass_road,trn_pass,S3S,linear,0.87209012211972,1,1,1,1
-SDP,OAS,"","","",Bus,trn_pass_road,trn_pass,S2S3,linear,0.160206681607861,0.110191151172767,0.0550955755863836,0.0550955755863836,0.0550955755863836
+SDP,OAS,"","","",Bus,trn_pass_road,trn_pass,S2S3,linear,0.240310022411792,0.140243283310795,0.0550955755863836,0.0550955755863836,0.0550955755863836
 SDP,OAS,"","","",trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1,1,1,1,1
 SDP,OAS,"","",trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,0.025341509717687,0.022332205438712,0.016313596880761,0.00427637976486,0.00427637976486
 SDP,OAS,"","",trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1,1,1,1,1
@@ -6800,18 +6800,18 @@ SDP,OAS,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Frei
 SDP,OAS,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1,1,1,1,1
 SDP,OAS,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,0.352966479972375,0.433845669975828,0.595604049982734,0.919120809996547,0.919120809996547
 SDP,OAS,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.039734307340706,0.0625,0.0785611032030326,0.0785611032030326
-SDP,OAS,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0158086243925223,0.0336176776712494,0.0762059301457946,0.0762059301457946
-SDP,OAS,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0158086243925223,0.0336176776712494,0.0762059301457946,0.0762059301457946
-SDP,OAS,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0158086243925223,0.0336176776712494,0.0762059301457946,0.0762059301457946
+SDP,OAS,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0158086243925223,0.0336176776712495,0.0762059301457946,0.0762059301457946
+SDP,OAS,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0158086243925223,0.0336176776712495,0.0762059301457946,0.0762059301457946
+SDP,OAS,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0158086243925223,0.0336176776712495,0.0762059301457946,0.0762059301457946
 SDP,OAS,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.039734307340706,0.0625,0.0785611032030326,0.0785611032030326
-SDP,OAS,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.002472623156635,0.017986209962092,0.0656116917729915,0.0656116917729915
+SDP,OAS,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.002472623156635,0.017986209962092,0.0656116917729916,0.0656116917729916
 SDP,OAS,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.011154751540475,0.0118564682943918,0.0292423431452002,0.0292423431452002
 SDP,OAS,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.00412103859439167,0.004496552490523,0.02,0.02
 SDP,OAS,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.00412103859439167,0.004496552490523,0.02,0.02
 SDP,OAS,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.00412103859439167,0.004496552490523,0.02,0.02
 SDP,OAS,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.011154751540475,0.0118564682943918,0.0292423431452002,0.0292423431452002
 SDP,OAS,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0,8.31528027664132e-07,4.53978687024344e-05,0.119202922022118,0.119202922022118
-SDP,OAS,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1,1,1,0.656116917729915,0.656116917729915
+SDP,OAS,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1,1,1,0.656116917729916,0.656116917729916
 SDP,OAS,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1,1,1,1,1
 SDP,OAS,Liquids,Domestic Ship_tmp_vehicletype,Domestic Ship_tmp_subsector_L1,Domestic Ship_tmp_subsector_L2,Domestic Ship,trn_freight,FV,linear,1,1,1,1,1
 SDP,OAS,Liquids,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1,1,1,1,1
@@ -6843,7 +6843,7 @@ SDP,REF,"","","","",Passenger Rail,trn_pass,S3S,linear,0.00236561326843326,0.004
 SDP,REF,"","","","",Walk,trn_pass,S3S,linear,0.317883555031073,0.317883555031073,0.317883555031073,1,1
 SDP,REF,"","","","",trn_freight_road,trn_freight,S3S,linear,1,1,1,1,1
 SDP,REF,"","","","",trn_pass_road,trn_pass,S3S,linear,1,1,1,0.943741804984768,0.943741804984768
-SDP,REF,"","","",Bus,trn_pass_road,trn_pass,S2S3,linear,0.106725224568562,0.0914787639159102,0.0762323032632585,0.0609858426106068,0.0609858426106068
+SDP,REF,"","","",Bus,trn_pass_road,trn_pass,S2S3,linear,0.118583582853958,0.0914787639159102,0.0762323032632585,0.0609858426106068,0.0609858426106068
 SDP,REF,"","","",trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1,1,1,1,1
 SDP,REF,"","",trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,0.369757606378564,0.369757606378564,0.369757606378564,0.369757606378564,0.369757606378564
 SDP,REF,"","",trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1,1,1,1,1
@@ -6900,18 +6900,18 @@ SDP,REF,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_su
 SDP,REF,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.063108879885637,0.087763909362331,0.137073968315718,0.188555268977994,0.188555268977994
 SDP,REF,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.030480218828266,0.055993897280154,0.107021254183929,0.167260774393184,0.167260774393184
 SDP,REF,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.026315789473684,0.078947368421053,0.147368421052631,0.147368421052631
-SDP,SSA,"","","","",Cycle,trn_pass,S3S,linear,0.013878678157857,0.0179527662940391,0.0291452241314997,0.0327883771479372,0.0327883771479372
-SDP,SSA,"","","","",Domestic Aviation,trn_pass,S3S,linear,0.00901317336217352,0.0509980791548766,0.0413961398176937,0.00620942097265405,0.00620942097265405
+SDP,SSA,"","","","",Cycle,trn_pass,S3S,linear,0.013878678157857,0.017952766294039,0.0291452241314997,0.0327883771479372,0.0327883771479372
+SDP,SSA,"","","","",Domestic Aviation,trn_pass,S3S,linear,0.00901317336217352,0.0509980791548764,0.0413961398176937,0.00620942097265405,0.00620942097265405
 SDP,SSA,"","","","",Domestic Ship,trn_freight,S3S,linear,0.001467441828354,0.001467441828354,0.001467441828354,0.001467441828354,0.001467441828354
 SDP,SSA,"","","","",Freight Rail,trn_freight,S3S,linear,0.01634165332484,0.01634165332484,0.01634165332484,0.01634165332484,0.01634165332484
-SDP,SSA,"","","","",HSR,trn_pass,S3S,linear,1.47506311523337e-05,2.00316440897408e-05,0.0650403115771387,0.0097560467365708,0.0097560467365708
+SDP,SSA,"","","","",HSR,trn_pass,S3S,linear,1.47506311523337e-05,2.00316440897407e-05,0.0650403115771387,0.0097560467365708,0.0097560467365708
 SDP,SSA,"","","","",International Aviation,trn_aviation_intl,S3S,linear,1,1,1,1,1
 SDP,SSA,"","","","",International Ship,trn_shipping_intl,S3S,linear,1,1,1,1,1
-SDP,SSA,"","","","",Passenger Rail,trn_pass,S3S,linear,0.000602417147703971,0.00155851359059413,0.00253015202035668,0.000569284204580253,0.000569284204580253
-SDP,SSA,"","","","",Walk,trn_pass,S3S,linear,1,0.903431854876908,1,1,1
+SDP,SSA,"","","","",Passenger Rail,trn_pass,S3S,linear,0.000602417147703971,0.00155851359059412,0.00253015202035668,0.000569284204580253,0.000569284204580253
+SDP,SSA,"","","","",Walk,trn_pass,S3S,linear,1,0.903431854876905,1,1,1
 SDP,SSA,"","","","",trn_freight_road,trn_freight,S3S,linear,1,1,1,1,1
-SDP,SSA,"","","","",trn_pass_road,trn_pass,S3S,linear,0.890164318010016,1,0.974063506007212,0.0974063506007212,0.0974063506007212
-SDP,SSA,"","","",Bus,trn_pass_road,trn_pass,S2S3,linear,0.206400000437543,0.105846154070534,0.0732781066642163,0.0952615386634812,0.0952615386634812
+SDP,SSA,"","","","",trn_pass_road,trn_pass,S3S,linear,0.890164318010017,1,0.974063506007213,0.0974063506007212,0.0974063506007212
+SDP,SSA,"","","",Bus,trn_pass_road,trn_pass,S2S3,linear,0.247680000525051,0.127015384884641,0.0732781066642163,0.0952615386634812,0.0952615386634812
 SDP,SSA,"","","",trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1,1,1,1,1
 SDP,SSA,"","",trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,0.039283595822529,0.039283595822529,0.039283595822529,0.039283595822529,0.039283595822529
 SDP,SSA,"","",trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1,1,1,1,1
@@ -6941,11 +6941,11 @@ SDP,SSA,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_
 SDP,SSA,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0094851746355134,0.053788284273999,0.14654986566499,0.14654986566499
 SDP,SSA,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0238405844044236,0.1,0.151079044621217,0.151079044621217
 SDP,SSA,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.002472623156635,0.017986209962092,0.075,0.075
-SDP,SSA,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.006692850924285,0.047425873177567,0.0281176376396156,0.0281176376396156
+SDP,SSA,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.006692850924285,0.047425873177567,0.0281176376396155,0.0281176376396155
 SDP,SSA,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.002472623156635,0.017986209962092,0.0192307692307692,0.0192307692307692
 SDP,SSA,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.002472623156635,0.017986209962092,0.0192307692307692,0.0192307692307692
 SDP,SSA,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.002472623156635,0.017986209962092,0.0192307692307692,0.0192307692307692
-SDP,SSA,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.006692850924285,0.047425873177567,0.0281176376396156,0.0281176376396156
+SDP,SSA,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.006692850924285,0.047425873177567,0.0281176376396155,0.0281176376396155
 SDP,SSA,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0,8.31528027664132e-07,4.53978687024344e-05,0.119202922022118,0.119202922022118
 SDP,SSA,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1,1,1,1,1
 SDP,SSA,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1,1,1,1,1
@@ -7000,14 +7000,14 @@ SDP,UKI,"",Van,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1
 SDP,UKI,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0,0,0,0,0
 SDP,UKI,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0,0,0,0,0
 SDP,UKI,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0,0,0,0,0
-SDP,UKI,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.118564682943918,0.322729705643994,0.85731671414019,0.85731671414019
+SDP,UKI,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.118564682943917,0.322729705643994,0.85731671414019,0.85731671414019
 SDP,UKI,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,0.826003073674058,0.847752689464801,0.891251921046287,0.978250384209257,0.978250384209257
 SDP,UKI,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1,1,1,1,1
 SDP,UKI,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1,1,1,1,1
 SDP,UKI,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.238405844044236,0.55,0.883812411034117,0.883812411034117
-SDP,UKI,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.094851746355134,0.295835563506995,0.85731671414019,0.85731671414019
-SDP,UKI,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.094851746355134,0.295835563506995,0.85731671414019,0.85731671414019
-SDP,UKI,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.094851746355134,0.295835563506995,0.85731671414019,0.85731671414019
+SDP,UKI,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.094851746355134,0.295835563506994,0.85731671414019,0.85731671414019
+SDP,UKI,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.094851746355134,0.295835563506994,0.85731671414019,0.85731671414019
+SDP,UKI,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.094851746355134,0.295835563506994,0.85731671414019,0.85731671414019
 SDP,UKI,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.238405844044236,0.55,0.883812411034117,0.883812411034117
 SDP,UKI,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.012363115783175,0.017986209962092,0.1,0.1
 SDP,UKI,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.06692850924285,0.189703492710268,0.146211715726001,0.146211715726001
@@ -7072,7 +7072,7 @@ SDP,USA,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Frei
 SDP,USA,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1,1,1,1,1
 SDP,USA,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1,1,1,1,1
 SDP,USA,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0298007305055295,0.25,0.785611032030326,0.785611032030326
-SDP,USA,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0118564682943918,0.134470710684997,0.762059301457946,0.762059301457946
+SDP,USA,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0118564682943918,0.134470710684998,0.762059301457946,0.762059301457946
 SDP,USA,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.03,0.25,0.5,0.8,0.8
 SDP,USA,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.03,0.25,0.5,0.8,0.8
 SDP,USA,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0298007305055295,0.25,0.785611032030326,0.785611032030326
@@ -7143,18 +7143,18 @@ SDP_RC,CAZ,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,F
 SDP_RC,CAZ,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1,1,1,1,1
 SDP_RC,CAZ,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1,1,1,1,1
 SDP_RC,CAZ,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.119202922022118,0.35,0.491006895018954,0.491006895018954
-SDP_RC,CAZ,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.047425873177567,0.188258994958996,0.476287063411217,0.476287063411217
-SDP_RC,CAZ,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.047425873177567,0.188258994958996,0.476287063411217,0.476287063411217
-SDP_RC,CAZ,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.047425873177567,0.188258994958996,0.476287063411217,0.476287063411217
+SDP_RC,CAZ,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.047425873177567,0.188258994958997,0.476287063411217,0.476287063411217
+SDP_RC,CAZ,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.047425873177567,0.188258994958997,0.476287063411217,0.476287063411217
+SDP_RC,CAZ,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.047425873177567,0.188258994958997,0.476287063411217,0.476287063411217
 SDP_RC,CAZ,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.119202922022118,0.35,0.491006895018954,0.491006895018954
-SDP_RC,CAZ,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.012363115783175,0.017986209962092,0.0954351880334422,0.0954351880334422
+SDP_RC,CAZ,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.012363115783175,0.017986209962092,0.0954351880334419,0.0954351880334419
 SDP_RC,CAZ,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.033464254621425,0.047425873177567,0.146211715726001,0.146211715726001
 SDP_RC,CAZ,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.012363115783175,0.017986209962092,0.1,0.1
 SDP_RC,CAZ,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.012363115783175,0.017986209962092,0.1,0.1
 SDP_RC,CAZ,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.012363115783175,0.017986209962092,0.1,0.1
 SDP_RC,CAZ,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.033464254621425,0.047425873177567,0.146211715726001,0.146211715726001
 SDP_RC,CAZ,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0,8.31528027664132e-07,4.53978687024344e-05,0.119202922022118,0.119202922022118
-SDP_RC,CAZ,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1,1,1,0.954351880334422,0.954351880334422
+SDP_RC,CAZ,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1,1,1,0.954351880334419,0.954351880334419
 SDP_RC,CAZ,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1,1,1,1,1
 SDP_RC,CAZ,Liquids,Domestic Ship_tmp_vehicletype,Domestic Ship_tmp_subsector_L1,Domestic Ship_tmp_subsector_L2,Domestic Ship,trn_freight,FV,linear,1,1,1,1,1
 SDP_RC,CAZ,Liquids,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1,1,1,1,1
@@ -7169,7 +7169,7 @@ SDP_RC,CAZ,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_roa
 SDP_RC,CAZ,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,1,1,1,1
 SDP_RC,CAZ,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,1,1,1,1
 SDP_RC,CAZ,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,1,1,1,1
-SDP_RC,CAZ,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.031042108230522,0.056541000119193,0.107538783896534,0.199969502302122,0.199969502302122
+SDP_RC,CAZ,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.031042108230522,0.056541000119193,0.107538783896534,0.199969502302121,0.199969502302121
 SDP_RC,CAZ,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.026315789473684,0.078947368421053,0.184210526315789,0.184210526315789
 SDP_RC,CAZ,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.026315789473684,0.078947368421053,0.184210526315789,0.184210526315789
 SDP_RC,CAZ,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.026315789473684,0.078947368421053,0.184210526315789,0.184210526315789
@@ -7186,7 +7186,7 @@ SDP_RC,CHA,"","","","",Passenger Rail,trn_pass,S3S,linear,0.00546103419952829,0.
 SDP_RC,CHA,"","","","",Walk,trn_pass,S3S,linear,0.877713076761744,1,1,1,1
 SDP_RC,CHA,"","","","",trn_freight_road,trn_freight,S3S,linear,1,1,1,1,1
 SDP_RC,CHA,"","","","",trn_pass_road,trn_pass,S3S,linear,1,0.455729794383114,0.227864897191557,0.0584268967157839,0.0584268967157839
-SDP_RC,CHA,"","","",Bus,trn_pass_road,trn_pass,S2S3,linear,0.254432114324843,0.191544432089459,0.170509316525779,0.189454796139754,0.189454796139754
+SDP_RC,CHA,"","","",Bus,trn_pass_road,trn_pass,S2S3,linear,0.381648171487265,0.191544432089459,0.170509316525779,0.189454796139754,0.189454796139754
 SDP_RC,CHA,"","","",trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1,1,1,1,1
 SDP_RC,CHA,"","",trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,0.01080602223644,0.009522807095863,0.006956376814708,0.001823516252399,0.001823516252399
 SDP_RC,CHA,"","",trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1,1,1,1,1
@@ -7214,14 +7214,14 @@ SDP_RC,CHA,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_ro
 SDP_RC,CHA,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.1,0.4,0.9,1,1
 SDP_RC,CHA,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.1,0.4,0.9,1,1
 SDP_RC,CHA,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0476811688088472,0.45,0.982013790037908,0.982013790037908
-SDP_RC,CHA,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.022253608409715,0.0668777976648958,0.0699858045578576,0.0699858045578576
+SDP_RC,CHA,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.022253608409715,0.0668777976648955,0.0699858045578576,0.0699858045578576
 SDP_RC,CHA,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.001338570184857,0.0284555239065402,0.146211715726001,0.146211715726001
 SDP_RC,CHA,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.000494524631327,0.0107917259772552,0.1,0.1
 SDP_RC,CHA,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.01,0.2,0.6,0.2,0.2
 SDP_RC,CHA,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.01,0.2,0.6,0.2,0.2
 SDP_RC,CHA,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.001338570184857,0.0284555239065402,0.146211715726001,0.146211715726001
 SDP_RC,CHA,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0,8.31528027664132e-07,4.53978687024344e-05,0.119202922022118,0.119202922022118
-SDP_RC,CHA,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1,1,0.743656365691809,0.349929022789288,0.349929022789288
+SDP_RC,CHA,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1,1,0.743656365691807,0.349929022789288,0.349929022789288
 SDP_RC,CHA,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1,1,1,1,1
 SDP_RC,CHA,Liquids,Domestic Ship_tmp_vehicletype,Domestic Ship_tmp_subsector_L1,Domestic Ship_tmp_subsector_L2,Domestic Ship,trn_freight,FV,linear,1,1,1,1,1
 SDP_RC,CHA,Liquids,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1,1,1,1,1
@@ -7236,7 +7236,7 @@ SDP_RC,CHA,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_roa
 SDP_RC,CHA,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,1,1,1,1
 SDP_RC,CHA,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,1,1,1,1
 SDP_RC,CHA,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,1,1,1,1
-SDP_RC,CHA,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.142120012637288,0.159432643883675,0.090195248368545,0.115174077598356,0.115174077598356
+SDP_RC,CHA,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.142120012637288,0.159432643883675,0.0901952483685446,0.115174077598355,0.115174077598355
 SDP_RC,CHA,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.8778097236668e-05,0.013188367964814,0.0553035143317804,0.0921307947813305,0.0921307947813305
 SDP_RC,CHA,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.0007853553299874,0.014432374877611,0.0569509829460257,0.093173070843404,0.093173070843404
 SDP_RC,CHA,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.3,0.5,0.7,0.5,0.5
@@ -7277,16 +7277,16 @@ SDP_RC,DEU,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,F
 SDP_RC,DEU,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1,1,1,1,1
 SDP_RC,DEU,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1,1,1,1,1
 SDP_RC,DEU,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.298007305055295,0.675,0.982013790037908,0.982013790037908
-SDP_RC,DEU,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.118564682943918,0.363070918849493,0.952574126822433,0.952574126822433
-SDP_RC,DEU,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.118564682943918,0.363070918849493,0.952574126822433,0.952574126822433
-SDP_RC,DEU,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.118564682943918,0.363070918849493,0.952574126822433,0.952574126822433
+SDP_RC,DEU,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.118564682943917,0.363070918849493,0.952574126822433,0.952574126822433
+SDP_RC,DEU,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.118564682943917,0.363070918849493,0.952574126822433,0.952574126822433
+SDP_RC,DEU,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.118564682943917,0.363070918849493,0.952574126822433,0.952574126822433
 SDP_RC,DEU,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.298007305055295,0.675,0.982013790037908,0.982013790037908
 SDP_RC,DEU,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.002472623156635,0.017986209962092,0.05,0.05
-SDP_RC,DEU,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.08031421109142,0.331981112242969,0.219317573589002,0.219317573589002
+SDP_RC,DEU,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.08031421109142,0.331981112242969,0.219317573589001,0.219317573589001
 SDP_RC,DEU,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.02967147787962,0.125903469734644,0.15,0.15
 SDP_RC,DEU,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.02967147787962,0.125903469734644,0.15,0.15
 SDP_RC,DEU,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.02967147787962,0.125903469734644,0.15,0.15
-SDP_RC,DEU,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.08031421109142,0.331981112242969,0.219317573589002,0.219317573589002
+SDP_RC,DEU,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.08031421109142,0.331981112242969,0.219317573589001,0.219317573589001
 SDP_RC,DEU,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0,8.31528027664132e-07,4.53978687024344e-05,0.119202922022118,0.119202922022118
 SDP_RC,DEU,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1,1,1,1,1
 SDP_RC,DEU,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1,1,1,1,1
@@ -7411,9 +7411,9 @@ SDP_RC,ECS,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,F
 SDP_RC,ECS,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1,1,1,1,1
 SDP_RC,ECS,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1,1,1,1,1
 SDP_RC,ECS,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.119202922022118,0.25,0.294604137011372,0.294604137011372
-SDP_RC,ECS,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.047425873177567,0.134470710684997,0.28577223804673,0.28577223804673
-SDP_RC,ECS,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.047425873177567,0.134470710684997,0.28577223804673,0.28577223804673
-SDP_RC,ECS,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.047425873177567,0.134470710684997,0.28577223804673,0.28577223804673
+SDP_RC,ECS,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.047425873177567,0.134470710684998,0.28577223804673,0.28577223804673
+SDP_RC,ECS,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.047425873177567,0.134470710684998,0.28577223804673,0.28577223804673
+SDP_RC,ECS,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.047425873177567,0.134470710684998,0.28577223804673,0.28577223804673
 SDP_RC,ECS,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.119202922022118,0.25,0.294604137011372,0.294604137011372
 SDP_RC,ECS,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.002472623156635,0.053958629886276,0.1,0.1
 SDP_RC,ECS,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.01338570184857,0.047425873177567,0.0731058578630005,0.0731058578630005
@@ -7491,7 +7491,7 @@ SDP_RC,ENC,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_t
 SDP_RC,ENC,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.02472623156635,0.08993104981046,0.1,0.1
 SDP_RC,ENC,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.06692850924285,0.237129365887835,0.146211715726001,0.146211715726001
 SDP_RC,ENC,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0,8.31528027664132e-07,4.53978687024344e-05,0.119202922022118,0.119202922022118
-SDP_RC,ENC,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1,1,1,0.524893534183932,0.524893534183932
+SDP_RC,ENC,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1,1,1,0.524893534183931,0.524893534183931
 SDP_RC,ENC,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1,1,1,1,1
 SDP_RC,ENC,Liquids,Domestic Ship_tmp_vehicletype,Domestic Ship_tmp_subsector_L1,Domestic Ship_tmp_subsector_L2,Domestic Ship,trn_freight,FV,linear,1,1,1,1,1
 SDP_RC,ENC,Liquids,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,0.1341454314254,0.1341454314254,0.1341454314254,0.1341454314254,0.1341454314254
@@ -7609,7 +7609,7 @@ SDP_RC,ESW,"",Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tm
 SDP_RC,ESW,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0,0,0,0,0
 SDP_RC,ESW,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0,0,0,0,0
 SDP_RC,ESW,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0,0,0,0,0
-SDP_RC,ESW,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.118564682943918,0.268941421369995,0.666801888775703,0.666801888775703
+SDP_RC,ESW,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.118564682943917,0.268941421369995,0.666801888775703,0.666801888775703
 SDP_RC,ESW,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,0.72951273091157,0.763323639547623,0.830945456819731,0.966189091363946,0.966189091363946
 SDP_RC,ESW,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1,1,1,1,1
 SDP_RC,ESW,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1,1,1,1,1
@@ -7748,18 +7748,18 @@ SDP_RC,FRA,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,F
 SDP_RC,FRA,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1,1,1,1,1
 SDP_RC,FRA,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1,1,1,1,1
 SDP_RC,FRA,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.298007305055295,0.75,0.982013790037908,0.982013790037908
-SDP_RC,FRA,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.118564682943918,0.403412132054992,0.952574126822433,0.952574126822433
-SDP_RC,FRA,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.118564682943918,0.403412132054992,0.952574126822433,0.952574126822433
-SDP_RC,FRA,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.118564682943918,0.403412132054992,0.952574126822433,0.952574126822433
+SDP_RC,FRA,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.118564682943917,0.403412132054992,0.952574126822433,0.952574126822433
+SDP_RC,FRA,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.118564682943917,0.403412132054992,0.952574126822433,0.952574126822433
+SDP_RC,FRA,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.118564682943917,0.403412132054992,0.952574126822433,0.952574126822433
 SDP_RC,FRA,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.298007305055295,0.75,0.982013790037908,0.982013790037908
-SDP_RC,FRA,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.012363115783175,0.017986209962092,0.0954351880334422,0.0954351880334422
+SDP_RC,FRA,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.012363115783175,0.017986209962092,0.0954351880334419,0.0954351880334419
 SDP_RC,FRA,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.06692850924285,0.047425873177567,0.146211715726001,0.146211715726001
 SDP_RC,FRA,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.02472623156635,0.017986209962092,0.1,0.1
 SDP_RC,FRA,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.02472623156635,0.017986209962092,0.1,0.1
 SDP_RC,FRA,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.02472623156635,0.017986209962092,0.1,0.1
 SDP_RC,FRA,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.06692850924285,0.047425873177567,0.146211715726001,0.146211715726001
 SDP_RC,FRA,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0,8.31528027664132e-07,4.53978687024344e-05,0.119202922022118,0.119202922022118
-SDP_RC,FRA,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1,1,1,0.954351880334422,0.954351880334422
+SDP_RC,FRA,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1,1,1,0.954351880334419,0.954351880334419
 SDP_RC,FRA,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1,1,1,1,1
 SDP_RC,FRA,Liquids,Domestic Ship_tmp_vehicletype,Domestic Ship_tmp_subsector_L1,Domestic Ship_tmp_subsector_L2,Domestic Ship,trn_freight,FV,linear,1,1,1,1,1
 SDP_RC,FRA,Liquids,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,0.160770475713231,0.160770475713231,0.160770475713231,0.160770475713231,0.160770475713231
@@ -7774,7 +7774,7 @@ SDP_RC,FRA,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_roa
 SDP_RC,FRA,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,1,1,1,1
 SDP_RC,FRA,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,1,1,1,1
 SDP_RC,FRA,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,1,1,1,1
-SDP_RC,FRA,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.026315789473684,0.078947368421053,0.175801662166867,0.175801662166867
+SDP_RC,FRA,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.026315789473684,0.078947368421053,0.175801662166866,0.175801662166866
 SDP_RC,FRA,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.026315789473684,0.078947368421053,0.184210526315789,0.184210526315789
 SDP_RC,FRA,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.026315789473684,0.078947368421053,0.184210526315789,0.184210526315789
 SDP_RC,FRA,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.026315789473684,0.078947368421053,0.184210526315789,0.184210526315789
@@ -7791,7 +7791,7 @@ SDP_RC,IND,"","","","",Passenger Rail,trn_pass,S3S,linear,0.000684210526315789,8
 SDP_RC,IND,"","","","",Walk,trn_pass,S3S,linear,0.131578947368421,0.0945454545454544,0.181818181818182,1,1
 SDP_RC,IND,"","","","",trn_freight_road,trn_freight,S3S,linear,1,1,1,1,1
 SDP_RC,IND,"","","","",trn_pass_road,trn_pass,S3S,linear,1,1,1,1,1
-SDP_RC,IND,"","","",Bus,trn_pass_road,trn_pass,S2S3,linear,0.118824252562298,0.0625,0.0323053436653747,0.0323053436653747,0.0323053436653747
+SDP_RC,IND,"","","",Bus,trn_pass_road,trn_pass,S2S3,linear,0.118824252562298,0.0714285714285714,0.0323053436653747,0.0323053436653747,0.0323053436653747
 SDP_RC,IND,"","","",trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1,1,1,1,1
 SDP_RC,IND,"","",trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,0.003027158638145,0.002667683549865,0.001948733373306,0.000510833020187,0.000510833020187
 SDP_RC,IND,"","",trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1,1,1,1,1
@@ -7871,7 +7871,7 @@ SDP_RC,JPN,"",Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tm
 SDP_RC,JPN,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0,0,0,0,0
 SDP_RC,JPN,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0,0,0,0,0
 SDP_RC,JPN,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0,0,0,0,0
-SDP_RC,JPN,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.109079508308404,0.17929428091333,0.381029650728973,0.381029650728973
+SDP_RC,JPN,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.109079508308404,0.17929428091333,0.381029650728972,0.381029650728972
 SDP_RC,JPN,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1,1,1,1,1
 SDP_RC,JPN,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1,1,1,1,1
 SDP_RC,JPN,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1,1,1,1,1
@@ -7881,11 +7881,11 @@ SDP_RC,JPN,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_ro
 SDP_RC,JPN,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,0.0636363636363636,0.133333333333333,0.833333333333333,0.833333333333333
 SDP_RC,JPN,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.125163068123224,0.352941176470588,0.81834482503159,0.81834482503159
 SDP_RC,JPN,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.061815578915875,0.131898873055341,0.1,0.1
-SDP_RC,JPN,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.110432040250703,0.251078152116531,0.304607741095835,0.304607741095835
+SDP_RC,JPN,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.110432040250702,0.251078152116531,0.304607741095835,0.304607741095835
 SDP_RC,JPN,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,1,1,0.416666666666667,0.416666666666667
 SDP_RC,JPN,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,1,1,0.416666666666667,0.416666666666667
 SDP_RC,JPN,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,1,1,0.416666666666667,0.416666666666667
-SDP_RC,JPN,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.110432040250703,0.251078152116531,0.304607741095835,0.304607741095835
+SDP_RC,JPN,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.110432040250702,0.251078152116531,0.304607741095835,0.304607741095835
 SDP_RC,JPN,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0,8.31528027664132e-07,4.53978687024344e-05,0.119202922022118,0.119202922022118
 SDP_RC,JPN,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1,1,1,1,1
 SDP_RC,JPN,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1,1,1,1,1
@@ -7903,11 +7903,11 @@ SDP_RC,JPN,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_roa
 SDP_RC,JPN,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,0.0606060606060606,0.188888888888889,1,1
 SDP_RC,JPN,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,1,1,1,1
 SDP_RC,JPN,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.0078947368421052,0.0157894736842106,0.0230263157894736,0.0230263157894736
-SDP_RC,JPN,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.013157894736842,0.0464396284829724,0.0460526315789472,0.0460526315789472
+SDP_RC,JPN,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.013157894736842,0.0464396284829724,0.0460526315789473,0.0460526315789473
 SDP_RC,JPN,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,0.0303030303030303,0.111111111111111,0.25,0.25
 SDP_RC,JPN,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,0.0303030303030303,0.111111111111111,0.25,0.25
 SDP_RC,JPN,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,0.0303030303030303,0.111111111111111,0.25,0.25
-SDP_RC,JPN,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.013157894736842,0.0464396284829724,0.0460526315789472,0.0460526315789472
+SDP_RC,JPN,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.013157894736842,0.0464396284829724,0.0460526315789473,0.0460526315789473
 SDP_RC,LAM,"","","","",Cycle,trn_pass,S3S,linear,0.00981212891217365,0.0185165853437172,0.0462914633592929,0.231457316796465,0.231457316796465
 SDP_RC,LAM,"","","","",Domestic Aviation,trn_pass,S3S,linear,0.00840668890350734,0.0105762418419885,0.0264406046049712,0.0198304534537284,0.0198304534537284
 SDP_RC,LAM,"","","","",Domestic Ship,trn_freight,S3S,linear,0.009523329319276,0.009523329319276,0.00865757210843273,0.00793610776606333,0.00793610776606333
@@ -7919,7 +7919,7 @@ SDP_RC,LAM,"","","","",Passenger Rail,trn_pass,S3S,linear,0.134842686357634,0.12
 SDP_RC,LAM,"","","","",Walk,trn_pass,S3S,linear,0.899323352244677,0.848561904989659,0.848561904989659,0.848561904989659,0.848561904989659
 SDP_RC,LAM,"","","","",trn_freight_road,trn_freight,S3S,linear,1,1,1,1,1
 SDP_RC,LAM,"","","","",trn_pass_road,trn_pass,S3S,linear,1,1,1,1,1
-SDP_RC,LAM,"","","",Bus,trn_pass_road,trn_pass,S2S3,linear,0.138594539617622,0.086621587261014,0.086621587261014,0.086621587261014,0.086621587261014
+SDP_RC,LAM,"","","",Bus,trn_pass_road,trn_pass,S2S3,linear,0.173243174522027,0.108276984076267,0.086621587261014,0.086621587261014,0.086621587261014
 SDP_RC,LAM,"","","",trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1,1,1,1,1
 SDP_RC,LAM,"","",trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,0.137734442638184,0.137734442638184,0.137734442638184,0.137734442638184,0.137734442638184
 SDP_RC,LAM,"","",trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1,1,1,1,1
@@ -7942,23 +7942,23 @@ SDP_RC,LAM,"",Van,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,
 SDP_RC,LAM,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0,0,0,0,0
 SDP_RC,LAM,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0,0,0,0,0
 SDP_RC,LAM,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0,0,0,0,0
-SDP_RC,LAM,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.118564682943918,0.53788284273999,1,1
+SDP_RC,LAM,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.118564682943917,0.53788284273999,1,1
 SDP_RC,LAM,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,0.0681034247188,0.18459049662895,0.41756464044925,0.88351292808985,0.88351292808985
 SDP_RC,LAM,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1,1,1,1,1
 SDP_RC,LAM,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1,1,1,1,1
 SDP_RC,LAM,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.079468614681412,0.2,0.2400478153426,0.2400478153426
-SDP_RC,LAM,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0316172487850447,0.107576568547998,0.232851453223261,0.232851453223261
-SDP_RC,LAM,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0316172487850447,0.107576568547998,0.232851453223261,0.232851453223261
-SDP_RC,LAM,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0316172487850447,0.107576568547998,0.232851453223261,0.232851453223261
+SDP_RC,LAM,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0316172487850447,0.107576568547998,0.232851453223262,0.232851453223262
+SDP_RC,LAM,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0316172487850447,0.107576568547998,0.232851453223262,0.232851453223262
+SDP_RC,LAM,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0316172487850447,0.107576568547998,0.232851453223262,0.232851453223262
 SDP_RC,LAM,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.079468614681412,0.2,0.2400478153426,0.2400478153426
-SDP_RC,LAM,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.002472623156635,0.017986209962092,0.0656116917729915,0.0656116917729915
-SDP_RC,LAM,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.00892380123238,0.0569110478130804,0.0812287309588894,0.0812287309588894
+SDP_RC,LAM,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.002472623156635,0.017986209962092,0.0656116917729916,0.0656116917729916
+SDP_RC,LAM,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.00892380123238,0.0569110478130804,0.0812287309588893,0.0812287309588893
 SDP_RC,LAM,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.00329683087551333,0.0215834519545104,0.0555555555555556,0.0555555555555556
 SDP_RC,LAM,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.00329683087551333,0.0215834519545104,0.0555555555555556,0.0555555555555556
 SDP_RC,LAM,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.00329683087551333,0.0215834519545104,0.0555555555555556,0.0555555555555556
-SDP_RC,LAM,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.00892380123238,0.0569110478130804,0.0812287309588894,0.0812287309588894
+SDP_RC,LAM,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.00892380123238,0.0569110478130804,0.0812287309588893,0.0812287309588893
 SDP_RC,LAM,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0,8.31528027664132e-07,4.53978687024344e-05,0.119202922022118,0.119202922022118
-SDP_RC,LAM,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1,1,1,0.721728609502907,0.721728609502907
+SDP_RC,LAM,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1,1,1,0.721728609502908,0.721728609502908
 SDP_RC,LAM,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1,1,1,1,1
 SDP_RC,LAM,Liquids,Domestic Ship_tmp_vehicletype,Domestic Ship_tmp_subsector_L1,Domestic Ship_tmp_subsector_L2,Domestic Ship,trn_freight,FV,linear,1,1,1,1,1
 SDP_RC,LAM,Liquids,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1,1,1,1,1
@@ -7974,11 +7974,11 @@ SDP_RC,LAM,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_roa
 SDP_RC,LAM,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,1,1,1,1
 SDP_RC,LAM,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,1,1,1,1
 SDP_RC,LAM,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.026893682222235,0.0472515688947483,0.10371786520469,0.135258574225718,0.135258574225718
-SDP_RC,LAM,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0175438596491227,0.0315789473684212,0.0614035087719297,0.0614035087719297
-SDP_RC,LAM,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0175438596491227,0.0315789473684212,0.0614035087719297,0.0614035087719297
-SDP_RC,LAM,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0175438596491227,0.0315789473684212,0.0614035087719297,0.0614035087719297
-SDP_RC,LAM,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0175438596491227,0.0315789473684212,0.0614035087719297,0.0614035087719297
-SDP_RC,LAM,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0175438596491227,0.0315789473684212,0.0614035087719297,0.0614035087719297
+SDP_RC,LAM,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0175438596491227,0.0315789473684212,0.0614035087719296,0.0614035087719296
+SDP_RC,LAM,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0175438596491227,0.0315789473684212,0.0614035087719296,0.0614035087719296
+SDP_RC,LAM,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0175438596491227,0.0315789473684212,0.0614035087719296,0.0614035087719296
+SDP_RC,LAM,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0175438596491227,0.0315789473684212,0.0614035087719296,0.0614035087719296
+SDP_RC,LAM,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0175438596491227,0.0315789473684212,0.0614035087719296,0.0614035087719296
 SDP_RC,MEA,"","","","",Cycle,trn_pass,S3S,linear,0.0165975108305109,0.0165975108305109,0.0165975108305109,0.0414937770762773,0.0414937770762773
 SDP_RC,MEA,"","","","",Domestic Aviation,trn_pass,S3S,linear,0.0089294530094782,0.00595296867298547,0.0178589060189564,0.0238118746919419,0.0238118746919419
 SDP_RC,MEA,"","","","",Domestic Ship,trn_freight,S3S,linear,0.002022051343562,0.002022051343562,0.002022051343562,0.002022051343562,0.002022051343562
@@ -7990,7 +7990,7 @@ SDP_RC,MEA,"","","","",Passenger Rail,trn_pass,S3S,linear,0.000556730785330985,0
 SDP_RC,MEA,"","","","",Walk,trn_pass,S3S,linear,1,1,1,1,1
 SDP_RC,MEA,"","","","",trn_freight_road,trn_freight,S3S,linear,1,1,1,1,1
 SDP_RC,MEA,"","","","",trn_pass_road,trn_pass,S3S,linear,0.639480996474237,0.71967693403545,0.71967693403545,0.71967693403545,0.71967693403545
-SDP_RC,MEA,"","","",Bus,trn_pass_road,trn_pass,S2S3,linear,0.183919217151252,0.122612811434168,0.0613064057170841,0.0490451245736673,0.0490451245736673
+SDP_RC,MEA,"","","",Bus,trn_pass_road,trn_pass,S2S3,linear,0.262741738787503,0.122612811434168,0.0613064057170841,0.0490451245736673,0.0490451245736673
 SDP_RC,MEA,"","","",trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1,1,1,1,1
 SDP_RC,MEA,"","",trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,0.007508394761241,0.007508394761241,0.007508394761241,0.007508394761241,0.007508394761241
 SDP_RC,MEA,"","",trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1,1,1,1,1
@@ -8007,12 +8007,12 @@ SDP_RC,MEA,"",Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tm
 SDP_RC,MEA,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1,1,1,1,1
 SDP_RC,MEA,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0,0,0,0,0
 SDP_RC,MEA,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1,1,1,1,1
-SDP_RC,MEA,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.047425873177567,0.295835563506995,0.654894712190423,0.654894712190423
+SDP_RC,MEA,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.047425873177567,0.295835563506994,0.654894712190425,0.654894712190425
 SDP_RC,MEA,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,0.402051171672381,0.476794775213334,0.626281982295238,0.925256396459048,0.925256396459048
 SDP_RC,MEA,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1,1,1,1,1
 SDP_RC,MEA,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1,1,1,1,1
 SDP_RC,MEA,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.059601461011059,0.1,0.14028768429113,0.14028768429113
-SDP_RC,MEA,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0237129365887835,0.053788284273999,0.13608201811749,0.13608201811749
+SDP_RC,MEA,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0237129365887835,0.053788284273999,0.136082018117491,0.136082018117491
 SDP_RC,MEA,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,0.142857142857143,0.2,0.142857142857143,0.142857142857143
 SDP_RC,MEA,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,0.142857142857143,0.2,0.142857142857143,0.142857142857143
 SDP_RC,MEA,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.059601461011059,0.1,0.14028768429113,0.14028768429113
@@ -8124,7 +8124,7 @@ SDP_RC,NES,"","","","",Passenger Rail,trn_pass,S3S,linear,0.00160675014597331,0.
 SDP_RC,NES,"","","","",Walk,trn_pass,S3S,linear,1,1,1,1,1
 SDP_RC,NES,"","","","",trn_freight_road,trn_freight,S3S,linear,1,1,1,1,1
 SDP_RC,NES,"","","","",trn_pass_road,trn_pass,S3S,linear,0.925821312685462,0.717579145423199,0.456641274360218,0.25115270089812,0.25115270089812
-SDP_RC,NES,"","","",Bus,trn_pass_road,trn_pass,S2S3,linear,0.021994137000963,0.0183284475008025,0.0109970685004815,0.0109970685004815,0.0109970685004815
+SDP_RC,NES,"","","",Bus,trn_pass_road,trn_pass,S2S3,linear,0.0549853425024075,0.021994137000963,0.0109970685004815,0.0109970685004815,0.0109970685004815
 SDP_RC,NES,"","","",trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1,1,1,1,1
 SDP_RC,NES,"","",trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,0.004922521505832,0.004922521505832,0.004922521505832,0.004922521505832,0.004922521505832
 SDP_RC,NES,"","",trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1,1,1,1,1
@@ -8193,7 +8193,7 @@ SDP_RC,OAS,"","","","",Passenger Rail,trn_pass,S3S,linear,0.00077008869031218,0.
 SDP_RC,OAS,"","","","",Walk,trn_pass,S3S,linear,1,0.689328623982319,0.689328623982319,0.689328623982319,0.689328623982319
 SDP_RC,OAS,"","","","",trn_freight_road,trn_freight,S3S,linear,1,1,1,1,1
 SDP_RC,OAS,"","","","",trn_pass_road,trn_pass,S3S,linear,0.87209012211972,1,1,1,1
-SDP_RC,OAS,"","","",Bus,trn_pass_road,trn_pass,S2S3,linear,0.160206681607861,0.110191151172767,0.0550955755863836,0.0550955755863836,0.0550955755863836
+SDP_RC,OAS,"","","",Bus,trn_pass_road,trn_pass,S2S3,linear,0.240310022411792,0.140243283310795,0.0550955755863836,0.0550955755863836,0.0550955755863836
 SDP_RC,OAS,"","","",trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1,1,1,1,1
 SDP_RC,OAS,"","",trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,0.025341509717687,0.022332205438712,0.016313596880761,0.00427637976486,0.00427637976486
 SDP_RC,OAS,"","",trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1,1,1,1,1
@@ -8221,18 +8221,18 @@ SDP_RC,OAS,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,F
 SDP_RC,OAS,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1,1,1,1,1
 SDP_RC,OAS,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,0.352966479972375,0.433845669975828,0.595604049982734,0.919120809996547,0.919120809996547
 SDP_RC,OAS,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.039734307340706,0.0625,0.0785611032030326,0.0785611032030326
-SDP_RC,OAS,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0158086243925223,0.0336176776712494,0.0762059301457946,0.0762059301457946
-SDP_RC,OAS,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0158086243925223,0.0336176776712494,0.0762059301457946,0.0762059301457946
-SDP_RC,OAS,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0158086243925223,0.0336176776712494,0.0762059301457946,0.0762059301457946
+SDP_RC,OAS,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0158086243925223,0.0336176776712495,0.0762059301457946,0.0762059301457946
+SDP_RC,OAS,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0158086243925223,0.0336176776712495,0.0762059301457946,0.0762059301457946
+SDP_RC,OAS,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0158086243925223,0.0336176776712495,0.0762059301457946,0.0762059301457946
 SDP_RC,OAS,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.039734307340706,0.0625,0.0785611032030326,0.0785611032030326
-SDP_RC,OAS,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.002472623156635,0.017986209962092,0.0656116917729915,0.0656116917729915
+SDP_RC,OAS,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.002472623156635,0.017986209962092,0.0656116917729916,0.0656116917729916
 SDP_RC,OAS,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.011154751540475,0.0118564682943918,0.0292423431452002,0.0292423431452002
 SDP_RC,OAS,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.00412103859439167,0.004496552490523,0.02,0.02
 SDP_RC,OAS,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.00412103859439167,0.004496552490523,0.02,0.02
 SDP_RC,OAS,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.00412103859439167,0.004496552490523,0.02,0.02
 SDP_RC,OAS,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.011154751540475,0.0118564682943918,0.0292423431452002,0.0292423431452002
 SDP_RC,OAS,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0,8.31528027664132e-07,4.53978687024344e-05,0.119202922022118,0.119202922022118
-SDP_RC,OAS,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1,1,1,0.656116917729915,0.656116917729915
+SDP_RC,OAS,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1,1,1,0.656116917729916,0.656116917729916
 SDP_RC,OAS,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1,1,1,1,1
 SDP_RC,OAS,Liquids,Domestic Ship_tmp_vehicletype,Domestic Ship_tmp_subsector_L1,Domestic Ship_tmp_subsector_L2,Domestic Ship,trn_freight,FV,linear,1,1,1,1,1
 SDP_RC,OAS,Liquids,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1,1,1,1,1
@@ -8264,7 +8264,7 @@ SDP_RC,REF,"","","","",Passenger Rail,trn_pass,S3S,linear,0.00236561326843326,0.
 SDP_RC,REF,"","","","",Walk,trn_pass,S3S,linear,0.317883555031073,0.317883555031073,0.317883555031073,1,1
 SDP_RC,REF,"","","","",trn_freight_road,trn_freight,S3S,linear,1,1,1,1,1
 SDP_RC,REF,"","","","",trn_pass_road,trn_pass,S3S,linear,1,1,1,0.943741804984768,0.943741804984768
-SDP_RC,REF,"","","",Bus,trn_pass_road,trn_pass,S2S3,linear,0.106725224568562,0.0914787639159102,0.0762323032632585,0.0609858426106068,0.0609858426106068
+SDP_RC,REF,"","","",Bus,trn_pass_road,trn_pass,S2S3,linear,0.118583582853958,0.0914787639159102,0.0762323032632585,0.0609858426106068,0.0609858426106068
 SDP_RC,REF,"","","",trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1,1,1,1,1
 SDP_RC,REF,"","",trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,0.369757606378564,0.369757606378564,0.369757606378564,0.369757606378564,0.369757606378564
 SDP_RC,REF,"","",trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1,1,1,1,1
@@ -8321,18 +8321,18 @@ SDP_RC,REF,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp
 SDP_RC,REF,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.063108879885637,0.087763909362331,0.137073968315718,0.188555268977994,0.188555268977994
 SDP_RC,REF,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.030480218828266,0.055993897280154,0.107021254183929,0.167260774393184,0.167260774393184
 SDP_RC,REF,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.026315789473684,0.078947368421053,0.147368421052631,0.147368421052631
-SDP_RC,SSA,"","","","",Cycle,trn_pass,S3S,linear,0.013878678157857,0.0179527662940391,0.0291452241314997,0.0327883771479372,0.0327883771479372
-SDP_RC,SSA,"","","","",Domestic Aviation,trn_pass,S3S,linear,0.00901317336217352,0.0509980791548766,0.0413961398176937,0.00620942097265405,0.00620942097265405
+SDP_RC,SSA,"","","","",Cycle,trn_pass,S3S,linear,0.013878678157857,0.017952766294039,0.0291452241314997,0.0327883771479372,0.0327883771479372
+SDP_RC,SSA,"","","","",Domestic Aviation,trn_pass,S3S,linear,0.00901317336217352,0.0509980791548764,0.0413961398176937,0.00620942097265405,0.00620942097265405
 SDP_RC,SSA,"","","","",Domestic Ship,trn_freight,S3S,linear,0.001467441828354,0.001467441828354,0.001467441828354,0.001467441828354,0.001467441828354
 SDP_RC,SSA,"","","","",Freight Rail,trn_freight,S3S,linear,0.01634165332484,0.01634165332484,0.01634165332484,0.01634165332484,0.01634165332484
-SDP_RC,SSA,"","","","",HSR,trn_pass,S3S,linear,1.47506311523337e-05,2.00316440897408e-05,0.0650403115771387,0.0097560467365708,0.0097560467365708
+SDP_RC,SSA,"","","","",HSR,trn_pass,S3S,linear,1.47506311523337e-05,2.00316440897407e-05,0.0650403115771387,0.0097560467365708,0.0097560467365708
 SDP_RC,SSA,"","","","",International Aviation,trn_aviation_intl,S3S,linear,1,1,1,1,1
 SDP_RC,SSA,"","","","",International Ship,trn_shipping_intl,S3S,linear,1,1,1,1,1
-SDP_RC,SSA,"","","","",Passenger Rail,trn_pass,S3S,linear,0.000602417147703971,0.00155851359059413,0.00253015202035668,0.000569284204580253,0.000569284204580253
-SDP_RC,SSA,"","","","",Walk,trn_pass,S3S,linear,1,0.903431854876908,1,1,1
+SDP_RC,SSA,"","","","",Passenger Rail,trn_pass,S3S,linear,0.000602417147703971,0.00155851359059412,0.00253015202035668,0.000569284204580253,0.000569284204580253
+SDP_RC,SSA,"","","","",Walk,trn_pass,S3S,linear,1,0.903431854876905,1,1,1
 SDP_RC,SSA,"","","","",trn_freight_road,trn_freight,S3S,linear,1,1,1,1,1
-SDP_RC,SSA,"","","","",trn_pass_road,trn_pass,S3S,linear,0.890164318010016,1,0.974063506007212,0.0974063506007212,0.0974063506007212
-SDP_RC,SSA,"","","",Bus,trn_pass_road,trn_pass,S2S3,linear,0.206400000437543,0.105846154070534,0.0732781066642163,0.0952615386634812,0.0952615386634812
+SDP_RC,SSA,"","","","",trn_pass_road,trn_pass,S3S,linear,0.890164318010017,1,0.974063506007213,0.0974063506007212,0.0974063506007212
+SDP_RC,SSA,"","","",Bus,trn_pass_road,trn_pass,S2S3,linear,0.247680000525051,0.127015384884641,0.0732781066642163,0.0952615386634812,0.0952615386634812
 SDP_RC,SSA,"","","",trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1,1,1,1,1
 SDP_RC,SSA,"","",trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,0.039283595822529,0.039283595822529,0.039283595822529,0.039283595822529,0.039283595822529
 SDP_RC,SSA,"","",trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1,1,1,1,1
@@ -8362,11 +8362,11 @@ SDP_RC,SSA,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_ro
 SDP_RC,SSA,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0094851746355134,0.053788284273999,0.14654986566499,0.14654986566499
 SDP_RC,SSA,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0238405844044236,0.1,0.151079044621217,0.151079044621217
 SDP_RC,SSA,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.002472623156635,0.017986209962092,0.075,0.075
-SDP_RC,SSA,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.006692850924285,0.047425873177567,0.0281176376396156,0.0281176376396156
+SDP_RC,SSA,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.006692850924285,0.047425873177567,0.0281176376396155,0.0281176376396155
 SDP_RC,SSA,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.002472623156635,0.017986209962092,0.0192307692307692,0.0192307692307692
 SDP_RC,SSA,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.002472623156635,0.017986209962092,0.0192307692307692,0.0192307692307692
 SDP_RC,SSA,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.002472623156635,0.017986209962092,0.0192307692307692,0.0192307692307692
-SDP_RC,SSA,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.006692850924285,0.047425873177567,0.0281176376396156,0.0281176376396156
+SDP_RC,SSA,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.006692850924285,0.047425873177567,0.0281176376396155,0.0281176376396155
 SDP_RC,SSA,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0,8.31528027664132e-07,4.53978687024344e-05,0.119202922022118,0.119202922022118
 SDP_RC,SSA,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1,1,1,1,1
 SDP_RC,SSA,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1,1,1,1,1
@@ -8421,14 +8421,14 @@ SDP_RC,UKI,"",Van,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,
 SDP_RC,UKI,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0,0,0,0,0
 SDP_RC,UKI,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0,0,0,0,0
 SDP_RC,UKI,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0,0,0,0,0
-SDP_RC,UKI,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.118564682943918,0.322729705643994,0.85731671414019,0.85731671414019
+SDP_RC,UKI,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.118564682943917,0.322729705643994,0.85731671414019,0.85731671414019
 SDP_RC,UKI,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,0.826003073674058,0.847752689464801,0.891251921046287,0.978250384209257,0.978250384209257
 SDP_RC,UKI,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1,1,1,1,1
 SDP_RC,UKI,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1,1,1,1,1
 SDP_RC,UKI,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.238405844044236,0.55,0.883812411034117,0.883812411034117
-SDP_RC,UKI,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.094851746355134,0.295835563506995,0.85731671414019,0.85731671414019
-SDP_RC,UKI,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.094851746355134,0.295835563506995,0.85731671414019,0.85731671414019
-SDP_RC,UKI,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.094851746355134,0.295835563506995,0.85731671414019,0.85731671414019
+SDP_RC,UKI,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.094851746355134,0.295835563506994,0.85731671414019,0.85731671414019
+SDP_RC,UKI,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.094851746355134,0.295835563506994,0.85731671414019,0.85731671414019
+SDP_RC,UKI,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.094851746355134,0.295835563506994,0.85731671414019,0.85731671414019
 SDP_RC,UKI,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.238405844044236,0.55,0.883812411034117,0.883812411034117
 SDP_RC,UKI,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.012363115783175,0.017986209962092,0.1,0.1
 SDP_RC,UKI,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.06692850924285,0.189703492710268,0.146211715726001,0.146211715726001
@@ -8493,7 +8493,7 @@ SDP_RC,USA,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,F
 SDP_RC,USA,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1,1,1,1,1
 SDP_RC,USA,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1,1,1,1,1
 SDP_RC,USA,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0298007305055295,0.25,0.785611032030326,0.785611032030326
-SDP_RC,USA,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0118564682943918,0.134470710684997,0.762059301457946,0.762059301457946
+SDP_RC,USA,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0118564682943918,0.134470710684998,0.762059301457946,0.762059301457946
 SDP_RC,USA,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.03,0.25,0.5,0.8,0.8
 SDP_RC,USA,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.03,0.25,0.5,0.8,0.8
 SDP_RC,USA,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0298007305055295,0.25,0.785611032030326,0.785611032030326
@@ -8564,18 +8564,18 @@ SDP_MC,CAZ,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,F
 SDP_MC,CAZ,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1,1,1,1,1
 SDP_MC,CAZ,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1,1,1,1,1
 SDP_MC,CAZ,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.119202922022118,0.35,0.491006895018954,0.491006895018954
-SDP_MC,CAZ,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.047425873177567,0.188258994958996,0.476287063411217,0.476287063411217
-SDP_MC,CAZ,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.047425873177567,0.188258994958996,0.476287063411217,0.476287063411217
-SDP_MC,CAZ,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.047425873177567,0.188258994958996,0.476287063411217,0.476287063411217
+SDP_MC,CAZ,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.047425873177567,0.188258994958997,0.476287063411217,0.476287063411217
+SDP_MC,CAZ,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.047425873177567,0.188258994958997,0.476287063411217,0.476287063411217
+SDP_MC,CAZ,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.047425873177567,0.188258994958997,0.476287063411217,0.476287063411217
 SDP_MC,CAZ,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.119202922022118,0.35,0.491006895018954,0.491006895018954
-SDP_MC,CAZ,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.012363115783175,0.017986209962092,0.0954351880334422,0.0954351880334422
+SDP_MC,CAZ,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.012363115783175,0.017986209962092,0.0954351880334419,0.0954351880334419
 SDP_MC,CAZ,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.033464254621425,0.047425873177567,0.146211715726001,0.146211715726001
 SDP_MC,CAZ,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.012363115783175,0.017986209962092,0.1,0.1
 SDP_MC,CAZ,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.012363115783175,0.017986209962092,0.1,0.1
 SDP_MC,CAZ,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.012363115783175,0.017986209962092,0.1,0.1
 SDP_MC,CAZ,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.033464254621425,0.047425873177567,0.146211715726001,0.146211715726001
 SDP_MC,CAZ,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0,8.31528027664132e-07,4.53978687024344e-05,0.119202922022118,0.119202922022118
-SDP_MC,CAZ,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1,1,1,0.954351880334422,0.954351880334422
+SDP_MC,CAZ,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1,1,1,0.954351880334419,0.954351880334419
 SDP_MC,CAZ,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1,1,1,1,1
 SDP_MC,CAZ,Liquids,Domestic Ship_tmp_vehicletype,Domestic Ship_tmp_subsector_L1,Domestic Ship_tmp_subsector_L2,Domestic Ship,trn_freight,FV,linear,1,1,1,1,1
 SDP_MC,CAZ,Liquids,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1,1,1,1,1
@@ -8590,7 +8590,7 @@ SDP_MC,CAZ,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_roa
 SDP_MC,CAZ,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,1,1,1,1
 SDP_MC,CAZ,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,1,1,1,1
 SDP_MC,CAZ,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,1,1,1,1
-SDP_MC,CAZ,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.031042108230522,0.056541000119193,0.107538783896534,0.199969502302122,0.199969502302122
+SDP_MC,CAZ,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.031042108230522,0.056541000119193,0.107538783896534,0.199969502302121,0.199969502302121
 SDP_MC,CAZ,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.026315789473684,0.078947368421053,0.184210526315789,0.184210526315789
 SDP_MC,CAZ,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.026315789473684,0.078947368421053,0.184210526315789,0.184210526315789
 SDP_MC,CAZ,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.026315789473684,0.078947368421053,0.184210526315789,0.184210526315789
@@ -8607,7 +8607,7 @@ SDP_MC,CHA,"","","","",Passenger Rail,trn_pass,S3S,linear,0.00546103419952829,0.
 SDP_MC,CHA,"","","","",Walk,trn_pass,S3S,linear,0.877713076761744,1,1,1,1
 SDP_MC,CHA,"","","","",trn_freight_road,trn_freight,S3S,linear,1,1,1,1,1
 SDP_MC,CHA,"","","","",trn_pass_road,trn_pass,S3S,linear,1,0.455729794383114,0.227864897191557,0.0584268967157839,0.0584268967157839
-SDP_MC,CHA,"","","",Bus,trn_pass_road,trn_pass,S2S3,linear,0.254432114324843,0.191544432089459,0.170509316525779,0.189454796139754,0.189454796139754
+SDP_MC,CHA,"","","",Bus,trn_pass_road,trn_pass,S2S3,linear,0.381648171487265,0.191544432089459,0.170509316525779,0.189454796139754,0.189454796139754
 SDP_MC,CHA,"","","",trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1,1,1,1,1
 SDP_MC,CHA,"","",trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,0.01080602223644,0.009522807095863,0.006956376814708,0.001823516252399,0.001823516252399
 SDP_MC,CHA,"","",trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1,1,1,1,1
@@ -8635,14 +8635,14 @@ SDP_MC,CHA,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_ro
 SDP_MC,CHA,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.1,0.4,0.9,1,1
 SDP_MC,CHA,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.1,0.4,0.9,1,1
 SDP_MC,CHA,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0476811688088472,0.45,0.982013790037908,0.982013790037908
-SDP_MC,CHA,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.022253608409715,0.0668777976648958,0.0699858045578576,0.0699858045578576
+SDP_MC,CHA,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.022253608409715,0.0668777976648955,0.0699858045578576,0.0699858045578576
 SDP_MC,CHA,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.001338570184857,0.0284555239065402,0.146211715726001,0.146211715726001
 SDP_MC,CHA,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.000494524631327,0.0107917259772552,0.1,0.1
 SDP_MC,CHA,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.01,0.2,0.6,0.2,0.2
 SDP_MC,CHA,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.01,0.2,0.6,0.2,0.2
 SDP_MC,CHA,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.001338570184857,0.0284555239065402,0.146211715726001,0.146211715726001
 SDP_MC,CHA,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0,8.31528027664132e-07,4.53978687024344e-05,0.119202922022118,0.119202922022118
-SDP_MC,CHA,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1,1,0.743656365691809,0.349929022789288,0.349929022789288
+SDP_MC,CHA,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1,1,0.743656365691807,0.349929022789288,0.349929022789288
 SDP_MC,CHA,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1,1,1,1,1
 SDP_MC,CHA,Liquids,Domestic Ship_tmp_vehicletype,Domestic Ship_tmp_subsector_L1,Domestic Ship_tmp_subsector_L2,Domestic Ship,trn_freight,FV,linear,1,1,1,1,1
 SDP_MC,CHA,Liquids,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1,1,1,1,1
@@ -8657,7 +8657,7 @@ SDP_MC,CHA,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_roa
 SDP_MC,CHA,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,1,1,1,1
 SDP_MC,CHA,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,1,1,1,1
 SDP_MC,CHA,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,1,1,1,1
-SDP_MC,CHA,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.142120012637288,0.159432643883675,0.090195248368545,0.115174077598356,0.115174077598356
+SDP_MC,CHA,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.142120012637288,0.159432643883675,0.0901952483685446,0.115174077598355,0.115174077598355
 SDP_MC,CHA,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.8778097236668e-05,0.013188367964814,0.0553035143317804,0.0921307947813305,0.0921307947813305
 SDP_MC,CHA,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.0007853553299874,0.014432374877611,0.0569509829460257,0.093173070843404,0.093173070843404
 SDP_MC,CHA,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.3,0.5,0.7,0.5,0.5
@@ -8698,16 +8698,16 @@ SDP_MC,DEU,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,F
 SDP_MC,DEU,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1,1,1,1,1
 SDP_MC,DEU,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1,1,1,1,1
 SDP_MC,DEU,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.298007305055295,0.675,0.982013790037908,0.982013790037908
-SDP_MC,DEU,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.118564682943918,0.363070918849493,0.952574126822433,0.952574126822433
-SDP_MC,DEU,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.118564682943918,0.363070918849493,0.952574126822433,0.952574126822433
-SDP_MC,DEU,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.118564682943918,0.363070918849493,0.952574126822433,0.952574126822433
+SDP_MC,DEU,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.118564682943917,0.363070918849493,0.952574126822433,0.952574126822433
+SDP_MC,DEU,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.118564682943917,0.363070918849493,0.952574126822433,0.952574126822433
+SDP_MC,DEU,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.118564682943917,0.363070918849493,0.952574126822433,0.952574126822433
 SDP_MC,DEU,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.298007305055295,0.675,0.982013790037908,0.982013790037908
 SDP_MC,DEU,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.002472623156635,0.017986209962092,0.05,0.05
-SDP_MC,DEU,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.08031421109142,0.331981112242969,0.219317573589002,0.219317573589002
+SDP_MC,DEU,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.08031421109142,0.331981112242969,0.219317573589001,0.219317573589001
 SDP_MC,DEU,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.02967147787962,0.125903469734644,0.15,0.15
 SDP_MC,DEU,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.02967147787962,0.125903469734644,0.15,0.15
 SDP_MC,DEU,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.02967147787962,0.125903469734644,0.15,0.15
-SDP_MC,DEU,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.08031421109142,0.331981112242969,0.219317573589002,0.219317573589002
+SDP_MC,DEU,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.08031421109142,0.331981112242969,0.219317573589001,0.219317573589001
 SDP_MC,DEU,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0,8.31528027664132e-07,4.53978687024344e-05,0.119202922022118,0.119202922022118
 SDP_MC,DEU,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1,1,1,1,1
 SDP_MC,DEU,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1,1,1,1,1
@@ -8832,9 +8832,9 @@ SDP_MC,ECS,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,F
 SDP_MC,ECS,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1,1,1,1,1
 SDP_MC,ECS,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1,1,1,1,1
 SDP_MC,ECS,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.119202922022118,0.25,0.294604137011372,0.294604137011372
-SDP_MC,ECS,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.047425873177567,0.134470710684997,0.28577223804673,0.28577223804673
-SDP_MC,ECS,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.047425873177567,0.134470710684997,0.28577223804673,0.28577223804673
-SDP_MC,ECS,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.047425873177567,0.134470710684997,0.28577223804673,0.28577223804673
+SDP_MC,ECS,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.047425873177567,0.134470710684998,0.28577223804673,0.28577223804673
+SDP_MC,ECS,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.047425873177567,0.134470710684998,0.28577223804673,0.28577223804673
+SDP_MC,ECS,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.047425873177567,0.134470710684998,0.28577223804673,0.28577223804673
 SDP_MC,ECS,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.119202922022118,0.25,0.294604137011372,0.294604137011372
 SDP_MC,ECS,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.002472623156635,0.053958629886276,0.1,0.1
 SDP_MC,ECS,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.01338570184857,0.047425873177567,0.0731058578630005,0.0731058578630005
@@ -8912,7 +8912,7 @@ SDP_MC,ENC,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_t
 SDP_MC,ENC,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.02472623156635,0.08993104981046,0.1,0.1
 SDP_MC,ENC,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.06692850924285,0.237129365887835,0.146211715726001,0.146211715726001
 SDP_MC,ENC,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0,8.31528027664132e-07,4.53978687024344e-05,0.119202922022118,0.119202922022118
-SDP_MC,ENC,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1,1,1,0.524893534183932,0.524893534183932
+SDP_MC,ENC,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1,1,1,0.524893534183931,0.524893534183931
 SDP_MC,ENC,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1,1,1,1,1
 SDP_MC,ENC,Liquids,Domestic Ship_tmp_vehicletype,Domestic Ship_tmp_subsector_L1,Domestic Ship_tmp_subsector_L2,Domestic Ship,trn_freight,FV,linear,1,1,1,1,1
 SDP_MC,ENC,Liquids,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,0.1341454314254,0.1341454314254,0.1341454314254,0.1341454314254,0.1341454314254
@@ -9030,7 +9030,7 @@ SDP_MC,ESW,"",Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tm
 SDP_MC,ESW,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0,0,0,0,0
 SDP_MC,ESW,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0,0,0,0,0
 SDP_MC,ESW,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0,0,0,0,0
-SDP_MC,ESW,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.118564682943918,0.268941421369995,0.666801888775703,0.666801888775703
+SDP_MC,ESW,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.118564682943917,0.268941421369995,0.666801888775703,0.666801888775703
 SDP_MC,ESW,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,0.72951273091157,0.763323639547623,0.830945456819731,0.966189091363946,0.966189091363946
 SDP_MC,ESW,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1,1,1,1,1
 SDP_MC,ESW,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1,1,1,1,1
@@ -9169,18 +9169,18 @@ SDP_MC,FRA,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,F
 SDP_MC,FRA,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1,1,1,1,1
 SDP_MC,FRA,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1,1,1,1,1
 SDP_MC,FRA,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.298007305055295,0.75,0.982013790037908,0.982013790037908
-SDP_MC,FRA,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.118564682943918,0.403412132054992,0.952574126822433,0.952574126822433
-SDP_MC,FRA,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.118564682943918,0.403412132054992,0.952574126822433,0.952574126822433
-SDP_MC,FRA,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.118564682943918,0.403412132054992,0.952574126822433,0.952574126822433
+SDP_MC,FRA,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.118564682943917,0.403412132054992,0.952574126822433,0.952574126822433
+SDP_MC,FRA,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.118564682943917,0.403412132054992,0.952574126822433,0.952574126822433
+SDP_MC,FRA,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.118564682943917,0.403412132054992,0.952574126822433,0.952574126822433
 SDP_MC,FRA,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.298007305055295,0.75,0.982013790037908,0.982013790037908
-SDP_MC,FRA,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.012363115783175,0.017986209962092,0.0954351880334422,0.0954351880334422
+SDP_MC,FRA,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.012363115783175,0.017986209962092,0.0954351880334419,0.0954351880334419
 SDP_MC,FRA,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.06692850924285,0.047425873177567,0.146211715726001,0.146211715726001
 SDP_MC,FRA,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.02472623156635,0.017986209962092,0.1,0.1
 SDP_MC,FRA,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.02472623156635,0.017986209962092,0.1,0.1
 SDP_MC,FRA,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.02472623156635,0.017986209962092,0.1,0.1
 SDP_MC,FRA,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.06692850924285,0.047425873177567,0.146211715726001,0.146211715726001
 SDP_MC,FRA,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0,8.31528027664132e-07,4.53978687024344e-05,0.119202922022118,0.119202922022118
-SDP_MC,FRA,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1,1,1,0.954351880334422,0.954351880334422
+SDP_MC,FRA,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1,1,1,0.954351880334419,0.954351880334419
 SDP_MC,FRA,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1,1,1,1,1
 SDP_MC,FRA,Liquids,Domestic Ship_tmp_vehicletype,Domestic Ship_tmp_subsector_L1,Domestic Ship_tmp_subsector_L2,Domestic Ship,trn_freight,FV,linear,1,1,1,1,1
 SDP_MC,FRA,Liquids,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,0.160770475713231,0.160770475713231,0.160770475713231,0.160770475713231,0.160770475713231
@@ -9195,7 +9195,7 @@ SDP_MC,FRA,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_roa
 SDP_MC,FRA,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,1,1,1,1
 SDP_MC,FRA,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,1,1,1,1
 SDP_MC,FRA,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,1,1,1,1
-SDP_MC,FRA,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.026315789473684,0.078947368421053,0.175801662166867,0.175801662166867
+SDP_MC,FRA,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.026315789473684,0.078947368421053,0.175801662166866,0.175801662166866
 SDP_MC,FRA,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.026315789473684,0.078947368421053,0.184210526315789,0.184210526315789
 SDP_MC,FRA,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.026315789473684,0.078947368421053,0.184210526315789,0.184210526315789
 SDP_MC,FRA,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.026315789473684,0.078947368421053,0.184210526315789,0.184210526315789
@@ -9212,7 +9212,7 @@ SDP_MC,IND,"","","","",Passenger Rail,trn_pass,S3S,linear,0.000684210526315789,8
 SDP_MC,IND,"","","","",Walk,trn_pass,S3S,linear,0.131578947368421,0.0945454545454544,0.181818181818182,1,1
 SDP_MC,IND,"","","","",trn_freight_road,trn_freight,S3S,linear,1,1,1,1,1
 SDP_MC,IND,"","","","",trn_pass_road,trn_pass,S3S,linear,1,1,1,1,1
-SDP_MC,IND,"","","",Bus,trn_pass_road,trn_pass,S2S3,linear,0.118824252562298,0.0625,0.0323053436653747,0.0323053436653747,0.0323053436653747
+SDP_MC,IND,"","","",Bus,trn_pass_road,trn_pass,S2S3,linear,0.118824252562298,0.0714285714285714,0.0323053436653747,0.0323053436653747,0.0323053436653747
 SDP_MC,IND,"","","",trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1,1,1,1,1
 SDP_MC,IND,"","",trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,0.003027158638145,0.002667683549865,0.001948733373306,0.000510833020187,0.000510833020187
 SDP_MC,IND,"","",trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1,1,1,1,1
@@ -9292,7 +9292,7 @@ SDP_MC,JPN,"",Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tm
 SDP_MC,JPN,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0,0,0,0,0
 SDP_MC,JPN,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0,0,0,0,0
 SDP_MC,JPN,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0,0,0,0,0
-SDP_MC,JPN,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.109079508308404,0.17929428091333,0.381029650728973,0.381029650728973
+SDP_MC,JPN,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.109079508308404,0.17929428091333,0.381029650728972,0.381029650728972
 SDP_MC,JPN,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1,1,1,1,1
 SDP_MC,JPN,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1,1,1,1,1
 SDP_MC,JPN,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1,1,1,1,1
@@ -9302,11 +9302,11 @@ SDP_MC,JPN,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_ro
 SDP_MC,JPN,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,0.0636363636363636,0.133333333333333,0.833333333333333,0.833333333333333
 SDP_MC,JPN,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.125163068123224,0.352941176470588,0.81834482503159,0.81834482503159
 SDP_MC,JPN,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.061815578915875,0.131898873055341,0.1,0.1
-SDP_MC,JPN,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.110432040250703,0.251078152116531,0.304607741095835,0.304607741095835
+SDP_MC,JPN,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.110432040250702,0.251078152116531,0.304607741095835,0.304607741095835
 SDP_MC,JPN,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,1,1,0.416666666666667,0.416666666666667
 SDP_MC,JPN,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,1,1,0.416666666666667,0.416666666666667
 SDP_MC,JPN,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,1,1,0.416666666666667,0.416666666666667
-SDP_MC,JPN,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.110432040250703,0.251078152116531,0.304607741095835,0.304607741095835
+SDP_MC,JPN,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.110432040250702,0.251078152116531,0.304607741095835,0.304607741095835
 SDP_MC,JPN,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0,8.31528027664132e-07,4.53978687024344e-05,0.119202922022118,0.119202922022118
 SDP_MC,JPN,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1,1,1,1,1
 SDP_MC,JPN,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1,1,1,1,1
@@ -9324,11 +9324,11 @@ SDP_MC,JPN,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_roa
 SDP_MC,JPN,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,0.0606060606060606,0.188888888888889,1,1
 SDP_MC,JPN,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,1,1,1,1
 SDP_MC,JPN,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.0078947368421052,0.0157894736842106,0.0230263157894736,0.0230263157894736
-SDP_MC,JPN,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.013157894736842,0.0464396284829724,0.0460526315789472,0.0460526315789472
+SDP_MC,JPN,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.013157894736842,0.0464396284829724,0.0460526315789473,0.0460526315789473
 SDP_MC,JPN,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,0.0303030303030303,0.111111111111111,0.25,0.25
 SDP_MC,JPN,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,0.0303030303030303,0.111111111111111,0.25,0.25
 SDP_MC,JPN,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,0.0303030303030303,0.111111111111111,0.25,0.25
-SDP_MC,JPN,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.013157894736842,0.0464396284829724,0.0460526315789472,0.0460526315789472
+SDP_MC,JPN,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.013157894736842,0.0464396284829724,0.0460526315789473,0.0460526315789473
 SDP_MC,LAM,"","","","",Cycle,trn_pass,S3S,linear,0.00981212891217365,0.0185165853437172,0.0462914633592929,0.231457316796465,0.231457316796465
 SDP_MC,LAM,"","","","",Domestic Aviation,trn_pass,S3S,linear,0.00840668890350734,0.0105762418419885,0.0264406046049712,0.0198304534537284,0.0198304534537284
 SDP_MC,LAM,"","","","",Domestic Ship,trn_freight,S3S,linear,0.009523329319276,0.009523329319276,0.00865757210843273,0.00793610776606333,0.00793610776606333
@@ -9340,7 +9340,7 @@ SDP_MC,LAM,"","","","",Passenger Rail,trn_pass,S3S,linear,0.134842686357634,0.12
 SDP_MC,LAM,"","","","",Walk,trn_pass,S3S,linear,0.899323352244677,0.848561904989659,0.848561904989659,0.848561904989659,0.848561904989659
 SDP_MC,LAM,"","","","",trn_freight_road,trn_freight,S3S,linear,1,1,1,1,1
 SDP_MC,LAM,"","","","",trn_pass_road,trn_pass,S3S,linear,1,1,1,1,1
-SDP_MC,LAM,"","","",Bus,trn_pass_road,trn_pass,S2S3,linear,0.138594539617622,0.086621587261014,0.086621587261014,0.086621587261014,0.086621587261014
+SDP_MC,LAM,"","","",Bus,trn_pass_road,trn_pass,S2S3,linear,0.173243174522027,0.108276984076267,0.086621587261014,0.086621587261014,0.086621587261014
 SDP_MC,LAM,"","","",trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1,1,1,1,1
 SDP_MC,LAM,"","",trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,0.137734442638184,0.137734442638184,0.137734442638184,0.137734442638184,0.137734442638184
 SDP_MC,LAM,"","",trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1,1,1,1,1
@@ -9363,23 +9363,23 @@ SDP_MC,LAM,"",Van,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,
 SDP_MC,LAM,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0,0,0,0,0
 SDP_MC,LAM,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0,0,0,0,0
 SDP_MC,LAM,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0,0,0,0,0
-SDP_MC,LAM,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.118564682943918,0.53788284273999,1,1
+SDP_MC,LAM,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.118564682943917,0.53788284273999,1,1
 SDP_MC,LAM,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,0.0681034247188,0.18459049662895,0.41756464044925,0.88351292808985,0.88351292808985
 SDP_MC,LAM,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1,1,1,1,1
 SDP_MC,LAM,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1,1,1,1,1
 SDP_MC,LAM,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.079468614681412,0.2,0.2400478153426,0.2400478153426
-SDP_MC,LAM,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0316172487850447,0.107576568547998,0.232851453223261,0.232851453223261
-SDP_MC,LAM,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0316172487850447,0.107576568547998,0.232851453223261,0.232851453223261
-SDP_MC,LAM,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0316172487850447,0.107576568547998,0.232851453223261,0.232851453223261
+SDP_MC,LAM,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0316172487850447,0.107576568547998,0.232851453223262,0.232851453223262
+SDP_MC,LAM,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0316172487850447,0.107576568547998,0.232851453223262,0.232851453223262
+SDP_MC,LAM,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0316172487850447,0.107576568547998,0.232851453223262,0.232851453223262
 SDP_MC,LAM,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.079468614681412,0.2,0.2400478153426,0.2400478153426
-SDP_MC,LAM,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.002472623156635,0.017986209962092,0.0656116917729915,0.0656116917729915
-SDP_MC,LAM,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.00892380123238,0.0569110478130804,0.0812287309588894,0.0812287309588894
+SDP_MC,LAM,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.002472623156635,0.017986209962092,0.0656116917729916,0.0656116917729916
+SDP_MC,LAM,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.00892380123238,0.0569110478130804,0.0812287309588893,0.0812287309588893
 SDP_MC,LAM,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.00329683087551333,0.0215834519545104,0.0555555555555556,0.0555555555555556
 SDP_MC,LAM,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.00329683087551333,0.0215834519545104,0.0555555555555556,0.0555555555555556
 SDP_MC,LAM,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.00329683087551333,0.0215834519545104,0.0555555555555556,0.0555555555555556
-SDP_MC,LAM,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.00892380123238,0.0569110478130804,0.0812287309588894,0.0812287309588894
+SDP_MC,LAM,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.00892380123238,0.0569110478130804,0.0812287309588893,0.0812287309588893
 SDP_MC,LAM,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0,8.31528027664132e-07,4.53978687024344e-05,0.119202922022118,0.119202922022118
-SDP_MC,LAM,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1,1,1,0.721728609502907,0.721728609502907
+SDP_MC,LAM,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1,1,1,0.721728609502908,0.721728609502908
 SDP_MC,LAM,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1,1,1,1,1
 SDP_MC,LAM,Liquids,Domestic Ship_tmp_vehicletype,Domestic Ship_tmp_subsector_L1,Domestic Ship_tmp_subsector_L2,Domestic Ship,trn_freight,FV,linear,1,1,1,1,1
 SDP_MC,LAM,Liquids,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1,1,1,1,1
@@ -9395,11 +9395,11 @@ SDP_MC,LAM,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_roa
 SDP_MC,LAM,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,1,1,1,1
 SDP_MC,LAM,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,1,1,1,1
 SDP_MC,LAM,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.026893682222235,0.0472515688947483,0.10371786520469,0.135258574225718,0.135258574225718
-SDP_MC,LAM,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0175438596491227,0.0315789473684212,0.0614035087719297,0.0614035087719297
-SDP_MC,LAM,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0175438596491227,0.0315789473684212,0.0614035087719297,0.0614035087719297
-SDP_MC,LAM,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0175438596491227,0.0315789473684212,0.0614035087719297,0.0614035087719297
-SDP_MC,LAM,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0175438596491227,0.0315789473684212,0.0614035087719297,0.0614035087719297
-SDP_MC,LAM,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0175438596491227,0.0315789473684212,0.0614035087719297,0.0614035087719297
+SDP_MC,LAM,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0175438596491227,0.0315789473684212,0.0614035087719296,0.0614035087719296
+SDP_MC,LAM,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0175438596491227,0.0315789473684212,0.0614035087719296,0.0614035087719296
+SDP_MC,LAM,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0175438596491227,0.0315789473684212,0.0614035087719296,0.0614035087719296
+SDP_MC,LAM,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0175438596491227,0.0315789473684212,0.0614035087719296,0.0614035087719296
+SDP_MC,LAM,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0175438596491227,0.0315789473684212,0.0614035087719296,0.0614035087719296
 SDP_MC,MEA,"","","","",Cycle,trn_pass,S3S,linear,0.0165975108305109,0.0165975108305109,0.0165975108305109,0.0414937770762773,0.0414937770762773
 SDP_MC,MEA,"","","","",Domestic Aviation,trn_pass,S3S,linear,0.0089294530094782,0.00595296867298547,0.0178589060189564,0.0238118746919419,0.0238118746919419
 SDP_MC,MEA,"","","","",Domestic Ship,trn_freight,S3S,linear,0.002022051343562,0.002022051343562,0.002022051343562,0.002022051343562,0.002022051343562
@@ -9411,7 +9411,7 @@ SDP_MC,MEA,"","","","",Passenger Rail,trn_pass,S3S,linear,0.000556730785330985,0
 SDP_MC,MEA,"","","","",Walk,trn_pass,S3S,linear,1,1,1,1,1
 SDP_MC,MEA,"","","","",trn_freight_road,trn_freight,S3S,linear,1,1,1,1,1
 SDP_MC,MEA,"","","","",trn_pass_road,trn_pass,S3S,linear,0.639480996474237,0.71967693403545,0.71967693403545,0.71967693403545,0.71967693403545
-SDP_MC,MEA,"","","",Bus,trn_pass_road,trn_pass,S2S3,linear,0.183919217151252,0.122612811434168,0.0613064057170841,0.0490451245736673,0.0490451245736673
+SDP_MC,MEA,"","","",Bus,trn_pass_road,trn_pass,S2S3,linear,0.262741738787503,0.122612811434168,0.0613064057170841,0.0490451245736673,0.0490451245736673
 SDP_MC,MEA,"","","",trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1,1,1,1,1
 SDP_MC,MEA,"","",trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,0.007508394761241,0.007508394761241,0.007508394761241,0.007508394761241,0.007508394761241
 SDP_MC,MEA,"","",trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1,1,1,1,1
@@ -9428,12 +9428,12 @@ SDP_MC,MEA,"",Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tm
 SDP_MC,MEA,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1,1,1,1,1
 SDP_MC,MEA,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0,0,0,0,0
 SDP_MC,MEA,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1,1,1,1,1
-SDP_MC,MEA,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.047425873177567,0.295835563506995,0.654894712190423,0.654894712190423
+SDP_MC,MEA,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.047425873177567,0.295835563506994,0.654894712190425,0.654894712190425
 SDP_MC,MEA,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,0.402051171672381,0.476794775213334,0.626281982295238,0.925256396459048,0.925256396459048
 SDP_MC,MEA,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1,1,1,1,1
 SDP_MC,MEA,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1,1,1,1,1
 SDP_MC,MEA,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.059601461011059,0.1,0.14028768429113,0.14028768429113
-SDP_MC,MEA,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0237129365887835,0.053788284273999,0.13608201811749,0.13608201811749
+SDP_MC,MEA,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0237129365887835,0.053788284273999,0.136082018117491,0.136082018117491
 SDP_MC,MEA,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,0.142857142857143,0.2,0.142857142857143,0.142857142857143
 SDP_MC,MEA,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,0.142857142857143,0.2,0.142857142857143,0.142857142857143
 SDP_MC,MEA,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.059601461011059,0.1,0.14028768429113,0.14028768429113
@@ -9545,7 +9545,7 @@ SDP_MC,NES,"","","","",Passenger Rail,trn_pass,S3S,linear,0.00160675014597331,0.
 SDP_MC,NES,"","","","",Walk,trn_pass,S3S,linear,1,1,1,1,1
 SDP_MC,NES,"","","","",trn_freight_road,trn_freight,S3S,linear,1,1,1,1,1
 SDP_MC,NES,"","","","",trn_pass_road,trn_pass,S3S,linear,0.925821312685462,0.717579145423199,0.456641274360218,0.25115270089812,0.25115270089812
-SDP_MC,NES,"","","",Bus,trn_pass_road,trn_pass,S2S3,linear,0.021994137000963,0.0183284475008025,0.0109970685004815,0.0109970685004815,0.0109970685004815
+SDP_MC,NES,"","","",Bus,trn_pass_road,trn_pass,S2S3,linear,0.0549853425024075,0.021994137000963,0.0109970685004815,0.0109970685004815,0.0109970685004815
 SDP_MC,NES,"","","",trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1,1,1,1,1
 SDP_MC,NES,"","",trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,0.004922521505832,0.004922521505832,0.004922521505832,0.004922521505832,0.004922521505832
 SDP_MC,NES,"","",trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1,1,1,1,1
@@ -9614,7 +9614,7 @@ SDP_MC,OAS,"","","","",Passenger Rail,trn_pass,S3S,linear,0.00077008869031218,0.
 SDP_MC,OAS,"","","","",Walk,trn_pass,S3S,linear,1,0.689328623982319,0.689328623982319,0.689328623982319,0.689328623982319
 SDP_MC,OAS,"","","","",trn_freight_road,trn_freight,S3S,linear,1,1,1,1,1
 SDP_MC,OAS,"","","","",trn_pass_road,trn_pass,S3S,linear,0.87209012211972,1,1,1,1
-SDP_MC,OAS,"","","",Bus,trn_pass_road,trn_pass,S2S3,linear,0.160206681607861,0.110191151172767,0.0550955755863836,0.0550955755863836,0.0550955755863836
+SDP_MC,OAS,"","","",Bus,trn_pass_road,trn_pass,S2S3,linear,0.240310022411792,0.140243283310795,0.0550955755863836,0.0550955755863836,0.0550955755863836
 SDP_MC,OAS,"","","",trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1,1,1,1,1
 SDP_MC,OAS,"","",trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,0.025341509717687,0.022332205438712,0.016313596880761,0.00427637976486,0.00427637976486
 SDP_MC,OAS,"","",trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1,1,1,1,1
@@ -9642,18 +9642,18 @@ SDP_MC,OAS,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,F
 SDP_MC,OAS,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1,1,1,1,1
 SDP_MC,OAS,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,0.352966479972375,0.433845669975828,0.595604049982734,0.919120809996547,0.919120809996547
 SDP_MC,OAS,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.039734307340706,0.0625,0.0785611032030326,0.0785611032030326
-SDP_MC,OAS,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0158086243925223,0.0336176776712494,0.0762059301457946,0.0762059301457946
-SDP_MC,OAS,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0158086243925223,0.0336176776712494,0.0762059301457946,0.0762059301457946
-SDP_MC,OAS,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0158086243925223,0.0336176776712494,0.0762059301457946,0.0762059301457946
+SDP_MC,OAS,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0158086243925223,0.0336176776712495,0.0762059301457946,0.0762059301457946
+SDP_MC,OAS,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0158086243925223,0.0336176776712495,0.0762059301457946,0.0762059301457946
+SDP_MC,OAS,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0158086243925223,0.0336176776712495,0.0762059301457946,0.0762059301457946
 SDP_MC,OAS,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.039734307340706,0.0625,0.0785611032030326,0.0785611032030326
-SDP_MC,OAS,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.002472623156635,0.017986209962092,0.0656116917729915,0.0656116917729915
+SDP_MC,OAS,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.002472623156635,0.017986209962092,0.0656116917729916,0.0656116917729916
 SDP_MC,OAS,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.011154751540475,0.0118564682943918,0.0292423431452002,0.0292423431452002
 SDP_MC,OAS,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.00412103859439167,0.004496552490523,0.02,0.02
 SDP_MC,OAS,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.00412103859439167,0.004496552490523,0.02,0.02
 SDP_MC,OAS,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.00412103859439167,0.004496552490523,0.02,0.02
 SDP_MC,OAS,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.011154751540475,0.0118564682943918,0.0292423431452002,0.0292423431452002
 SDP_MC,OAS,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0,8.31528027664132e-07,4.53978687024344e-05,0.119202922022118,0.119202922022118
-SDP_MC,OAS,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1,1,1,0.656116917729915,0.656116917729915
+SDP_MC,OAS,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1,1,1,0.656116917729916,0.656116917729916
 SDP_MC,OAS,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1,1,1,1,1
 SDP_MC,OAS,Liquids,Domestic Ship_tmp_vehicletype,Domestic Ship_tmp_subsector_L1,Domestic Ship_tmp_subsector_L2,Domestic Ship,trn_freight,FV,linear,1,1,1,1,1
 SDP_MC,OAS,Liquids,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1,1,1,1,1
@@ -9685,7 +9685,7 @@ SDP_MC,REF,"","","","",Passenger Rail,trn_pass,S3S,linear,0.00236561326843326,0.
 SDP_MC,REF,"","","","",Walk,trn_pass,S3S,linear,0.317883555031073,0.317883555031073,0.317883555031073,1,1
 SDP_MC,REF,"","","","",trn_freight_road,trn_freight,S3S,linear,1,1,1,1,1
 SDP_MC,REF,"","","","",trn_pass_road,trn_pass,S3S,linear,1,1,1,0.943741804984768,0.943741804984768
-SDP_MC,REF,"","","",Bus,trn_pass_road,trn_pass,S2S3,linear,0.106725224568562,0.0914787639159102,0.0762323032632585,0.0609858426106068,0.0609858426106068
+SDP_MC,REF,"","","",Bus,trn_pass_road,trn_pass,S2S3,linear,0.118583582853958,0.0914787639159102,0.0762323032632585,0.0609858426106068,0.0609858426106068
 SDP_MC,REF,"","","",trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1,1,1,1,1
 SDP_MC,REF,"","",trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,0.369757606378564,0.369757606378564,0.369757606378564,0.369757606378564,0.369757606378564
 SDP_MC,REF,"","",trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1,1,1,1,1
@@ -9742,18 +9742,18 @@ SDP_MC,REF,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp
 SDP_MC,REF,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.063108879885637,0.087763909362331,0.137073968315718,0.188555268977994,0.188555268977994
 SDP_MC,REF,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.030480218828266,0.055993897280154,0.107021254183929,0.167260774393184,0.167260774393184
 SDP_MC,REF,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.026315789473684,0.078947368421053,0.147368421052631,0.147368421052631
-SDP_MC,SSA,"","","","",Cycle,trn_pass,S3S,linear,0.013878678157857,0.0179527662940391,0.0291452241314997,0.0327883771479372,0.0327883771479372
-SDP_MC,SSA,"","","","",Domestic Aviation,trn_pass,S3S,linear,0.00901317336217352,0.0509980791548766,0.0413961398176937,0.00620942097265405,0.00620942097265405
+SDP_MC,SSA,"","","","",Cycle,trn_pass,S3S,linear,0.013878678157857,0.017952766294039,0.0291452241314997,0.0327883771479372,0.0327883771479372
+SDP_MC,SSA,"","","","",Domestic Aviation,trn_pass,S3S,linear,0.00901317336217352,0.0509980791548764,0.0413961398176937,0.00620942097265405,0.00620942097265405
 SDP_MC,SSA,"","","","",Domestic Ship,trn_freight,S3S,linear,0.001467441828354,0.001467441828354,0.001467441828354,0.001467441828354,0.001467441828354
 SDP_MC,SSA,"","","","",Freight Rail,trn_freight,S3S,linear,0.01634165332484,0.01634165332484,0.01634165332484,0.01634165332484,0.01634165332484
-SDP_MC,SSA,"","","","",HSR,trn_pass,S3S,linear,1.47506311523337e-05,2.00316440897408e-05,0.0650403115771387,0.0097560467365708,0.0097560467365708
+SDP_MC,SSA,"","","","",HSR,trn_pass,S3S,linear,1.47506311523337e-05,2.00316440897407e-05,0.0650403115771387,0.0097560467365708,0.0097560467365708
 SDP_MC,SSA,"","","","",International Aviation,trn_aviation_intl,S3S,linear,1,1,1,1,1
 SDP_MC,SSA,"","","","",International Ship,trn_shipping_intl,S3S,linear,1,1,1,1,1
-SDP_MC,SSA,"","","","",Passenger Rail,trn_pass,S3S,linear,0.000602417147703971,0.00155851359059413,0.00253015202035668,0.000569284204580253,0.000569284204580253
-SDP_MC,SSA,"","","","",Walk,trn_pass,S3S,linear,1,0.903431854876908,1,1,1
+SDP_MC,SSA,"","","","",Passenger Rail,trn_pass,S3S,linear,0.000602417147703971,0.00155851359059412,0.00253015202035668,0.000569284204580253,0.000569284204580253
+SDP_MC,SSA,"","","","",Walk,trn_pass,S3S,linear,1,0.903431854876905,1,1,1
 SDP_MC,SSA,"","","","",trn_freight_road,trn_freight,S3S,linear,1,1,1,1,1
-SDP_MC,SSA,"","","","",trn_pass_road,trn_pass,S3S,linear,0.890164318010016,1,0.974063506007212,0.0974063506007212,0.0974063506007212
-SDP_MC,SSA,"","","",Bus,trn_pass_road,trn_pass,S2S3,linear,0.206400000437543,0.105846154070534,0.0732781066642163,0.0952615386634812,0.0952615386634812
+SDP_MC,SSA,"","","","",trn_pass_road,trn_pass,S3S,linear,0.890164318010017,1,0.974063506007213,0.0974063506007212,0.0974063506007212
+SDP_MC,SSA,"","","",Bus,trn_pass_road,trn_pass,S2S3,linear,0.247680000525051,0.127015384884641,0.0732781066642163,0.0952615386634812,0.0952615386634812
 SDP_MC,SSA,"","","",trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1,1,1,1,1
 SDP_MC,SSA,"","",trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,0.039283595822529,0.039283595822529,0.039283595822529,0.039283595822529,0.039283595822529
 SDP_MC,SSA,"","",trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1,1,1,1,1
@@ -9783,11 +9783,11 @@ SDP_MC,SSA,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_ro
 SDP_MC,SSA,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0094851746355134,0.053788284273999,0.14654986566499,0.14654986566499
 SDP_MC,SSA,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0238405844044236,0.1,0.151079044621217,0.151079044621217
 SDP_MC,SSA,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.002472623156635,0.017986209962092,0.075,0.075
-SDP_MC,SSA,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.006692850924285,0.047425873177567,0.0281176376396156,0.0281176376396156
+SDP_MC,SSA,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.006692850924285,0.047425873177567,0.0281176376396155,0.0281176376396155
 SDP_MC,SSA,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.002472623156635,0.017986209962092,0.0192307692307692,0.0192307692307692
 SDP_MC,SSA,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.002472623156635,0.017986209962092,0.0192307692307692,0.0192307692307692
 SDP_MC,SSA,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.002472623156635,0.017986209962092,0.0192307692307692,0.0192307692307692
-SDP_MC,SSA,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.006692850924285,0.047425873177567,0.0281176376396156,0.0281176376396156
+SDP_MC,SSA,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.006692850924285,0.047425873177567,0.0281176376396155,0.0281176376396155
 SDP_MC,SSA,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0,8.31528027664132e-07,4.53978687024344e-05,0.119202922022118,0.119202922022118
 SDP_MC,SSA,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1,1,1,1,1
 SDP_MC,SSA,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1,1,1,1,1
@@ -9842,14 +9842,14 @@ SDP_MC,UKI,"",Van,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,
 SDP_MC,UKI,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0,0,0,0,0
 SDP_MC,UKI,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0,0,0,0,0
 SDP_MC,UKI,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0,0,0,0,0
-SDP_MC,UKI,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.118564682943918,0.322729705643994,0.85731671414019,0.85731671414019
+SDP_MC,UKI,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.118564682943917,0.322729705643994,0.85731671414019,0.85731671414019
 SDP_MC,UKI,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,0.826003073674058,0.847752689464801,0.891251921046287,0.978250384209257,0.978250384209257
 SDP_MC,UKI,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1,1,1,1,1
 SDP_MC,UKI,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1,1,1,1,1
 SDP_MC,UKI,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.238405844044236,0.55,0.883812411034117,0.883812411034117
-SDP_MC,UKI,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.094851746355134,0.295835563506995,0.85731671414019,0.85731671414019
-SDP_MC,UKI,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.094851746355134,0.295835563506995,0.85731671414019,0.85731671414019
-SDP_MC,UKI,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.094851746355134,0.295835563506995,0.85731671414019,0.85731671414019
+SDP_MC,UKI,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.094851746355134,0.295835563506994,0.85731671414019,0.85731671414019
+SDP_MC,UKI,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.094851746355134,0.295835563506994,0.85731671414019,0.85731671414019
+SDP_MC,UKI,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.094851746355134,0.295835563506994,0.85731671414019,0.85731671414019
 SDP_MC,UKI,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.238405844044236,0.55,0.883812411034117,0.883812411034117
 SDP_MC,UKI,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.012363115783175,0.017986209962092,0.1,0.1
 SDP_MC,UKI,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.06692850924285,0.189703492710268,0.146211715726001,0.146211715726001
@@ -9914,7 +9914,7 @@ SDP_MC,USA,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,F
 SDP_MC,USA,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1,1,1,1,1
 SDP_MC,USA,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1,1,1,1,1
 SDP_MC,USA,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0298007305055295,0.25,0.785611032030326,0.785611032030326
-SDP_MC,USA,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0118564682943918,0.134470710684997,0.762059301457946,0.762059301457946
+SDP_MC,USA,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0118564682943918,0.134470710684998,0.762059301457946,0.762059301457946
 SDP_MC,USA,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.03,0.25,0.5,0.8,0.8
 SDP_MC,USA,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.03,0.25,0.5,0.8,0.8
 SDP_MC,USA,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0298007305055295,0.25,0.785611032030326,0.785611032030326
@@ -9985,18 +9985,18 @@ SDP_EI,CAZ,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,F
 SDP_EI,CAZ,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1,1,1,1,1
 SDP_EI,CAZ,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1,1,1,1,1
 SDP_EI,CAZ,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.119202922022118,0.35,0.491006895018954,0.491006895018954
-SDP_EI,CAZ,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.047425873177567,0.188258994958996,0.476287063411217,0.476287063411217
-SDP_EI,CAZ,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.047425873177567,0.188258994958996,0.476287063411217,0.476287063411217
-SDP_EI,CAZ,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.047425873177567,0.188258994958996,0.476287063411217,0.476287063411217
+SDP_EI,CAZ,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.047425873177567,0.188258994958997,0.476287063411217,0.476287063411217
+SDP_EI,CAZ,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.047425873177567,0.188258994958997,0.476287063411217,0.476287063411217
+SDP_EI,CAZ,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.047425873177567,0.188258994958997,0.476287063411217,0.476287063411217
 SDP_EI,CAZ,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.119202922022118,0.35,0.491006895018954,0.491006895018954
-SDP_EI,CAZ,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.012363115783175,0.017986209962092,0.0954351880334422,0.0954351880334422
+SDP_EI,CAZ,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.012363115783175,0.017986209962092,0.0954351880334419,0.0954351880334419
 SDP_EI,CAZ,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.033464254621425,0.047425873177567,0.146211715726001,0.146211715726001
 SDP_EI,CAZ,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.012363115783175,0.017986209962092,0.1,0.1
 SDP_EI,CAZ,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.012363115783175,0.017986209962092,0.1,0.1
 SDP_EI,CAZ,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.012363115783175,0.017986209962092,0.1,0.1
 SDP_EI,CAZ,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.033464254621425,0.047425873177567,0.146211715726001,0.146211715726001
 SDP_EI,CAZ,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0,8.31528027664132e-07,4.53978687024344e-05,0.119202922022118,0.119202922022118
-SDP_EI,CAZ,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1,1,1,0.954351880334422,0.954351880334422
+SDP_EI,CAZ,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1,1,1,0.954351880334419,0.954351880334419
 SDP_EI,CAZ,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1,1,1,1,1
 SDP_EI,CAZ,Liquids,Domestic Ship_tmp_vehicletype,Domestic Ship_tmp_subsector_L1,Domestic Ship_tmp_subsector_L2,Domestic Ship,trn_freight,FV,linear,1,1,1,1,1
 SDP_EI,CAZ,Liquids,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1,1,1,1,1
@@ -10011,7 +10011,7 @@ SDP_EI,CAZ,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_roa
 SDP_EI,CAZ,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,1,1,1,1
 SDP_EI,CAZ,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,1,1,1,1
 SDP_EI,CAZ,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,1,1,1,1
-SDP_EI,CAZ,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.031042108230522,0.056541000119193,0.107538783896534,0.199969502302122,0.199969502302122
+SDP_EI,CAZ,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.031042108230522,0.056541000119193,0.107538783896534,0.199969502302121,0.199969502302121
 SDP_EI,CAZ,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.026315789473684,0.078947368421053,0.184210526315789,0.184210526315789
 SDP_EI,CAZ,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.026315789473684,0.078947368421053,0.184210526315789,0.184210526315789
 SDP_EI,CAZ,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.026315789473684,0.078947368421053,0.184210526315789,0.184210526315789
@@ -10028,7 +10028,7 @@ SDP_EI,CHA,"","","","",Passenger Rail,trn_pass,S3S,linear,0.00546103419952829,0.
 SDP_EI,CHA,"","","","",Walk,trn_pass,S3S,linear,0.877713076761744,1,1,1,1
 SDP_EI,CHA,"","","","",trn_freight_road,trn_freight,S3S,linear,1,1,1,1,1
 SDP_EI,CHA,"","","","",trn_pass_road,trn_pass,S3S,linear,1,0.455729794383114,0.227864897191557,0.0584268967157839,0.0584268967157839
-SDP_EI,CHA,"","","",Bus,trn_pass_road,trn_pass,S2S3,linear,0.254432114324843,0.191544432089459,0.170509316525779,0.189454796139754,0.189454796139754
+SDP_EI,CHA,"","","",Bus,trn_pass_road,trn_pass,S2S3,linear,0.381648171487265,0.191544432089459,0.170509316525779,0.189454796139754,0.189454796139754
 SDP_EI,CHA,"","","",trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1,1,1,1,1
 SDP_EI,CHA,"","",trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,0.01080602223644,0.009522807095863,0.006956376814708,0.001823516252399,0.001823516252399
 SDP_EI,CHA,"","",trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1,1,1,1,1
@@ -10056,14 +10056,14 @@ SDP_EI,CHA,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_ro
 SDP_EI,CHA,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.1,0.4,0.9,1,1
 SDP_EI,CHA,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.1,0.4,0.9,1,1
 SDP_EI,CHA,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0476811688088472,0.45,0.982013790037908,0.982013790037908
-SDP_EI,CHA,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.022253608409715,0.0668777976648958,0.0699858045578576,0.0699858045578576
+SDP_EI,CHA,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.022253608409715,0.0668777976648955,0.0699858045578576,0.0699858045578576
 SDP_EI,CHA,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.001338570184857,0.0284555239065402,0.146211715726001,0.146211715726001
 SDP_EI,CHA,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.000494524631327,0.0107917259772552,0.1,0.1
 SDP_EI,CHA,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.01,0.2,0.6,0.2,0.2
 SDP_EI,CHA,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.01,0.2,0.6,0.2,0.2
 SDP_EI,CHA,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.001338570184857,0.0284555239065402,0.146211715726001,0.146211715726001
 SDP_EI,CHA,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0,8.31528027664132e-07,4.53978687024344e-05,0.119202922022118,0.119202922022118
-SDP_EI,CHA,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1,1,0.743656365691809,0.349929022789288,0.349929022789288
+SDP_EI,CHA,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1,1,0.743656365691807,0.349929022789288,0.349929022789288
 SDP_EI,CHA,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1,1,1,1,1
 SDP_EI,CHA,Liquids,Domestic Ship_tmp_vehicletype,Domestic Ship_tmp_subsector_L1,Domestic Ship_tmp_subsector_L2,Domestic Ship,trn_freight,FV,linear,1,1,1,1,1
 SDP_EI,CHA,Liquids,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1,1,1,1,1
@@ -10078,7 +10078,7 @@ SDP_EI,CHA,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_roa
 SDP_EI,CHA,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,1,1,1,1
 SDP_EI,CHA,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,1,1,1,1
 SDP_EI,CHA,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,1,1,1,1
-SDP_EI,CHA,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.142120012637288,0.159432643883675,0.090195248368545,0.115174077598356,0.115174077598356
+SDP_EI,CHA,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.142120012637288,0.159432643883675,0.0901952483685446,0.115174077598355,0.115174077598355
 SDP_EI,CHA,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.8778097236668e-05,0.013188367964814,0.0553035143317804,0.0921307947813305,0.0921307947813305
 SDP_EI,CHA,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.0007853553299874,0.014432374877611,0.0569509829460257,0.093173070843404,0.093173070843404
 SDP_EI,CHA,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.3,0.5,0.7,0.5,0.5
@@ -10119,16 +10119,16 @@ SDP_EI,DEU,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,F
 SDP_EI,DEU,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1,1,1,1,1
 SDP_EI,DEU,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1,1,1,1,1
 SDP_EI,DEU,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.298007305055295,0.675,0.982013790037908,0.982013790037908
-SDP_EI,DEU,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.118564682943918,0.363070918849493,0.952574126822433,0.952574126822433
-SDP_EI,DEU,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.118564682943918,0.363070918849493,0.952574126822433,0.952574126822433
-SDP_EI,DEU,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.118564682943918,0.363070918849493,0.952574126822433,0.952574126822433
+SDP_EI,DEU,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.118564682943917,0.363070918849493,0.952574126822433,0.952574126822433
+SDP_EI,DEU,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.118564682943917,0.363070918849493,0.952574126822433,0.952574126822433
+SDP_EI,DEU,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.118564682943917,0.363070918849493,0.952574126822433,0.952574126822433
 SDP_EI,DEU,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.298007305055295,0.675,0.982013790037908,0.982013790037908
 SDP_EI,DEU,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.002472623156635,0.017986209962092,0.05,0.05
-SDP_EI,DEU,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.08031421109142,0.331981112242969,0.219317573589002,0.219317573589002
+SDP_EI,DEU,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.08031421109142,0.331981112242969,0.219317573589001,0.219317573589001
 SDP_EI,DEU,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.02967147787962,0.125903469734644,0.15,0.15
 SDP_EI,DEU,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.02967147787962,0.125903469734644,0.15,0.15
 SDP_EI,DEU,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.02967147787962,0.125903469734644,0.15,0.15
-SDP_EI,DEU,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.08031421109142,0.331981112242969,0.219317573589002,0.219317573589002
+SDP_EI,DEU,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.08031421109142,0.331981112242969,0.219317573589001,0.219317573589001
 SDP_EI,DEU,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0,8.31528027664132e-07,4.53978687024344e-05,0.119202922022118,0.119202922022118
 SDP_EI,DEU,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1,1,1,1,1
 SDP_EI,DEU,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1,1,1,1,1
@@ -10253,9 +10253,9 @@ SDP_EI,ECS,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,F
 SDP_EI,ECS,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1,1,1,1,1
 SDP_EI,ECS,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1,1,1,1,1
 SDP_EI,ECS,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.119202922022118,0.25,0.294604137011372,0.294604137011372
-SDP_EI,ECS,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.047425873177567,0.134470710684997,0.28577223804673,0.28577223804673
-SDP_EI,ECS,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.047425873177567,0.134470710684997,0.28577223804673,0.28577223804673
-SDP_EI,ECS,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.047425873177567,0.134470710684997,0.28577223804673,0.28577223804673
+SDP_EI,ECS,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.047425873177567,0.134470710684998,0.28577223804673,0.28577223804673
+SDP_EI,ECS,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.047425873177567,0.134470710684998,0.28577223804673,0.28577223804673
+SDP_EI,ECS,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.047425873177567,0.134470710684998,0.28577223804673,0.28577223804673
 SDP_EI,ECS,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.119202922022118,0.25,0.294604137011372,0.294604137011372
 SDP_EI,ECS,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.002472623156635,0.053958629886276,0.1,0.1
 SDP_EI,ECS,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.01338570184857,0.047425873177567,0.0731058578630005,0.0731058578630005
@@ -10333,7 +10333,7 @@ SDP_EI,ENC,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_t
 SDP_EI,ENC,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.02472623156635,0.08993104981046,0.1,0.1
 SDP_EI,ENC,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.06692850924285,0.237129365887835,0.146211715726001,0.146211715726001
 SDP_EI,ENC,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0,8.31528027664132e-07,4.53978687024344e-05,0.119202922022118,0.119202922022118
-SDP_EI,ENC,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1,1,1,0.524893534183932,0.524893534183932
+SDP_EI,ENC,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1,1,1,0.524893534183931,0.524893534183931
 SDP_EI,ENC,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1,1,1,1,1
 SDP_EI,ENC,Liquids,Domestic Ship_tmp_vehicletype,Domestic Ship_tmp_subsector_L1,Domestic Ship_tmp_subsector_L2,Domestic Ship,trn_freight,FV,linear,1,1,1,1,1
 SDP_EI,ENC,Liquids,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,0.1341454314254,0.1341454314254,0.1341454314254,0.1341454314254,0.1341454314254
@@ -10451,7 +10451,7 @@ SDP_EI,ESW,"",Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tm
 SDP_EI,ESW,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0,0,0,0,0
 SDP_EI,ESW,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0,0,0,0,0
 SDP_EI,ESW,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0,0,0,0,0
-SDP_EI,ESW,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.118564682943918,0.268941421369995,0.666801888775703,0.666801888775703
+SDP_EI,ESW,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.118564682943917,0.268941421369995,0.666801888775703,0.666801888775703
 SDP_EI,ESW,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,0.72951273091157,0.763323639547623,0.830945456819731,0.966189091363946,0.966189091363946
 SDP_EI,ESW,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1,1,1,1,1
 SDP_EI,ESW,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1,1,1,1,1
@@ -10590,18 +10590,18 @@ SDP_EI,FRA,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,F
 SDP_EI,FRA,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1,1,1,1,1
 SDP_EI,FRA,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1,1,1,1,1
 SDP_EI,FRA,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.298007305055295,0.75,0.982013790037908,0.982013790037908
-SDP_EI,FRA,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.118564682943918,0.403412132054992,0.952574126822433,0.952574126822433
-SDP_EI,FRA,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.118564682943918,0.403412132054992,0.952574126822433,0.952574126822433
-SDP_EI,FRA,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.118564682943918,0.403412132054992,0.952574126822433,0.952574126822433
+SDP_EI,FRA,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.118564682943917,0.403412132054992,0.952574126822433,0.952574126822433
+SDP_EI,FRA,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.118564682943917,0.403412132054992,0.952574126822433,0.952574126822433
+SDP_EI,FRA,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.118564682943917,0.403412132054992,0.952574126822433,0.952574126822433
 SDP_EI,FRA,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.298007305055295,0.75,0.982013790037908,0.982013790037908
-SDP_EI,FRA,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.012363115783175,0.017986209962092,0.0954351880334422,0.0954351880334422
+SDP_EI,FRA,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.012363115783175,0.017986209962092,0.0954351880334419,0.0954351880334419
 SDP_EI,FRA,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.06692850924285,0.047425873177567,0.146211715726001,0.146211715726001
 SDP_EI,FRA,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.02472623156635,0.017986209962092,0.1,0.1
 SDP_EI,FRA,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.02472623156635,0.017986209962092,0.1,0.1
 SDP_EI,FRA,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.02472623156635,0.017986209962092,0.1,0.1
 SDP_EI,FRA,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.06692850924285,0.047425873177567,0.146211715726001,0.146211715726001
 SDP_EI,FRA,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0,8.31528027664132e-07,4.53978687024344e-05,0.119202922022118,0.119202922022118
-SDP_EI,FRA,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1,1,1,0.954351880334422,0.954351880334422
+SDP_EI,FRA,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1,1,1,0.954351880334419,0.954351880334419
 SDP_EI,FRA,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1,1,1,1,1
 SDP_EI,FRA,Liquids,Domestic Ship_tmp_vehicletype,Domestic Ship_tmp_subsector_L1,Domestic Ship_tmp_subsector_L2,Domestic Ship,trn_freight,FV,linear,1,1,1,1,1
 SDP_EI,FRA,Liquids,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,0.160770475713231,0.160770475713231,0.160770475713231,0.160770475713231,0.160770475713231
@@ -10616,7 +10616,7 @@ SDP_EI,FRA,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_roa
 SDP_EI,FRA,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,1,1,1,1
 SDP_EI,FRA,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,1,1,1,1
 SDP_EI,FRA,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,1,1,1,1
-SDP_EI,FRA,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.026315789473684,0.078947368421053,0.175801662166867,0.175801662166867
+SDP_EI,FRA,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.026315789473684,0.078947368421053,0.175801662166866,0.175801662166866
 SDP_EI,FRA,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.026315789473684,0.078947368421053,0.184210526315789,0.184210526315789
 SDP_EI,FRA,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.026315789473684,0.078947368421053,0.184210526315789,0.184210526315789
 SDP_EI,FRA,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.026315789473684,0.078947368421053,0.184210526315789,0.184210526315789
@@ -10633,7 +10633,7 @@ SDP_EI,IND,"","","","",Passenger Rail,trn_pass,S3S,linear,0.000684210526315789,8
 SDP_EI,IND,"","","","",Walk,trn_pass,S3S,linear,0.131578947368421,0.0945454545454544,0.181818181818182,1,1
 SDP_EI,IND,"","","","",trn_freight_road,trn_freight,S3S,linear,1,1,1,1,1
 SDP_EI,IND,"","","","",trn_pass_road,trn_pass,S3S,linear,1,1,1,1,1
-SDP_EI,IND,"","","",Bus,trn_pass_road,trn_pass,S2S3,linear,0.118824252562298,0.0625,0.0323053436653747,0.0323053436653747,0.0323053436653747
+SDP_EI,IND,"","","",Bus,trn_pass_road,trn_pass,S2S3,linear,0.118824252562298,0.0714285714285714,0.0323053436653747,0.0323053436653747,0.0323053436653747
 SDP_EI,IND,"","","",trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1,1,1,1,1
 SDP_EI,IND,"","",trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,0.003027158638145,0.002667683549865,0.001948733373306,0.000510833020187,0.000510833020187
 SDP_EI,IND,"","",trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1,1,1,1,1
@@ -10713,7 +10713,7 @@ SDP_EI,JPN,"",Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tm
 SDP_EI,JPN,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0,0,0,0,0
 SDP_EI,JPN,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0,0,0,0,0
 SDP_EI,JPN,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0,0,0,0,0
-SDP_EI,JPN,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.109079508308404,0.17929428091333,0.381029650728973,0.381029650728973
+SDP_EI,JPN,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.109079508308404,0.17929428091333,0.381029650728972,0.381029650728972
 SDP_EI,JPN,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1,1,1,1,1
 SDP_EI,JPN,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1,1,1,1,1
 SDP_EI,JPN,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1,1,1,1,1
@@ -10723,11 +10723,11 @@ SDP_EI,JPN,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_ro
 SDP_EI,JPN,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,0.0636363636363636,0.133333333333333,0.833333333333333,0.833333333333333
 SDP_EI,JPN,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.125163068123224,0.352941176470588,0.81834482503159,0.81834482503159
 SDP_EI,JPN,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.061815578915875,0.131898873055341,0.1,0.1
-SDP_EI,JPN,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.110432040250703,0.251078152116531,0.304607741095835,0.304607741095835
+SDP_EI,JPN,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.110432040250702,0.251078152116531,0.304607741095835,0.304607741095835
 SDP_EI,JPN,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,1,1,0.416666666666667,0.416666666666667
 SDP_EI,JPN,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,1,1,0.416666666666667,0.416666666666667
 SDP_EI,JPN,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,1,1,0.416666666666667,0.416666666666667
-SDP_EI,JPN,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.110432040250703,0.251078152116531,0.304607741095835,0.304607741095835
+SDP_EI,JPN,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.110432040250702,0.251078152116531,0.304607741095835,0.304607741095835
 SDP_EI,JPN,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0,8.31528027664132e-07,4.53978687024344e-05,0.119202922022118,0.119202922022118
 SDP_EI,JPN,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1,1,1,1,1
 SDP_EI,JPN,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1,1,1,1,1
@@ -10745,11 +10745,11 @@ SDP_EI,JPN,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_roa
 SDP_EI,JPN,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,0.0606060606060606,0.188888888888889,1,1
 SDP_EI,JPN,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,1,1,1,1
 SDP_EI,JPN,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.0078947368421052,0.0157894736842106,0.0230263157894736,0.0230263157894736
-SDP_EI,JPN,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.013157894736842,0.0464396284829724,0.0460526315789472,0.0460526315789472
+SDP_EI,JPN,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.013157894736842,0.0464396284829724,0.0460526315789473,0.0460526315789473
 SDP_EI,JPN,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,0.0303030303030303,0.111111111111111,0.25,0.25
 SDP_EI,JPN,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,0.0303030303030303,0.111111111111111,0.25,0.25
 SDP_EI,JPN,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,0.0303030303030303,0.111111111111111,0.25,0.25
-SDP_EI,JPN,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.013157894736842,0.0464396284829724,0.0460526315789472,0.0460526315789472
+SDP_EI,JPN,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.013157894736842,0.0464396284829724,0.0460526315789473,0.0460526315789473
 SDP_EI,LAM,"","","","",Cycle,trn_pass,S3S,linear,0.00981212891217365,0.0185165853437172,0.0462914633592929,0.231457316796465,0.231457316796465
 SDP_EI,LAM,"","","","",Domestic Aviation,trn_pass,S3S,linear,0.00840668890350734,0.0105762418419885,0.0264406046049712,0.0198304534537284,0.0198304534537284
 SDP_EI,LAM,"","","","",Domestic Ship,trn_freight,S3S,linear,0.009523329319276,0.009523329319276,0.00865757210843273,0.00793610776606333,0.00793610776606333
@@ -10761,7 +10761,7 @@ SDP_EI,LAM,"","","","",Passenger Rail,trn_pass,S3S,linear,0.134842686357634,0.12
 SDP_EI,LAM,"","","","",Walk,trn_pass,S3S,linear,0.899323352244677,0.848561904989659,0.848561904989659,0.848561904989659,0.848561904989659
 SDP_EI,LAM,"","","","",trn_freight_road,trn_freight,S3S,linear,1,1,1,1,1
 SDP_EI,LAM,"","","","",trn_pass_road,trn_pass,S3S,linear,1,1,1,1,1
-SDP_EI,LAM,"","","",Bus,trn_pass_road,trn_pass,S2S3,linear,0.138594539617622,0.086621587261014,0.086621587261014,0.086621587261014,0.086621587261014
+SDP_EI,LAM,"","","",Bus,trn_pass_road,trn_pass,S2S3,linear,0.173243174522027,0.108276984076267,0.086621587261014,0.086621587261014,0.086621587261014
 SDP_EI,LAM,"","","",trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1,1,1,1,1
 SDP_EI,LAM,"","",trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,0.137734442638184,0.137734442638184,0.137734442638184,0.137734442638184,0.137734442638184
 SDP_EI,LAM,"","",trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1,1,1,1,1
@@ -10784,23 +10784,23 @@ SDP_EI,LAM,"",Van,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,
 SDP_EI,LAM,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0,0,0,0,0
 SDP_EI,LAM,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0,0,0,0,0
 SDP_EI,LAM,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0,0,0,0,0
-SDP_EI,LAM,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.118564682943918,0.53788284273999,1,1
+SDP_EI,LAM,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.118564682943917,0.53788284273999,1,1
 SDP_EI,LAM,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,0.0681034247188,0.18459049662895,0.41756464044925,0.88351292808985,0.88351292808985
 SDP_EI,LAM,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1,1,1,1,1
 SDP_EI,LAM,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1,1,1,1,1
 SDP_EI,LAM,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.079468614681412,0.2,0.2400478153426,0.2400478153426
-SDP_EI,LAM,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0316172487850447,0.107576568547998,0.232851453223261,0.232851453223261
-SDP_EI,LAM,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0316172487850447,0.107576568547998,0.232851453223261,0.232851453223261
-SDP_EI,LAM,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0316172487850447,0.107576568547998,0.232851453223261,0.232851453223261
+SDP_EI,LAM,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0316172487850447,0.107576568547998,0.232851453223262,0.232851453223262
+SDP_EI,LAM,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0316172487850447,0.107576568547998,0.232851453223262,0.232851453223262
+SDP_EI,LAM,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0316172487850447,0.107576568547998,0.232851453223262,0.232851453223262
 SDP_EI,LAM,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.079468614681412,0.2,0.2400478153426,0.2400478153426
-SDP_EI,LAM,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.002472623156635,0.017986209962092,0.0656116917729915,0.0656116917729915
-SDP_EI,LAM,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.00892380123238,0.0569110478130804,0.0812287309588894,0.0812287309588894
+SDP_EI,LAM,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.002472623156635,0.017986209962092,0.0656116917729916,0.0656116917729916
+SDP_EI,LAM,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.00892380123238,0.0569110478130804,0.0812287309588893,0.0812287309588893
 SDP_EI,LAM,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.00329683087551333,0.0215834519545104,0.0555555555555556,0.0555555555555556
 SDP_EI,LAM,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.00329683087551333,0.0215834519545104,0.0555555555555556,0.0555555555555556
 SDP_EI,LAM,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.00329683087551333,0.0215834519545104,0.0555555555555556,0.0555555555555556
-SDP_EI,LAM,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.00892380123238,0.0569110478130804,0.0812287309588894,0.0812287309588894
+SDP_EI,LAM,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.00892380123238,0.0569110478130804,0.0812287309588893,0.0812287309588893
 SDP_EI,LAM,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0,8.31528027664132e-07,4.53978687024344e-05,0.119202922022118,0.119202922022118
-SDP_EI,LAM,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1,1,1,0.721728609502907,0.721728609502907
+SDP_EI,LAM,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1,1,1,0.721728609502908,0.721728609502908
 SDP_EI,LAM,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1,1,1,1,1
 SDP_EI,LAM,Liquids,Domestic Ship_tmp_vehicletype,Domestic Ship_tmp_subsector_L1,Domestic Ship_tmp_subsector_L2,Domestic Ship,trn_freight,FV,linear,1,1,1,1,1
 SDP_EI,LAM,Liquids,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1,1,1,1,1
@@ -10816,11 +10816,11 @@ SDP_EI,LAM,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_roa
 SDP_EI,LAM,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,1,1,1,1
 SDP_EI,LAM,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,1,1,1,1
 SDP_EI,LAM,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.026893682222235,0.0472515688947483,0.10371786520469,0.135258574225718,0.135258574225718
-SDP_EI,LAM,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0175438596491227,0.0315789473684212,0.0614035087719297,0.0614035087719297
-SDP_EI,LAM,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0175438596491227,0.0315789473684212,0.0614035087719297,0.0614035087719297
-SDP_EI,LAM,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0175438596491227,0.0315789473684212,0.0614035087719297,0.0614035087719297
-SDP_EI,LAM,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0175438596491227,0.0315789473684212,0.0614035087719297,0.0614035087719297
-SDP_EI,LAM,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0175438596491227,0.0315789473684212,0.0614035087719297,0.0614035087719297
+SDP_EI,LAM,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0175438596491227,0.0315789473684212,0.0614035087719296,0.0614035087719296
+SDP_EI,LAM,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0175438596491227,0.0315789473684212,0.0614035087719296,0.0614035087719296
+SDP_EI,LAM,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0175438596491227,0.0315789473684212,0.0614035087719296,0.0614035087719296
+SDP_EI,LAM,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0175438596491227,0.0315789473684212,0.0614035087719296,0.0614035087719296
+SDP_EI,LAM,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0175438596491227,0.0315789473684212,0.0614035087719296,0.0614035087719296
 SDP_EI,MEA,"","","","",Cycle,trn_pass,S3S,linear,0.0165975108305109,0.0165975108305109,0.0165975108305109,0.0414937770762773,0.0414937770762773
 SDP_EI,MEA,"","","","",Domestic Aviation,trn_pass,S3S,linear,0.0089294530094782,0.00595296867298547,0.0178589060189564,0.0238118746919419,0.0238118746919419
 SDP_EI,MEA,"","","","",Domestic Ship,trn_freight,S3S,linear,0.002022051343562,0.002022051343562,0.002022051343562,0.002022051343562,0.002022051343562
@@ -10832,7 +10832,7 @@ SDP_EI,MEA,"","","","",Passenger Rail,trn_pass,S3S,linear,0.000556730785330985,0
 SDP_EI,MEA,"","","","",Walk,trn_pass,S3S,linear,1,1,1,1,1
 SDP_EI,MEA,"","","","",trn_freight_road,trn_freight,S3S,linear,1,1,1,1,1
 SDP_EI,MEA,"","","","",trn_pass_road,trn_pass,S3S,linear,0.639480996474237,0.71967693403545,0.71967693403545,0.71967693403545,0.71967693403545
-SDP_EI,MEA,"","","",Bus,trn_pass_road,trn_pass,S2S3,linear,0.183919217151252,0.122612811434168,0.0613064057170841,0.0490451245736673,0.0490451245736673
+SDP_EI,MEA,"","","",Bus,trn_pass_road,trn_pass,S2S3,linear,0.262741738787503,0.122612811434168,0.0613064057170841,0.0490451245736673,0.0490451245736673
 SDP_EI,MEA,"","","",trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1,1,1,1,1
 SDP_EI,MEA,"","",trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,0.007508394761241,0.007508394761241,0.007508394761241,0.007508394761241,0.007508394761241
 SDP_EI,MEA,"","",trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1,1,1,1,1
@@ -10849,12 +10849,12 @@ SDP_EI,MEA,"",Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tm
 SDP_EI,MEA,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1,1,1,1,1
 SDP_EI,MEA,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0,0,0,0,0
 SDP_EI,MEA,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1,1,1,1,1
-SDP_EI,MEA,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.047425873177567,0.295835563506995,0.654894712190423,0.654894712190423
+SDP_EI,MEA,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.047425873177567,0.295835563506994,0.654894712190425,0.654894712190425
 SDP_EI,MEA,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,0.402051171672381,0.476794775213334,0.626281982295238,0.925256396459048,0.925256396459048
 SDP_EI,MEA,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1,1,1,1,1
 SDP_EI,MEA,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1,1,1,1,1
 SDP_EI,MEA,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.059601461011059,0.1,0.14028768429113,0.14028768429113
-SDP_EI,MEA,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0237129365887835,0.053788284273999,0.13608201811749,0.13608201811749
+SDP_EI,MEA,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0237129365887835,0.053788284273999,0.136082018117491,0.136082018117491
 SDP_EI,MEA,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,0.142857142857143,0.2,0.142857142857143,0.142857142857143
 SDP_EI,MEA,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1,0.142857142857143,0.2,0.142857142857143,0.142857142857143
 SDP_EI,MEA,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.059601461011059,0.1,0.14028768429113,0.14028768429113
@@ -10966,7 +10966,7 @@ SDP_EI,NES,"","","","",Passenger Rail,trn_pass,S3S,linear,0.00160675014597331,0.
 SDP_EI,NES,"","","","",Walk,trn_pass,S3S,linear,1,1,1,1,1
 SDP_EI,NES,"","","","",trn_freight_road,trn_freight,S3S,linear,1,1,1,1,1
 SDP_EI,NES,"","","","",trn_pass_road,trn_pass,S3S,linear,0.925821312685462,0.717579145423199,0.456641274360218,0.25115270089812,0.25115270089812
-SDP_EI,NES,"","","",Bus,trn_pass_road,trn_pass,S2S3,linear,0.021994137000963,0.0183284475008025,0.0109970685004815,0.0109970685004815,0.0109970685004815
+SDP_EI,NES,"","","",Bus,trn_pass_road,trn_pass,S2S3,linear,0.0549853425024075,0.021994137000963,0.0109970685004815,0.0109970685004815,0.0109970685004815
 SDP_EI,NES,"","","",trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1,1,1,1,1
 SDP_EI,NES,"","",trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,0.004922521505832,0.004922521505832,0.004922521505832,0.004922521505832,0.004922521505832
 SDP_EI,NES,"","",trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1,1,1,1,1
@@ -11035,7 +11035,7 @@ SDP_EI,OAS,"","","","",Passenger Rail,trn_pass,S3S,linear,0.00077008869031218,0.
 SDP_EI,OAS,"","","","",Walk,trn_pass,S3S,linear,1,0.689328623982319,0.689328623982319,0.689328623982319,0.689328623982319
 SDP_EI,OAS,"","","","",trn_freight_road,trn_freight,S3S,linear,1,1,1,1,1
 SDP_EI,OAS,"","","","",trn_pass_road,trn_pass,S3S,linear,0.87209012211972,1,1,1,1
-SDP_EI,OAS,"","","",Bus,trn_pass_road,trn_pass,S2S3,linear,0.160206681607861,0.110191151172767,0.0550955755863836,0.0550955755863836,0.0550955755863836
+SDP_EI,OAS,"","","",Bus,trn_pass_road,trn_pass,S2S3,linear,0.240310022411792,0.140243283310795,0.0550955755863836,0.0550955755863836,0.0550955755863836
 SDP_EI,OAS,"","","",trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1,1,1,1,1
 SDP_EI,OAS,"","",trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,0.025341509717687,0.022332205438712,0.016313596880761,0.00427637976486,0.00427637976486
 SDP_EI,OAS,"","",trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1,1,1,1,1
@@ -11063,18 +11063,18 @@ SDP_EI,OAS,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,F
 SDP_EI,OAS,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1,1,1,1,1
 SDP_EI,OAS,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,0.352966479972375,0.433845669975828,0.595604049982734,0.919120809996547,0.919120809996547
 SDP_EI,OAS,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.039734307340706,0.0625,0.0785611032030326,0.0785611032030326
-SDP_EI,OAS,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0158086243925223,0.0336176776712494,0.0762059301457946,0.0762059301457946
-SDP_EI,OAS,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0158086243925223,0.0336176776712494,0.0762059301457946,0.0762059301457946
-SDP_EI,OAS,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0158086243925223,0.0336176776712494,0.0762059301457946,0.0762059301457946
+SDP_EI,OAS,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0158086243925223,0.0336176776712495,0.0762059301457946,0.0762059301457946
+SDP_EI,OAS,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0158086243925223,0.0336176776712495,0.0762059301457946,0.0762059301457946
+SDP_EI,OAS,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0158086243925223,0.0336176776712495,0.0762059301457946,0.0762059301457946
 SDP_EI,OAS,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.039734307340706,0.0625,0.0785611032030326,0.0785611032030326
-SDP_EI,OAS,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.002472623156635,0.017986209962092,0.0656116917729915,0.0656116917729915
+SDP_EI,OAS,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.002472623156635,0.017986209962092,0.0656116917729916,0.0656116917729916
 SDP_EI,OAS,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.011154751540475,0.0118564682943918,0.0292423431452002,0.0292423431452002
 SDP_EI,OAS,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.00412103859439167,0.004496552490523,0.02,0.02
 SDP_EI,OAS,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.00412103859439167,0.004496552490523,0.02,0.02
 SDP_EI,OAS,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.00412103859439167,0.004496552490523,0.02,0.02
 SDP_EI,OAS,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.011154751540475,0.0118564682943918,0.0292423431452002,0.0292423431452002
 SDP_EI,OAS,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0,8.31528027664132e-07,4.53978687024344e-05,0.119202922022118,0.119202922022118
-SDP_EI,OAS,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1,1,1,0.656116917729915,0.656116917729915
+SDP_EI,OAS,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1,1,1,0.656116917729916,0.656116917729916
 SDP_EI,OAS,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1,1,1,1,1
 SDP_EI,OAS,Liquids,Domestic Ship_tmp_vehicletype,Domestic Ship_tmp_subsector_L1,Domestic Ship_tmp_subsector_L2,Domestic Ship,trn_freight,FV,linear,1,1,1,1,1
 SDP_EI,OAS,Liquids,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1,1,1,1,1
@@ -11106,7 +11106,7 @@ SDP_EI,REF,"","","","",Passenger Rail,trn_pass,S3S,linear,0.00236561326843326,0.
 SDP_EI,REF,"","","","",Walk,trn_pass,S3S,linear,0.317883555031073,0.317883555031073,0.317883555031073,1,1
 SDP_EI,REF,"","","","",trn_freight_road,trn_freight,S3S,linear,1,1,1,1,1
 SDP_EI,REF,"","","","",trn_pass_road,trn_pass,S3S,linear,1,1,1,0.943741804984768,0.943741804984768
-SDP_EI,REF,"","","",Bus,trn_pass_road,trn_pass,S2S3,linear,0.106725224568562,0.0914787639159102,0.0762323032632585,0.0609858426106068,0.0609858426106068
+SDP_EI,REF,"","","",Bus,trn_pass_road,trn_pass,S2S3,linear,0.118583582853958,0.0914787639159102,0.0762323032632585,0.0609858426106068,0.0609858426106068
 SDP_EI,REF,"","","",trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1,1,1,1,1
 SDP_EI,REF,"","",trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,0.369757606378564,0.369757606378564,0.369757606378564,0.369757606378564,0.369757606378564
 SDP_EI,REF,"","",trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1,1,1,1,1
@@ -11163,18 +11163,18 @@ SDP_EI,REF,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp
 SDP_EI,REF,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.063108879885637,0.087763909362331,0.137073968315718,0.188555268977994,0.188555268977994
 SDP_EI,REF,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.030480218828266,0.055993897280154,0.107021254183929,0.167260774393184,0.167260774393184
 SDP_EI,REF,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.026315789473684,0.078947368421053,0.147368421052631,0.147368421052631
-SDP_EI,SSA,"","","","",Cycle,trn_pass,S3S,linear,0.013878678157857,0.0179527662940391,0.0291452241314997,0.0327883771479372,0.0327883771479372
-SDP_EI,SSA,"","","","",Domestic Aviation,trn_pass,S3S,linear,0.00901317336217352,0.0509980791548766,0.0413961398176937,0.00620942097265405,0.00620942097265405
+SDP_EI,SSA,"","","","",Cycle,trn_pass,S3S,linear,0.013878678157857,0.017952766294039,0.0291452241314997,0.0327883771479372,0.0327883771479372
+SDP_EI,SSA,"","","","",Domestic Aviation,trn_pass,S3S,linear,0.00901317336217352,0.0509980791548764,0.0413961398176937,0.00620942097265405,0.00620942097265405
 SDP_EI,SSA,"","","","",Domestic Ship,trn_freight,S3S,linear,0.001467441828354,0.001467441828354,0.001467441828354,0.001467441828354,0.001467441828354
 SDP_EI,SSA,"","","","",Freight Rail,trn_freight,S3S,linear,0.01634165332484,0.01634165332484,0.01634165332484,0.01634165332484,0.01634165332484
-SDP_EI,SSA,"","","","",HSR,trn_pass,S3S,linear,1.47506311523337e-05,2.00316440897408e-05,0.0650403115771387,0.0097560467365708,0.0097560467365708
+SDP_EI,SSA,"","","","",HSR,trn_pass,S3S,linear,1.47506311523337e-05,2.00316440897407e-05,0.0650403115771387,0.0097560467365708,0.0097560467365708
 SDP_EI,SSA,"","","","",International Aviation,trn_aviation_intl,S3S,linear,1,1,1,1,1
 SDP_EI,SSA,"","","","",International Ship,trn_shipping_intl,S3S,linear,1,1,1,1,1
-SDP_EI,SSA,"","","","",Passenger Rail,trn_pass,S3S,linear,0.000602417147703971,0.00155851359059413,0.00253015202035668,0.000569284204580253,0.000569284204580253
-SDP_EI,SSA,"","","","",Walk,trn_pass,S3S,linear,1,0.903431854876908,1,1,1
+SDP_EI,SSA,"","","","",Passenger Rail,trn_pass,S3S,linear,0.000602417147703971,0.00155851359059412,0.00253015202035668,0.000569284204580253,0.000569284204580253
+SDP_EI,SSA,"","","","",Walk,trn_pass,S3S,linear,1,0.903431854876905,1,1,1
 SDP_EI,SSA,"","","","",trn_freight_road,trn_freight,S3S,linear,1,1,1,1,1
-SDP_EI,SSA,"","","","",trn_pass_road,trn_pass,S3S,linear,0.890164318010016,1,0.974063506007212,0.0974063506007212,0.0974063506007212
-SDP_EI,SSA,"","","",Bus,trn_pass_road,trn_pass,S2S3,linear,0.206400000437543,0.105846154070534,0.0732781066642163,0.0952615386634812,0.0952615386634812
+SDP_EI,SSA,"","","","",trn_pass_road,trn_pass,S3S,linear,0.890164318010017,1,0.974063506007213,0.0974063506007212,0.0974063506007212
+SDP_EI,SSA,"","","",Bus,trn_pass_road,trn_pass,S2S3,linear,0.247680000525051,0.127015384884641,0.0732781066642163,0.0952615386634812,0.0952615386634812
 SDP_EI,SSA,"","","",trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1,1,1,1,1
 SDP_EI,SSA,"","",trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,0.039283595822529,0.039283595822529,0.039283595822529,0.039283595822529,0.039283595822529
 SDP_EI,SSA,"","",trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1,1,1,1,1
@@ -11204,11 +11204,11 @@ SDP_EI,SSA,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_ro
 SDP_EI,SSA,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0094851746355134,0.053788284273999,0.14654986566499,0.14654986566499
 SDP_EI,SSA,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0238405844044236,0.1,0.151079044621217,0.151079044621217
 SDP_EI,SSA,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.002472623156635,0.017986209962092,0.075,0.075
-SDP_EI,SSA,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.006692850924285,0.047425873177567,0.0281176376396156,0.0281176376396156
+SDP_EI,SSA,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.006692850924285,0.047425873177567,0.0281176376396155,0.0281176376396155
 SDP_EI,SSA,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.002472623156635,0.017986209962092,0.0192307692307692,0.0192307692307692
 SDP_EI,SSA,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.002472623156635,0.017986209962092,0.0192307692307692,0.0192307692307692
 SDP_EI,SSA,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.002472623156635,0.017986209962092,0.0192307692307692,0.0192307692307692
-SDP_EI,SSA,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.006692850924285,0.047425873177567,0.0281176376396156,0.0281176376396156
+SDP_EI,SSA,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.006692850924285,0.047425873177567,0.0281176376396155,0.0281176376396155
 SDP_EI,SSA,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0,8.31528027664132e-07,4.53978687024344e-05,0.119202922022118,0.119202922022118
 SDP_EI,SSA,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1,1,1,1,1
 SDP_EI,SSA,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1,1,1,1,1
@@ -11263,14 +11263,14 @@ SDP_EI,UKI,"",Van,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,
 SDP_EI,UKI,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0,0,0,0,0
 SDP_EI,UKI,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0,0,0,0,0
 SDP_EI,UKI,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0,0,0,0,0
-SDP_EI,UKI,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.118564682943918,0.322729705643994,0.85731671414019,0.85731671414019
+SDP_EI,UKI,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.118564682943917,0.322729705643994,0.85731671414019,0.85731671414019
 SDP_EI,UKI,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,0.826003073674058,0.847752689464801,0.891251921046287,0.978250384209257,0.978250384209257
 SDP_EI,UKI,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1,1,1,1,1
 SDP_EI,UKI,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1,1,1,1,1
 SDP_EI,UKI,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.238405844044236,0.55,0.883812411034117,0.883812411034117
-SDP_EI,UKI,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.094851746355134,0.295835563506995,0.85731671414019,0.85731671414019
-SDP_EI,UKI,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.094851746355134,0.295835563506995,0.85731671414019,0.85731671414019
-SDP_EI,UKI,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.094851746355134,0.295835563506995,0.85731671414019,0.85731671414019
+SDP_EI,UKI,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.094851746355134,0.295835563506994,0.85731671414019,0.85731671414019
+SDP_EI,UKI,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.094851746355134,0.295835563506994,0.85731671414019,0.85731671414019
+SDP_EI,UKI,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.094851746355134,0.295835563506994,0.85731671414019,0.85731671414019
 SDP_EI,UKI,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.238405844044236,0.55,0.883812411034117,0.883812411034117
 SDP_EI,UKI,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0,0.012363115783175,0.017986209962092,0.1,0.1
 SDP_EI,UKI,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.06692850924285,0.189703492710268,0.146211715726001,0.146211715726001
@@ -11335,7 +11335,7 @@ SDP_EI,USA,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,F
 SDP_EI,USA,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1,1,1,1,1
 SDP_EI,USA,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1,1,1,1,1
 SDP_EI,USA,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0298007305055295,0.25,0.785611032030326,0.785611032030326
-SDP_EI,USA,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0118564682943918,0.134470710684997,0.762059301457946,0.762059301457946
+SDP_EI,USA,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0118564682943918,0.134470710684998,0.762059301457946,0.762059301457946
 SDP_EI,USA,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.03,0.25,0.5,0.8,0.8
 SDP_EI,USA,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.03,0.25,0.5,0.8,0.8
 SDP_EI,USA,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0,0.0298007305055295,0.25,0.785611032030326,0.785611032030326


### PR DESCRIPTION
In an effort to tackle https://github.com/remindmodel/development_issues/issues/97 we reduce the total demand in OAS (via elasticity adjustments) and the LDV share in low-to-mid income regions such that they do not face a short term surge in transport sector costs.