### PR TITLE
Roll out new ssp2 swtrends to all scenarios

### DIFF
--- a/inst/extdata/sw_trends.csv
+++ b/inst/extdata/sw_trends.csv
@@ -9947,17 +9947,17 @@ SSP2EU,USA,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp
 SSP2EU,USA,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,5.000e-03,1.538e-01,2.857e-01,3.333e-01,3.333e-01
 SSP2EU,USA,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.049e-03,2.256e-02,6.140e-02,6.140e-02
 SSP5,CAZ,,,,,Cycle,trn_pass,S3S,linear,1.911e-02,3.822e-02,3.822e-02,7.645e-02,7.645e-02
-SSP5,CAZ,,,,,Domestic Aviation,trn_pass,S3S,linear,1.500e-03,1.600e-03,1.900e-03,2.000e-03,2.000e-03
-SSP5,CAZ,,,,,Domestic Ship,trn_freight,S3S,linear,1.554e-02,1.554e-02,1.554e-02,1.554e-02,1.554e-02
-SSP5,CAZ,,,,,Freight Rail,trn_freight,S3S,linear,1.051e-01,1.051e-01,1.051e-01,1.051e-01,1.051e-01
+SSP5,CAZ,,,,,Domestic Aviation,trn_pass,S3S,linear,1.432e-03,1.527e-03,1.813e-03,1.909e-03,1.909e-03
+SSP5,CAZ,,,,,Domestic Ship,trn_freight,S3S,linear,1.583e-02,1.583e-02,1.583e-02,1.583e-02,1.583e-02
+SSP5,CAZ,,,,,Freight Rail,trn_freight,S3S,linear,1.070e-01,1.070e-01,1.070e-01,9.633e-02,9.633e-02
 SSP5,CAZ,,,,,HSR,trn_pass,S3S,linear,8.792e-08,8.792e-05,2.638e-04,2.638e-04,2.638e-04
 SSP5,CAZ,,,,,International Aviation,trn_aviation_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,CAZ,,,,,International Ship,trn_shipping_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,CAZ,,,,,Passenger Rail,trn_pass,S3S,linear,8.785e-04,8.785e-04,8.785e-04,8.785e-04,8.785e-04
 SSP5,CAZ,,,,,Walk,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,CAZ,,,,,trn_freight_road,trn_freight,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP5,CAZ,,,,,trn_pass_road,trn_pass,S3S,linear,1.537e-01,1.537e-01,1.537e-01,1.537e-01,1.537e-01
-SSP5,CAZ,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,8.691e-02,8.691e-02,1.086e-01,1.376e-01,1.376e-01
+SSP5,CAZ,,,,,trn_pass_road,trn_pass,S3S,linear,1.509e-01,1.509e-01,1.509e-01,1.509e-01,1.509e-01
+SSP5,CAZ,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,8.852e-02,8.852e-02,1.107e-01,1.402e-01,1.402e-01
 SSP5,CAZ,,,,trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,CAZ,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.939e-02,1.939e-02,1.939e-02,1.939e-02,1.939e-02
 SSP5,CAZ,,,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
@@ -9977,26 +9977,26 @@ SSP5,CAZ,,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_sub
 SSP5,CAZ,,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,3.497e-05,3.497e-05,3.497e-05,3.497e-05,3.497e-05
 SSP5,CAZ,,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,6.282e-01,6.282e-01,6.282e-01,6.282e-01,6.282e-01
 SSP5,CAZ,,Van,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,2.082e-01,2.082e-01,2.082e-01,2.082e-01,2.082e-01
-SSP5,CAZ,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP5,CAZ,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP5,CAZ,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP5,CAZ,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,9.485e-02,4.572e-01,1.000e+00,1.000e+00
+SSP5,CAZ,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.400e-02,1.920e-01,3.360e-01,3.360e-01
+SSP5,CAZ,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.400e-02,1.920e-01,3.360e-01,3.360e-01
+SSP5,CAZ,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.400e-02,1.920e-01,3.360e-01,3.360e-01
+SSP5,CAZ,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.122e-01,4.423e-01,9.735e-01,9.735e-01
 SSP5,CAZ,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,9.074e-02,2.044e-01,4.317e-01,8.863e-01,8.863e-01
 SSP5,CAZ,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,CAZ,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP5,CAZ,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.192e-01,3.500e-01,4.910e-01,4.910e-01
-SSP5,CAZ,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.743e-02,1.883e-01,4.763e-01,4.763e-01
-SSP5,CAZ,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.743e-02,1.883e-01,4.763e-01,4.763e-01
-SSP5,CAZ,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.743e-02,1.883e-01,4.763e-01,4.763e-01
-SSP5,CAZ,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.192e-01,3.500e-01,4.910e-01,4.910e-01
-SSP5,CAZ,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.236e-02,1.799e-02,9.544e-02,9.544e-02
-SSP5,CAZ,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.346e-02,4.743e-02,1.462e-01,1.462e-01
-SSP5,CAZ,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.236e-02,1.799e-02,1.000e-01,1.000e-01
-SSP5,CAZ,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.236e-02,1.799e-02,1.000e-01,1.000e-01
-SSP5,CAZ,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.236e-02,1.799e-02,1.000e-01,1.000e-01
-SSP5,CAZ,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.346e-02,4.743e-02,1.462e-01,1.462e-01
+SSP5,CAZ,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.409e-01,3.311e-01,4.354e-01,4.354e-01
+SSP5,CAZ,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.608e-02,1.781e-01,4.224e-01,4.224e-01
+SSP5,CAZ,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.608e-02,1.781e-01,4.224e-01,4.224e-01
+SSP5,CAZ,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.608e-02,1.781e-01,4.224e-01,4.224e-01
+SSP5,CAZ,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.409e-01,3.311e-01,4.354e-01,4.354e-01
+SSP5,CAZ,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.462e-02,1.933e-02,7.601e-02,7.601e-02
+SSP5,CAZ,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.957e-02,5.608e-02,1.153e-01,1.153e-01
+SSP5,CAZ,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.462e-02,2.127e-02,7.883e-02,7.883e-02
+SSP5,CAZ,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.462e-02,2.127e-02,7.883e-02,7.883e-02
+SSP5,CAZ,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.462e-02,2.127e-02,7.883e-02,7.883e-02
+SSP5,CAZ,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.957e-02,5.608e-02,1.153e-01,1.153e-01
 SSP5,CAZ,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0.000e+00,8.315e-07,4.540e-05,1.192e-01,1.192e-01
-SSP5,CAZ,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,9.544e-01,9.544e-01
+SSP5,CAZ,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,CAZ,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,CAZ,Liquids,Domestic Ship_tmp_vehicletype,Domestic Ship_tmp_subsector_L1,Domestic Ship_tmp_subsector_L2,Domestic Ship,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,CAZ,Liquids,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
@@ -10011,124 +10011,124 @@ SSP5,CAZ,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_
 SSP5,CAZ,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,CAZ,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,CAZ,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP5,CAZ,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,3.104e-02,5.654e-02,1.075e-01,2.000e-01,2.000e-01
-SSP5,CAZ,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SSP5,CAZ,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SSP5,CAZ,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SSP5,CAZ,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SSP5,CAZ,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SSP5,CHA,,,,,Cycle,trn_pass,S3S,linear,8.298e-02,4.412e-02,3.782e-02,4.848e-02,4.848e-02
-SSP5,CHA,,,,,Domestic Aviation,trn_pass,S3S,linear,1.104e-01,2.842e-02,1.829e-02,3.517e-03,3.517e-03
-SSP5,CHA,,,,,Domestic Ship,trn_freight,S3S,linear,2.849e-02,8.548e-02,8.548e-02,8.548e-02,8.548e-02
-SSP5,CHA,,,,,Freight Rail,trn_freight,S3S,linear,6.920e-02,2.076e-01,2.076e-01,2.076e-01,2.076e-01
-SSP5,CHA,,,,,HSR,trn_pass,S3S,linear,2.108e-01,8.143e-02,1.916e-02,3.695e-03,3.695e-03
+SSP5,CAZ,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,3.104e-02,5.654e-02,9.776e-02,1.497e-01,1.497e-01
+SSP5,CAZ,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.535e-01,1.535e-01
+SSP5,CAZ,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.535e-01,1.535e-01
+SSP5,CAZ,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.535e-01,1.535e-01
+SSP5,CAZ,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.535e-01,1.535e-01
+SSP5,CAZ,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.535e-01,1.535e-01
+SSP5,CHA,,,,,Cycle,trn_pass,S3S,linear,9.454e-02,4.412e-02,3.782e-02,4.848e-02,4.848e-02
+SSP5,CHA,,,,,Domestic Aviation,trn_pass,S3S,linear,1.200e-01,2.712e-02,1.745e-02,3.357e-03,3.357e-03
+SSP5,CHA,,,,,Domestic Ship,trn_freight,S3S,linear,1.847e-02,1.922e-02,2.232e-02,2.232e-02,2.232e-02
+SSP5,CHA,,,,,Freight Rail,trn_freight,S3S,linear,3.204e-02,3.570e-02,3.795e-02,3.795e-02,3.795e-02
+SSP5,CHA,,,,,HSR,trn_pass,S3S,linear,2.402e-01,8.143e-02,1.916e-02,3.695e-03,3.695e-03
 SSP5,CHA,,,,,International Aviation,trn_aviation_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,CHA,,,,,International Ship,trn_shipping_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP5,CHA,,,,,Passenger Rail,trn_pass,S3S,linear,5.461e-03,3.111e-03,1.867e-03,9.572e-04,9.572e-04
-SSP5,CHA,,,,,Walk,trn_pass,S3S,linear,8.777e-01,1.000e+00,1.000e+00,1.000e+00,1.000e+00
+SSP5,CHA,,,,,Passenger Rail,trn_pass,S3S,linear,6.222e-03,3.111e-03,1.867e-03,9.572e-04,9.572e-04
+SSP5,CHA,,,,,Walk,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,CHA,,,,,trn_freight_road,trn_freight,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP5,CHA,,,,,trn_pass_road,trn_pass,S3S,linear,1.000e+00,4.557e-01,2.279e-01,5.843e-02,5.843e-02
-SSP5,CHA,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,3.816e-01,1.915e-01,1.705e-01,1.895e-01,1.895e-01
+SSP5,CHA,,,,,trn_pass_road,trn_pass,S3S,linear,6.711e-01,2.684e-01,1.342e-01,4.015e-02,4.015e-02
+SSP5,CHA,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,6.609e-01,2.927e-01,2.084e-01,9.649e-02,9.649e-02
 SSP5,CHA,,,,trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP5,CHA,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.081e-02,9.523e-03,6.956e-03,1.824e-03,1.824e-03
+SSP5,CHA,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,2.702e-01,2.116e-01,1.391e-01,1.459e-01,1.459e-01
 SSP5,CHA,,,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP5,CHA,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,3.616e-01,3.616e-01,3.616e-01,3.616e-01,3.616e-01
+SSP5,CHA,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,8.035e-01,7.232e-01,6.574e-01,5.563e-01,5.563e-01
 SSP5,CHA,,Large Car and SUV,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP5,CHA,,Mini Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,8.023e-03,8.023e-03,8.023e-03,8.023e-03,8.023e-03
+SSP5,CHA,,Mini Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.783e-02,1.605e-02,1.459e-02,1.234e-02,1.234e-02
 SSP5,CHA,,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,4.044e-02,4.044e-02,4.044e-02,4.044e-02,4.044e-02
 SSP5,CHA,,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,CHA,,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP5,CHA,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,3.898e-02,3.898e-02,3.898e-02,3.898e-02,3.898e-02
+SSP5,CHA,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,8.662e-02,7.795e-02,7.087e-02,5.996e-02,5.996e-02
 SSP5,CHA,,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,CHA,,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,2.234e-01,2.234e-01,2.234e-01,2.234e-01,2.234e-01
-SSP5,CHA,,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,4.469e-01,3.352e-01,3.352e-01,3.352e-01,3.352e-01
-SSP5,CHA,,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,4.469e-01,3.352e-01,3.352e-01,3.352e-01,3.352e-01
+SSP5,CHA,,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,4.022e-01,3.352e-01,3.016e-01,3.352e-01,3.352e-01
+SSP5,CHA,,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,4.022e-01,3.352e-01,3.016e-01,3.352e-01,3.352e-01
 SSP5,CHA,,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.657e-01,1.657e-01,1.657e-01,1.657e-01,1.657e-01
-SSP5,CHA,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP5,CHA,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,8.402e-02,8.402e-02,8.402e-02,8.402e-02,8.402e-02
-SSP5,CHA,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP5,CHA,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,3.320e-01,1.000e+00,1.000e+00,1.000e+00
+SSP5,CHA,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,6.000e-01,1.000e+00,1.000e+00,1.000e+00
+SSP5,CHA,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,6.000e-02,6.000e-01,1.000e+00,1.000e+00,1.000e+00
+SSP5,CHA,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,6.000e-01,1.000e+00,1.000e+00,1.000e+00
+SSP5,CHA,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,3.019e-01,1.000e+00,1.000e+00,1.000e+00
 SSP5,CHA,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,4.553e-01,5.234e-01,6.595e-01,9.319e-01,9.319e-01
 SSP5,CHA,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,CHA,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,4.158e-01,4.888e-01,6.349e-01,9.270e-01,9.270e-01
-SSP5,CHA,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.768e-02,4.500e-01,9.820e-01,9.820e-01
-SSP5,CHA,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.897e-02,2.420e-01,9.526e-01,9.526e-01
-SSP5,CHA,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e-01,4.000e-01,9.000e-01,1.000e+00,1.000e+00
-SSP5,CHA,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e-01,4.000e-01,9.000e-01,1.000e+00,1.000e+00
-SSP5,CHA,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.768e-02,4.500e-01,9.820e-01,9.820e-01
-SSP5,CHA,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.225e-02,6.688e-02,6.999e-02,6.999e-02
-SSP5,CHA,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.339e-03,2.846e-02,1.462e-01,1.462e-01
-SSP5,CHA,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.945e-04,1.079e-02,1.000e-01,1.000e-01
-SSP5,CHA,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e-02,2.000e-01,6.000e-01,2.000e-01,2.000e-01
-SSP5,CHA,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e-02,2.000e-01,6.000e-01,2.000e-01,2.000e-01
-SSP5,CHA,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.339e-03,2.846e-02,1.462e-01,1.462e-01
+SSP5,CHA,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.002e-02,3.725e-01,8.768e-01,8.768e-01
+SSP5,CHA,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.592e-02,2.004e-01,8.505e-01,8.505e-01
+SSP5,CHA,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,9.920e-02,3.358e-01,7.450e-01,8.928e-01,8.928e-01
+SSP5,CHA,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,9.920e-02,3.358e-01,7.450e-01,8.928e-01,8.928e-01
+SSP5,CHA,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.002e-02,3.725e-01,8.768e-01,8.768e-01
+SSP5,CHA,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.024e-02,9.554e-02,6.999e-02,6.999e-02
+SSP5,CHA,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.124e-03,1.713e-02,1.450e-01,1.450e-01
+SSP5,CHA,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.151e-04,6.497e-03,9.920e-02,9.920e-02
+SSP5,CHA,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,9.920e-03,1.679e-01,3.612e-01,1.984e-01,1.984e-01
+SSP5,CHA,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,9.920e-03,1.679e-01,3.612e-01,1.984e-01,1.984e-01
+SSP5,CHA,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.124e-03,1.713e-02,1.450e-01,1.450e-01
 SSP5,CHA,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0.000e+00,8.315e-07,4.540e-05,1.192e-01,1.192e-01
-SSP5,CHA,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,7.437e-01,3.499e-01,3.499e-01
+SSP5,CHA,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,9.736e-01,3.527e-01,3.527e-01
 SSP5,CHA,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,CHA,Liquids,Domestic Ship_tmp_vehicletype,Domestic Ship_tmp_subsector_L1,Domestic Ship_tmp_subsector_L2,Domestic Ship,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,CHA,Liquids,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,CHA,Liquids,International Aviation_tmp_vehicletype,International Aviation_tmp_subsector_L1,International Aviation_tmp_subsector_L2,International Aviation,trn_aviation_intl,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,CHA,Liquids,International Ship_tmp_vehicletype,International Ship_tmp_subsector_L1,International Ship_tmp_subsector_L2,International Ship,trn_shipping_intl,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP5,CHA,Liquids,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP5,CHA,Liquids,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP5,CHA,Liquids,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
+SSP5,CHA,Liquids,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,8.333e-01,6.803e-01,6.803e-01
+SSP5,CHA,Liquids,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,8.333e-01,6.803e-01,6.803e-01
+SSP5,CHA,Liquids,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,8.333e-01,6.803e-01,6.803e-01
 SSP5,CHA,Liquids,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,CHA,Liquids,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,CHA,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,CHA,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,CHA,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,CHA,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP5,CHA,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.421e-01,1.594e-01,9.020e-02,1.152e-01,1.152e-01
-SSP5,CHA,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.878e-05,1.319e-02,5.530e-02,9.213e-02,9.213e-02
-SSP5,CHA,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,7.854e-04,1.443e-02,5.695e-02,9.317e-02,9.317e-02
-SSP5,CHA,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,3.000e-01,5.000e-01,7.000e-01,5.000e-01,5.000e-01
-SSP5,CHA,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,3.000e-01,5.000e-01,7.000e-01,5.000e-01,5.000e-01
-SSP5,CHA,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,3.309e-04,1.369e-02,5.597e-02,9.256e-02,9.256e-02
+SSP5,CHA,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.421e-01,1.329e-01,1.181e-01,1.055e-01,1.055e-01
+SSP5,CHA,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.707e-05,1.014e-02,3.814e-02,8.376e-02,8.376e-02
+SSP5,CHA,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,7.140e-04,1.110e-02,3.928e-02,8.470e-02,8.470e-02
+SSP5,CHA,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,2.727e-01,3.846e-01,4.828e-01,4.545e-01,4.545e-01
+SSP5,CHA,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,2.727e-01,3.846e-01,4.828e-01,4.545e-01,4.545e-01
+SSP5,CHA,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,3.008e-04,1.053e-02,3.860e-02,8.414e-02,8.414e-02
 SSP5,DEU,,,,,Cycle,trn_pass,S3S,linear,2.500e-02,2.500e-02,2.500e-02,1.875e-01,1.875e-01
-SSP5,DEU,,,,,Domestic Aviation,trn_pass,S3S,linear,6.250e-05,6.250e-05,6.250e-05,6.250e-05,6.250e-05
-SSP5,DEU,,,,,Domestic Ship,trn_freight,S3S,linear,2.088e-03,2.088e-03,2.088e-03,2.088e-03,2.088e-03
-SSP5,DEU,,,,,Freight Rail,trn_freight,S3S,linear,2.749e-02,2.749e-02,2.749e-02,2.749e-02,2.749e-02
+SSP5,DEU,,,,,Domestic Aviation,trn_pass,S3S,linear,5.965e-05,5.965e-05,5.965e-05,5.965e-05,5.965e-05
+SSP5,DEU,,,,,Domestic Ship,trn_freight,S3S,linear,2.127e-03,2.127e-03,2.127e-03,2.127e-03,2.127e-03
+SSP5,DEU,,,,,Freight Rail,trn_freight,S3S,linear,2.800e-02,2.800e-02,2.800e-02,2.800e-02,2.800e-02
 SSP5,DEU,,,,,HSR,trn_pass,S3S,linear,1.250e-04,2.500e-04,6.250e-04,6.250e-04,6.250e-04
 SSP5,DEU,,,,,International Aviation,trn_aviation_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,DEU,,,,,International Ship,trn_shipping_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,DEU,,,,,Passenger Rail,trn_pass,S3S,linear,2.500e-03,3.750e-03,3.750e-03,3.750e-03,3.750e-03
 SSP5,DEU,,,,,Walk,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,DEU,,,,,trn_freight_road,trn_freight,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP5,DEU,,,,,trn_pass_road,trn_pass,S3S,linear,7.500e-02,7.500e-02,7.500e-02,7.500e-02,7.500e-02
-SSP5,DEU,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,8.000e-02,8.000e-02,8.000e-02,1.500e-01,1.500e-01
+SSP5,DEU,,,,,trn_pass_road,trn_pass,S3S,linear,7.363e-02,7.363e-02,7.363e-02,7.363e-02,7.363e-02
+SSP5,DEU,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,8.149e-02,8.149e-02,8.149e-02,1.528e-01,1.528e-01
 SSP5,DEU,,,,trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,DEU,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,3.054e-02,3.054e-02,3.054e-02,3.054e-02,3.054e-02
 SSP5,DEU,,,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP5,DEU,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,4.724e-01,4.724e-01,4.724e-01,4.724e-01,4.724e-01
+SSP5,DEU,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,5.249e-01,5.249e-01,4.724e-01,4.724e-01,4.724e-01
 SSP5,DEU,,Large Car and SUV,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,DEU,,Midsize Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,2.716e-01,2.716e-01,2.716e-01,2.716e-01,2.716e-01
 SSP5,DEU,,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,2.183e-01,2.183e-01,2.183e-01,2.183e-01,2.183e-01
 SSP5,DEU,,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,6.630e-03,6.630e-03,6.630e-03,6.630e-03,6.630e-03
 SSP5,DEU,,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP5,DEU,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,4.803e-01,4.803e-01,4.803e-01,4.803e-01,4.803e-01
+SSP5,DEU,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,5.337e-01,5.337e-01,4.803e-01,4.803e-01,4.803e-01
 SSP5,DEU,,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,4.427e-01,4.427e-01,4.427e-01,4.427e-01,4.427e-01
 SSP5,DEU,,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,8.345e-02,8.345e-02,8.345e-02,8.345e-02,8.345e-02
 SSP5,DEU,,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,2.127e-01,2.127e-01,2.127e-01,2.127e-01,2.127e-01
 SSP5,DEU,,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,4.934e-01,4.934e-01,4.934e-01,4.934e-01,4.934e-01
 SSP5,DEU,,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP5,DEU,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP5,DEU,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP5,DEU,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP5,DEU,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.423e-01,4.034e-01,8.573e-01,8.573e-01
+SSP5,DEU,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.000e-02,2.500e-01,4.500e-01,4.500e-01
+SSP5,DEU,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.000e-02,2.500e-01,4.500e-01,4.500e-01
+SSP5,DEU,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.000e-02,2.500e-01,4.500e-01,4.500e-01
+SSP5,DEU,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.294e-01,3.669e-01,7.798e-01,7.798e-01
 SSP5,DEU,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,DEU,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,DEU,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP5,DEU,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.980e-01,6.750e-01,9.820e-01,9.820e-01
-SSP5,DEU,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.186e-01,3.631e-01,9.526e-01,9.526e-01
-SSP5,DEU,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.186e-01,3.631e-01,9.526e-01,9.526e-01
-SSP5,DEU,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.186e-01,3.631e-01,9.526e-01,9.526e-01
-SSP5,DEU,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.980e-01,6.750e-01,9.820e-01,9.820e-01
-SSP5,DEU,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.473e-03,1.799e-02,5.000e-02,5.000e-02
-SSP5,DEU,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,8.031e-02,3.320e-01,2.193e-01,2.193e-01
-SSP5,DEU,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.967e-02,1.259e-01,1.500e-01,1.500e-01
-SSP5,DEU,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.967e-02,1.259e-01,1.500e-01,1.500e-01
-SSP5,DEU,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.967e-02,1.259e-01,1.500e-01,1.500e-01
-SSP5,DEU,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,8.031e-02,3.320e-01,2.193e-01,2.193e-01
+SSP5,DEU,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.524e-01,6.784e-01,8.709e-01,8.709e-01
+SSP5,DEU,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.402e-01,3.649e-01,8.448e-01,8.448e-01
+SSP5,DEU,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.402e-01,3.649e-01,8.448e-01,8.448e-01
+SSP5,DEU,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.402e-01,3.649e-01,8.448e-01,8.448e-01
+SSP5,DEU,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.524e-01,6.784e-01,8.709e-01,8.709e-01
+SSP5,DEU,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.249e-03,1.636e-02,4.548e-02,4.548e-02
+SSP5,DEU,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,9.497e-02,3.925e-01,1.837e-01,1.837e-01
+SSP5,DEU,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.508e-02,1.489e-01,1.257e-01,1.257e-01
+SSP5,DEU,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.508e-02,1.489e-01,1.257e-01,1.257e-01
+SSP5,DEU,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.508e-02,1.489e-01,1.257e-01,1.257e-01
+SSP5,DEU,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,9.497e-02,3.925e-01,1.837e-01,1.837e-01
 SSP5,DEU,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0.000e+00,8.315e-07,4.540e-05,1.192e-01,1.192e-01
 SSP5,DEU,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,DEU,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
@@ -10145,59 +10145,59 @@ SSP5,DEU,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_
 SSP5,DEU,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,DEU,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,DEU,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP5,DEU,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,3.948e-02,6.475e-02,1.153e-01,1.731e-01,1.731e-01
-SSP5,DEU,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,2.615e-02,4.142e-02,1.030e-01,2.055e-01,2.055e-01
-SSP5,DEU,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.105e-02,7.895e-02,1.842e-01,1.842e-01
-SSP5,DEU,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.105e-02,7.895e-02,1.842e-01,1.842e-01
-SSP5,DEU,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.105e-02,7.895e-02,1.842e-01,1.842e-01
-SSP5,DEU,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.105e-02,7.895e-02,1.842e-01,1.842e-01
+SSP5,DEU,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,3.948e-02,4.981e-02,8.870e-02,1.332e-01,1.332e-01
+SSP5,DEU,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,2.615e-02,4.142e-02,1.030e-01,1.713e-01,1.713e-01
+SSP5,DEU,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.105e-02,7.895e-02,1.535e-01,1.535e-01
+SSP5,DEU,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.105e-02,7.895e-02,1.535e-01,1.535e-01
+SSP5,DEU,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.105e-02,7.895e-02,1.535e-01,1.535e-01
+SSP5,DEU,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.105e-02,7.895e-02,1.535e-01,1.535e-01
 SSP5,ECE,,,,,Cycle,trn_pass,S3S,linear,1.942e-02,1.942e-02,9.709e-02,1.092e-01,1.092e-01
-SSP5,ECE,,,,,Domestic Aviation,trn_pass,S3S,linear,7.313e-05,7.313e-05,7.313e-05,2.057e-05,2.057e-05
-SSP5,ECE,,,,,Domestic Ship,trn_freight,S3S,linear,3.893e-04,3.893e-04,3.893e-04,3.893e-04,3.893e-04
-SSP5,ECE,,,,,Freight Rail,trn_freight,S3S,linear,5.909e-02,5.909e-02,5.909e-02,5.909e-02,5.909e-02
+SSP5,ECE,,,,,Domestic Aviation,trn_pass,S3S,linear,6.979e-05,6.979e-05,6.979e-05,1.963e-05,1.963e-05
+SSP5,ECE,,,,,Domestic Ship,trn_freight,S3S,linear,3.966e-04,3.966e-04,3.966e-04,3.966e-04,3.966e-04
+SSP5,ECE,,,,,Freight Rail,trn_freight,S3S,linear,6.019e-02,6.019e-02,5.417e-02,5.417e-02,5.417e-02
 SSP5,ECE,,,,,HSR,trn_pass,S3S,linear,1.139e-04,1.708e-04,4.555e-04,3.202e-04,3.202e-04
 SSP5,ECE,,,,,International Aviation,trn_aviation_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,ECE,,,,,International Ship,trn_shipping_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,ECE,,,,,Passenger Rail,trn_pass,S3S,linear,6.799e-03,6.799e-03,9.065e-03,3.824e-03,3.824e-03
 SSP5,ECE,,,,,Walk,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,ECE,,,,,trn_freight_road,trn_freight,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP5,ECE,,,,,trn_pass_road,trn_pass,S3S,linear,8.972e-01,8.972e-01,7.177e-01,1.615e-01,1.615e-01
-SSP5,ECE,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,1.664e-01,1.664e-01,1.109e-01,1.109e-01,1.109e-01
+SSP5,ECE,,,,,trn_pass_road,trn_pass,S3S,linear,6.166e-01,6.166e-01,4.933e-01,1.268e-01,1.268e-01
+SSP5,ECE,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,2.712e-01,2.543e-01,1.469e-01,1.130e-01,1.130e-01
 SSP5,ECE,,,,trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,ECE,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,6.159e-03,6.159e-03,6.159e-03,6.159e-03,6.159e-03
 SSP5,ECE,,,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP5,ECE,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,3.451e-01,3.451e-01,3.451e-01,3.451e-01,3.451e-01
+SSP5,ECE,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,4.706e-01,4.706e-01,4.601e-01,4.314e-01,4.314e-01
 SSP5,ECE,,Large Car and SUV,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,7.825e-01,7.825e-01,7.825e-01,7.825e-01,7.825e-01
 SSP5,ECE,,Midsize Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,ECE,,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,5.321e-02,5.321e-02,5.321e-02,5.321e-02,5.321e-02
 SSP5,ECE,,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,4.728e-04,4.728e-04,4.728e-04,4.728e-04,4.728e-04
 SSP5,ECE,,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP5,ECE,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,4.683e-01,4.683e-01,4.683e-01,4.683e-01,4.683e-01
+SSP5,ECE,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,6.386e-01,6.386e-01,6.244e-01,5.854e-01,5.854e-01
 SSP5,ECE,,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,6.161e-01,6.161e-01,6.161e-01,6.161e-01,6.161e-01
 SSP5,ECE,,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.384e-01,1.384e-01,1.384e-01,1.384e-01,1.384e-01
 SSP5,ECE,,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.370e-01,1.370e-01,1.370e-01,1.370e-01,1.370e-01
 SSP5,ECE,,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.691e-01,1.691e-01,1.691e-01,1.691e-01,1.691e-01
 SSP5,ECE,,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP5,ECE,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP5,ECE,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP5,ECE,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP5,ECE,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.423e-01,5.379e-01,1.000e+00,1.000e+00
+SSP5,ECE,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.000e-02,1.900e-01,4.300e-01,4.300e-01
+SSP5,ECE,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.000e-02,1.900e-01,4.300e-01,4.300e-01
+SSP5,ECE,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.000e-02,1.900e-01,4.300e-01,4.300e-01
+SSP5,ECE,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.553e-01,5.283e-01,1.000e+00,1.000e+00
 SSP5,ECE,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,ECE,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,ECE,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP5,ECE,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.960e-02,1.500e-01,2.946e-01,2.946e-01
-SSP5,ECE,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.371e-02,8.068e-02,2.858e-01,2.858e-01
-SSP5,ECE,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.371e-02,8.068e-02,2.858e-01,2.858e-01
-SSP5,ECE,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.371e-02,8.068e-02,2.858e-01,2.858e-01
-SSP5,ECE,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.960e-02,1.500e-01,2.946e-01,2.946e-01
-SSP5,ECE,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.236e-02,1.799e-02,8.748e-02,8.748e-02
-SSP5,ECE,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.339e-02,4.743e-02,1.462e-01,1.462e-01
-SSP5,ECE,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.945e-03,1.799e-02,1.000e-01,1.000e-01
-SSP5,ECE,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.945e-03,1.799e-02,1.000e-01,1.000e-01
-SSP5,ECE,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.945e-03,1.799e-02,1.000e-01,1.000e-01
-SSP5,ECE,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.339e-02,4.743e-02,1.462e-01,1.462e-01
+SSP5,ECE,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.504e-02,1.455e-01,2.786e-01,2.786e-01
+SSP5,ECE,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.588e-02,7.826e-02,2.703e-01,2.703e-01
+SSP5,ECE,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.588e-02,7.826e-02,2.703e-01,2.703e-01
+SSP5,ECE,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.588e-02,7.826e-02,2.703e-01,2.703e-01
+SSP5,ECE,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.504e-02,1.455e-01,2.786e-01,2.786e-01
+SSP5,ECE,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.349e-02,1.963e-02,8.748e-02,8.748e-02
+SSP5,ECE,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.461e-02,5.750e-02,6.382e-02,6.382e-02
+SSP5,ECE,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.396e-03,2.181e-02,4.365e-02,4.365e-02
+SSP5,ECE,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.396e-03,2.181e-02,4.365e-02,4.365e-02
+SSP5,ECE,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.396e-03,2.181e-02,4.365e-02,4.365e-02
+SSP5,ECE,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.461e-02,5.750e-02,6.382e-02,6.382e-02
 SSP5,ECE,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0.000e+00,8.315e-07,4.540e-05,1.192e-01,1.192e-01
-SSP5,ECE,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,8.748e-01,8.748e-01
+SSP5,ECE,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,8.017e-01,8.017e-01
 SSP5,ECE,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,ECE,Liquids,Domestic Ship_tmp_vehicletype,Domestic Ship_tmp_subsector_L1,Domestic Ship_tmp_subsector_L2,Domestic Ship,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,ECE,Liquids,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,5.870e-01,5.870e-01,5.870e-01,5.870e-01,5.870e-01
@@ -10212,57 +10212,57 @@ SSP5,ECE,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_
 SSP5,ECE,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,ECE,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,ECE,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP5,ECE,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP5,ECE,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP5,ECE,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP5,ECE,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
+SSP5,ECE,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e-02,2.000e-02,7.000e-02,9.000e-02,9.000e-02
+SSP5,ECE,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.000e-02,1.111e-01,1.867e-01,1.867e-01
+SSP5,ECE,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.000e-02,1.111e-01,1.867e-01,1.867e-01
+SSP5,ECE,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.000e-02,1.111e-01,1.867e-01,1.867e-01
 SSP5,ECE,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP5,ECE,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP5,ECS,,,,,Cycle,trn_pass,S3S,linear,7.196e-03,2.159e-02,8.635e-02,8.738e-02,8.738e-02
-SSP5,ECS,,,,,Domestic Aviation,trn_pass,S3S,linear,2.566e-03,2.566e-03,2.566e-03,3.895e-04,3.895e-04
-SSP5,ECS,,,,,Domestic Ship,trn_freight,S3S,linear,3.878e-03,3.878e-03,3.878e-03,3.878e-03,3.878e-03
-SSP5,ECS,,,,,Freight Rail,trn_freight,S3S,linear,5.867e-02,5.867e-02,5.867e-02,5.867e-02,5.867e-02
-SSP5,ECS,,,,,HSR,trn_pass,S3S,linear,1.956e-04,1.956e-04,5.216e-04,4.000e-04,4.000e-04
+SSP5,ECE,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.000e-02,1.111e-01,1.867e-01,1.867e-01
+SSP5,ECS,,,,,Cycle,trn_pass,S3S,linear,1.092e-02,3.277e-02,1.311e-01,8.738e-02,8.738e-02
+SSP5,ECS,,,,,Domestic Aviation,trn_pass,S3S,linear,3.717e-03,3.717e-03,3.717e-03,3.717e-04,3.717e-04
+SSP5,ECS,,,,,Domestic Ship,trn_freight,S3S,linear,3.950e-03,3.950e-03,3.591e-03,3.950e-03,3.950e-03
+SSP5,ECS,,,,,Freight Rail,trn_freight,S3S,linear,5.976e-02,5.976e-02,5.433e-02,5.379e-02,5.379e-02
+SSP5,ECS,,,,,HSR,trn_pass,S3S,linear,2.969e-04,2.969e-04,7.917e-04,4.000e-04,4.000e-04
 SSP5,ECS,,,,,International Aviation,trn_aviation_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,ECS,,,,,International Ship,trn_shipping_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP5,ECS,,,,,Passenger Rail,trn_pass,S3S,linear,5.215e-03,6.953e-03,8.691e-03,2.638e-03,2.638e-03
-SSP5,ECS,,,,,Walk,trn_pass,S3S,linear,6.588e-01,6.588e-01,6.588e-01,1.000e+00,1.000e+00
+SSP5,ECS,,,,,Passenger Rail,trn_pass,S3S,linear,7.915e-03,1.055e-02,1.319e-02,2.638e-03,2.638e-03
+SSP5,ECS,,,,,Walk,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,ECS,,,,,trn_freight_road,trn_freight,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP5,ECS,,,,,trn_pass_road,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.518e-01,1.518e-01
-SSP5,ECS,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,1.140e-01,1.140e-01,7.980e-02,6.840e-02,6.840e-02
+SSP5,ECS,,,,,trn_pass_road,trn_pass,S3S,linear,7.451e-01,7.451e-01,7.451e-01,8.941e-02,8.941e-02
+SSP5,ECS,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,2.090e-01,1.742e-01,1.219e-01,1.045e-01,1.045e-01
 SSP5,ECS,,,,trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,ECS,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,2.175e-03,2.175e-03,2.175e-03,2.175e-03,2.175e-03
 SSP5,ECS,,,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP5,ECS,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,3.336e-01,3.336e-01,3.336e-01,3.336e-01,3.336e-01
+SSP5,ECS,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,5.004e-01,5.004e-01,5.004e-01,4.549e-01,4.549e-01
 SSP5,ECS,,Large Car and SUV,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,ECS,,Midsize Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,9.609e-01,9.609e-01,9.609e-01,9.609e-01,9.609e-01
 SSP5,ECS,,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.125e-01,1.125e-01,1.125e-01,1.125e-01,1.125e-01
 SSP5,ECS,,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,3.579e-02,3.579e-02,3.579e-02,3.579e-02,3.579e-02
 SSP5,ECS,,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP5,ECS,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,6.520e-01,6.520e-01,6.520e-01,6.520e-01,6.520e-01
+SSP5,ECS,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,9.780e-01,9.780e-01,9.780e-01,8.891e-01,8.891e-01
 SSP5,ECS,,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,ECS,,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,2.555e-01,2.555e-01,2.555e-01,2.555e-01,2.555e-01
 SSP5,ECS,,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,3.104e-01,3.104e-01,3.104e-01,3.104e-01,3.104e-01
 SSP5,ECS,,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.282e-01,1.282e-01,1.282e-01,1.282e-01,1.282e-01
 SSP5,ECS,,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,4.409e-01,4.409e-01,4.409e-01,4.409e-01,4.409e-01
-SSP5,ECS,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP5,ECS,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP5,ECS,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP5,ECS,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.743e-02,3.496e-01,8.573e-01,8.573e-01
+SSP5,ECS,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,3.200e-02,1.920e-01,4.200e-01,4.200e-01
+SSP5,ECS,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,3.200e-02,1.920e-01,4.200e-01,4.200e-01
+SSP5,ECS,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,3.200e-02,1.920e-01,4.200e-01,4.200e-01
+SSP5,ECS,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,9.315e-02,3.815e-01,8.420e-01,8.420e-01
 SSP5,ECS,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,ECS,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,ECS,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP5,ECS,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.192e-01,2.500e-01,2.946e-01,2.946e-01
-SSP5,ECS,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.743e-02,1.345e-01,2.858e-01,2.858e-01
-SSP5,ECS,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.743e-02,1.345e-01,2.858e-01,2.858e-01
-SSP5,ECS,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.743e-02,1.345e-01,2.858e-01,2.858e-01
-SSP5,ECS,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.192e-01,2.500e-01,2.946e-01,2.946e-01
-SSP5,ECS,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.473e-03,5.396e-02,1.000e-01,1.000e-01
-SSP5,ECS,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.339e-02,4.743e-02,7.311e-02,7.311e-02
-SSP5,ECS,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.945e-03,1.799e-02,5.000e-02,5.000e-02
-SSP5,ECS,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.945e-03,1.799e-02,5.000e-02,5.000e-02
-SSP5,ECS,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.945e-03,1.799e-02,5.000e-02,5.000e-02
-SSP5,ECS,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.339e-02,4.743e-02,7.311e-02,7.311e-02
+SSP5,ECS,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.041e-01,2.182e-01,2.893e-01,2.893e-01
+SSP5,ECS,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.140e-02,1.174e-01,2.807e-01,2.807e-01
+SSP5,ECS,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.140e-02,1.174e-01,2.807e-01,2.807e-01
+SSP5,ECS,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.140e-02,1.174e-01,2.807e-01,2.807e-01
+SSP5,ECS,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.041e-01,2.182e-01,2.893e-01,2.893e-01
+SSP5,ECS,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.698e-03,7.360e-02,1.091e-01,1.091e-01
+SSP5,ECS,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.461e-02,6.900e-02,7.977e-02,7.977e-02
+SSP5,ECS,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.396e-03,2.617e-02,5.456e-02,5.456e-02
+SSP5,ECS,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.396e-03,2.617e-02,5.456e-02,5.456e-02
+SSP5,ECS,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.396e-03,2.617e-02,5.456e-02,5.456e-02
+SSP5,ECS,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.461e-02,6.900e-02,7.977e-02,7.977e-02
 SSP5,ECS,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0.000e+00,8.315e-07,4.540e-05,1.192e-01,1.192e-01
 SSP5,ECS,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,ECS,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
@@ -10279,61 +10279,61 @@ SSP5,ECS,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_
 SSP5,ECS,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,ECS,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,ECS,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP5,ECS,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP5,ECS,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP5,ECS,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP5,ECS,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP5,ECS,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP5,ECS,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
+SSP5,ECS,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e-02,2.000e-02,6.250e-02,1.000e-01,1.000e-01
+SSP5,ECS,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e-05,1.300e-02,6.667e-02,1.400e-01,1.400e-01
+SSP5,ECS,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e-05,1.300e-02,6.667e-02,1.400e-01,1.400e-01
+SSP5,ECS,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e-05,1.300e-02,6.667e-02,1.400e-01,1.400e-01
+SSP5,ECS,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e-05,1.300e-02,6.667e-02,1.400e-01,1.400e-01
+SSP5,ECS,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e-05,1.300e-02,6.667e-02,1.400e-01,1.400e-01
 SSP5,ENC,,,,,Cycle,trn_pass,S3S,linear,2.500e-02,2.500e-02,5.556e-02,1.000e-01,1.000e-01
-SSP5,ENC,,,,,Domestic Aviation,trn_pass,S3S,linear,6.250e-05,6.250e-05,5.556e-05,2.500e-05,2.500e-05
-SSP5,ENC,,,,,Domestic Ship,trn_freight,S3S,linear,1.223e-02,1.223e-02,1.223e-02,1.223e-02,1.223e-02
-SSP5,ENC,,,,,Freight Rail,trn_freight,S3S,linear,2.875e-02,2.875e-02,2.875e-02,2.875e-02,2.875e-02
+SSP5,ENC,,,,,Domestic Aviation,trn_pass,S3S,linear,5.965e-05,5.965e-05,5.302e-05,2.386e-05,2.386e-05
+SSP5,ENC,,,,,Domestic Ship,trn_freight,S3S,linear,1.246e-02,1.246e-02,1.246e-02,1.246e-02,1.246e-02
+SSP5,ENC,,,,,Freight Rail,trn_freight,S3S,linear,2.928e-02,2.928e-02,2.928e-02,2.928e-02,2.928e-02
 SSP5,ENC,,,,,HSR,trn_pass,S3S,linear,1.250e-04,2.500e-04,2.222e-04,2.000e-04,2.000e-04
 SSP5,ENC,,,,,International Aviation,trn_aviation_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,ENC,,,,,International Ship,trn_shipping_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,ENC,,,,,Passenger Rail,trn_pass,S3S,linear,3.125e-03,3.125e-03,3.333e-03,2.000e-03,2.000e-03
 SSP5,ENC,,,,,Walk,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,ENC,,,,,trn_freight_road,trn_freight,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP5,ENC,,,,,trn_pass_road,trn_pass,S3S,linear,7.500e-02,7.500e-02,6.667e-02,3.000e-02,3.000e-02
-SSP5,ENC,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,2.000e-01,1.500e-01,1.500e-01,1.500e-01,1.500e-01
+SSP5,ENC,,,,,trn_pass_road,trn_pass,S3S,linear,7.363e-02,7.363e-02,6.545e-02,2.945e-02,2.945e-02
+SSP5,ENC,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,2.037e-01,1.528e-01,1.528e-01,1.528e-01,1.528e-01
 SSP5,ENC,,,,trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,ENC,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,3.014e-02,3.014e-02,3.014e-02,3.014e-02,3.014e-02
 SSP5,ENC,,,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP5,ENC,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,3.559e-01,3.559e-01,3.559e-01,3.559e-01,3.559e-01
+SSP5,ENC,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,3.955e-01,3.955e-01,3.955e-01,3.559e-01,3.559e-01
 SSP5,ENC,,Large Car and SUV,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,ENC,,Midsize Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.960e-01,1.960e-01,1.960e-01,1.960e-01,1.960e-01
-SSP5,ENC,,Mini Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,2.357e-07,2.357e-07,2.357e-07,2.357e-07,2.357e-07
+SSP5,ENC,,Mini Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,2.619e-07,2.619e-07,2.619e-07,2.357e-07,2.357e-07
 SSP5,ENC,,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.576e-01,1.576e-01,1.576e-01,1.576e-01,1.576e-01
 SSP5,ENC,,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,3.751e-02,3.751e-02,3.751e-02,3.751e-02,3.751e-02
 SSP5,ENC,,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP5,ENC,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.963e-01,1.963e-01,1.963e-01,1.963e-01,1.963e-01
+SSP5,ENC,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,2.181e-01,2.181e-01,2.181e-01,1.963e-01,1.963e-01
 SSP5,ENC,,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,ENC,,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.002e-01,1.002e-01,1.002e-01,1.002e-01,1.002e-01
 SSP5,ENC,,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,3.593e-01,3.593e-01,3.593e-01,3.593e-01,3.593e-01
 SSP5,ENC,,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,4.374e-01,4.374e-01,4.374e-01,4.374e-01,4.374e-01
 SSP5,ENC,,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,4.946e-01,4.946e-01,4.946e-01,4.946e-01,4.946e-01
 SSP5,ENC,,Van,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.049e-03,1.049e-03,1.049e-03,1.049e-03,1.049e-03
-SSP5,ENC,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP5,ENC,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP5,ENC,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP5,ENC,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.371e-01,6.724e-01,1.000e+00,1.000e+00
+SSP5,ENC,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,5.000e-02,2.300e-01,5.000e-01,5.000e-01
+SSP5,ENC,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,5.000e-02,2.300e-01,5.000e-01,5.000e-01
+SSP5,ENC,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,5.000e-02,2.300e-01,5.000e-01,5.000e-01
+SSP5,ENC,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.157e-01,7.227e-01,1.000e+00,1.000e+00
 SSP5,ENC,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,ENC,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,ENC,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP5,ENC,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.622e-01,6.000e-01,9.820e-01,9.820e-01
-SSP5,ENC,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.043e-01,3.227e-01,9.526e-01,9.526e-01
-SSP5,ENC,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.043e-01,3.227e-01,9.526e-01,9.526e-01
-SSP5,ENC,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.043e-01,3.227e-01,9.526e-01,9.526e-01
-SSP5,ENC,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.622e-01,6.000e-01,9.820e-01,9.820e-01
-SSP5,ENC,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.236e-02,5.396e-02,1.312e-01,1.312e-01
-SSP5,ENC,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.693e-02,2.371e-01,1.462e-01,1.462e-01
-SSP5,ENC,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-02,8.993e-02,1.000e-01,1.000e-01
-SSP5,ENC,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-02,8.993e-02,1.000e-01,1.000e-01
-SSP5,ENC,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-02,8.993e-02,1.000e-01,1.000e-01
-SSP5,ENC,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.693e-02,2.371e-01,1.462e-01,1.462e-01
+SSP5,ENC,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.101e-01,6.386e-01,9.289e-01,9.289e-01
+SSP5,ENC,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.234e-01,3.434e-01,9.011e-01,9.011e-01
+SSP5,ENC,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.234e-01,3.434e-01,9.011e-01,9.011e-01
+SSP5,ENC,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.234e-01,3.434e-01,9.011e-01,9.011e-01
+SSP5,ENC,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.101e-01,6.386e-01,9.289e-01,9.289e-01
+SSP5,ENC,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.124e-02,5.800e-02,1.021e-01,1.021e-01
+SSP5,ENC,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,7.914e-02,2.804e-01,1.729e-01,1.729e-01
+SSP5,ENC,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.924e-02,1.063e-01,1.183e-01,1.183e-01
+SSP5,ENC,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.924e-02,1.063e-01,1.183e-01,1.183e-01
+SSP5,ENC,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.924e-02,1.063e-01,1.183e-01,1.183e-01
+SSP5,ENC,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,7.914e-02,2.804e-01,1.729e-01,1.729e-01
 SSP5,ENC,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0.000e+00,8.315e-07,4.540e-05,1.192e-01,1.192e-01
-SSP5,ENC,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,5.249e-01,5.249e-01
+SSP5,ENC,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,5.426e-01,5.426e-01
 SSP5,ENC,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,ENC,Liquids,Domestic Ship_tmp_vehicletype,Domestic Ship_tmp_subsector_L1,Domestic Ship_tmp_subsector_L2,Domestic Ship,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,ENC,Liquids,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1.341e-01,1.341e-01,1.341e-01,1.341e-01,1.341e-01
@@ -10348,30 +10348,30 @@ SSP5,ENC,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_
 SSP5,ENC,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,ENC,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,ENC,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP5,ENC,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,2.533e-02,5.098e-02,1.023e-01,1.075e-01,1.075e-01
+SSP5,ENC,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,2.533e-02,3.921e-02,9.298e-02,1.011e-01,1.011e-01
 SSP5,ENC,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
 SSP5,ENC,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
 SSP5,ENC,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
 SSP5,ENC,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
 SSP5,ENC,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
 SSP5,ESC,,,,,Cycle,trn_pass,S3S,linear,1.942e-02,2.184e-02,4.369e-02,1.638e-01,1.638e-01
-SSP5,ESC,,,,,Domestic Aviation,trn_pass,S3S,linear,1.347e-04,3.789e-05,3.789e-05,7.579e-05,7.579e-05
-SSP5,ESC,,,,,Domestic Ship,trn_freight,S3S,linear,1.187e-02,1.187e-02,1.187e-02,1.187e-02,1.187e-02
-SSP5,ESC,,,,,Freight Rail,trn_freight,S3S,linear,4.020e-03,4.020e-03,4.020e-03,4.020e-03,4.020e-03
+SSP5,ESC,,,,,Domestic Aviation,trn_pass,S3S,linear,1.286e-04,3.616e-05,3.616e-05,7.233e-05,7.233e-05
+SSP5,ESC,,,,,Domestic Ship,trn_freight,S3S,linear,1.209e-02,1.209e-02,1.209e-02,1.209e-02,1.209e-02
+SSP5,ESC,,,,,Freight Rail,trn_freight,S3S,linear,4.094e-03,4.094e-03,4.094e-03,4.094e-03,4.094e-03
 SSP5,ESC,,,,,HSR,trn_pass,S3S,linear,6.613e-04,1.860e-04,6.200e-04,6.200e-04,6.200e-04
 SSP5,ESC,,,,,International Aviation,trn_aviation_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,ESC,,,,,International Ship,trn_shipping_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,ESC,,,,,Passenger Rail,trn_pass,S3S,linear,3.195e-03,2.696e-03,2.696e-03,4.044e-03,4.044e-03
 SSP5,ESC,,,,,Walk,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,ESC,,,,,trn_freight_road,trn_freight,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP5,ESC,,,,,trn_pass_road,trn_pass,S3S,linear,1.832e-01,1.030e-01,8.242e-02,6.594e-02,6.594e-02
-SSP5,ESC,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,6.591e-02,6.591e-02,6.591e-02,9.887e-02,9.887e-02
+SSP5,ESC,,,,,trn_pass_road,trn_pass,S3S,linear,1.798e-01,1.011e-01,8.092e-02,6.473e-02,6.473e-02
+SSP5,ESC,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,6.714e-02,6.714e-02,6.714e-02,1.007e-01,1.007e-01
 SSP5,ESC,,,,trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP5,ESC,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.687e-01,1.687e-01,1.687e-01,1.687e-01,1.687e-01
+SSP5,ESC,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.205e-01,1.125e-01,1.125e-01,1.125e-01,1.125e-01
 SSP5,ESC,,,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,ESC,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,3.942e-01,3.942e-01,3.942e-01,3.942e-01,3.942e-01
-SSP5,ESC,,Large Car and SUV,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,8.712e-01,8.712e-01,8.712e-01,8.712e-01,8.712e-01
-SSP5,ESC,,Midsize Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,2.323e-01,2.323e-01,2.323e-01,2.323e-01,2.323e-01
+SSP5,ESC,,Large Car and SUV,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,8.712e-01,7.840e-01,8.712e-01,8.712e-01,8.712e-01
+SSP5,ESC,,Midsize Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,2.323e-01,2.091e-01,2.323e-01,2.323e-01,2.323e-01
 SSP5,ESC,,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.009e-01,1.009e-01,1.009e-01,1.009e-01,1.009e-01
 SSP5,ESC,,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,6.375e-02,6.375e-02,6.375e-02,6.375e-02,6.375e-02
 SSP5,ESC,,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
@@ -10381,24 +10381,24 @@ SSP5,ESC,,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_sub
 SSP5,ESC,,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,2.234e-01,2.234e-01,2.234e-01,2.234e-01,2.234e-01
 SSP5,ESC,,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,2.172e-01,2.172e-01,2.172e-01,2.172e-01,2.172e-01
 SSP5,ESC,,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP5,ESC,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP5,ESC,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP5,ESC,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP5,ESC,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.423e-01,4.034e-01,9.526e-01,9.526e-01
+SSP5,ESC,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.000e-02,2.200e-01,4.200e-01,4.200e-01
+SSP5,ESC,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.000e-02,2.200e-01,4.200e-01,4.200e-01
+SSP5,ESC,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.000e-02,2.200e-01,4.200e-01,4.200e-01
+SSP5,ESC,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.359e-01,3.816e-01,8.448e-01,8.448e-01
 SSP5,ESC,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,ESC,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,ESC,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP5,ESC,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.384e-01,5.000e-01,9.820e-01,9.820e-01
-SSP5,ESC,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,9.485e-02,2.689e-01,9.526e-01,9.526e-01
-SSP5,ESC,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,9.485e-02,2.689e-01,9.526e-01,9.526e-01
-SSP5,ESC,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,9.485e-02,2.689e-01,9.526e-01,9.526e-01
-SSP5,ESC,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.384e-01,5.000e-01,9.820e-01,9.820e-01
-SSP5,ESC,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.236e-02,5.396e-02,1.000e-01,1.000e-01
-SSP5,ESC,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.693e-02,4.743e-02,1.462e-01,1.462e-01
-SSP5,ESC,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-02,1.799e-02,1.000e-01,1.000e-01
-SSP5,ESC,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-02,1.799e-02,1.000e-01,1.000e-01
-SSP5,ESC,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-02,1.799e-02,1.000e-01,1.000e-01
-SSP5,ESC,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.693e-02,4.743e-02,1.462e-01,1.462e-01
+SSP5,ESC,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.819e-01,5.321e-01,7.741e-01,7.741e-01
+SSP5,ESC,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.122e-01,2.862e-01,7.509e-01,7.509e-01
+SSP5,ESC,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.122e-01,2.862e-01,7.509e-01,7.509e-01
+SSP5,ESC,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.122e-01,2.862e-01,7.509e-01,7.509e-01
+SSP5,ESC,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.819e-01,5.321e-01,7.741e-01,7.741e-01
+SSP5,ESC,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.124e-02,6.380e-02,7.883e-02,7.883e-02
+SSP5,ESC,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,7.914e-02,5.608e-02,1.441e-01,1.441e-01
+SSP5,ESC,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.924e-02,2.127e-02,9.854e-02,9.854e-02
+SSP5,ESC,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.924e-02,2.127e-02,9.854e-02,9.854e-02
+SSP5,ESC,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.924e-02,2.127e-02,9.854e-02,9.854e-02
+SSP5,ESC,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,7.914e-02,5.608e-02,1.441e-01,1.441e-01
 SSP5,ESC,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0.000e+00,8.315e-07,4.540e-05,1.192e-01,1.192e-01
 SSP5,ESC,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,ESC,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
@@ -10415,57 +10415,57 @@ SSP5,ESC,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_
 SSP5,ESC,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,ESC,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,ESC,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP5,ESC,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,2.742e-02,5.301e-02,1.042e-01,2.066e-01,2.066e-01
-SSP5,ESC,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SSP5,ESC,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SSP5,ESC,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SSP5,ESC,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SSP5,ESC,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
+SSP5,ESC,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,2.742e-02,4.078e-02,1.042e-01,1.721e-01,1.721e-01
+SSP5,ESC,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.535e-01,1.535e-01
+SSP5,ESC,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.535e-01,1.535e-01
+SSP5,ESC,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.535e-01,1.535e-01
+SSP5,ESC,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.535e-01,1.535e-01
+SSP5,ESC,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.535e-01,1.535e-01
 SSP5,ESW,,,,,Cycle,trn_pass,S3S,linear,1.942e-02,3.884e-02,5.825e-02,1.019e-01,1.019e-01
-SSP5,ESW,,,,,Domestic Aviation,trn_pass,S3S,linear,7.179e-04,7.179e-04,5.744e-04,1.346e-04,1.346e-04
-SSP5,ESW,,,,,Domestic Ship,trn_freight,S3S,linear,6.018e-03,6.018e-03,6.018e-03,6.018e-03,6.018e-03
-SSP5,ESW,,,,,Freight Rail,trn_freight,S3S,linear,1.394e-02,1.394e-02,1.394e-02,1.394e-02,1.394e-02
+SSP5,ESW,,,,,Domestic Aviation,trn_pass,S3S,linear,6.852e-04,6.852e-04,5.482e-04,1.285e-04,1.285e-04
+SSP5,ESW,,,,,Domestic Ship,trn_freight,S3S,linear,6.130e-03,6.130e-03,6.130e-03,6.130e-03,6.130e-03
+SSP5,ESW,,,,,Freight Rail,trn_freight,S3S,linear,1.420e-02,1.420e-02,1.420e-02,1.420e-02,1.420e-02
 SSP5,ESW,,,,,HSR,trn_pass,S3S,linear,9.579e-04,9.579e-04,9.579e-04,3.592e-04,3.592e-04
 SSP5,ESW,,,,,International Aviation,trn_aviation_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,ESW,,,,,International Ship,trn_shipping_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,ESW,,,,,Passenger Rail,trn_pass,S3S,linear,3.621e-03,3.621e-03,5.432e-03,2.037e-03,2.037e-03
 SSP5,ESW,,,,,Walk,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,ESW,,,,,trn_freight_road,trn_freight,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP5,ESW,,,,,trn_pass_road,trn_pass,S3S,linear,1.411e-01,1.129e-01,1.129e-01,3.175e-02,3.175e-02
-SSP5,ESW,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,5.667e-02,5.667e-02,7.083e-02,1.063e-01,1.063e-01
+SSP5,ESW,,,,,trn_pass_road,trn_pass,S3S,linear,1.385e-01,1.108e-01,1.108e-01,3.117e-02,3.117e-02
+SSP5,ESW,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,5.772e-02,5.772e-02,7.215e-02,1.082e-01,1.082e-01
 SSP5,ESW,,,,trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP5,ESW,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,8.570e-02,8.570e-02,8.570e-02,8.570e-02,8.570e-02
+SSP5,ESW,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,7.141e-02,7.141e-02,7.141e-02,6.592e-02,6.592e-02
 SSP5,ESW,,,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP5,ESW,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,5.153e-01,5.153e-01,5.153e-01,5.153e-01,5.153e-01
+SSP5,ESW,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,5.725e-01,5.725e-01,5.725e-01,5.725e-01,5.725e-01
 SSP5,ESW,,Large Car and SUV,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,ESW,,Midsize Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,2.963e-01,2.963e-01,2.963e-01,2.963e-01,2.963e-01
 SSP5,ESW,,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,9.741e-02,9.741e-02,9.741e-02,9.741e-02,9.741e-02
 SSP5,ESW,,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.669e-01,1.669e-01,1.669e-01,1.669e-01,1.669e-01
 SSP5,ESW,,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP5,ESW,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,4.003e-01,4.003e-01,4.003e-01,4.003e-01,4.003e-01
+SSP5,ESW,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,4.448e-01,4.448e-01,4.448e-01,4.448e-01,4.448e-01
 SSP5,ESW,,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,2.850e-01,2.850e-01,2.850e-01,2.850e-01,2.850e-01
 SSP5,ESW,,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,6.043e-02,6.043e-02,6.043e-02,6.043e-02,6.043e-02
 SSP5,ESW,,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,8.424e-02,8.424e-02,8.424e-02,8.424e-02,8.424e-02
 SSP5,ESW,,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,4.041e-01,4.041e-01,4.041e-01,4.041e-01,4.041e-01
 SSP5,ESW,,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP5,ESW,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP5,ESW,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP5,ESW,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP5,ESW,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.186e-01,2.689e-01,6.668e-01,6.668e-01
+SSP5,ESW,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.800e-02,2.160e-01,4.200e-01,4.200e-01
+SSP5,ESW,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.800e-02,2.160e-01,4.200e-01,4.200e-01
+SSP5,ESW,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.800e-02,2.160e-01,4.200e-01,4.200e-01
+SSP5,ESW,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.078e-02,1.164e-01,2.935e-01,6.237e-01,6.237e-01
 SSP5,ESW,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,7.295e-01,7.633e-01,8.309e-01,9.662e-01,9.662e-01
 SSP5,ESW,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,ESW,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP5,ESW,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.576e-01,7.000e-01,9.820e-01,9.820e-01
-SSP5,ESW,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.423e-01,3.765e-01,9.526e-01,9.526e-01
-SSP5,ESW,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.423e-01,3.765e-01,9.526e-01,9.526e-01
-SSP5,ESW,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.423e-01,3.765e-01,9.526e-01,9.526e-01
-SSP5,ESW,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.576e-01,7.000e-01,9.820e-01,9.820e-01
-SSP5,ESW,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.473e-03,1.799e-02,7.500e-02,7.500e-02
-SSP5,ESW,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.693e-02,2.371e-01,1.462e-01,1.462e-01
-SSP5,ESW,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-02,8.993e-02,1.000e-01,1.000e-01
-SSP5,ESW,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-02,8.993e-02,1.000e-01,1.000e-01
-SSP5,ESW,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-02,8.993e-02,1.000e-01,1.000e-01
-SSP5,ESW,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.693e-02,2.371e-01,1.462e-01,1.462e-01
+SSP5,ESW,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.902e-01,6.875e-01,1.000e+00,1.000e+00
+SSP5,ESW,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.553e-01,3.698e-01,1.000e+00,1.000e+00
+SSP5,ESW,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.553e-01,3.698e-01,1.000e+00,1.000e+00
+SSP5,ESW,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.553e-01,3.698e-01,1.000e+00,1.000e+00
+SSP5,ESW,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.902e-01,6.875e-01,1.000e+00,1.000e+00
+SSP5,ESW,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,2.248e-03,2.698e-03,1.963e-02,5.846e-02,5.846e-02
+SSP5,ESW,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,7.303e-02,2.588e-01,1.489e-01,1.489e-01
+SSP5,ESW,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.698e-02,9.813e-02,1.050e-01,1.050e-01
+SSP5,ESW,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.698e-02,9.813e-02,1.050e-01,1.050e-01
+SSP5,ESW,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.698e-02,9.813e-02,1.050e-01,1.050e-01
+SSP5,ESW,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,7.303e-02,2.588e-01,1.489e-01,1.489e-01
 SSP5,ESW,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0.000e+00,8.315e-07,4.540e-05,1.192e-01,1.192e-01
 SSP5,ESW,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,ESW,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
@@ -10477,39 +10477,39 @@ SSP5,ESW,Liquids,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_
 SSP5,ESW,Liquids,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,ESW,Liquids,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,ESW,Liquids,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,5.162e-01,5.162e-01,5.162e-01,5.162e-01,5.162e-01
-SSP5,ESW,Liquids,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP5,ESW,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP5,ESW,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP5,ESW,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP5,ESW,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP5,ESW,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SSP5,ESW,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SSP5,ESW,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SSP5,ESW,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SSP5,ESW,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SSP5,ESW,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
+SSP5,ESW,Liquids,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,9.332e-01,9.332e-01
+SSP5,ESW,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,9.620e-01,9.620e-01
+SSP5,ESW,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,9.620e-01,9.620e-01
+SSP5,ESW,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,9.620e-01,9.620e-01
+SSP5,ESW,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,9.332e-01,9.332e-01
+SSP5,ESW,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.754e-02,2.632e-02,7.895e-02,1.316e-01,1.316e-01
+SSP5,ESW,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.719e-01,1.719e-01
+SSP5,ESW,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.772e-01,1.772e-01
+SSP5,ESW,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.772e-01,1.772e-01
+SSP5,ESW,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.772e-01,1.772e-01
+SSP5,ESW,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.719e-01,1.719e-01
 SSP5,EWN,,,,,Cycle,trn_pass,S3S,linear,1.000e-02,1.000e-02,5.000e-02,1.000e-01,1.000e-01
-SSP5,EWN,,,,,Domestic Aviation,trn_pass,S3S,linear,5.000e-05,5.000e-05,5.000e-05,5.000e-06,5.000e-06
-SSP5,EWN,,,,,Domestic Ship,trn_freight,S3S,linear,6.147e-03,6.830e-03,6.147e-03,6.147e-03,6.147e-03
-SSP5,EWN,,,,,Freight Rail,trn_freight,S3S,linear,1.246e-02,1.385e-02,1.246e-02,1.246e-02,1.246e-02
+SSP5,EWN,,,,,Domestic Aviation,trn_pass,S3S,linear,4.772e-05,4.772e-05,4.772e-05,4.772e-06,4.772e-06
+SSP5,EWN,,,,,Domestic Ship,trn_freight,S3S,linear,6.261e-03,6.957e-03,6.261e-03,6.261e-03,6.261e-03
+SSP5,EWN,,,,,Freight Rail,trn_freight,S3S,linear,1.270e-02,1.411e-02,1.270e-02,1.270e-02,1.270e-02
 SSP5,EWN,,,,,HSR,trn_pass,S3S,linear,1.000e-04,1.000e-04,4.000e-04,2.000e-04,2.000e-04
 SSP5,EWN,,,,,International Aviation,trn_aviation_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,EWN,,,,,International Ship,trn_shipping_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,EWN,,,,,Passenger Rail,trn_pass,S3S,linear,2.000e-03,3.000e-03,3.000e-03,2.000e-03,2.000e-03
 SSP5,EWN,,,,,Walk,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,EWN,,,,,trn_freight_road,trn_freight,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP5,EWN,,,,,trn_pass_road,trn_pass,S3S,linear,6.000e-02,6.000e-02,6.000e-02,3.000e-02,3.000e-02
-SSP5,EWN,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,1.000e-01,1.000e-01,1.000e-01,1.500e-01,1.500e-01
+SSP5,EWN,,,,,trn_pass_road,trn_pass,S3S,linear,5.891e-02,5.891e-02,5.891e-02,2.945e-02,2.945e-02
+SSP5,EWN,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,1.019e-01,1.019e-01,1.019e-01,1.528e-01,1.528e-01
 SSP5,EWN,,,,trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,EWN,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,4.166e-02,4.166e-02,4.166e-02,4.166e-02,4.166e-02
 SSP5,EWN,,,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP5,EWN,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,3.886e-01,3.886e-01,3.886e-01,3.886e-01,3.886e-01
+SSP5,EWN,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,4.317e-01,4.317e-01,3.886e-01,3.886e-01,3.886e-01
 SSP5,EWN,,Large Car and SUV,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,EWN,,Midsize Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,2.283e-01,2.283e-01,2.283e-01,2.283e-01,2.283e-01
 SSP5,EWN,,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.183e-01,1.183e-01,1.183e-01,1.183e-01,1.183e-01
 SSP5,EWN,,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,4.339e-02,4.339e-02,4.339e-02,4.339e-02,4.339e-02
 SSP5,EWN,,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP5,EWN,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,4.377e-01,4.377e-01,4.377e-01,4.377e-01,4.377e-01
+SSP5,EWN,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,4.864e-01,4.864e-01,4.377e-01,4.377e-01,4.377e-01
 SSP5,EWN,,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,EWN,,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.164e-01,1.164e-01,1.164e-01,1.164e-01,1.164e-01
 SSP5,EWN,,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,5.225e-01,5.225e-01,5.225e-01,5.225e-01,5.225e-01
@@ -10518,21 +10518,21 @@ SSP5,EWN,,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_su
 SSP5,EWN,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1.000e-03,6.000e-02,2.450e-01,4.500e-01,4.500e-01
 SSP5,EWN,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1.000e-03,6.000e-02,2.450e-01,4.500e-01,4.500e-01
 SSP5,EWN,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1.000e-03,6.000e-02,2.450e-01,4.500e-01,4.500e-01
-SSP5,EWN,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.958e-02,2.323e-01,4.763e-01,4.763e-01
+SSP5,EWN,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,8.794e-02,2.197e-01,5.006e-01,5.006e-01
 SSP5,EWN,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,EWN,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,EWN,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP5,EWN,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.550e-01,6.500e-01,8.729e-01,8.729e-01
-SSP5,EWN,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.165e-02,3.496e-01,8.467e-01,8.467e-01
-SSP5,EWN,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.165e-02,3.496e-01,8.467e-01,8.467e-01
-SSP5,EWN,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.165e-02,3.496e-01,8.467e-01,8.467e-01
-SSP5,EWN,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.550e-01,6.500e-01,8.729e-01,8.729e-01
-SSP5,EWN,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.573e-03,6.540e-03,1.667e-02,1.667e-02
-SSP5,EWN,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,9.370e-03,4.743e-02,4.061e-02,4.061e-02
-SSP5,EWN,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.462e-03,1.799e-02,2.778e-02,2.778e-02
-SSP5,EWN,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.462e-03,1.799e-02,2.778e-02,2.778e-02
-SSP5,EWN,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.462e-03,1.799e-02,2.778e-02,2.778e-02
-SSP5,EWN,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,9.370e-03,4.743e-02,4.061e-02,4.061e-02
+SSP5,EWN,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.436e-01,6.405e-01,9.031e-01,9.031e-01
+SSP5,EWN,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.367e-01,3.445e-01,8.760e-01,8.760e-01
+SSP5,EWN,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.367e-01,3.445e-01,8.760e-01,8.760e-01
+SSP5,EWN,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.367e-01,3.445e-01,8.760e-01,8.760e-01
+SSP5,EWN,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.436e-01,6.405e-01,9.031e-01,9.031e-01
+SSP5,EWN,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.861e-03,7.734e-03,2.190e-02,2.190e-02
+SSP5,EWN,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.385e-02,1.059e-01,6.003e-02,6.003e-02
+SSP5,EWN,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.116e-03,4.017e-02,4.106e-02,4.106e-02
+SSP5,EWN,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.116e-03,4.017e-02,4.106e-02,4.106e-02
+SSP5,EWN,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.116e-03,4.017e-02,4.106e-02,4.106e-02
+SSP5,EWN,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.385e-02,1.059e-01,6.003e-02,6.003e-02
 SSP5,EWN,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0.000e+00,8.315e-07,4.540e-05,1.192e-01,1.192e-01
 SSP5,EWN,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,EWN,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
@@ -10549,26 +10549,26 @@ SSP5,EWN,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_
 SSP5,EWN,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,EWN,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,EWN,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP5,EWN,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,8.070e-03,3.107e-02,6.282e-02,8.745e-02,8.745e-02
-SSP5,EWN,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,8.171e-04,2.711e-02,7.970e-02,1.027e-01,1.027e-01
-SSP5,EWN,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.023e-01,1.023e-01
-SSP5,EWN,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.023e-01,1.023e-01
-SSP5,EWN,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.023e-01,1.023e-01
-SSP5,EWN,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.023e-01,1.023e-01
+SSP5,EWN,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,8.070e-03,3.107e-02,6.282e-02,9.716e-02,9.716e-02
+SSP5,EWN,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,8.171e-04,3.389e-02,8.856e-02,1.284e-01,1.284e-01
+SSP5,EWN,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.289e-02,8.772e-02,1.279e-01,1.279e-01
+SSP5,EWN,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.289e-02,8.772e-02,1.279e-01,1.279e-01
+SSP5,EWN,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.289e-02,8.772e-02,1.279e-01,1.279e-01
+SSP5,EWN,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.289e-02,8.772e-02,1.279e-01,1.279e-01
 SSP5,FRA,,,,,Cycle,trn_pass,S3S,linear,1.942e-02,2.184e-02,3.641e-02,1.019e-01,1.019e-01
-SSP5,FRA,,,,,Domestic Aviation,trn_pass,S3S,linear,1.225e-04,6.891e-05,4.594e-05,2.297e-05,2.297e-05
-SSP5,FRA,,,,,Domestic Ship,trn_freight,S3S,linear,3.357e-03,3.357e-03,3.357e-03,3.357e-03,3.357e-03
-SSP5,FRA,,,,,Freight Rail,trn_freight,S3S,linear,1.766e-02,1.766e-02,1.766e-02,1.766e-02,1.766e-02
+SSP5,FRA,,,,,Domestic Aviation,trn_pass,S3S,linear,1.169e-04,6.577e-05,4.385e-05,2.192e-05,2.192e-05
+SSP5,FRA,,,,,Domestic Ship,trn_freight,S3S,linear,3.419e-03,3.419e-03,3.419e-03,3.419e-03,3.419e-03
+SSP5,FRA,,,,,Freight Rail,trn_freight,S3S,linear,1.799e-02,1.799e-02,1.799e-02,1.799e-02,1.799e-02
 SSP5,FRA,,,,,HSR,trn_pass,S3S,linear,3.359e-04,2.267e-04,2.015e-04,2.015e-04,2.015e-04
 SSP5,FRA,,,,,International Aviation,trn_aviation_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,FRA,,,,,International Ship,trn_shipping_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,FRA,,,,,Passenger Rail,trn_pass,S3S,linear,3.972e-03,2.979e-03,1.986e-03,1.986e-03,1.986e-03
 SSP5,FRA,,,,,Walk,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,FRA,,,,,trn_freight_road,trn_freight,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP5,FRA,,,,,trn_pass_road,trn_pass,S3S,linear,9.224e-02,5.188e-02,3.459e-02,2.767e-02,2.767e-02
-SSP5,FRA,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,7.788e-02,8.566e-02,9.345e-02,1.402e-01,1.402e-01
+SSP5,FRA,,,,,trn_pass_road,trn_pass,S3S,linear,9.055e-02,5.094e-02,3.396e-02,2.717e-02,2.717e-02
+SSP5,FRA,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,7.932e-02,8.726e-02,9.519e-02,1.428e-01,1.428e-01
 SSP5,FRA,,,,trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP5,FRA,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,9.470e-02,9.470e-02,9.470e-02,9.470e-02,9.470e-02
+SSP5,FRA,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,7.285e-02,7.285e-02,7.285e-02,6.764e-02,6.764e-02
 SSP5,FRA,,,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,FRA,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,6.352e-01,6.352e-01,6.352e-01,6.352e-01,6.352e-01
 SSP5,FRA,,Large Car and SUV,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
@@ -10582,26 +10582,26 @@ SSP5,FRA,,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_sub
 SSP5,FRA,,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.602e-01,1.602e-01,1.602e-01,1.602e-01,1.602e-01
 SSP5,FRA,,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,4.011e-01,4.011e-01,4.011e-01,4.011e-01,4.011e-01
 SSP5,FRA,,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,3.755e-01,3.755e-01,3.755e-01,3.755e-01,3.755e-01
-SSP5,FRA,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP5,FRA,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP5,FRA,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP5,FRA,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.423e-01,4.303e-01,1.000e+00,1.000e+00
+SSP5,FRA,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.000e-02,2.400e-01,4.200e-01,4.200e-01
+SSP5,FRA,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.000e-02,2.400e-01,4.200e-01,4.200e-01
+SSP5,FRA,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.000e-02,2.400e-01,4.200e-01,4.200e-01
+SSP5,FRA,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.402e-02,1.682e-01,4.579e-01,9.531e-01,9.531e-01
 SSP5,FRA,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,FRA,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,FRA,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP5,FRA,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.980e-01,7.500e-01,9.820e-01,9.820e-01
-SSP5,FRA,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.186e-01,4.034e-01,9.526e-01,9.526e-01
-SSP5,FRA,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.186e-01,4.034e-01,9.526e-01,9.526e-01
-SSP5,FRA,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.186e-01,4.034e-01,9.526e-01,9.526e-01
-SSP5,FRA,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.980e-01,7.500e-01,9.820e-01,9.820e-01
-SSP5,FRA,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.236e-02,1.799e-02,9.544e-02,9.544e-02
-SSP5,FRA,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.693e-02,4.743e-02,1.462e-01,1.462e-01
-SSP5,FRA,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-02,1.799e-02,1.000e-01,1.000e-01
-SSP5,FRA,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-02,1.799e-02,1.000e-01,1.000e-01
-SSP5,FRA,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-02,1.799e-02,1.000e-01,1.000e-01
-SSP5,FRA,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.693e-02,4.743e-02,1.462e-01,1.462e-01
+SSP5,FRA,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.171e-01,6.651e-01,9.087e-01,9.087e-01
+SSP5,FRA,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.262e-01,3.578e-01,8.815e-01,8.815e-01
+SSP5,FRA,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.262e-01,3.578e-01,8.815e-01,8.815e-01
+SSP5,FRA,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.262e-01,3.578e-01,8.815e-01,8.815e-01
+SSP5,FRA,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.171e-01,6.651e-01,9.087e-01,9.087e-01
+SSP5,FRA,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.218e-02,1.462e-02,2.127e-02,8.186e-02,8.186e-02
+SSP5,FRA,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,7.914e-02,2.337e-01,1.503e-01,1.503e-01
+SSP5,FRA,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.924e-02,8.861e-02,1.028e-01,1.028e-01
+SSP5,FRA,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.924e-02,8.861e-02,1.028e-01,1.028e-01
+SSP5,FRA,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.924e-02,8.861e-02,1.028e-01,1.028e-01
+SSP5,FRA,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,7.914e-02,2.337e-01,1.503e-01,1.503e-01
 SSP5,FRA,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0.000e+00,8.315e-07,4.540e-05,1.192e-01,1.192e-01
-SSP5,FRA,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,9.544e-01,9.544e-01
+SSP5,FRA,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,FRA,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,FRA,Liquids,Domestic Ship_tmp_vehicletype,Domestic Ship_tmp_subsector_L1,Domestic Ship_tmp_subsector_L2,Domestic Ship,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,FRA,Liquids,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1.608e-01,1.608e-01,1.608e-01,1.608e-01,1.608e-01
@@ -10616,26 +10616,26 @@ SSP5,FRA,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_
 SSP5,FRA,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,FRA,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,FRA,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP5,FRA,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.758e-01,1.758e-01
-SSP5,FRA,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SSP5,FRA,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SSP5,FRA,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SSP5,FRA,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SSP5,FRA,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SSP5,IND,,,,,Cycle,trn_pass,S3S,linear,2.632e-03,4.364e-03,9.091e-03,1.000e-01,1.000e-01
-SSP5,IND,,,,,Domestic Aviation,trn_pass,S3S,linear,9.589e-02,1.091e-01,1.000e-01,2.000e-01,2.000e-01
-SSP5,IND,,,,,Domestic Ship,trn_freight,S3S,linear,1.180e-03,1.180e-03,1.073e-03,9.075e-04,9.075e-04
-SSP5,IND,,,,,Freight Rail,trn_freight,S3S,linear,1.889e-01,1.889e-01,1.717e-01,1.453e-01,1.453e-01
-SSP5,IND,,,,,HSR,trn_pass,S3S,linear,0.000e+00,4.364e-05,1.000e-04,3.000e-04,3.000e-04
+SSP5,FRA,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.535e-02,2.632e-02,7.895e-02,1.417e-01,1.417e-01
+SSP5,FRA,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,6.579e-02,1.602e-01,1.602e-01
+SSP5,FRA,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,6.579e-02,1.602e-01,1.602e-01
+SSP5,FRA,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,6.579e-02,1.602e-01,1.602e-01
+SSP5,FRA,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,6.579e-02,1.602e-01,1.602e-01
+SSP5,FRA,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,6.579e-02,1.602e-01,1.602e-01
+SSP5,IND,,,,,Cycle,trn_pass,S3S,linear,1.915e-02,3.175e-02,4.630e-02,1.000e-01,1.000e-01
+SSP5,IND,,,,,Domestic Aviation,trn_pass,S3S,linear,6.659e-01,7.575e-01,4.861e-01,1.909e-01,1.909e-01
+SSP5,IND,,,,,Domestic Ship,trn_freight,S3S,linear,1.202e-03,1.202e-03,1.092e-03,9.244e-04,9.244e-04
+SSP5,IND,,,,,Freight Rail,trn_freight,S3S,linear,1.924e-01,1.924e-01,1.574e-01,1.332e-01,1.332e-01
+SSP5,IND,,,,,HSR,trn_pass,S3S,linear,0.000e+00,3.175e-04,5.093e-04,3.000e-04,3.000e-04
 SSP5,IND,,,,,International Aviation,trn_aviation_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,IND,,,,,International Ship,trn_shipping_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP5,IND,,,,,Passenger Rail,trn_pass,S3S,linear,6.842e-04,8.000e-04,1.091e-03,4.000e-03,4.000e-03
-SSP5,IND,,,,,Walk,trn_pass,S3S,linear,1.316e-01,9.455e-02,1.818e-01,1.000e+00,1.000e+00
+SSP5,IND,,,,,Passenger Rail,trn_pass,S3S,linear,4.978e-03,5.820e-03,5.556e-03,4.000e-03,4.000e-03
+SSP5,IND,,,,,Walk,trn_pass,S3S,linear,9.573e-01,6.879e-01,9.260e-01,1.000e+00,1.000e+00
 SSP5,IND,,,,,trn_freight_road,trn_freight,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP5,IND,,,,,trn_pass_road,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP5,IND,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,1.188e-01,7.143e-02,3.231e-02,3.231e-02,3.231e-02
-SSP5,IND,,,,trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP5,IND,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,3.027e-03,2.668e-03,1.949e-03,5.108e-04,5.108e-04
+SSP5,IND,,,,,trn_pass_road,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,2.945e-01,2.945e-01
+SSP5,IND,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,1.000e+00,3.638e-01,1.645e-01,9.872e-02,9.872e-02
+SSP5,IND,,,,trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,9.180e-01,1.000e+00,1.000e+00,1.000e+00,1.000e+00
+SSP5,IND,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.816e-02,1.867e-02,2.923e-02,5.108e-02,5.108e-02
 SSP5,IND,,,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,IND,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,IND,,Mini Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,6.374e-03,6.374e-03,6.374e-03,6.374e-03,6.374e-03
@@ -10646,24 +10646,24 @@ SSP5,IND,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,tr
 SSP5,IND,,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.853e-01,1.853e-01,1.853e-01,1.853e-01,1.853e-01
 SSP5,IND,,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.987e-01,1.987e-01,1.987e-01,1.987e-01,1.987e-01
 SSP5,IND,,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP5,IND,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP5,IND,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP5,IND,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP5,IND,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.743e-02,2.689e-01,7.621e-01,7.621e-01
+SSP5,IND,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.000e-01,3.600e-01,3.780e-01,3.780e-01
+SSP5,IND,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.000e-01,3.600e-01,3.780e-01,3.780e-01
+SSP5,IND,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.000e-01,3.600e-01,3.780e-01,3.780e-01
+SSP5,IND,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,5.175e-02,2.935e-01,6.653e-01,6.653e-01
 SSP5,IND,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,IND,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,IND,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,8.340e-01,8.547e-01,8.962e-01,9.792e-01,9.792e-01
-SSP5,IND,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.576e-02,1.000e-01,9.820e-02,9.820e-02
-SSP5,IND,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.423e-02,5.379e-02,9.526e-02,9.526e-02
-SSP5,IND,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,3.000e-01,2.000e-01,1.000e-01,1.000e-01
-SSP5,IND,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,3.000e-01,2.000e-01,1.000e-01,1.000e-01
-SSP5,IND,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.576e-02,1.000e-01,9.820e-02,9.820e-02
-SSP5,IND,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.473e-03,1.799e-02,5.000e-02,5.000e-02
-SSP5,IND,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.693e-03,9.485e-03,1.462e-02,1.462e-02
-SSP5,IND,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-03,3.597e-03,1.000e-02,1.000e-02
-SSP5,IND,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,2.000e-01,2.000e-02,2.000e-02
-SSP5,IND,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,2.000e-01,2.000e-02,2.000e-02
-SSP5,IND,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.693e-03,9.485e-03,1.462e-02,1.462e-02
+SSP5,IND,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.787e-02,6.365e-02,6.430e-02,6.430e-02
+SSP5,IND,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.109e-02,3.424e-02,6.237e-02,6.237e-02
+SSP5,IND,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,2.338e-01,1.273e-01,6.547e-02,6.547e-02
+SSP5,IND,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,2.338e-01,1.273e-01,6.547e-02,6.547e-02
+SSP5,IND,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.787e-02,6.365e-02,6.430e-02,6.430e-02
+SSP5,IND,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.698e-03,1.963e-02,5.456e-02,5.456e-02
+SSP5,IND,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.217e-03,8.625e-03,1.595e-03,1.595e-03
+SSP5,IND,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.927e-03,3.271e-03,1.091e-03,1.091e-03
+SSP5,IND,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,7.794e-01,1.819e-01,2.182e-03,2.182e-03
+SSP5,IND,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,7.794e-01,1.819e-01,2.182e-03,2.182e-03
+SSP5,IND,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.217e-03,8.625e-03,1.595e-03,1.595e-03
 SSP5,IND,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0.000e+00,8.315e-07,4.540e-05,1.192e-01,1.192e-01
 SSP5,IND,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,IND,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
@@ -10677,27 +10677,27 @@ SSP5,IND,Liquids,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_
 SSP5,IND,Liquids,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,IND,Liquids,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,IND,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP5,IND,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP5,IND,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
+SSP5,IND,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,9.164e-01,1.000e+00,1.000e+00,1.000e+00,1.000e+00
+SSP5,IND,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,9.164e-01,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,IND,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,IND,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,2.408e-01,2.086e-01,2.105e-01,1.903e-01,1.903e-01
-SSP5,IND,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,8.768e-02,1.117e-01,7.985e-02,2.557e-02,2.557e-02
-SSP5,IND,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,3.947e-02,1.842e-02,1.842e-02
-SSP5,IND,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,5.000e-01,1.000e-01,1.000e-01
-SSP5,IND,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,5.000e-01,1.000e-01,1.000e-01
-SSP5,IND,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,3.947e-02,1.842e-02,1.842e-02
+SSP5,IND,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,8.768e-02,7.978e-02,6.655e-02,2.557e-02,2.557e-02
+SSP5,IND,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.880e-02,3.289e-02,1.842e-02,1.842e-02
+SSP5,IND,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,9.164e-01,7.143e-01,4.167e-01,1.000e-01,1.000e-01
+SSP5,IND,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,9.164e-01,7.143e-01,4.167e-01,1.000e-01,1.000e-01
+SSP5,IND,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.880e-02,3.289e-02,1.842e-02,1.842e-02
 SSP5,JPN,,,,,Cycle,trn_pass,S3S,linear,1.743e-02,1.743e-02,3.486e-02,1.961e-02,1.961e-02
-SSP5,JPN,,,,,Domestic Aviation,trn_pass,S3S,linear,1.811e-04,2.174e-04,3.261e-04,9.170e-05,9.170e-05
-SSP5,JPN,,,,,Domestic Ship,trn_freight,S3S,linear,1.146e-02,1.146e-02,1.146e-02,1.146e-02,1.146e-02
-SSP5,JPN,,,,,Freight Rail,trn_freight,S3S,linear,2.781e-03,2.781e-03,2.781e-03,2.781e-03,2.781e-03
+SSP5,JPN,,,,,Domestic Aviation,trn_pass,S3S,linear,1.729e-04,2.075e-04,3.112e-04,8.752e-05,8.752e-05
+SSP5,JPN,,,,,Domestic Ship,trn_freight,S3S,linear,1.167e-02,1.111e-02,1.167e-02,1.167e-02,1.167e-02
+SSP5,JPN,,,,,Freight Rail,trn_freight,S3S,linear,2.833e-03,2.698e-03,2.833e-03,2.833e-03,2.833e-03
 SSP5,JPN,,,,,HSR,trn_pass,S3S,linear,4.081e-04,4.081e-04,4.591e-04,1.291e-04,1.291e-04
 SSP5,JPN,,,,,International Aviation,trn_aviation_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,JPN,,,,,International Ship,trn_shipping_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,JPN,,,,,Passenger Rail,trn_pass,S3S,linear,6.084e-03,6.084e-03,7.000e-03,2.281e-03,2.281e-03
 SSP5,JPN,,,,,Walk,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,JPN,,,,,trn_freight_road,trn_freight,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP5,JPN,,,,,trn_pass_road,trn_pass,S3S,linear,7.245e-02,7.770e-02,7.770e-02,2.185e-02,2.185e-02
-SSP5,JPN,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,5.971e-02,5.971e-02,5.971e-02,5.971e-02,5.971e-02
+SSP5,JPN,,,,,trn_pass_road,trn_pass,S3S,linear,7.113e-02,7.629e-02,7.629e-02,2.146e-02,2.146e-02
+SSP5,JPN,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,6.081e-02,6.081e-02,6.081e-02,6.081e-02,6.081e-02
 SSP5,JPN,,,,trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,JPN,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,5.491e-02,5.491e-02,5.491e-02,5.491e-02,5.491e-02
 SSP5,JPN,,,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
@@ -10710,24 +10710,24 @@ SSP5,JPN,,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_ro
 SSP5,JPN,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.286e-01,1.286e-01,1.286e-01,1.286e-01,1.286e-01
 SSP5,JPN,,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,JPN,,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,5.896e-01,5.896e-01,5.896e-01,5.896e-01,5.896e-01
-SSP5,JPN,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP5,JPN,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP5,JPN,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP5,JPN,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.091e-01,1.793e-01,3.810e-01,3.810e-01
+SSP5,JPN,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.600e-01,5.280e-01,1.000e+00,1.000e+00
+SSP5,JPN,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.600e-01,5.280e-01,1.000e+00,1.000e+00
+SSP5,JPN,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.600e-01,5.280e-01,1.000e+00,1.000e+00
+SSP5,JPN,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,9.673e-02,1.794e-01,3.754e-01,3.754e-01
 SSP5,JPN,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,JPN,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,JPN,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP5,JPN,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.252e-01,3.529e-01,8.183e-01,8.183e-01
-SSP5,JPN,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,6.364e-02,1.333e-01,8.333e-01,8.333e-01
-SSP5,JPN,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,6.364e-02,1.333e-01,8.333e-01,8.333e-01
-SSP5,JPN,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,6.364e-02,1.333e-01,8.333e-01,8.333e-01
-SSP5,JPN,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.252e-01,3.529e-01,8.183e-01,8.183e-01
-SSP5,JPN,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,6.182e-02,1.319e-01,1.000e-01,1.000e-01
-SSP5,JPN,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.104e-01,2.511e-01,3.046e-01,3.046e-01
-SSP5,JPN,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,4.167e-01,4.167e-01
-SSP5,JPN,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,4.167e-01,4.167e-01
-SSP5,JPN,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,4.167e-01,4.167e-01
-SSP5,JPN,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.104e-01,2.511e-01,3.046e-01,3.046e-01
+SSP5,JPN,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.332e-01,3.414e-01,8.870e-01,8.870e-01
+SSP5,JPN,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,5.727e-02,1.200e-01,9.032e-01,9.032e-01
+SSP5,JPN,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,5.727e-02,1.200e-01,9.032e-01,9.032e-01
+SSP5,JPN,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,5.727e-02,1.200e-01,9.032e-01,9.032e-01
+SSP5,JPN,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.332e-01,3.414e-01,8.870e-01,8.870e-01
+SSP5,JPN,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,6.091e-02,1.200e-01,9.854e-02,9.854e-02
+SSP5,JPN,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.306e-01,2.699e-01,2.701e-01,2.701e-01
+SSP5,JPN,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,3.695e-01,3.695e-01
+SSP5,JPN,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,3.695e-01,3.695e-01
+SSP5,JPN,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,3.695e-01,3.695e-01
+SSP5,JPN,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.306e-01,2.699e-01,2.701e-01,2.701e-01
 SSP5,JPN,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0.000e+00,8.315e-07,4.540e-05,1.192e-01,1.192e-01
 SSP5,JPN,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,JPN,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
@@ -10735,41 +10735,41 @@ SSP5,JPN,Liquids,Domestic Ship_tmp_vehicletype,Domestic Ship_tmp_subsector_L1,Do
 SSP5,JPN,Liquids,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,8.837e-01,8.837e-01,8.837e-01,8.837e-01,8.837e-01
 SSP5,JPN,Liquids,International Aviation_tmp_vehicletype,International Aviation_tmp_subsector_L1,International Aviation_tmp_subsector_L2,International Aviation,trn_aviation_intl,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,JPN,Liquids,International Ship_tmp_vehicletype,International Ship_tmp_subsector_L1,International Ship_tmp_subsector_L2,International Ship,trn_shipping_intl,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP5,JPN,Liquids,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP5,JPN,Liquids,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP5,JPN,Liquids,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
+SSP5,JPN,Liquids,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,9.921e-01,9.921e-01
+SSP5,JPN,Liquids,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,9.921e-01,9.921e-01
+SSP5,JPN,Liquids,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,9.921e-01,9.921e-01
 SSP5,JPN,Liquids,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,3.433e-02,3.433e-02,3.433e-02,3.433e-02,3.433e-02
 SSP5,JPN,Liquids,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP5,JPN,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,6.061e-02,1.889e-01,1.000e+00,1.000e+00
-SSP5,JPN,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,6.061e-02,1.889e-01,1.000e+00,1.000e+00
-SSP5,JPN,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,6.061e-02,1.889e-01,1.000e+00,1.000e+00
+SSP5,JPN,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,8.457e-01,5.126e-02,1.757e-01,1.000e+00,1.000e+00
+SSP5,JPN,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,8.457e-01,5.126e-02,1.757e-01,1.000e+00,1.000e+00
+SSP5,JPN,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,8.457e-01,5.126e-02,1.757e-01,1.000e+00,1.000e+00
 SSP5,JPN,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP5,JPN,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,7.895e-03,1.579e-02,2.303e-02,2.303e-02
-SSP5,JPN,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.316e-02,4.644e-02,4.605e-02,4.605e-02
-SSP5,JPN,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,3.030e-02,1.111e-01,2.500e-01,2.500e-01
-SSP5,JPN,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,3.030e-02,1.111e-01,2.500e-01,2.500e-01
-SSP5,JPN,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,3.030e-02,1.111e-01,2.500e-01,2.500e-01
-SSP5,JPN,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.316e-02,4.644e-02,4.605e-02,4.605e-02
-SSP5,LAM,,,,,Cycle,trn_pass,S3S,linear,9.812e-03,1.852e-02,4.629e-02,2.315e-01,2.315e-01
-SSP5,LAM,,,,,Domestic Aviation,trn_pass,S3S,linear,8.407e-03,1.058e-02,2.644e-02,1.983e-02,1.983e-02
-SSP5,LAM,,,,,Domestic Ship,trn_freight,S3S,linear,9.523e-03,9.523e-03,8.658e-03,7.936e-03,7.936e-03
-SSP5,LAM,,,,,Freight Rail,trn_freight,S3S,linear,4.694e-02,4.694e-02,4.268e-02,3.912e-02,3.912e-02
-SSP5,LAM,,,,,HSR,trn_pass,S3S,linear,4.709e-03,2.465e-01,2.465e-01,2.465e-01,2.465e-01
+SSP5,JPN,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,6.579e-03,1.215e-02,1.919e-02,1.919e-02
+SSP5,JPN,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.316e-02,4.222e-02,3.838e-02,3.838e-02
+SSP5,JPN,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,8.457e-01,2.563e-02,9.397e-02,2.083e-01,2.083e-01
+SSP5,JPN,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,8.457e-01,2.563e-02,9.397e-02,2.083e-01,2.083e-01
+SSP5,JPN,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,8.457e-01,2.563e-02,9.397e-02,2.083e-01,2.083e-01
+SSP5,JPN,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.316e-02,4.222e-02,3.838e-02,3.838e-02
+SSP5,LAM,,,,,Cycle,trn_pass,S3S,linear,1.091e-02,2.182e-02,5.455e-02,2.728e-01,2.728e-01
+SSP5,LAM,,,,,Domestic Aviation,trn_pass,S3S,linear,8.921e-03,1.190e-02,2.974e-02,2.230e-02,2.230e-02
+SSP5,LAM,,,,,Domestic Ship,trn_freight,S3S,linear,9.700e-03,9.700e-03,8.908e-03,6.736e-03,6.736e-03
+SSP5,LAM,,,,,Freight Rail,trn_freight,S3S,linear,4.782e-02,4.782e-02,4.391e-02,3.985e-02,3.985e-02
+SSP5,LAM,,,,,HSR,trn_pass,S3S,linear,5.236e-03,2.905e-01,2.905e-01,2.905e-01,2.905e-01
 SSP5,LAM,,,,,International Aviation,trn_aviation_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,LAM,,,,,International Ship,trn_shipping_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP5,LAM,,,,,Passenger Rail,trn_pass,S3S,linear,1.348e-01,1.272e-01,1.272e-01,8.482e-02,8.482e-02
-SSP5,LAM,,,,,Walk,trn_pass,S3S,linear,8.993e-01,8.486e-01,8.486e-01,8.486e-01,8.486e-01
+SSP5,LAM,,,,,Passenger Rail,trn_pass,S3S,linear,1.499e-01,1.499e-01,1.499e-01,9.996e-02,9.996e-02
+SSP5,LAM,,,,,Walk,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,LAM,,,,,trn_freight_road,trn_freight,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP5,LAM,,,,,trn_pass_road,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP5,LAM,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,1.732e-01,1.083e-01,8.662e-02,8.662e-02,8.662e-02
+SSP5,LAM,,,,,trn_pass_road,trn_pass,S3S,linear,6.550e-01,6.942e-01,6.942e-01,8.099e-01,8.099e-01
+SSP5,LAM,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,2.647e-01,1.654e-01,1.323e-01,1.323e-01,1.323e-01
 SSP5,LAM,,,,trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,LAM,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.377e-01,1.377e-01,1.377e-01,1.377e-01,1.377e-01
 SSP5,LAM,,,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,LAM,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP5,LAM,,Large Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,5.465e-02,5.465e-02,5.465e-02,5.465e-02,5.465e-02
-SSP5,LAM,,Large Car and SUV,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,6.039e-01,6.039e-01,6.039e-01,6.039e-01,6.039e-01
-SSP5,LAM,,Light Truck and SUV,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,2.182e-01,2.182e-01,2.182e-01,2.182e-01,2.182e-01
-SSP5,LAM,,Midsize Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,7.979e-02,7.979e-02,7.979e-02,7.979e-02,7.979e-02
+SSP5,LAM,,Large Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,3.279e-02,3.935e-02,4.099e-02,4.372e-02,4.372e-02
+SSP5,LAM,,Large Car and SUV,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,3.624e-01,4.348e-01,4.529e-01,4.831e-01,4.831e-01
+SSP5,LAM,,Light Truck and SUV,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.309e-01,1.571e-01,1.636e-01,1.745e-01,1.745e-01
+SSP5,LAM,,Midsize Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,4.788e-02,5.745e-02,5.984e-02,6.383e-02,6.383e-02
 SSP5,LAM,,Mini Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.226e-02,1.226e-02,1.226e-02,1.226e-02,1.226e-02
 SSP5,LAM,,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,4.580e-04,4.580e-04,4.580e-04,4.580e-04,4.580e-04
 SSP5,LAM,,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
@@ -10780,27 +10780,27 @@ SSP5,LAM,,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_sub
 SSP5,LAM,,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,LAM,,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,5.079e-04,5.079e-04,5.079e-04,5.079e-04,5.079e-04
 SSP5,LAM,,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.892e-01,1.892e-01,1.892e-01,1.892e-01,1.892e-01
-SSP5,LAM,,Van,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,2.455e-03,2.455e-03,2.455e-03,2.455e-03,2.455e-03
-SSP5,LAM,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP5,LAM,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP5,LAM,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP5,LAM,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.186e-01,5.379e-01,1.000e+00,1.000e+00
+SSP5,LAM,,Van,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.473e-03,1.768e-03,1.842e-03,1.964e-03,1.964e-03
+SSP5,LAM,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,5.600e-02,2.160e-01,5.040e-01,5.040e-01
+SSP5,LAM,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,5.600e-02,2.160e-01,5.040e-01,5.040e-01
+SSP5,LAM,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,5.600e-02,2.160e-01,5.040e-01,5.040e-01
+SSP5,LAM,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.294e-01,5.869e-01,1.000e+00,1.000e+00
 SSP5,LAM,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,6.810e-02,1.846e-01,4.176e-01,8.835e-01,8.835e-01
 SSP5,LAM,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,LAM,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP5,LAM,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,7.947e-02,2.000e-01,2.400e-01,2.400e-01
-SSP5,LAM,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.162e-02,1.076e-01,2.329e-01,2.329e-01
-SSP5,LAM,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.162e-02,1.076e-01,2.329e-01,2.329e-01
-SSP5,LAM,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.162e-02,1.076e-01,2.329e-01,2.329e-01
-SSP5,LAM,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,7.947e-02,2.000e-01,2.400e-01,2.400e-01
-SSP5,LAM,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.473e-03,1.799e-02,6.561e-02,6.561e-02
-SSP5,LAM,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,8.924e-03,5.691e-02,8.123e-02,8.123e-02
-SSP5,LAM,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.297e-03,2.158e-02,5.556e-02,5.556e-02
-SSP5,LAM,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.297e-03,2.158e-02,5.556e-02,5.556e-02
-SSP5,LAM,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.297e-03,2.158e-02,5.556e-02,5.556e-02
-SSP5,LAM,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,8.924e-03,5.691e-02,8.123e-02,8.123e-02
+SSP5,LAM,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.041e-01,1.964e-01,2.357e-01,2.357e-01
+SSP5,LAM,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.140e-02,1.057e-01,2.287e-01,2.287e-01
+SSP5,LAM,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.140e-02,1.057e-01,2.287e-01,2.287e-01
+SSP5,LAM,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.140e-02,1.057e-01,2.287e-01,2.287e-01
+SSP5,LAM,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.041e-01,1.964e-01,2.357e-01,2.357e-01
+SSP5,LAM,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.698e-03,1.963e-02,6.561e-02,6.561e-02
+SSP5,LAM,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,9.738e-03,6.210e-02,8.864e-02,8.864e-02
+SSP5,LAM,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.598e-03,2.355e-02,6.062e-02,6.062e-02
+SSP5,LAM,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.598e-03,2.355e-02,6.062e-02,6.062e-02
+SSP5,LAM,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.598e-03,2.355e-02,6.062e-02,6.062e-02
+SSP5,LAM,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,9.738e-03,6.210e-02,8.864e-02,8.864e-02
 SSP5,LAM,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0.000e+00,8.315e-07,4.540e-05,1.192e-01,1.192e-01
-SSP5,LAM,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,7.217e-01,7.217e-01
+SSP5,LAM,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,7.275e-01,7.275e-01
 SSP5,LAM,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,LAM,Liquids,Domestic Ship_tmp_vehicletype,Domestic Ship_tmp_subsector_L1,Domestic Ship_tmp_subsector_L2,Domestic Ship,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,LAM,Liquids,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
@@ -10815,55 +10815,55 @@ SSP5,LAM,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_
 SSP5,LAM,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,LAM,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,LAM,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP5,LAM,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,2.689e-02,4.725e-02,1.037e-01,1.353e-01,1.353e-01
+SSP5,LAM,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,2.689e-02,4.725e-02,1.037e-01,1.240e-01,1.240e-01
 SSP5,LAM,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.754e-02,3.158e-02,6.140e-02,6.140e-02
 SSP5,LAM,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.754e-02,3.158e-02,6.140e-02,6.140e-02
 SSP5,LAM,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.754e-02,3.158e-02,6.140e-02,6.140e-02
 SSP5,LAM,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.754e-02,3.158e-02,6.140e-02,6.140e-02
 SSP5,LAM,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.754e-02,3.158e-02,6.140e-02,6.140e-02
 SSP5,MEA,,,,,Cycle,trn_pass,S3S,linear,1.660e-02,1.660e-02,1.660e-02,4.149e-02,4.149e-02
-SSP5,MEA,,,,,Domestic Aviation,trn_pass,S3S,linear,8.929e-03,5.953e-03,1.786e-02,2.381e-02,2.381e-02
-SSP5,MEA,,,,,Domestic Ship,trn_freight,S3S,linear,2.022e-03,2.022e-03,2.022e-03,2.022e-03,2.022e-03
-SSP5,MEA,,,,,Freight Rail,trn_freight,S3S,linear,3.143e-03,3.143e-03,3.143e-03,3.143e-03,3.143e-03
+SSP5,MEA,,,,,Domestic Aviation,trn_pass,S3S,linear,8.522e-03,5.681e-03,1.704e-02,2.500e-02,2.500e-02
+SSP5,MEA,,,,,Domestic Ship,trn_freight,S3S,linear,2.060e-03,2.060e-03,2.060e-03,2.060e-03,2.060e-03
+SSP5,MEA,,,,,Freight Rail,trn_freight,S3S,linear,3.202e-03,3.202e-03,3.202e-03,3.202e-03,3.202e-03
 SSP5,MEA,,,,,HSR,trn_pass,S3S,linear,0.000e+00,1.667e-02,1.667e-02,1.667e-02,1.667e-02
 SSP5,MEA,,,,,International Aviation,trn_aviation_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,MEA,,,,,International Ship,trn_shipping_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,MEA,,,,,Passenger Rail,trn_pass,S3S,linear,5.567e-04,1.113e-03,1.113e-03,1.856e-03,1.856e-03
 SSP5,MEA,,,,,Walk,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,MEA,,,,,trn_freight_road,trn_freight,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP5,MEA,,,,,trn_pass_road,trn_pass,S3S,linear,6.395e-01,7.197e-01,7.197e-01,7.197e-01,7.197e-01
-SSP5,MEA,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,2.627e-01,1.226e-01,6.131e-02,4.905e-02,4.905e-02
+SSP5,MEA,,,,,trn_pass_road,trn_pass,S3S,linear,3.767e-01,4.239e-01,3.815e-01,3.815e-01,3.815e-01
+SSP5,MEA,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,2.676e-01,1.873e-01,9.367e-02,7.493e-02,7.493e-02
 SSP5,MEA,,,,trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP5,MEA,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,7.508e-03,7.508e-03,7.508e-03,7.508e-03,7.508e-03
+SSP5,MEA,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.502e-02,1.502e-02,1.502e-02,1.502e-02,1.502e-02
 SSP5,MEA,,,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP5,MEA,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,4.732e-01,4.732e-01,4.732e-01,4.732e-01,4.732e-01
+SSP5,MEA,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,5.257e-01,4.732e-01,4.337e-01,3.943e-01,3.943e-01
 SSP5,MEA,,Large Car and SUV,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP5,MEA,,Mini Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,3.955e-02,3.955e-02,3.955e-02,3.955e-02,3.955e-02
+SSP5,MEA,,Mini Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,4.395e-02,3.955e-02,3.626e-02,3.296e-02,3.296e-02
 SSP5,MEA,,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,MEA,,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,MEA,,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP5,MEA,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.864e-01,1.864e-01,1.864e-01,1.864e-01,1.864e-01
+SSP5,MEA,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,2.071e-01,1.864e-01,1.709e-01,1.553e-01,1.553e-01
 SSP5,MEA,,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.304e-01,1.304e-01,1.304e-01,1.304e-01,1.304e-01
 SSP5,MEA,,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,2.013e-01,2.013e-01,2.013e-01,2.013e-01,2.013e-01
 SSP5,MEA,,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP5,MEA,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP5,MEA,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP5,MEA,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP5,MEA,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.743e-02,2.958e-01,6.549e-01,6.549e-01
+SSP5,MEA,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.200e-01,2.160e-01,2.100e-01,2.100e-01
+SSP5,MEA,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.200e-01,2.160e-01,2.100e-01,2.100e-01
+SSP5,MEA,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.200e-01,2.160e-01,2.100e-01,2.100e-01
+SSP5,MEA,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,5.175e-02,2.935e-01,6.497e-01,6.497e-01
 SSP5,MEA,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,4.021e-01,4.768e-01,6.263e-01,9.253e-01,9.253e-01
 SSP5,MEA,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,MEA,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP5,MEA,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.960e-02,1.000e-01,1.403e-01,1.403e-01
-SSP5,MEA,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.371e-02,5.379e-02,1.361e-01,1.361e-01
-SSP5,MEA,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.429e-01,2.000e-01,1.429e-01,1.429e-01
-SSP5,MEA,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.429e-01,2.000e-01,1.429e-01,1.429e-01
-SSP5,MEA,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.960e-02,1.000e-01,1.403e-01,1.403e-01
-SSP5,MEA,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.473e-03,1.799e-02,6.250e-02,6.250e-02
-SSP5,MEA,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.346e-03,9.485e-03,4.177e-02,4.177e-02
-SSP5,MEA,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.236e-03,3.597e-03,2.857e-02,2.857e-02
-SSP5,MEA,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.429e-01,2.000e-01,5.714e-02,5.714e-02
-SSP5,MEA,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.429e-01,2.000e-01,5.714e-02,5.714e-02
-SSP5,MEA,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.346e-03,9.485e-03,4.177e-02,4.177e-02
+SSP5,MEA,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.504e-02,1.091e-01,1.392e-01,1.392e-01
+SSP5,MEA,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.588e-02,5.869e-02,1.350e-01,1.350e-01
+SSP5,MEA,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.559e-01,2.182e-01,1.417e-01,1.417e-01
+SSP5,MEA,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.559e-01,2.182e-01,1.417e-01,1.417e-01
+SSP5,MEA,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.504e-02,1.091e-01,1.392e-01,1.392e-01
+SSP5,MEA,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.698e-03,1.784e-02,5.580e-02,5.580e-02
+SSP5,MEA,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.652e-03,1.035e-02,4.144e-04,4.144e-04
+SSP5,MEA,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.349e-03,3.925e-03,2.834e-04,2.834e-04
+SSP5,MEA,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.559e-01,2.182e-01,5.669e-04,5.669e-04
+SSP5,MEA,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.559e-01,2.182e-01,5.669e-04,5.669e-04
+SSP5,MEA,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.652e-03,1.035e-02,4.144e-04,4.144e-04
 SSP5,MEA,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0.000e+00,8.315e-07,4.540e-05,1.192e-01,1.192e-01
 SSP5,MEA,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,MEA,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
@@ -10877,27 +10877,27 @@ SSP5,MEA,Liquids,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_
 SSP5,MEA,Liquids,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,7.852e-02,7.852e-02,7.852e-02,7.852e-02,7.852e-02
 SSP5,MEA,Liquids,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,MEA,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP5,MEA,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,2.857e-01,1.000e+00,1.000e+00,1.000e+00
-SSP5,MEA,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,2.857e-01,1.000e+00,1.000e+00,1.000e+00
+SSP5,MEA,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,9.164e-01,2.857e-01,1.000e+00,1.000e+00,1.000e+00
+SSP5,MEA,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,9.164e-01,2.857e-01,1.000e+00,1.000e+00,1.000e+00
 SSP5,MEA,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP5,MEA,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.342e-02,3.938e-02,9.130e-02,1.220e-01,1.220e-01
-SSP5,MEA,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,9.283e-04,9.527e-02,4.788e-02,5.285e-02,5.285e-02
-SSP5,MEA,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,9.211e-02,4.737e-02,5.263e-02,5.263e-02
-SSP5,MEA,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,6.000e-01,2.857e-01,2.857e-01
-SSP5,MEA,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,6.000e-01,2.857e-01,2.857e-01
-SSP5,MEA,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,9.211e-02,4.737e-02,5.263e-02,5.263e-02
+SSP5,MEA,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.342e-02,3.938e-02,8.300e-02,1.109e-01,1.109e-01
+SSP5,MEA,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,9.283e-04,9.527e-02,4.788e-02,4.804e-02,4.804e-02
+SSP5,MEA,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,9.211e-02,4.737e-02,4.785e-02,4.785e-02
+SSP5,MEA,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,9.164e-01,1.000e+00,6.000e-01,2.597e-01,2.597e-01
+SSP5,MEA,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,9.164e-01,1.000e+00,6.000e-01,2.597e-01,2.597e-01
+SSP5,MEA,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,9.211e-02,4.737e-02,4.785e-02,4.785e-02
 SSP5,NEN,,,,,Cycle,trn_pass,S3S,linear,3.033e-03,3.024e-03,2.621e-03,1.820e-02,1.820e-02
-SSP5,NEN,,,,,Domestic Aviation,trn_pass,S3S,linear,7.555e-06,7.895e-06,2.566e-06,1.497e-06,1.497e-06
-SSP5,NEN,,,,,Domestic Ship,trn_freight,S3S,linear,3.117e-02,3.117e-02,3.117e-02,3.117e-02,3.117e-02
-SSP5,NEN,,,,,Freight Rail,trn_freight,S3S,linear,1.890e-02,1.890e-02,1.890e-02,1.890e-02,1.890e-02
+SSP5,NEN,,,,,Domestic Aviation,trn_pass,S3S,linear,7.210e-06,7.535e-06,2.449e-06,1.428e-06,1.428e-06
+SSP5,NEN,,,,,Domestic Ship,trn_freight,S3S,linear,3.175e-02,3.175e-02,3.175e-02,3.175e-02,3.175e-02
+SSP5,NEN,,,,,Freight Rail,trn_freight,S3S,linear,1.925e-02,1.925e-02,1.925e-02,1.925e-02,1.925e-02
 SSP5,NEN,,,,,HSR,trn_pass,S3S,linear,2.000e-05,4.532e-05,7.364e-06,5.523e-06,5.523e-06
 SSP5,NEN,,,,,International Aviation,trn_aviation_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,NEN,,,,,International Ship,trn_shipping_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,NEN,,,,,Passenger Rail,trn_pass,S3S,linear,3.000e-06,2.967e-06,6.751e-07,3.215e-07,3.215e-07
 SSP5,NEN,,,,,Walk,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,NEN,,,,,trn_freight_road,trn_freight,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP5,NEN,,,,,trn_pass_road,trn_pass,S3S,linear,5.052e-02,6.996e-02,2.842e-02,2.368e-02,2.368e-02
-SSP5,NEN,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,1.263e-02,7.897e-03,3.948e-03,1.974e-03,1.974e-03
+SSP5,NEN,,,,,trn_pass_road,trn_pass,S3S,linear,4.960e-02,6.868e-02,2.790e-02,2.325e-02,2.325e-02
+SSP5,NEN,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,1.287e-02,8.044e-03,4.022e-03,2.011e-03,2.011e-03
 SSP5,NEN,,,,trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,NEN,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,3.994e-02,3.994e-02,3.994e-02,3.994e-02,3.994e-02
 SSP5,NEN,,,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
@@ -10915,24 +10915,24 @@ SSP5,NEN,,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_sub
 SSP5,NEN,,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,6.397e-02,6.397e-02,6.397e-02,6.397e-02,6.397e-02
 SSP5,NEN,,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,3.433e-01,3.433e-01,3.433e-01,3.433e-01,3.433e-01
 SSP5,NEN,,Van,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,7.350e-03,7.350e-03,7.350e-03,7.350e-03,7.350e-03
-SSP5,NEN,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP5,NEN,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP5,NEN,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP5,NEN,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.743e-02,2.689e-01,9.526e-01,9.526e-01
+SSP5,NEN,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.000e-02,1.680e-01,2.940e-01,2.940e-01
+SSP5,NEN,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.000e-02,1.680e-01,2.940e-01,2.940e-01
+SSP5,NEN,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.000e-02,1.680e-01,2.940e-01,2.940e-01
+SSP5,NEN,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,5.608e-02,1.402e-01,4.134e-01,9.856e-01,9.856e-01
 SSP5,NEN,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,NEN,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,NEN,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP5,NEN,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.192e-01,5.000e-01,9.820e-01,9.820e-01
-SSP5,NEN,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.743e-02,2.689e-01,9.526e-01,9.526e-01
-SSP5,NEN,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.743e-02,2.689e-01,9.526e-01,9.526e-01
-SSP5,NEN,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.743e-02,2.689e-01,9.526e-01,9.526e-01
-SSP5,NEN,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.192e-01,5.000e-01,9.820e-01,9.820e-01
-SSP5,NEN,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.473e-03,1.799e-02,5.000e-01,5.000e-01
-SSP5,NEN,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.693e-03,4.743e-02,7.311e-01,7.311e-01
-SSP5,NEN,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-03,1.799e-02,5.000e-01,5.000e-01
-SSP5,NEN,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-03,1.799e-02,5.000e-01,5.000e-01
-SSP5,NEN,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-03,1.799e-02,5.000e-01,5.000e-01
-SSP5,NEN,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.693e-03,4.743e-02,7.311e-01,7.311e-01
+SSP5,NEN,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.537e-01,5.912e-01,8.932e-01,8.932e-01
+SSP5,NEN,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.009e-01,3.180e-01,8.664e-01,8.664e-01
+SSP5,NEN,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.009e-01,3.180e-01,8.664e-01,8.664e-01
+SSP5,NEN,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.009e-01,3.180e-01,8.664e-01,8.664e-01
+SSP5,NEN,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.537e-01,5.912e-01,8.932e-01,8.932e-01
+SSP5,NEN,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.924e-03,2.127e-02,5.543e-02,5.543e-02
+SSP5,NEN,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,7.914e-03,1.682e-01,9.974e-02,9.974e-02
+SSP5,NEN,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.924e-03,6.380e-02,6.822e-02,6.822e-02
+SSP5,NEN,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.924e-03,6.380e-02,6.822e-02,6.822e-02
+SSP5,NEN,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.924e-03,6.380e-02,6.822e-02,6.822e-02
+SSP5,NEN,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,7.914e-03,1.682e-01,9.974e-02,9.974e-02
 SSP5,NEN,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0.000e+00,8.315e-07,4.540e-05,1.192e-01,1.192e-01
 SSP5,NEN,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,NEN,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
@@ -10949,59 +10949,59 @@ SSP5,NEN,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_
 SSP5,NEN,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,NEN,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,NEN,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP5,NEN,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,2.147e-02,4.722e-02,9.872e-02,2.017e-01,2.017e-01
-SSP5,NEN,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,6.427e-03,3.257e-02,8.487e-02,1.895e-01,1.895e-01
-SSP5,NEN,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SSP5,NEN,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SSP5,NEN,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SSP5,NEN,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
+SSP5,NEN,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,2.362e-02,3.778e-02,9.872e-02,1.261e-01,1.261e-01
+SSP5,NEN,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,6.427e-03,3.257e-02,8.487e-02,1.457e-01,1.457e-01
+SSP5,NEN,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.417e-01,1.417e-01
+SSP5,NEN,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.417e-01,1.417e-01
+SSP5,NEN,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.417e-01,1.417e-01
+SSP5,NEN,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.417e-01,1.417e-01
 SSP5,NES,,,,,Cycle,trn_pass,S3S,linear,8.738e-03,7.802e-03,9.929e-03,1.365e-02,1.365e-02
-SSP5,NES,,,,,Domestic Aviation,trn_pass,S3S,linear,4.947e-03,3.534e-03,1.499e-03,4.123e-04,4.123e-04
-SSP5,NES,,,,,Domestic Ship,trn_freight,S3S,linear,1.442e-02,1.442e-02,1.442e-02,1.442e-02,1.442e-02
-SSP5,NES,,,,,Freight Rail,trn_freight,S3S,linear,1.666e-02,1.666e-02,1.666e-02,1.666e-02,1.666e-02
+SSP5,NES,,,,,Domestic Aviation,trn_pass,S3S,linear,4.721e-03,3.372e-03,1.431e-03,3.935e-04,3.935e-04
+SSP5,NES,,,,,Domestic Ship,trn_freight,S3S,linear,1.468e-02,1.468e-02,1.468e-02,1.322e-02,1.322e-02
+SSP5,NES,,,,,Freight Rail,trn_freight,S3S,linear,1.697e-02,1.697e-02,1.697e-02,1.697e-02,1.697e-02
 SSP5,NES,,,,,HSR,trn_pass,S3S,linear,5.085e-04,3.632e-04,2.311e-04,1.271e-04,1.271e-04
 SSP5,NES,,,,,International Aviation,trn_aviation_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,NES,,,,,International Ship,trn_shipping_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,NES,,,,,Passenger Rail,trn_pass,S3S,linear,1.607e-03,1.148e-03,7.303e-04,4.017e-04,4.017e-04
 SSP5,NES,,,,,Walk,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,NES,,,,,trn_freight_road,trn_freight,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP5,NES,,,,,trn_pass_road,trn_pass,S3S,linear,9.258e-01,7.176e-01,4.566e-01,2.512e-01,2.512e-01
-SSP5,NES,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,5.499e-02,2.199e-02,1.100e-02,1.100e-02,1.100e-02
+SSP5,NES,,,,,trn_pass_road,trn_pass,S3S,linear,2.727e-01,2.818e-01,2.242e-01,1.233e-01,1.233e-01
+SSP5,NES,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,8.401e-02,3.734e-02,2.240e-02,2.240e-02,2.240e-02
 SSP5,NES,,,,trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,NES,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,4.923e-03,4.923e-03,4.923e-03,4.923e-03,4.923e-03
 SSP5,NES,,,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP5,NES,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,4.608e-01,4.608e-01,4.608e-01,4.608e-01,4.608e-01
+SSP5,NES,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,5.760e-01,5.760e-01,6.144e-01,6.144e-01,6.144e-01
 SSP5,NES,,Large Car and SUV,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,NES,,Midsize Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,2.352e-01,2.352e-01,2.352e-01,2.352e-01,2.352e-01
-SSP5,NES,,Mini Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.509e-03,1.509e-03,1.509e-03,1.509e-03,1.509e-03
+SSP5,NES,,Mini Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.886e-03,1.886e-03,2.012e-03,2.012e-03,2.012e-03
 SSP5,NES,,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.148e-02,1.148e-02,1.148e-02,1.148e-02,1.148e-02
 SSP5,NES,,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.337e-01,1.337e-01,1.337e-01,1.337e-01,1.337e-01
 SSP5,NES,,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP5,NES,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,7.460e-02,7.460e-02,7.460e-02,7.460e-02,7.460e-02
+SSP5,NES,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,9.325e-02,9.325e-02,9.946e-02,9.946e-02,9.946e-02
 SSP5,NES,,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,NES,,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,6.299e-02,6.299e-02,6.299e-02,6.299e-02,6.299e-02
 SSP5,NES,,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,3.651e-01,3.651e-01,3.651e-01,3.651e-01,3.651e-01
 SSP5,NES,,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,5.704e-01,5.704e-01,5.704e-01,5.704e-01,5.704e-01
 SSP5,NES,,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,4.799e-01,4.799e-01,4.799e-01,4.799e-01,4.799e-01
 SSP5,NES,,Van,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,2.880e-03,2.880e-03,2.880e-03,2.880e-03,2.880e-03
-SSP5,NES,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP5,NES,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP5,NES,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP5,NES,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.743e-02,2.689e-01,9.526e-01,9.526e-01
+SSP5,NES,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.000e-02,1.680e-01,3.360e-01,3.360e-01
+SSP5,NES,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.000e-02,1.680e-01,3.360e-01,3.360e-01
+SSP5,NES,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.000e-02,1.680e-01,3.360e-01,3.360e-01
+SSP5,NES,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,5.175e-02,1.739e-01,3.465e-01,3.465e-01
 SSP5,NES,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,2.081e-01,3.071e-01,5.050e-01,9.010e-01,9.010e-01
 SSP5,NES,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,NES,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP5,NES,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.192e-01,5.000e-01,9.820e-01,9.820e-01
-SSP5,NES,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.743e-02,2.689e-01,9.526e-01,9.526e-01
-SSP5,NES,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.743e-02,2.689e-01,9.526e-01,9.526e-01
-SSP5,NES,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.743e-02,2.689e-01,9.526e-01,9.526e-01
-SSP5,NES,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.192e-01,5.000e-01,9.820e-01,9.820e-01
-SSP5,NES,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.473e-03,1.799e-02,5.000e-01,5.000e-01
-SSP5,NES,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.693e-03,4.743e-02,7.311e-01,7.311e-01
-SSP5,NES,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-03,1.799e-02,5.000e-01,5.000e-01
-SSP5,NES,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-03,1.799e-02,5.000e-01,5.000e-01
-SSP5,NES,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-03,1.799e-02,5.000e-01,5.000e-01
-SSP5,NES,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.693e-03,4.743e-02,7.311e-01,7.311e-01
+SSP5,NES,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.138e-01,2.182e-01,3.215e-01,3.215e-01
+SSP5,NES,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.528e-02,1.174e-01,3.118e-01,3.118e-01
+SSP5,NES,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.528e-02,1.174e-01,3.118e-01,3.118e-01
+SSP5,NES,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.528e-02,1.174e-01,3.118e-01,3.118e-01
+SSP5,NES,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.138e-01,2.182e-01,3.215e-01,3.215e-01
+SSP5,NES,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.698e-03,1.454e-02,3.637e-02,3.637e-02
+SSP5,NES,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,9.129e-03,3.833e-02,8.376e-02,8.376e-02
+SSP5,NES,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.373e-03,1.454e-02,5.729e-02,5.729e-02
+SSP5,NES,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.373e-03,1.454e-02,5.729e-02,5.729e-02
+SSP5,NES,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.373e-03,1.454e-02,5.729e-02,5.729e-02
+SSP5,NES,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,9.129e-03,3.833e-02,8.376e-02,8.376e-02
 SSP5,NES,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0.000e+00,8.315e-07,4.540e-05,1.192e-01,1.192e-01
 SSP5,NES,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,NES,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
@@ -11018,63 +11018,63 @@ SSP5,NES,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_
 SSP5,NES,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,NES,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,NES,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP5,NES,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,3.476e-03,2.970e-02,8.215e-02,1.870e-01,1.870e-01
-SSP5,NES,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SSP5,NES,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SSP5,NES,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SSP5,NES,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SSP5,NES,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SSP5,OAS,,,,,Cycle,trn_pass,S3S,linear,1.256e-02,2.493e-02,3.323e-02,8.309e-02,8.309e-02
-SSP5,OAS,,,,,Domestic Aviation,trn_pass,S3S,linear,2.574e-02,2.661e-02,3.726e-02,7.983e-02,7.983e-02
-SSP5,OAS,,,,,Domestic Ship,trn_freight,S3S,linear,3.645e-02,3.645e-02,2.804e-02,3.645e-02,3.645e-02
-SSP5,OAS,,,,,Freight Rail,trn_freight,S3S,linear,4.649e-02,4.649e-02,3.576e-02,4.649e-02,4.649e-02
-SSP5,OAS,,,,,HSR,trn_pass,S3S,linear,9.660e-04,2.997e-03,2.997e-03,3.995e-03,3.995e-03
+SSP5,NES,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,3.476e-03,2.970e-02,6.085e-02,7.482e-02,7.482e-02
+SSP5,NES,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.289e-02,8.772e-02,1.289e-01,1.289e-01
+SSP5,NES,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.289e-02,8.772e-02,1.289e-01,1.289e-01
+SSP5,NES,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.289e-02,8.772e-02,1.289e-01,1.289e-01
+SSP5,NES,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.289e-02,8.772e-02,1.289e-01,1.289e-01
+SSP5,NES,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.289e-02,8.772e-02,1.289e-01,1.289e-01
+SSP5,OAS,,,,,Cycle,trn_pass,S3S,linear,1.256e-02,3.616e-02,4.821e-02,1.205e-01,1.205e-01
+SSP5,OAS,,,,,Domestic Aviation,trn_pass,S3S,linear,2.456e-02,3.684e-02,5.158e-02,1.326e-01,1.326e-01
+SSP5,OAS,,,,,Domestic Ship,trn_freight,S3S,linear,3.712e-02,3.375e-02,2.856e-02,2.700e-02,2.700e-02
+SSP5,OAS,,,,,Freight Rail,trn_freight,S3S,linear,4.736e-02,4.305e-02,3.643e-02,3.444e-02,3.444e-02
+SSP5,OAS,,,,,HSR,trn_pass,S3S,linear,9.660e-04,4.347e-03,4.347e-03,5.796e-03,5.796e-03
 SSP5,OAS,,,,,International Aviation,trn_aviation_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,OAS,,,,,International Ship,trn_shipping_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP5,OAS,,,,,Passenger Rail,trn_pass,S3S,linear,7.701e-04,7.963e-04,1.194e-03,1.593e-03,1.593e-03
-SSP5,OAS,,,,,Walk,trn_pass,S3S,linear,1.000e+00,6.893e-01,6.893e-01,6.893e-01,6.893e-01
+SSP5,OAS,,,,,Passenger Rail,trn_pass,S3S,linear,7.701e-04,1.155e-03,1.733e-03,2.310e-03,2.310e-03
+SSP5,OAS,,,,,Walk,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,OAS,,,,,trn_freight_road,trn_freight,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP5,OAS,,,,,trn_pass_road,trn_pass,S3S,linear,8.721e-01,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP5,OAS,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,2.403e-01,1.402e-01,5.510e-02,5.510e-02,5.510e-02
+SSP5,OAS,,,,,trn_pass_road,trn_pass,S3S,linear,4.452e-01,5.697e-01,5.697e-01,7.121e-01,7.121e-01
+SSP5,OAS,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,4.352e-01,2.571e-01,1.122e-01,9.620e-02,9.620e-02
 SSP5,OAS,,,,trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP5,OAS,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,2.534e-02,2.233e-02,1.631e-02,4.276e-03,4.276e-03
+SSP5,OAS,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,3.520e-01,1.718e-01,1.631e-01,9.503e-02,9.503e-02
 SSP5,OAS,,,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP5,OAS,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,6.745e-03,6.745e-03,6.745e-03,6.745e-03,6.745e-03
+SSP5,OAS,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,2.698e-03,2.811e-03,4.216e-03,5.621e-03,5.621e-03
 SSP5,OAS,,Large Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,3.018e-01,3.018e-01,3.018e-01,3.018e-01,3.018e-01
 SSP5,OAS,,Large Car and SUV,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,6.459e-04,6.459e-04,6.459e-04,6.459e-04,6.459e-04
 SSP5,OAS,,Light Truck and SUV,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,OAS,,Midsize Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,2.500e-04,2.500e-04,2.500e-04,2.500e-04,2.500e-04
-SSP5,OAS,,Mini Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,6.938e-05,6.938e-05,6.938e-05,6.938e-05,6.938e-05
+SSP5,OAS,,Mini Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,2.775e-05,2.891e-05,4.336e-05,5.782e-05,5.782e-05
 SSP5,OAS,,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,7.762e-03,7.762e-03,7.762e-03,7.762e-03,7.762e-03
 SSP5,OAS,,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,OAS,,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,6.391e-03,6.391e-03,6.391e-03,6.391e-03,6.391e-03
-SSP5,OAS,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,8.508e-03,8.508e-03,8.508e-03,8.508e-03,8.508e-03
+SSP5,OAS,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,3.403e-03,3.545e-03,5.318e-03,7.090e-03,7.090e-03
 SSP5,OAS,,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,3.765e-01,3.765e-01,3.765e-01,3.765e-01,3.765e-01
 SSP5,OAS,,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,4.784e-01,4.784e-01,4.784e-01,4.784e-01,4.784e-01
 SSP5,OAS,,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.365e-03,1.365e-03,1.365e-03,1.365e-03,1.365e-03
 SSP5,OAS,,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,7.361e-04,7.361e-04,7.361e-04,7.361e-04,7.361e-04
 SSP5,OAS,,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,OAS,,Van,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.027e-05,1.027e-05,1.027e-05,1.027e-05,1.027e-05
-SSP5,OAS,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP5,OAS,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1.452e-05,1.452e-05,1.452e-05,1.452e-05,1.452e-05
-SSP5,OAS,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP5,OAS,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.423e-01,6.724e-01,1.000e+00,1.000e+00
+SSP5,OAS,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.400e-02,1.680e-01,2.940e-01,2.940e-01
+SSP5,OAS,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.400e-02,1.680e-01,2.940e-01,2.940e-01
+SSP5,OAS,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.400e-02,1.680e-01,2.940e-01,2.940e-01
+SSP5,OAS,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.411e-01,6.670e-01,1.000e+00,1.000e+00
 SSP5,OAS,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1.733e-01,2.767e-01,4.833e-01,8.967e-01,8.967e-01
 SSP5,OAS,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,OAS,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,3.530e-01,4.338e-01,5.956e-01,9.191e-01,9.191e-01
-SSP5,OAS,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.973e-02,6.250e-02,7.856e-02,7.856e-02
-SSP5,OAS,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.581e-02,3.362e-02,7.621e-02,7.621e-02
-SSP5,OAS,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.581e-02,3.362e-02,7.621e-02,7.621e-02
-SSP5,OAS,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.581e-02,3.362e-02,7.621e-02,7.621e-02
-SSP5,OAS,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.973e-02,6.250e-02,7.856e-02,7.856e-02
-SSP5,OAS,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.473e-03,1.799e-02,6.561e-02,6.561e-02
-SSP5,OAS,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.115e-02,1.186e-02,2.924e-02,2.924e-02
-SSP5,OAS,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.121e-03,4.497e-03,2.000e-02,2.000e-02
-SSP5,OAS,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.121e-03,4.497e-03,2.000e-02,2.000e-02
-SSP5,OAS,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.121e-03,4.497e-03,2.000e-02,2.000e-02
-SSP5,OAS,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.115e-02,1.186e-02,2.924e-02,2.924e-02
+SSP5,OAS,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.469e-02,5.456e-02,7.144e-02,7.144e-02
+SSP5,OAS,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.380e-02,2.935e-02,6.930e-02,6.930e-02
+SSP5,OAS,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.380e-02,2.935e-02,6.930e-02,6.930e-02
+SSP5,OAS,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.380e-02,2.935e-02,6.930e-02,6.930e-02
+SSP5,OAS,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.469e-02,5.456e-02,7.144e-02,7.144e-02
+SSP5,OAS,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.453e-03,1.784e-02,7.290e-02,7.290e-02
+SSP5,OAS,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.217e-02,1.294e-02,2.127e-02,2.127e-02
+SSP5,OAS,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.497e-03,4.907e-03,1.455e-02,1.455e-02
+SSP5,OAS,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.497e-03,4.907e-03,1.455e-02,1.455e-02
+SSP5,OAS,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.497e-03,4.907e-03,1.455e-02,1.455e-02
+SSP5,OAS,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.217e-02,1.294e-02,2.127e-02,2.127e-02
 SSP5,OAS,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0.000e+00,8.315e-07,4.540e-05,1.192e-01,1.192e-01
-SSP5,OAS,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,6.561e-01,6.561e-01
+SSP5,OAS,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,6.681e-01,6.681e-01
 SSP5,OAS,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,OAS,Liquids,Domestic Ship_tmp_vehicletype,Domestic Ship_tmp_subsector_L1,Domestic Ship_tmp_subsector_L2,Domestic Ship,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,OAS,Liquids,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
@@ -11089,58 +11089,58 @@ SSP5,OAS,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_
 SSP5,OAS,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,OAS,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,OAS,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP5,OAS,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.967e-01,2.178e-01,2.601e-01,2.261e-01,2.261e-01
-SSP5,OAS,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,4.535e-04,8.919e-03,3.968e-02,7.383e-02,7.383e-02
-SSP5,OAS,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,8.772e-03,3.947e-02,7.368e-02,7.368e-02
-SSP5,OAS,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.395e-01,5.404e-02,1.037e-01,1.192e-01,1.192e-01
-SSP5,OAS,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,2.466e-01,8.882e-02,1.531e-01,1.542e-01,1.542e-01
-SSP5,OAS,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,8.772e-03,3.947e-02,7.368e-02,7.368e-02
-SSP5,REF,,,,,Cycle,trn_pass,S3S,linear,4.737e-03,4.737e-03,2.369e-02,7.824e-02,7.824e-02
-SSP5,REF,,,,,Domestic Aviation,trn_pass,S3S,linear,1.287e-02,1.232e-02,1.540e-02,1.454e-02,1.454e-02
-SSP5,REF,,,,,Domestic Ship,trn_freight,S3S,linear,7.096e-03,7.096e-03,7.096e-03,7.096e-03,7.096e-03
-SSP5,REF,,,,,Freight Rail,trn_freight,S3S,linear,1.272e-01,1.272e-01,1.272e-01,1.272e-01,1.272e-01
-SSP5,REF,,,,,HSR,trn_pass,S3S,linear,0.000e+00,8.000e-04,8.000e-04,7.550e-04,7.550e-04
+SSP5,OAS,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.967e-01,1.980e-01,2.365e-01,2.303e-01,2.303e-01
+SSP5,OAS,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,4.535e-04,8.919e-03,3.968e-02,6.153e-02,6.153e-02
+SSP5,OAS,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,8.772e-03,3.947e-02,6.140e-02,6.140e-02
+SSP5,OAS,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.395e-01,5.404e-02,1.037e-01,9.933e-02,9.933e-02
+SSP5,OAS,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,2.466e-01,8.882e-02,1.531e-01,1.285e-01,1.285e-01
+SSP5,OAS,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,8.772e-03,3.947e-02,6.140e-02,6.140e-02
+SSP5,REF,,,,,Cycle,trn_pass,S3S,linear,1.379e-02,1.206e-02,6.031e-02,7.824e-02,7.824e-02
+SSP5,REF,,,,,Domestic Aviation,trn_pass,S3S,linear,3.574e-02,2.995e-02,3.743e-02,1.387e-02,1.387e-02
+SSP5,REF,,,,,Domestic Ship,trn_freight,S3S,linear,7.227e-03,7.227e-03,7.227e-03,7.227e-03,7.227e-03
+SSP5,REF,,,,,Freight Rail,trn_freight,S3S,linear,1.296e-01,1.296e-01,1.296e-01,1.296e-01,1.296e-01
+SSP5,REF,,,,,HSR,trn_pass,S3S,linear,0.000e+00,2.037e-03,2.037e-03,7.550e-04,7.550e-04
 SSP5,REF,,,,,International Aviation,trn_aviation_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,REF,,,,,International Ship,trn_shipping_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP5,REF,,,,,Passenger Rail,trn_pass,S3S,linear,2.366e-03,4.731e-03,5.914e-03,1.116e-02,1.116e-02
-SSP5,REF,,,,,Walk,trn_pass,S3S,linear,3.179e-01,3.179e-01,3.179e-01,1.000e+00,1.000e+00
+SSP5,REF,,,,,Passenger Rail,trn_pass,S3S,linear,6.884e-03,1.205e-02,1.506e-02,1.116e-02,1.116e-02
+SSP5,REF,,,,,Walk,trn_pass,S3S,linear,9.251e-01,8.095e-01,8.095e-01,1.000e+00,1.000e+00
 SSP5,REF,,,,,trn_freight_road,trn_freight,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP5,REF,,,,,trn_pass_road,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,9.437e-01,9.437e-01
-SSP5,REF,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,1.186e-01,9.148e-02,7.623e-02,6.099e-02,6.099e-02
+SSP5,REF,,,,,trn_pass_road,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,4.633e-01,4.633e-01
+SSP5,REF,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,2.684e-01,1.864e-01,1.553e-01,1.242e-01,1.242e-01
 SSP5,REF,,,,trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,REF,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,3.698e-01,3.698e-01,3.698e-01,3.698e-01,3.698e-01
 SSP5,REF,,,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP5,REF,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,2.227e-01,2.227e-01,2.227e-01,2.227e-01,2.227e-01
+SSP5,REF,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,4.455e-01,4.176e-01,4.176e-01,3.818e-01,3.818e-01
 SSP5,REF,,Large Car and SUV,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,REF,,Midsize Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.842e-01,1.842e-01,1.842e-01,1.842e-01,1.842e-01
-SSP5,REF,,Mini Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,7.127e-05,7.127e-05,7.127e-05,7.127e-05,7.127e-05
+SSP5,REF,,Mini Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.425e-04,1.336e-04,1.336e-04,1.222e-04,1.222e-04
 SSP5,REF,,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,3.376e-03,3.376e-03,3.376e-03,3.376e-03,3.376e-03
 SSP5,REF,,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,REF,,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,4.141e-01,4.141e-01,4.141e-01,4.141e-01,4.141e-01
-SSP5,REF,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.254e-02,1.254e-02,1.254e-02,1.254e-02,1.254e-02
+SSP5,REF,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,2.508e-02,2.351e-02,2.351e-02,2.150e-02,2.150e-02
 SSP5,REF,,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,REF,,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,5.081e-03,5.081e-03,5.081e-03,5.081e-03,5.081e-03
 SSP5,REF,,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,5.837e-01,5.837e-01,5.837e-01,5.837e-01,5.837e-01
 SSP5,REF,,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.888e-01,1.888e-01,1.888e-01,1.888e-01,1.888e-01
 SSP5,REF,,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.676e-02,1.676e-02,1.676e-02,1.676e-02,1.676e-02
-SSP5,REF,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP5,REF,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,6.589e-03,6.589e-03,6.589e-03,6.589e-03,6.589e-03
-SSP5,REF,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP5,REF,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.743e-02,3.227e-01,9.526e-01,9.526e-01
+SSP5,REF,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.000e-02,1.680e-01,3.360e-01,3.360e-01
+SSP5,REF,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.000e-02,1.680e-01,3.360e-01,3.360e-01
+SSP5,REF,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.000e-02,1.680e-01,3.360e-01,3.360e-01
+SSP5,REF,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,7.245e-02,3.202e-01,7.425e-01,7.425e-01
 SSP5,REF,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,REF,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,REF,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP5,REF,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.192e-01,3.000e-01,3.928e-01,3.928e-01
-SSP5,REF,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.743e-02,1.614e-01,3.810e-01,3.810e-01
-SSP5,REF,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.743e-02,1.614e-01,3.810e-01,3.810e-01
-SSP5,REF,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.743e-02,1.614e-01,3.810e-01,3.810e-01
-SSP5,REF,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.192e-01,3.000e-01,3.928e-01,3.928e-01
-SSP5,REF,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.473e-03,3.597e-02,1.000e-01,1.000e-01
-SSP5,REF,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.024e-02,4.743e-02,7.311e-02,7.311e-02
-SSP5,REF,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.225e-02,1.799e-02,5.000e-02,5.000e-02
-SSP5,REF,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.225e-02,1.799e-02,5.000e-02,5.000e-02
-SSP5,REF,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.225e-02,1.799e-02,5.000e-02,5.000e-02
-SSP5,REF,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.024e-02,4.743e-02,7.311e-02,7.311e-02
+SSP5,REF,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.183e-01,2.678e-01,3.957e-01,3.957e-01
+SSP5,REF,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.705e-02,1.441e-01,3.838e-01,3.838e-01
+SSP5,REF,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.705e-02,1.441e-01,3.838e-01,3.838e-01
+SSP5,REF,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.705e-02,1.441e-01,3.838e-01,3.838e-01
+SSP5,REF,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.183e-01,2.678e-01,3.957e-01,3.957e-01
+SSP5,REF,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.698e-03,3.569e-02,6.236e-02,6.236e-02
+SSP5,REF,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.975e-02,4.705e-02,5.523e-02,5.523e-02
+SSP5,REF,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.208e-02,1.784e-02,3.777e-02,3.777e-02
+SSP5,REF,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.208e-02,1.784e-02,3.777e-02,3.777e-02
+SSP5,REF,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.208e-02,1.784e-02,3.777e-02,3.777e-02
+SSP5,REF,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.975e-02,4.705e-02,5.523e-02,5.523e-02
 SSP5,REF,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0.000e+00,8.315e-07,4.540e-05,1.192e-01,1.192e-01
 SSP5,REF,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,REF,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
@@ -11157,26 +11157,26 @@ SSP5,REF,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_
 SSP5,REF,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,REF,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,REF,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP5,REF,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.400e-02,3.994e-02,7.347e-02,1.369e-01,1.369e-01
-SSP5,REF,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,4.158e-02,6.680e-02,1.172e-01,1.745e-01,1.745e-01
-SSP5,REF,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.474e-01,1.474e-01
-SSP5,REF,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,6.311e-02,8.776e-02,1.371e-01,1.886e-01,1.886e-01
-SSP5,REF,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,3.048e-02,5.599e-02,1.070e-01,1.673e-01,1.673e-01
-SSP5,REF,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.474e-01,1.474e-01
-SSP5,SSA,,,,,Cycle,trn_pass,S3S,linear,1.388e-02,1.795e-02,2.915e-02,3.279e-02,3.279e-02
-SSP5,SSA,,,,,Domestic Aviation,trn_pass,S3S,linear,9.013e-03,5.100e-02,4.140e-02,6.209e-03,6.209e-03
-SSP5,SSA,,,,,Domestic Ship,trn_freight,S3S,linear,1.467e-03,1.467e-03,1.467e-03,1.467e-03,1.467e-03
-SSP5,SSA,,,,,Freight Rail,trn_freight,S3S,linear,1.634e-02,1.634e-02,1.634e-02,1.634e-02,1.634e-02
-SSP5,SSA,,,,,HSR,trn_pass,S3S,linear,1.475e-05,2.003e-05,6.504e-02,9.756e-03,9.756e-03
+SSP5,REF,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.400e-02,3.195e-02,6.011e-02,7.825e-02,7.825e-02
+SSP5,REF,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,3.465e-02,6.073e-02,9.593e-02,1.342e-01,1.342e-01
+SSP5,REF,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.392e-02,6.459e-02,1.134e-01,1.134e-01
+SSP5,REF,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,5.259e-02,7.979e-02,1.122e-01,1.450e-01,1.450e-01
+SSP5,REF,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,2.540e-02,5.090e-02,8.756e-02,1.287e-01,1.287e-01
+SSP5,REF,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.392e-02,6.459e-02,1.134e-01,1.134e-01
+SSP5,SSA,,,,,Cycle,trn_pass,S3S,linear,1.388e-02,1.987e-02,2.915e-02,3.279e-02,3.279e-02
+SSP5,SSA,,,,,Domestic Aviation,trn_pass,S3S,linear,8.602e-03,5.387e-02,3.951e-02,5.926e-03,5.926e-03
+SSP5,SSA,,,,,Domestic Ship,trn_freight,S3S,linear,1.495e-03,1.495e-03,1.495e-03,1.495e-03,1.495e-03
+SSP5,SSA,,,,,Freight Rail,trn_freight,S3S,linear,1.665e-02,1.665e-02,1.665e-02,1.498e-02,1.498e-02
+SSP5,SSA,,,,,HSR,trn_pass,S3S,linear,1.475e-05,2.217e-05,6.504e-02,9.756e-03,9.756e-03
 SSP5,SSA,,,,,International Aviation,trn_aviation_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,SSA,,,,,International Ship,trn_shipping_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP5,SSA,,,,,Passenger Rail,trn_pass,S3S,linear,6.024e-04,1.559e-03,2.530e-03,5.693e-04,5.693e-04
-SSP5,SSA,,,,,Walk,trn_pass,S3S,linear,1.000e+00,9.034e-01,1.000e+00,1.000e+00,1.000e+00
+SSP5,SSA,,,,,Passenger Rail,trn_pass,S3S,linear,6.024e-04,1.725e-03,2.530e-03,5.693e-04,5.693e-04
+SSP5,SSA,,,,,Walk,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,SSA,,,,,trn_freight_road,trn_freight,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP5,SSA,,,,,trn_pass_road,trn_pass,S3S,linear,8.902e-01,1.000e+00,9.741e-01,9.741e-02,9.741e-02
-SSP5,SSA,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,2.477e-01,1.270e-01,7.328e-02,9.526e-02,9.526e-02
+SSP5,SSA,,,,,trn_pass_road,trn_pass,S3S,linear,2.622e-01,3.260e-01,2.869e-01,4.781e-02,4.781e-02
+SSP5,SSA,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,7.568e-01,3.234e-01,1.493e-01,9.703e-02,9.703e-02
 SSP5,SSA,,,,trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP5,SSA,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,3.928e-02,3.928e-02,3.928e-02,3.928e-02,3.928e-02
+SSP5,SSA,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,2.619e-02,2.619e-02,2.619e-02,3.928e-02,3.928e-02
 SSP5,SSA,,,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,SSA,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,SSA,,Large Car and SUV,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,3.022e-03,3.022e-03,3.022e-03,3.022e-03,3.022e-03
@@ -11191,24 +11191,24 @@ SSP5,SSA,,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_sub
 SSP5,SSA,,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,4.207e-06,4.207e-06,4.207e-06,4.207e-06,4.207e-06
 SSP5,SSA,,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,SSA,,Van,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,7.570e-05,7.570e-05,7.570e-05,7.570e-05,7.570e-05
-SSP5,SSA,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP5,SSA,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP5,SSA,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP5,SSA,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.743e-02,4.034e-01,9.526e-01,9.526e-01
+SSP5,SSA,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.000e-01,2.160e-01,3.360e-01,3.360e-01
+SSP5,SSA,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.000e-01,2.160e-01,3.360e-01,3.360e-01
+SSP5,SSA,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.000e-01,2.160e-01,3.360e-01,3.360e-01
+SSP5,SSA,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,6.210e-02,3.962e-01,8.470e-01,8.470e-01
 SSP5,SSA,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,SSA,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,SSA,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP5,SSA,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.384e-02,1.000e-01,1.511e-01,1.511e-01
-SSP5,SSA,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,9.485e-03,5.379e-02,1.465e-01,1.465e-01
-SSP5,SSA,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,9.485e-03,5.379e-02,1.465e-01,1.465e-01
-SSP5,SSA,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,9.485e-03,5.379e-02,1.465e-01,1.465e-01
-SSP5,SSA,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.384e-02,1.000e-01,1.511e-01,1.511e-01
-SSP5,SSA,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.473e-03,1.799e-02,7.500e-02,7.500e-02
-SSP5,SSA,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.693e-03,4.743e-02,2.812e-02,2.812e-02
-SSP5,SSA,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-03,1.799e-02,1.923e-02,1.923e-02
-SSP5,SSA,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-03,1.799e-02,1.923e-02,1.923e-02
-SSP5,SSA,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-03,1.799e-02,1.923e-02,1.923e-02
-SSP5,SSA,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.693e-03,4.743e-02,2.812e-02,2.812e-02
+SSP5,SSA,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.602e-02,1.007e-01,1.511e-01,1.511e-01
+SSP5,SSA,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.035e-02,5.418e-02,1.466e-01,1.466e-01
+SSP5,SSA,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.035e-02,5.418e-02,1.466e-01,1.466e-01
+SSP5,SSA,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.035e-02,5.418e-02,1.466e-01,1.466e-01
+SSP5,SSA,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.602e-02,1.007e-01,1.511e-01,1.511e-01
+SSP5,SSA,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.698e-03,1.963e-02,4.850e-02,4.850e-02
+SSP5,SSA,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,7.303e-03,1.194e-02,2.045e-02,2.045e-02
+SSP5,SSA,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.698e-03,4.529e-03,1.399e-02,1.399e-02
+SSP5,SSA,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.698e-03,4.529e-03,1.399e-02,1.399e-02
+SSP5,SSA,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.698e-03,4.529e-03,1.399e-02,1.399e-02
+SSP5,SSA,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,7.303e-03,1.194e-02,2.045e-02,2.045e-02
 SSP5,SSA,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0.000e+00,8.315e-07,4.540e-05,1.192e-01,1.192e-01
 SSP5,SSA,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,SSA,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
@@ -11225,59 +11225,59 @@ SSP5,SSA,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_
 SSP5,SSA,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,SSA,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,SSA,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP5,SSA,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,3.981e-04,2.670e-02,5.552e-02,9.227e-02,9.227e-02
-SSP5,SSA,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,7.085e-02,7.085e-02
-SSP5,SSA,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,7.085e-02,7.085e-02
-SSP5,SSA,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,7.085e-02,7.085e-02
-SSP5,SSA,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,7.085e-02,7.085e-02
-SSP5,SSA,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,7.085e-02,7.085e-02
+SSP5,SSA,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,3.981e-04,2.670e-02,4.997e-02,6.835e-02,6.835e-02
+SSP5,SSA,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,4.251e-02,5.904e-02,5.904e-02
+SSP5,SSA,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,4.251e-02,5.904e-02,5.904e-02
+SSP5,SSA,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,4.251e-02,5.904e-02,5.904e-02
+SSP5,SSA,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,4.251e-02,5.904e-02,5.904e-02
+SSP5,SSA,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,4.251e-02,5.904e-02,5.904e-02
 SSP5,UKI,,,,,Cycle,trn_pass,S3S,linear,2.500e-02,1.092e-02,3.277e-02,6.553e-02,6.553e-02
-SSP5,UKI,,,,,Domestic Aviation,trn_pass,S3S,linear,6.250e-05,9.365e-06,9.365e-06,9.365e-06,9.365e-06
-SSP5,UKI,,,,,Domestic Ship,trn_freight,S3S,linear,8.512e-03,8.512e-03,8.512e-03,8.512e-03,8.512e-03
-SSP5,UKI,,,,,Freight Rail,trn_freight,S3S,linear,6.067e-03,6.067e-03,6.067e-03,6.067e-03,6.067e-03
+SSP5,UKI,,,,,Domestic Aviation,trn_pass,S3S,linear,5.965e-05,8.938e-06,8.938e-06,8.938e-06,8.938e-06
+SSP5,UKI,,,,,Domestic Ship,trn_freight,S3S,linear,8.670e-03,8.670e-03,8.670e-03,8.670e-03,8.670e-03
+SSP5,UKI,,,,,Freight Rail,trn_freight,S3S,linear,6.180e-03,6.180e-03,6.180e-03,6.180e-03,6.180e-03
 SSP5,UKI,,,,,HSR,trn_pass,S3S,linear,1.250e-04,1.334e-04,1.779e-04,2.224e-04,2.224e-04
 SSP5,UKI,,,,,International Aviation,trn_aviation_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,UKI,,,,,International Ship,trn_shipping_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,UKI,,,,,Passenger Rail,trn_pass,S3S,linear,3.125e-03,2.502e-03,1.876e-03,1.876e-03,1.876e-03
 SSP5,UKI,,,,,Walk,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,UKI,,,,,trn_freight_road,trn_freight,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP5,UKI,,,,,trn_pass_road,trn_pass,S3S,linear,7.500e-02,5.325e-02,3.408e-02,3.408e-02,3.408e-02
-SSP5,UKI,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,2.500e-01,2.010e-01,1.843e-01,1.675e-01,1.675e-01
+SSP5,UKI,,,,,trn_pass_road,trn_pass,S3S,linear,7.363e-02,5.228e-02,3.346e-02,3.346e-02,3.346e-02
+SSP5,UKI,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,2.546e-01,2.048e-01,1.877e-01,1.706e-01,1.706e-01
 SSP5,UKI,,,,trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,UKI,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,3.935e-02,3.935e-02,3.935e-02,3.935e-02,3.935e-02
 SSP5,UKI,,,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP5,UKI,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,4.864e-01,4.864e-01,4.864e-01,4.864e-01,4.864e-01
+SSP5,UKI,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,5.404e-01,5.404e-01,4.864e-01,4.864e-01,4.864e-01
 SSP5,UKI,,Large Car and SUV,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,UKI,,Midsize Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,2.616e-01,2.616e-01,2.616e-01,2.616e-01,2.616e-01
-SSP5,UKI,,Mini Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,4.751e-07,4.751e-07,4.751e-07,4.751e-07,4.751e-07
+SSP5,UKI,,Mini Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,5.279e-07,5.279e-07,4.751e-07,4.751e-07,4.751e-07
 SSP5,UKI,,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,2.088e-02,2.088e-02,2.088e-02,2.088e-02,2.088e-02
 SSP5,UKI,,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,3.798e-03,3.798e-03,3.798e-03,3.798e-03,3.798e-03
 SSP5,UKI,,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP5,UKI,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,5.119e-01,5.119e-01,5.119e-01,5.119e-01,5.119e-01
+SSP5,UKI,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,5.688e-01,5.688e-01,5.119e-01,5.119e-01,5.119e-01
 SSP5,UKI,,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,UKI,,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,4.528e-02,4.528e-02,4.528e-02,4.528e-02,4.528e-02
 SSP5,UKI,,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,9.437e-02,9.437e-02,9.437e-02,9.437e-02,9.437e-02
 SSP5,UKI,,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,5.696e-01,5.696e-01,5.696e-01,5.696e-01,5.696e-01
 SSP5,UKI,,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,7.765e-01,7.765e-01,7.765e-01,7.765e-01,7.765e-01
 SSP5,UKI,,Van,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,2.681e-03,2.681e-03,2.681e-03,2.681e-03,2.681e-03
-SSP5,UKI,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP5,UKI,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP5,UKI,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP5,UKI,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.186e-01,3.227e-01,8.573e-01,8.573e-01
+SSP5,UKI,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,5.000e-02,2.000e-01,3.700e-01,3.700e-01
+SSP5,UKI,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,5.000e-02,2.000e-01,3.700e-01,3.700e-01
+SSP5,UKI,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,5.000e-02,2.000e-01,3.700e-01,3.700e-01
+SSP5,UKI,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,2.500e-02,1.168e-01,3.434e-01,7.434e-01,7.434e-01
 SSP5,UKI,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,8.260e-01,8.478e-01,8.913e-01,9.783e-01,9.783e-01
 SSP5,UKI,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,UKI,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP5,UKI,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.384e-01,5.500e-01,8.838e-01,8.838e-01
-SSP5,UKI,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,9.485e-02,2.958e-01,8.573e-01,8.573e-01
-SSP5,UKI,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,9.485e-02,2.958e-01,8.573e-01,8.573e-01
-SSP5,UKI,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,9.485e-02,2.958e-01,8.573e-01,8.573e-01
-SSP5,UKI,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.384e-01,5.500e-01,8.838e-01,8.838e-01
-SSP5,UKI,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.236e-02,1.799e-02,1.000e-01,1.000e-01
-SSP5,UKI,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.693e-02,1.897e-01,1.462e-01,1.462e-01
-SSP5,UKI,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-02,7.194e-02,1.000e-01,1.000e-01
-SSP5,UKI,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-02,7.194e-02,1.000e-01,1.000e-01
-SSP5,UKI,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-02,7.194e-02,1.000e-01,1.000e-01
-SSP5,UKI,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.693e-02,1.897e-01,1.462e-01,1.462e-01
+SSP5,UKI,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.819e-01,5.853e-01,8.360e-01,8.360e-01
+SSP5,UKI,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.122e-01,3.148e-01,8.110e-01,8.110e-01
+SSP5,UKI,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.122e-01,3.148e-01,8.110e-01,8.110e-01
+SSP5,UKI,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.122e-01,3.148e-01,8.110e-01,8.110e-01
+SSP5,UKI,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.819e-01,5.853e-01,8.360e-01,8.360e-01
+SSP5,UKI,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,2.500e-05,1.218e-02,2.127e-02,7.883e-02,7.883e-02
+SSP5,UKI,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,7.914e-02,2.243e-01,1.729e-01,1.729e-01
+SSP5,UKI,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.924e-02,8.507e-02,1.182e-01,1.182e-01
+SSP5,UKI,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.924e-02,8.507e-02,1.182e-01,1.182e-01
+SSP5,UKI,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.924e-02,8.507e-02,1.182e-01,1.182e-01
+SSP5,UKI,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,7.914e-02,2.243e-01,1.729e-01,1.729e-01
 SSP5,UKI,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0.000e+00,8.315e-07,4.540e-05,1.192e-01,1.192e-01
 SSP5,UKI,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,UKI,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
@@ -11294,24 +11294,24 @@ SSP5,UKI,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_
 SSP5,UKI,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,UKI,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,UKI,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP5,UKI,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,3.616e-04,2.667e-02,7.928e-02,1.845e-01,1.845e-01
+SSP5,UKI,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,9.040e-04,2.222e-02,7.928e-02,1.230e-01,1.230e-01
 SSP5,UKI,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
 SSP5,UKI,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
 SSP5,UKI,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
 SSP5,UKI,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
 SSP5,UKI,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
 SSP5,USA,,,,,Cycle,trn_pass,S3S,linear,8.197e-03,8.197e-03,8.197e-03,4.098e-02,4.098e-02
-SSP5,USA,,,,,Domestic Aviation,trn_pass,S3S,linear,1.057e-03,1.600e-03,1.800e-03,1.100e-03,1.100e-03
-SSP5,USA,,,,,Domestic Ship,trn_freight,S3S,linear,3.208e-03,3.208e-03,3.208e-03,3.208e-03,3.208e-03
-SSP5,USA,,,,,Freight Rail,trn_freight,S3S,linear,3.364e-02,3.364e-02,3.364e-02,3.364e-02,3.364e-02
+SSP5,USA,,,,,Domestic Aviation,trn_pass,S3S,linear,1.009e-03,1.527e-03,1.718e-03,1.050e-03,1.050e-03
+SSP5,USA,,,,,Domestic Ship,trn_freight,S3S,linear,3.267e-03,3.267e-03,3.267e-03,3.267e-03,3.267e-03
+SSP5,USA,,,,,Freight Rail,trn_freight,S3S,linear,3.427e-02,3.427e-02,3.427e-02,3.427e-02,3.427e-02
 SSP5,USA,,,,,HSR,trn_pass,S3S,linear,4.530e-06,4.530e-06,4.530e-06,2.265e-04,2.265e-04
 SSP5,USA,,,,,International Aviation,trn_aviation_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,USA,,,,,International Ship,trn_shipping_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,USA,,,,,Passenger Rail,trn_pass,S3S,linear,1.933e-03,1.933e-03,1.933e-03,9.665e-04,9.665e-04
 SSP5,USA,,,,,Walk,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,USA,,,,,trn_freight_road,trn_freight,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP5,USA,,,,,trn_pass_road,trn_pass,S3S,linear,1.329e-01,1.329e-01,1.276e-01,6.647e-02,6.647e-02
-SSP5,USA,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,8.561e-02,1.070e-01,1.070e-01,1.213e-01,1.213e-01
+SSP5,USA,,,,,trn_pass_road,trn_pass,S3S,linear,1.305e-01,1.305e-01,1.253e-01,6.526e-02,6.526e-02
+SSP5,USA,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,8.720e-02,1.090e-01,1.090e-01,1.235e-01,1.235e-01
 SSP5,USA,,,,trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,USA,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,3.805e-02,3.805e-02,3.805e-02,3.805e-02,3.805e-02
 SSP5,USA,,,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
@@ -11324,29 +11324,29 @@ SSP5,USA,,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_
 SSP5,USA,,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,USA,,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,7.057e-01,7.057e-01,7.057e-01,7.057e-01,7.057e-01
 SSP5,USA,,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP5,USA,,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP5,USA,,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
+SSP5,USA,,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,9.000e-01,1.000e+00,1.000e+00,1.000e+00,1.000e+00
+SSP5,USA,,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,9.000e-01,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,USA,,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,6.263e-01,6.263e-01,6.263e-01,6.263e-01,6.263e-01
-SSP5,USA,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP5,USA,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP5,USA,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP5,USA,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.423e-01,5.379e-01,1.000e+00,1.000e+00
+SSP5,USA,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.400e-02,2.160e-01,3.780e-01,3.780e-01
+SSP5,USA,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.400e-02,2.160e-01,3.780e-01,3.780e-01
+SSP5,USA,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.400e-02,2.160e-01,3.780e-01,3.780e-01
+SSP5,USA,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.122e-01,5.382e-01,1.000e+00,1.000e+00
 SSP5,USA,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,0.000e+00,1.250e-01,3.750e-01,8.750e-01,8.750e-01
 SSP5,USA,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,USA,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP5,USA,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.980e-02,2.500e-01,7.856e-01,7.856e-01
-SSP5,USA,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.186e-02,1.345e-01,7.621e-01,7.621e-01
-SSP5,USA,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,3.000e-02,2.500e-01,5.000e-01,8.000e-01,8.000e-01
-SSP5,USA,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,3.000e-02,2.500e-01,5.000e-01,8.000e-01,8.000e-01
-SSP5,USA,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.980e-02,2.500e-01,7.856e-01,7.856e-01
-SSP5,USA,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.473e-02,1.799e-02,6.999e-02,6.999e-02
-SSP5,USA,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.339e-03,1.423e-02,1.462e-01,1.462e-01
-SSP5,USA,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.945e-04,5.396e-03,1.000e-01,1.000e-01
-SSP5,USA,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,5.000e-02,2.000e-01,3.000e-01,2.000e-01,2.000e-01
-SSP5,USA,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,5.000e-02,2.000e-01,3.000e-01,2.000e-01,2.000e-01
-SSP5,USA,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.339e-03,1.423e-02,1.462e-01,1.462e-01
+SSP5,USA,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.626e-02,2.323e-01,6.967e-01,6.967e-01
+SSP5,USA,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.470e-03,1.249e-01,6.758e-01,6.758e-01
+SSP5,USA,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,3.547e-02,1.364e-01,4.645e-01,7.095e-01,7.095e-01
+SSP5,USA,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,3.547e-02,1.364e-01,4.645e-01,7.095e-01,7.095e-01
+SSP5,USA,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.626e-02,2.323e-01,6.967e-01,6.967e-01
+SSP5,USA,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.436e-02,1.636e-02,7.776e-02,7.776e-02
+SSP5,USA,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.218e-03,1.202e-02,1.008e-01,1.008e-01
+SSP5,USA,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.498e-04,4.557e-03,6.897e-02,6.897e-02
+SSP5,USA,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,5.912e-02,1.819e-01,2.534e-01,1.379e-01,1.379e-01
+SSP5,USA,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,5.912e-02,1.819e-01,2.534e-01,1.379e-01,1.379e-01
+SSP5,USA,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.218e-03,1.202e-02,1.008e-01,1.008e-01
 SSP5,USA,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0.000e+00,8.315e-07,4.540e-05,1.192e-01,1.192e-01
-SSP5,USA,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,6.999e-01,6.999e-01
+SSP5,USA,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,7.892e-01,7.892e-01
 SSP5,USA,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,USA,Liquids,Domestic Ship_tmp_vehicletype,Domestic Ship_tmp_subsector_L1,Domestic Ship_tmp_subsector_L2,Domestic Ship,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,USA,Liquids,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
@@ -11361,9 +11361,9 @@ SSP5,USA,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_
 SSP5,USA,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,USA,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP5,USA,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP5,USA,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,8.478e-02,1.089e-01,1.570e-01,1.773e-01,1.773e-01
-SSP5,USA,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.263e-03,3.158e-02,7.368e-02,7.368e-02
-SSP5,USA,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.263e-03,3.158e-02,7.368e-02,7.368e-02
-SSP5,USA,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e-01,2.000e-01,4.000e-01,4.000e-01,4.000e-01
-SSP5,USA,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e-01,2.000e-01,4.000e-01,4.000e-01,4.000e-01
-SSP5,USA,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.263e-03,3.158e-02,7.368e-02,7.368e-02
+SSP5,USA,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,8.478e-02,9.072e-02,1.208e-01,1.666e-01,1.666e-01
+SSP5,USA,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.049e-03,2.256e-02,6.140e-02,6.140e-02
+SSP5,USA,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.049e-03,2.256e-02,6.140e-02,6.140e-02
+SSP5,USA,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,5.000e-03,1.538e-01,2.857e-01,3.333e-01,3.333e-01
+SSP5,USA,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,5.000e-03,1.538e-01,2.857e-01,3.333e-01,3.333e-01
+SSP5,USA,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.049e-03,2.256e-02,6.140e-02,6.140e-02

--- a/inst/extdata/sw_trends.csv
+++ b/inst/extdata/sw_trends.csv
@@ -5684,17 +5684,17 @@ SDP_RC,USA,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp
 SDP_RC,USA,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,5.000e-03,1.538e-01,2.857e-01,3.333e-01,3.333e-01
 SDP_RC,USA,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.049e-03,2.256e-02,6.140e-02,6.140e-02
 SSP1,CAZ,,,,,Cycle,trn_pass,S3S,linear,1.911e-02,3.822e-02,3.822e-02,7.645e-02,7.645e-02
-SSP1,CAZ,,,,,Domestic Aviation,trn_pass,S3S,linear,1.500e-03,1.600e-03,1.900e-03,2.000e-03,2.000e-03
-SSP1,CAZ,,,,,Domestic Ship,trn_freight,S3S,linear,1.554e-02,1.554e-02,1.554e-02,1.554e-02,1.554e-02
-SSP1,CAZ,,,,,Freight Rail,trn_freight,S3S,linear,1.051e-01,1.051e-01,1.051e-01,1.051e-01,1.051e-01
+SSP1,CAZ,,,,,Domestic Aviation,trn_pass,S3S,linear,1.432e-03,1.527e-03,1.813e-03,1.909e-03,1.909e-03
+SSP1,CAZ,,,,,Domestic Ship,trn_freight,S3S,linear,1.583e-02,1.583e-02,1.583e-02,1.583e-02,1.583e-02
+SSP1,CAZ,,,,,Freight Rail,trn_freight,S3S,linear,1.070e-01,1.070e-01,1.070e-01,9.633e-02,9.633e-02
 SSP1,CAZ,,,,,HSR,trn_pass,S3S,linear,8.792e-08,8.792e-05,2.638e-04,2.638e-04,2.638e-04
 SSP1,CAZ,,,,,International Aviation,trn_aviation_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,CAZ,,,,,International Ship,trn_shipping_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,CAZ,,,,,Passenger Rail,trn_pass,S3S,linear,8.785e-04,8.785e-04,8.785e-04,8.785e-04,8.785e-04
 SSP1,CAZ,,,,,Walk,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,CAZ,,,,,trn_freight_road,trn_freight,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP1,CAZ,,,,,trn_pass_road,trn_pass,S3S,linear,1.537e-01,1.537e-01,1.537e-01,1.537e-01,1.537e-01
-SSP1,CAZ,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,8.691e-02,8.691e-02,1.086e-01,1.376e-01,1.376e-01
+SSP1,CAZ,,,,,trn_pass_road,trn_pass,S3S,linear,1.509e-01,1.509e-01,1.509e-01,1.509e-01,1.509e-01
+SSP1,CAZ,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,8.852e-02,8.852e-02,1.107e-01,1.402e-01,1.402e-01
 SSP1,CAZ,,,,trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,CAZ,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.939e-02,1.939e-02,1.939e-02,1.939e-02,1.939e-02
 SSP1,CAZ,,,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
@@ -5714,26 +5714,26 @@ SSP1,CAZ,,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_sub
 SSP1,CAZ,,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,3.497e-05,3.497e-05,3.497e-05,3.497e-05,3.497e-05
 SSP1,CAZ,,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,6.282e-01,6.282e-01,6.282e-01,6.282e-01,6.282e-01
 SSP1,CAZ,,Van,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,2.082e-01,2.082e-01,2.082e-01,2.082e-01,2.082e-01
-SSP1,CAZ,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP1,CAZ,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP1,CAZ,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP1,CAZ,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,9.485e-02,4.572e-01,1.000e+00,1.000e+00
+SSP1,CAZ,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.400e-02,1.920e-01,3.360e-01,3.360e-01
+SSP1,CAZ,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.400e-02,1.920e-01,3.360e-01,3.360e-01
+SSP1,CAZ,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.400e-02,1.920e-01,3.360e-01,3.360e-01
+SSP1,CAZ,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.122e-01,4.423e-01,9.735e-01,9.735e-01
 SSP1,CAZ,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,9.074e-02,2.044e-01,4.317e-01,8.863e-01,8.863e-01
 SSP1,CAZ,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,CAZ,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP1,CAZ,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.192e-01,3.500e-01,4.910e-01,4.910e-01
-SSP1,CAZ,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.743e-02,1.883e-01,4.763e-01,4.763e-01
-SSP1,CAZ,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.743e-02,1.883e-01,4.763e-01,4.763e-01
-SSP1,CAZ,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.743e-02,1.883e-01,4.763e-01,4.763e-01
-SSP1,CAZ,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.192e-01,3.500e-01,4.910e-01,4.910e-01
-SSP1,CAZ,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.236e-02,1.799e-02,9.544e-02,9.544e-02
-SSP1,CAZ,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.346e-02,4.743e-02,1.462e-01,1.462e-01
-SSP1,CAZ,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.236e-02,1.799e-02,1.000e-01,1.000e-01
-SSP1,CAZ,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.236e-02,1.799e-02,1.000e-01,1.000e-01
-SSP1,CAZ,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.236e-02,1.799e-02,1.000e-01,1.000e-01
-SSP1,CAZ,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.346e-02,4.743e-02,1.462e-01,1.462e-01
+SSP1,CAZ,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.409e-01,3.311e-01,4.354e-01,4.354e-01
+SSP1,CAZ,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.608e-02,1.781e-01,4.224e-01,4.224e-01
+SSP1,CAZ,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.608e-02,1.781e-01,4.224e-01,4.224e-01
+SSP1,CAZ,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.608e-02,1.781e-01,4.224e-01,4.224e-01
+SSP1,CAZ,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.409e-01,3.311e-01,4.354e-01,4.354e-01
+SSP1,CAZ,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.462e-02,1.933e-02,7.601e-02,7.601e-02
+SSP1,CAZ,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.957e-02,5.608e-02,1.153e-01,1.153e-01
+SSP1,CAZ,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.462e-02,2.127e-02,7.883e-02,7.883e-02
+SSP1,CAZ,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.462e-02,2.127e-02,7.883e-02,7.883e-02
+SSP1,CAZ,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.462e-02,2.127e-02,7.883e-02,7.883e-02
+SSP1,CAZ,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.957e-02,5.608e-02,1.153e-01,1.153e-01
 SSP1,CAZ,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0.000e+00,8.315e-07,4.540e-05,1.192e-01,1.192e-01
-SSP1,CAZ,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,9.544e-01,9.544e-01
+SSP1,CAZ,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,CAZ,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,CAZ,Liquids,Domestic Ship_tmp_vehicletype,Domestic Ship_tmp_subsector_L1,Domestic Ship_tmp_subsector_L2,Domestic Ship,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,CAZ,Liquids,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
@@ -5748,124 +5748,124 @@ SSP1,CAZ,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_
 SSP1,CAZ,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,CAZ,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,CAZ,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP1,CAZ,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,3.104e-02,5.654e-02,1.075e-01,2.000e-01,2.000e-01
-SSP1,CAZ,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SSP1,CAZ,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SSP1,CAZ,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SSP1,CAZ,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SSP1,CAZ,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SSP1,CHA,,,,,Cycle,trn_pass,S3S,linear,8.298e-02,4.412e-02,3.782e-02,4.848e-02,4.848e-02
-SSP1,CHA,,,,,Domestic Aviation,trn_pass,S3S,linear,1.104e-01,2.842e-02,1.829e-02,3.517e-03,3.517e-03
-SSP1,CHA,,,,,Domestic Ship,trn_freight,S3S,linear,2.849e-02,8.548e-02,8.548e-02,8.548e-02,8.548e-02
-SSP1,CHA,,,,,Freight Rail,trn_freight,S3S,linear,6.920e-02,2.076e-01,2.076e-01,2.076e-01,2.076e-01
-SSP1,CHA,,,,,HSR,trn_pass,S3S,linear,2.108e-01,8.143e-02,1.916e-02,3.695e-03,3.695e-03
+SSP1,CAZ,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,3.104e-02,5.654e-02,9.776e-02,1.497e-01,1.497e-01
+SSP1,CAZ,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.535e-01,1.535e-01
+SSP1,CAZ,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.535e-01,1.535e-01
+SSP1,CAZ,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.535e-01,1.535e-01
+SSP1,CAZ,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.535e-01,1.535e-01
+SSP1,CAZ,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.535e-01,1.535e-01
+SSP1,CHA,,,,,Cycle,trn_pass,S3S,linear,9.454e-02,4.412e-02,3.782e-02,4.848e-02,4.848e-02
+SSP1,CHA,,,,,Domestic Aviation,trn_pass,S3S,linear,1.200e-01,2.712e-02,1.745e-02,3.357e-03,3.357e-03
+SSP1,CHA,,,,,Domestic Ship,trn_freight,S3S,linear,1.847e-02,1.922e-02,2.232e-02,2.232e-02,2.232e-02
+SSP1,CHA,,,,,Freight Rail,trn_freight,S3S,linear,3.204e-02,3.570e-02,3.795e-02,3.795e-02,3.795e-02
+SSP1,CHA,,,,,HSR,trn_pass,S3S,linear,2.402e-01,8.143e-02,1.916e-02,3.695e-03,3.695e-03
 SSP1,CHA,,,,,International Aviation,trn_aviation_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,CHA,,,,,International Ship,trn_shipping_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP1,CHA,,,,,Passenger Rail,trn_pass,S3S,linear,5.461e-03,3.111e-03,1.867e-03,9.572e-04,9.572e-04
-SSP1,CHA,,,,,Walk,trn_pass,S3S,linear,8.777e-01,1.000e+00,1.000e+00,1.000e+00,1.000e+00
+SSP1,CHA,,,,,Passenger Rail,trn_pass,S3S,linear,6.222e-03,3.111e-03,1.867e-03,9.572e-04,9.572e-04
+SSP1,CHA,,,,,Walk,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,CHA,,,,,trn_freight_road,trn_freight,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP1,CHA,,,,,trn_pass_road,trn_pass,S3S,linear,1.000e+00,4.557e-01,2.279e-01,5.843e-02,5.843e-02
-SSP1,CHA,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,3.816e-01,1.915e-01,1.705e-01,1.895e-01,1.895e-01
+SSP1,CHA,,,,,trn_pass_road,trn_pass,S3S,linear,6.711e-01,2.684e-01,1.342e-01,4.015e-02,4.015e-02
+SSP1,CHA,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,6.609e-01,2.927e-01,2.084e-01,9.649e-02,9.649e-02
 SSP1,CHA,,,,trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP1,CHA,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.081e-02,9.523e-03,6.956e-03,1.824e-03,1.824e-03
+SSP1,CHA,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,2.702e-01,2.116e-01,1.391e-01,1.459e-01,1.459e-01
 SSP1,CHA,,,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP1,CHA,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,3.616e-01,3.616e-01,3.616e-01,3.616e-01,3.616e-01
+SSP1,CHA,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,8.035e-01,7.232e-01,6.574e-01,5.563e-01,5.563e-01
 SSP1,CHA,,Large Car and SUV,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP1,CHA,,Mini Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,8.023e-03,8.023e-03,8.023e-03,8.023e-03,8.023e-03
+SSP1,CHA,,Mini Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.783e-02,1.605e-02,1.459e-02,1.234e-02,1.234e-02
 SSP1,CHA,,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,4.044e-02,4.044e-02,4.044e-02,4.044e-02,4.044e-02
 SSP1,CHA,,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,CHA,,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP1,CHA,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,3.898e-02,3.898e-02,3.898e-02,3.898e-02,3.898e-02
+SSP1,CHA,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,8.662e-02,7.795e-02,7.087e-02,5.996e-02,5.996e-02
 SSP1,CHA,,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,CHA,,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,2.234e-01,2.234e-01,2.234e-01,2.234e-01,2.234e-01
-SSP1,CHA,,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,4.469e-01,3.352e-01,3.352e-01,3.352e-01,3.352e-01
-SSP1,CHA,,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,4.469e-01,3.352e-01,3.352e-01,3.352e-01,3.352e-01
+SSP1,CHA,,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,4.022e-01,3.352e-01,3.016e-01,3.352e-01,3.352e-01
+SSP1,CHA,,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,4.022e-01,3.352e-01,3.016e-01,3.352e-01,3.352e-01
 SSP1,CHA,,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.657e-01,1.657e-01,1.657e-01,1.657e-01,1.657e-01
-SSP1,CHA,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP1,CHA,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,8.402e-02,8.402e-02,8.402e-02,8.402e-02,8.402e-02
-SSP1,CHA,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP1,CHA,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,3.320e-01,1.000e+00,1.000e+00,1.000e+00
+SSP1,CHA,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,6.000e-01,1.000e+00,1.000e+00,1.000e+00
+SSP1,CHA,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,6.000e-02,6.000e-01,1.000e+00,1.000e+00,1.000e+00
+SSP1,CHA,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,6.000e-01,1.000e+00,1.000e+00,1.000e+00
+SSP1,CHA,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,3.019e-01,1.000e+00,1.000e+00,1.000e+00
 SSP1,CHA,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,4.553e-01,5.234e-01,6.595e-01,9.319e-01,9.319e-01
 SSP1,CHA,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,CHA,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,4.158e-01,4.888e-01,6.349e-01,9.270e-01,9.270e-01
-SSP1,CHA,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.768e-02,4.500e-01,9.820e-01,9.820e-01
-SSP1,CHA,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.897e-02,2.420e-01,9.526e-01,9.526e-01
-SSP1,CHA,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e-01,4.000e-01,9.000e-01,1.000e+00,1.000e+00
-SSP1,CHA,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e-01,4.000e-01,9.000e-01,1.000e+00,1.000e+00
-SSP1,CHA,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.768e-02,4.500e-01,9.820e-01,9.820e-01
-SSP1,CHA,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.225e-02,6.688e-02,6.999e-02,6.999e-02
-SSP1,CHA,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.339e-03,2.846e-02,1.462e-01,1.462e-01
-SSP1,CHA,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.945e-04,1.079e-02,1.000e-01,1.000e-01
-SSP1,CHA,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e-02,2.000e-01,6.000e-01,2.000e-01,2.000e-01
-SSP1,CHA,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e-02,2.000e-01,6.000e-01,2.000e-01,2.000e-01
-SSP1,CHA,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.339e-03,2.846e-02,1.462e-01,1.462e-01
+SSP1,CHA,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.002e-02,3.725e-01,8.768e-01,8.768e-01
+SSP1,CHA,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.592e-02,2.004e-01,8.505e-01,8.505e-01
+SSP1,CHA,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,9.920e-02,3.358e-01,7.450e-01,8.928e-01,8.928e-01
+SSP1,CHA,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,9.920e-02,3.358e-01,7.450e-01,8.928e-01,8.928e-01
+SSP1,CHA,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.002e-02,3.725e-01,8.768e-01,8.768e-01
+SSP1,CHA,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.024e-02,9.554e-02,6.999e-02,6.999e-02
+SSP1,CHA,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.124e-03,1.713e-02,1.450e-01,1.450e-01
+SSP1,CHA,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.151e-04,6.497e-03,9.920e-02,9.920e-02
+SSP1,CHA,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,9.920e-03,1.679e-01,3.612e-01,1.984e-01,1.984e-01
+SSP1,CHA,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,9.920e-03,1.679e-01,3.612e-01,1.984e-01,1.984e-01
+SSP1,CHA,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.124e-03,1.713e-02,1.450e-01,1.450e-01
 SSP1,CHA,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0.000e+00,8.315e-07,4.540e-05,1.192e-01,1.192e-01
-SSP1,CHA,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,7.437e-01,3.499e-01,3.499e-01
+SSP1,CHA,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,9.736e-01,3.527e-01,3.527e-01
 SSP1,CHA,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,CHA,Liquids,Domestic Ship_tmp_vehicletype,Domestic Ship_tmp_subsector_L1,Domestic Ship_tmp_subsector_L2,Domestic Ship,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,CHA,Liquids,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,CHA,Liquids,International Aviation_tmp_vehicletype,International Aviation_tmp_subsector_L1,International Aviation_tmp_subsector_L2,International Aviation,trn_aviation_intl,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,CHA,Liquids,International Ship_tmp_vehicletype,International Ship_tmp_subsector_L1,International Ship_tmp_subsector_L2,International Ship,trn_shipping_intl,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP1,CHA,Liquids,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP1,CHA,Liquids,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP1,CHA,Liquids,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
+SSP1,CHA,Liquids,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,8.333e-01,6.803e-01,6.803e-01
+SSP1,CHA,Liquids,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,8.333e-01,6.803e-01,6.803e-01
+SSP1,CHA,Liquids,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,8.333e-01,6.803e-01,6.803e-01
 SSP1,CHA,Liquids,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,CHA,Liquids,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,CHA,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,CHA,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,CHA,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,CHA,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP1,CHA,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.421e-01,1.594e-01,9.020e-02,1.152e-01,1.152e-01
-SSP1,CHA,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.878e-05,1.319e-02,5.530e-02,9.213e-02,9.213e-02
-SSP1,CHA,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,7.854e-04,1.443e-02,5.695e-02,9.317e-02,9.317e-02
-SSP1,CHA,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,3.000e-01,5.000e-01,7.000e-01,5.000e-01,5.000e-01
-SSP1,CHA,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,3.000e-01,5.000e-01,7.000e-01,5.000e-01,5.000e-01
-SSP1,CHA,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,3.309e-04,1.369e-02,5.597e-02,9.256e-02,9.256e-02
+SSP1,CHA,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.421e-01,1.329e-01,1.181e-01,1.055e-01,1.055e-01
+SSP1,CHA,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.707e-05,1.014e-02,3.814e-02,8.376e-02,8.376e-02
+SSP1,CHA,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,7.140e-04,1.110e-02,3.928e-02,8.470e-02,8.470e-02
+SSP1,CHA,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,2.727e-01,3.846e-01,4.828e-01,4.545e-01,4.545e-01
+SSP1,CHA,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,2.727e-01,3.846e-01,4.828e-01,4.545e-01,4.545e-01
+SSP1,CHA,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,3.008e-04,1.053e-02,3.860e-02,8.414e-02,8.414e-02
 SSP1,DEU,,,,,Cycle,trn_pass,S3S,linear,2.500e-02,2.500e-02,2.500e-02,1.875e-01,1.875e-01
-SSP1,DEU,,,,,Domestic Aviation,trn_pass,S3S,linear,6.250e-05,6.250e-05,6.250e-05,6.250e-05,6.250e-05
-SSP1,DEU,,,,,Domestic Ship,trn_freight,S3S,linear,2.088e-03,2.088e-03,2.088e-03,2.088e-03,2.088e-03
-SSP1,DEU,,,,,Freight Rail,trn_freight,S3S,linear,2.749e-02,2.749e-02,2.749e-02,2.749e-02,2.749e-02
+SSP1,DEU,,,,,Domestic Aviation,trn_pass,S3S,linear,5.965e-05,5.965e-05,5.965e-05,5.965e-05,5.965e-05
+SSP1,DEU,,,,,Domestic Ship,trn_freight,S3S,linear,2.127e-03,2.127e-03,2.127e-03,2.127e-03,2.127e-03
+SSP1,DEU,,,,,Freight Rail,trn_freight,S3S,linear,2.800e-02,2.800e-02,2.800e-02,2.800e-02,2.800e-02
 SSP1,DEU,,,,,HSR,trn_pass,S3S,linear,1.250e-04,2.500e-04,6.250e-04,6.250e-04,6.250e-04
 SSP1,DEU,,,,,International Aviation,trn_aviation_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,DEU,,,,,International Ship,trn_shipping_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,DEU,,,,,Passenger Rail,trn_pass,S3S,linear,2.500e-03,3.750e-03,3.750e-03,3.750e-03,3.750e-03
 SSP1,DEU,,,,,Walk,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,DEU,,,,,trn_freight_road,trn_freight,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP1,DEU,,,,,trn_pass_road,trn_pass,S3S,linear,7.500e-02,7.500e-02,7.500e-02,7.500e-02,7.500e-02
-SSP1,DEU,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,8.000e-02,8.000e-02,8.000e-02,1.500e-01,1.500e-01
+SSP1,DEU,,,,,trn_pass_road,trn_pass,S3S,linear,7.363e-02,7.363e-02,7.363e-02,7.363e-02,7.363e-02
+SSP1,DEU,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,8.149e-02,8.149e-02,8.149e-02,1.528e-01,1.528e-01
 SSP1,DEU,,,,trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,DEU,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,3.054e-02,3.054e-02,3.054e-02,3.054e-02,3.054e-02
 SSP1,DEU,,,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP1,DEU,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,4.724e-01,4.724e-01,4.724e-01,4.724e-01,4.724e-01
+SSP1,DEU,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,5.249e-01,5.249e-01,4.724e-01,4.724e-01,4.724e-01
 SSP1,DEU,,Large Car and SUV,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,DEU,,Midsize Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,2.716e-01,2.716e-01,2.716e-01,2.716e-01,2.716e-01
 SSP1,DEU,,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,2.183e-01,2.183e-01,2.183e-01,2.183e-01,2.183e-01
 SSP1,DEU,,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,6.630e-03,6.630e-03,6.630e-03,6.630e-03,6.630e-03
 SSP1,DEU,,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP1,DEU,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,4.803e-01,4.803e-01,4.803e-01,4.803e-01,4.803e-01
+SSP1,DEU,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,5.337e-01,5.337e-01,4.803e-01,4.803e-01,4.803e-01
 SSP1,DEU,,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,4.427e-01,4.427e-01,4.427e-01,4.427e-01,4.427e-01
 SSP1,DEU,,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,8.345e-02,8.345e-02,8.345e-02,8.345e-02,8.345e-02
 SSP1,DEU,,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,2.127e-01,2.127e-01,2.127e-01,2.127e-01,2.127e-01
 SSP1,DEU,,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,4.934e-01,4.934e-01,4.934e-01,4.934e-01,4.934e-01
 SSP1,DEU,,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP1,DEU,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP1,DEU,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP1,DEU,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP1,DEU,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.423e-01,4.034e-01,8.573e-01,8.573e-01
+SSP1,DEU,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.000e-02,2.500e-01,4.500e-01,4.500e-01
+SSP1,DEU,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.000e-02,2.500e-01,4.500e-01,4.500e-01
+SSP1,DEU,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.000e-02,2.500e-01,4.500e-01,4.500e-01
+SSP1,DEU,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.294e-01,3.669e-01,7.798e-01,7.798e-01
 SSP1,DEU,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,DEU,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,DEU,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP1,DEU,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.980e-01,6.750e-01,9.820e-01,9.820e-01
-SSP1,DEU,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.186e-01,3.631e-01,9.526e-01,9.526e-01
-SSP1,DEU,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.186e-01,3.631e-01,9.526e-01,9.526e-01
-SSP1,DEU,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.186e-01,3.631e-01,9.526e-01,9.526e-01
-SSP1,DEU,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.980e-01,6.750e-01,9.820e-01,9.820e-01
-SSP1,DEU,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.473e-03,1.799e-02,5.000e-02,5.000e-02
-SSP1,DEU,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,8.031e-02,3.320e-01,2.193e-01,2.193e-01
-SSP1,DEU,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.967e-02,1.259e-01,1.500e-01,1.500e-01
-SSP1,DEU,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.967e-02,1.259e-01,1.500e-01,1.500e-01
-SSP1,DEU,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.967e-02,1.259e-01,1.500e-01,1.500e-01
-SSP1,DEU,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,8.031e-02,3.320e-01,2.193e-01,2.193e-01
+SSP1,DEU,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.524e-01,6.784e-01,8.709e-01,8.709e-01
+SSP1,DEU,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.402e-01,3.649e-01,8.448e-01,8.448e-01
+SSP1,DEU,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.402e-01,3.649e-01,8.448e-01,8.448e-01
+SSP1,DEU,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.402e-01,3.649e-01,8.448e-01,8.448e-01
+SSP1,DEU,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.524e-01,6.784e-01,8.709e-01,8.709e-01
+SSP1,DEU,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.249e-03,1.636e-02,4.548e-02,4.548e-02
+SSP1,DEU,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,9.497e-02,3.925e-01,1.837e-01,1.837e-01
+SSP1,DEU,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.508e-02,1.489e-01,1.257e-01,1.257e-01
+SSP1,DEU,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.508e-02,1.489e-01,1.257e-01,1.257e-01
+SSP1,DEU,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.508e-02,1.489e-01,1.257e-01,1.257e-01
+SSP1,DEU,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,9.497e-02,3.925e-01,1.837e-01,1.837e-01
 SSP1,DEU,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0.000e+00,8.315e-07,4.540e-05,1.192e-01,1.192e-01
 SSP1,DEU,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,DEU,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
@@ -5882,59 +5882,59 @@ SSP1,DEU,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_
 SSP1,DEU,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,DEU,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,DEU,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP1,DEU,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,3.948e-02,6.475e-02,1.153e-01,1.731e-01,1.731e-01
-SSP1,DEU,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,2.615e-02,4.142e-02,1.030e-01,2.055e-01,2.055e-01
-SSP1,DEU,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.105e-02,7.895e-02,1.842e-01,1.842e-01
-SSP1,DEU,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.105e-02,7.895e-02,1.842e-01,1.842e-01
-SSP1,DEU,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.105e-02,7.895e-02,1.842e-01,1.842e-01
-SSP1,DEU,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.105e-02,7.895e-02,1.842e-01,1.842e-01
+SSP1,DEU,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,3.948e-02,4.981e-02,8.870e-02,1.332e-01,1.332e-01
+SSP1,DEU,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,2.615e-02,4.142e-02,1.030e-01,1.713e-01,1.713e-01
+SSP1,DEU,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.105e-02,7.895e-02,1.535e-01,1.535e-01
+SSP1,DEU,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.105e-02,7.895e-02,1.535e-01,1.535e-01
+SSP1,DEU,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.105e-02,7.895e-02,1.535e-01,1.535e-01
+SSP1,DEU,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.105e-02,7.895e-02,1.535e-01,1.535e-01
 SSP1,ECE,,,,,Cycle,trn_pass,S3S,linear,1.942e-02,1.942e-02,9.709e-02,1.092e-01,1.092e-01
-SSP1,ECE,,,,,Domestic Aviation,trn_pass,S3S,linear,7.313e-05,7.313e-05,7.313e-05,2.057e-05,2.057e-05
-SSP1,ECE,,,,,Domestic Ship,trn_freight,S3S,linear,3.893e-04,3.893e-04,3.893e-04,3.893e-04,3.893e-04
-SSP1,ECE,,,,,Freight Rail,trn_freight,S3S,linear,5.909e-02,5.909e-02,5.909e-02,5.909e-02,5.909e-02
+SSP1,ECE,,,,,Domestic Aviation,trn_pass,S3S,linear,6.979e-05,6.979e-05,6.979e-05,1.963e-05,1.963e-05
+SSP1,ECE,,,,,Domestic Ship,trn_freight,S3S,linear,3.966e-04,3.966e-04,3.966e-04,3.966e-04,3.966e-04
+SSP1,ECE,,,,,Freight Rail,trn_freight,S3S,linear,6.019e-02,6.019e-02,5.417e-02,5.417e-02,5.417e-02
 SSP1,ECE,,,,,HSR,trn_pass,S3S,linear,1.139e-04,1.708e-04,4.555e-04,3.202e-04,3.202e-04
 SSP1,ECE,,,,,International Aviation,trn_aviation_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,ECE,,,,,International Ship,trn_shipping_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,ECE,,,,,Passenger Rail,trn_pass,S3S,linear,6.799e-03,6.799e-03,9.065e-03,3.824e-03,3.824e-03
 SSP1,ECE,,,,,Walk,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,ECE,,,,,trn_freight_road,trn_freight,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP1,ECE,,,,,trn_pass_road,trn_pass,S3S,linear,8.972e-01,8.972e-01,7.177e-01,1.615e-01,1.615e-01
-SSP1,ECE,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,1.664e-01,1.664e-01,1.109e-01,1.109e-01,1.109e-01
+SSP1,ECE,,,,,trn_pass_road,trn_pass,S3S,linear,6.166e-01,6.166e-01,4.933e-01,1.268e-01,1.268e-01
+SSP1,ECE,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,2.712e-01,2.543e-01,1.469e-01,1.130e-01,1.130e-01
 SSP1,ECE,,,,trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,ECE,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,6.159e-03,6.159e-03,6.159e-03,6.159e-03,6.159e-03
 SSP1,ECE,,,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP1,ECE,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,3.451e-01,3.451e-01,3.451e-01,3.451e-01,3.451e-01
+SSP1,ECE,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,4.706e-01,4.706e-01,4.601e-01,4.314e-01,4.314e-01
 SSP1,ECE,,Large Car and SUV,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,7.825e-01,7.825e-01,7.825e-01,7.825e-01,7.825e-01
 SSP1,ECE,,Midsize Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,ECE,,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,5.321e-02,5.321e-02,5.321e-02,5.321e-02,5.321e-02
 SSP1,ECE,,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,4.728e-04,4.728e-04,4.728e-04,4.728e-04,4.728e-04
 SSP1,ECE,,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP1,ECE,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,4.683e-01,4.683e-01,4.683e-01,4.683e-01,4.683e-01
+SSP1,ECE,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,6.386e-01,6.386e-01,6.244e-01,5.854e-01,5.854e-01
 SSP1,ECE,,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,6.161e-01,6.161e-01,6.161e-01,6.161e-01,6.161e-01
 SSP1,ECE,,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.384e-01,1.384e-01,1.384e-01,1.384e-01,1.384e-01
 SSP1,ECE,,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.370e-01,1.370e-01,1.370e-01,1.370e-01,1.370e-01
 SSP1,ECE,,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.691e-01,1.691e-01,1.691e-01,1.691e-01,1.691e-01
 SSP1,ECE,,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP1,ECE,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP1,ECE,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP1,ECE,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP1,ECE,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.423e-01,5.379e-01,1.000e+00,1.000e+00
+SSP1,ECE,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.000e-02,1.900e-01,4.300e-01,4.300e-01
+SSP1,ECE,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.000e-02,1.900e-01,4.300e-01,4.300e-01
+SSP1,ECE,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.000e-02,1.900e-01,4.300e-01,4.300e-01
+SSP1,ECE,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.553e-01,5.283e-01,1.000e+00,1.000e+00
 SSP1,ECE,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,ECE,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,ECE,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP1,ECE,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.960e-02,1.500e-01,2.946e-01,2.946e-01
-SSP1,ECE,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.371e-02,8.068e-02,2.858e-01,2.858e-01
-SSP1,ECE,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.371e-02,8.068e-02,2.858e-01,2.858e-01
-SSP1,ECE,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.371e-02,8.068e-02,2.858e-01,2.858e-01
-SSP1,ECE,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.960e-02,1.500e-01,2.946e-01,2.946e-01
-SSP1,ECE,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.236e-02,1.799e-02,8.748e-02,8.748e-02
-SSP1,ECE,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.339e-02,4.743e-02,1.462e-01,1.462e-01
-SSP1,ECE,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.945e-03,1.799e-02,1.000e-01,1.000e-01
-SSP1,ECE,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.945e-03,1.799e-02,1.000e-01,1.000e-01
-SSP1,ECE,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.945e-03,1.799e-02,1.000e-01,1.000e-01
-SSP1,ECE,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.339e-02,4.743e-02,1.462e-01,1.462e-01
+SSP1,ECE,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.504e-02,1.455e-01,2.786e-01,2.786e-01
+SSP1,ECE,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.588e-02,7.826e-02,2.703e-01,2.703e-01
+SSP1,ECE,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.588e-02,7.826e-02,2.703e-01,2.703e-01
+SSP1,ECE,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.588e-02,7.826e-02,2.703e-01,2.703e-01
+SSP1,ECE,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.504e-02,1.455e-01,2.786e-01,2.786e-01
+SSP1,ECE,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.349e-02,1.963e-02,8.748e-02,8.748e-02
+SSP1,ECE,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.461e-02,5.750e-02,6.382e-02,6.382e-02
+SSP1,ECE,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.396e-03,2.181e-02,4.365e-02,4.365e-02
+SSP1,ECE,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.396e-03,2.181e-02,4.365e-02,4.365e-02
+SSP1,ECE,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.396e-03,2.181e-02,4.365e-02,4.365e-02
+SSP1,ECE,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.461e-02,5.750e-02,6.382e-02,6.382e-02
 SSP1,ECE,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0.000e+00,8.315e-07,4.540e-05,1.192e-01,1.192e-01
-SSP1,ECE,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,8.748e-01,8.748e-01
+SSP1,ECE,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,8.017e-01,8.017e-01
 SSP1,ECE,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,ECE,Liquids,Domestic Ship_tmp_vehicletype,Domestic Ship_tmp_subsector_L1,Domestic Ship_tmp_subsector_L2,Domestic Ship,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,ECE,Liquids,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,5.870e-01,5.870e-01,5.870e-01,5.870e-01,5.870e-01
@@ -5949,57 +5949,57 @@ SSP1,ECE,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_
 SSP1,ECE,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,ECE,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,ECE,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP1,ECE,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP1,ECE,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP1,ECE,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP1,ECE,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
+SSP1,ECE,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e-02,2.000e-02,7.000e-02,9.000e-02,9.000e-02
+SSP1,ECE,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.000e-02,1.111e-01,1.867e-01,1.867e-01
+SSP1,ECE,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.000e-02,1.111e-01,1.867e-01,1.867e-01
+SSP1,ECE,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.000e-02,1.111e-01,1.867e-01,1.867e-01
 SSP1,ECE,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP1,ECE,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP1,ECS,,,,,Cycle,trn_pass,S3S,linear,7.196e-03,2.159e-02,8.635e-02,8.738e-02,8.738e-02
-SSP1,ECS,,,,,Domestic Aviation,trn_pass,S3S,linear,2.566e-03,2.566e-03,2.566e-03,3.895e-04,3.895e-04
-SSP1,ECS,,,,,Domestic Ship,trn_freight,S3S,linear,3.878e-03,3.878e-03,3.878e-03,3.878e-03,3.878e-03
-SSP1,ECS,,,,,Freight Rail,trn_freight,S3S,linear,5.867e-02,5.867e-02,5.867e-02,5.867e-02,5.867e-02
-SSP1,ECS,,,,,HSR,trn_pass,S3S,linear,1.956e-04,1.956e-04,5.216e-04,4.000e-04,4.000e-04
+SSP1,ECE,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.000e-02,1.111e-01,1.867e-01,1.867e-01
+SSP1,ECS,,,,,Cycle,trn_pass,S3S,linear,1.092e-02,3.277e-02,1.311e-01,8.738e-02,8.738e-02
+SSP1,ECS,,,,,Domestic Aviation,trn_pass,S3S,linear,3.717e-03,3.717e-03,3.717e-03,3.717e-04,3.717e-04
+SSP1,ECS,,,,,Domestic Ship,trn_freight,S3S,linear,3.950e-03,3.950e-03,3.591e-03,3.950e-03,3.950e-03
+SSP1,ECS,,,,,Freight Rail,trn_freight,S3S,linear,5.976e-02,5.976e-02,5.433e-02,5.379e-02,5.379e-02
+SSP1,ECS,,,,,HSR,trn_pass,S3S,linear,2.969e-04,2.969e-04,7.917e-04,4.000e-04,4.000e-04
 SSP1,ECS,,,,,International Aviation,trn_aviation_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,ECS,,,,,International Ship,trn_shipping_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP1,ECS,,,,,Passenger Rail,trn_pass,S3S,linear,5.215e-03,6.953e-03,8.691e-03,2.638e-03,2.638e-03
-SSP1,ECS,,,,,Walk,trn_pass,S3S,linear,6.588e-01,6.588e-01,6.588e-01,1.000e+00,1.000e+00
+SSP1,ECS,,,,,Passenger Rail,trn_pass,S3S,linear,7.915e-03,1.055e-02,1.319e-02,2.638e-03,2.638e-03
+SSP1,ECS,,,,,Walk,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,ECS,,,,,trn_freight_road,trn_freight,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP1,ECS,,,,,trn_pass_road,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.518e-01,1.518e-01
-SSP1,ECS,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,1.140e-01,1.140e-01,7.980e-02,6.840e-02,6.840e-02
+SSP1,ECS,,,,,trn_pass_road,trn_pass,S3S,linear,7.451e-01,7.451e-01,7.451e-01,8.941e-02,8.941e-02
+SSP1,ECS,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,2.090e-01,1.742e-01,1.219e-01,1.045e-01,1.045e-01
 SSP1,ECS,,,,trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,ECS,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,2.175e-03,2.175e-03,2.175e-03,2.175e-03,2.175e-03
 SSP1,ECS,,,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP1,ECS,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,3.336e-01,3.336e-01,3.336e-01,3.336e-01,3.336e-01
+SSP1,ECS,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,5.004e-01,5.004e-01,5.004e-01,4.549e-01,4.549e-01
 SSP1,ECS,,Large Car and SUV,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,ECS,,Midsize Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,9.609e-01,9.609e-01,9.609e-01,9.609e-01,9.609e-01
 SSP1,ECS,,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.125e-01,1.125e-01,1.125e-01,1.125e-01,1.125e-01
 SSP1,ECS,,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,3.579e-02,3.579e-02,3.579e-02,3.579e-02,3.579e-02
 SSP1,ECS,,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP1,ECS,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,6.520e-01,6.520e-01,6.520e-01,6.520e-01,6.520e-01
+SSP1,ECS,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,9.780e-01,9.780e-01,9.780e-01,8.891e-01,8.891e-01
 SSP1,ECS,,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,ECS,,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,2.555e-01,2.555e-01,2.555e-01,2.555e-01,2.555e-01
 SSP1,ECS,,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,3.104e-01,3.104e-01,3.104e-01,3.104e-01,3.104e-01
 SSP1,ECS,,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.282e-01,1.282e-01,1.282e-01,1.282e-01,1.282e-01
 SSP1,ECS,,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,4.409e-01,4.409e-01,4.409e-01,4.409e-01,4.409e-01
-SSP1,ECS,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP1,ECS,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP1,ECS,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP1,ECS,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.743e-02,3.496e-01,8.573e-01,8.573e-01
+SSP1,ECS,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,3.200e-02,1.920e-01,4.200e-01,4.200e-01
+SSP1,ECS,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,3.200e-02,1.920e-01,4.200e-01,4.200e-01
+SSP1,ECS,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,3.200e-02,1.920e-01,4.200e-01,4.200e-01
+SSP1,ECS,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,9.315e-02,3.815e-01,8.420e-01,8.420e-01
 SSP1,ECS,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,ECS,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,ECS,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP1,ECS,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.192e-01,2.500e-01,2.946e-01,2.946e-01
-SSP1,ECS,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.743e-02,1.345e-01,2.858e-01,2.858e-01
-SSP1,ECS,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.743e-02,1.345e-01,2.858e-01,2.858e-01
-SSP1,ECS,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.743e-02,1.345e-01,2.858e-01,2.858e-01
-SSP1,ECS,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.192e-01,2.500e-01,2.946e-01,2.946e-01
-SSP1,ECS,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.473e-03,5.396e-02,1.000e-01,1.000e-01
-SSP1,ECS,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.339e-02,4.743e-02,7.311e-02,7.311e-02
-SSP1,ECS,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.945e-03,1.799e-02,5.000e-02,5.000e-02
-SSP1,ECS,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.945e-03,1.799e-02,5.000e-02,5.000e-02
-SSP1,ECS,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.945e-03,1.799e-02,5.000e-02,5.000e-02
-SSP1,ECS,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.339e-02,4.743e-02,7.311e-02,7.311e-02
+SSP1,ECS,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.041e-01,2.182e-01,2.893e-01,2.893e-01
+SSP1,ECS,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.140e-02,1.174e-01,2.807e-01,2.807e-01
+SSP1,ECS,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.140e-02,1.174e-01,2.807e-01,2.807e-01
+SSP1,ECS,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.140e-02,1.174e-01,2.807e-01,2.807e-01
+SSP1,ECS,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.041e-01,2.182e-01,2.893e-01,2.893e-01
+SSP1,ECS,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.698e-03,7.360e-02,1.091e-01,1.091e-01
+SSP1,ECS,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.461e-02,6.900e-02,7.977e-02,7.977e-02
+SSP1,ECS,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.396e-03,2.617e-02,5.456e-02,5.456e-02
+SSP1,ECS,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.396e-03,2.617e-02,5.456e-02,5.456e-02
+SSP1,ECS,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.396e-03,2.617e-02,5.456e-02,5.456e-02
+SSP1,ECS,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.461e-02,6.900e-02,7.977e-02,7.977e-02
 SSP1,ECS,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0.000e+00,8.315e-07,4.540e-05,1.192e-01,1.192e-01
 SSP1,ECS,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,ECS,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
@@ -6016,61 +6016,61 @@ SSP1,ECS,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_
 SSP1,ECS,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,ECS,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,ECS,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP1,ECS,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP1,ECS,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP1,ECS,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP1,ECS,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP1,ECS,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP1,ECS,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
+SSP1,ECS,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e-02,2.000e-02,6.250e-02,1.000e-01,1.000e-01
+SSP1,ECS,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e-05,1.300e-02,6.667e-02,1.400e-01,1.400e-01
+SSP1,ECS,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e-05,1.300e-02,6.667e-02,1.400e-01,1.400e-01
+SSP1,ECS,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e-05,1.300e-02,6.667e-02,1.400e-01,1.400e-01
+SSP1,ECS,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e-05,1.300e-02,6.667e-02,1.400e-01,1.400e-01
+SSP1,ECS,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e-05,1.300e-02,6.667e-02,1.400e-01,1.400e-01
 SSP1,ENC,,,,,Cycle,trn_pass,S3S,linear,2.500e-02,2.500e-02,5.556e-02,1.000e-01,1.000e-01
-SSP1,ENC,,,,,Domestic Aviation,trn_pass,S3S,linear,6.250e-05,6.250e-05,5.556e-05,2.500e-05,2.500e-05
-SSP1,ENC,,,,,Domestic Ship,trn_freight,S3S,linear,1.223e-02,1.223e-02,1.223e-02,1.223e-02,1.223e-02
-SSP1,ENC,,,,,Freight Rail,trn_freight,S3S,linear,2.875e-02,2.875e-02,2.875e-02,2.875e-02,2.875e-02
+SSP1,ENC,,,,,Domestic Aviation,trn_pass,S3S,linear,5.965e-05,5.965e-05,5.302e-05,2.386e-05,2.386e-05
+SSP1,ENC,,,,,Domestic Ship,trn_freight,S3S,linear,1.246e-02,1.246e-02,1.246e-02,1.246e-02,1.246e-02
+SSP1,ENC,,,,,Freight Rail,trn_freight,S3S,linear,2.928e-02,2.928e-02,2.928e-02,2.928e-02,2.928e-02
 SSP1,ENC,,,,,HSR,trn_pass,S3S,linear,1.250e-04,2.500e-04,2.222e-04,2.000e-04,2.000e-04
 SSP1,ENC,,,,,International Aviation,trn_aviation_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,ENC,,,,,International Ship,trn_shipping_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,ENC,,,,,Passenger Rail,trn_pass,S3S,linear,3.125e-03,3.125e-03,3.333e-03,2.000e-03,2.000e-03
 SSP1,ENC,,,,,Walk,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,ENC,,,,,trn_freight_road,trn_freight,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP1,ENC,,,,,trn_pass_road,trn_pass,S3S,linear,7.500e-02,7.500e-02,6.667e-02,3.000e-02,3.000e-02
-SSP1,ENC,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,2.000e-01,1.500e-01,1.500e-01,1.500e-01,1.500e-01
+SSP1,ENC,,,,,trn_pass_road,trn_pass,S3S,linear,7.363e-02,7.363e-02,6.545e-02,2.945e-02,2.945e-02
+SSP1,ENC,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,2.037e-01,1.528e-01,1.528e-01,1.528e-01,1.528e-01
 SSP1,ENC,,,,trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,ENC,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,3.014e-02,3.014e-02,3.014e-02,3.014e-02,3.014e-02
 SSP1,ENC,,,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP1,ENC,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,3.559e-01,3.559e-01,3.559e-01,3.559e-01,3.559e-01
+SSP1,ENC,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,3.955e-01,3.955e-01,3.955e-01,3.559e-01,3.559e-01
 SSP1,ENC,,Large Car and SUV,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,ENC,,Midsize Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.960e-01,1.960e-01,1.960e-01,1.960e-01,1.960e-01
-SSP1,ENC,,Mini Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,2.357e-07,2.357e-07,2.357e-07,2.357e-07,2.357e-07
+SSP1,ENC,,Mini Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,2.619e-07,2.619e-07,2.619e-07,2.357e-07,2.357e-07
 SSP1,ENC,,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.576e-01,1.576e-01,1.576e-01,1.576e-01,1.576e-01
 SSP1,ENC,,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,3.751e-02,3.751e-02,3.751e-02,3.751e-02,3.751e-02
 SSP1,ENC,,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP1,ENC,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.963e-01,1.963e-01,1.963e-01,1.963e-01,1.963e-01
+SSP1,ENC,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,2.181e-01,2.181e-01,2.181e-01,1.963e-01,1.963e-01
 SSP1,ENC,,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,ENC,,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.002e-01,1.002e-01,1.002e-01,1.002e-01,1.002e-01
 SSP1,ENC,,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,3.593e-01,3.593e-01,3.593e-01,3.593e-01,3.593e-01
 SSP1,ENC,,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,4.374e-01,4.374e-01,4.374e-01,4.374e-01,4.374e-01
 SSP1,ENC,,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,4.946e-01,4.946e-01,4.946e-01,4.946e-01,4.946e-01
 SSP1,ENC,,Van,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.049e-03,1.049e-03,1.049e-03,1.049e-03,1.049e-03
-SSP1,ENC,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP1,ENC,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP1,ENC,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP1,ENC,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.371e-01,6.724e-01,1.000e+00,1.000e+00
+SSP1,ENC,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,5.000e-02,2.300e-01,5.000e-01,5.000e-01
+SSP1,ENC,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,5.000e-02,2.300e-01,5.000e-01,5.000e-01
+SSP1,ENC,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,5.000e-02,2.300e-01,5.000e-01,5.000e-01
+SSP1,ENC,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.157e-01,7.227e-01,1.000e+00,1.000e+00
 SSP1,ENC,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,ENC,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,ENC,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP1,ENC,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.622e-01,6.000e-01,9.820e-01,9.820e-01
-SSP1,ENC,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.043e-01,3.227e-01,9.526e-01,9.526e-01
-SSP1,ENC,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.043e-01,3.227e-01,9.526e-01,9.526e-01
-SSP1,ENC,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.043e-01,3.227e-01,9.526e-01,9.526e-01
-SSP1,ENC,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.622e-01,6.000e-01,9.820e-01,9.820e-01
-SSP1,ENC,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.236e-02,5.396e-02,1.312e-01,1.312e-01
-SSP1,ENC,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.693e-02,2.371e-01,1.462e-01,1.462e-01
-SSP1,ENC,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-02,8.993e-02,1.000e-01,1.000e-01
-SSP1,ENC,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-02,8.993e-02,1.000e-01,1.000e-01
-SSP1,ENC,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-02,8.993e-02,1.000e-01,1.000e-01
-SSP1,ENC,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.693e-02,2.371e-01,1.462e-01,1.462e-01
+SSP1,ENC,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.101e-01,6.386e-01,9.289e-01,9.289e-01
+SSP1,ENC,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.234e-01,3.434e-01,9.011e-01,9.011e-01
+SSP1,ENC,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.234e-01,3.434e-01,9.011e-01,9.011e-01
+SSP1,ENC,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.234e-01,3.434e-01,9.011e-01,9.011e-01
+SSP1,ENC,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.101e-01,6.386e-01,9.289e-01,9.289e-01
+SSP1,ENC,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.124e-02,5.800e-02,1.021e-01,1.021e-01
+SSP1,ENC,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,7.914e-02,2.804e-01,1.729e-01,1.729e-01
+SSP1,ENC,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.924e-02,1.063e-01,1.183e-01,1.183e-01
+SSP1,ENC,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.924e-02,1.063e-01,1.183e-01,1.183e-01
+SSP1,ENC,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.924e-02,1.063e-01,1.183e-01,1.183e-01
+SSP1,ENC,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,7.914e-02,2.804e-01,1.729e-01,1.729e-01
 SSP1,ENC,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0.000e+00,8.315e-07,4.540e-05,1.192e-01,1.192e-01
-SSP1,ENC,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,5.249e-01,5.249e-01
+SSP1,ENC,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,5.426e-01,5.426e-01
 SSP1,ENC,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,ENC,Liquids,Domestic Ship_tmp_vehicletype,Domestic Ship_tmp_subsector_L1,Domestic Ship_tmp_subsector_L2,Domestic Ship,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,ENC,Liquids,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1.341e-01,1.341e-01,1.341e-01,1.341e-01,1.341e-01
@@ -6085,30 +6085,30 @@ SSP1,ENC,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_
 SSP1,ENC,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,ENC,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,ENC,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP1,ENC,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,2.533e-02,5.098e-02,1.023e-01,1.075e-01,1.075e-01
+SSP1,ENC,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,2.533e-02,3.921e-02,9.298e-02,1.011e-01,1.011e-01
 SSP1,ENC,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
 SSP1,ENC,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
 SSP1,ENC,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
 SSP1,ENC,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
 SSP1,ENC,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
 SSP1,ESC,,,,,Cycle,trn_pass,S3S,linear,1.942e-02,2.184e-02,4.369e-02,1.638e-01,1.638e-01
-SSP1,ESC,,,,,Domestic Aviation,trn_pass,S3S,linear,1.347e-04,3.789e-05,3.789e-05,7.579e-05,7.579e-05
-SSP1,ESC,,,,,Domestic Ship,trn_freight,S3S,linear,1.187e-02,1.187e-02,1.187e-02,1.187e-02,1.187e-02
-SSP1,ESC,,,,,Freight Rail,trn_freight,S3S,linear,4.020e-03,4.020e-03,4.020e-03,4.020e-03,4.020e-03
+SSP1,ESC,,,,,Domestic Aviation,trn_pass,S3S,linear,1.286e-04,3.616e-05,3.616e-05,7.233e-05,7.233e-05
+SSP1,ESC,,,,,Domestic Ship,trn_freight,S3S,linear,1.209e-02,1.209e-02,1.209e-02,1.209e-02,1.209e-02
+SSP1,ESC,,,,,Freight Rail,trn_freight,S3S,linear,4.094e-03,4.094e-03,4.094e-03,4.094e-03,4.094e-03
 SSP1,ESC,,,,,HSR,trn_pass,S3S,linear,6.613e-04,1.860e-04,6.200e-04,6.200e-04,6.200e-04
 SSP1,ESC,,,,,International Aviation,trn_aviation_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,ESC,,,,,International Ship,trn_shipping_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,ESC,,,,,Passenger Rail,trn_pass,S3S,linear,3.195e-03,2.696e-03,2.696e-03,4.044e-03,4.044e-03
 SSP1,ESC,,,,,Walk,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,ESC,,,,,trn_freight_road,trn_freight,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP1,ESC,,,,,trn_pass_road,trn_pass,S3S,linear,1.832e-01,1.030e-01,8.242e-02,6.594e-02,6.594e-02
-SSP1,ESC,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,6.591e-02,6.591e-02,6.591e-02,9.887e-02,9.887e-02
+SSP1,ESC,,,,,trn_pass_road,trn_pass,S3S,linear,1.798e-01,1.011e-01,8.092e-02,6.473e-02,6.473e-02
+SSP1,ESC,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,6.714e-02,6.714e-02,6.714e-02,1.007e-01,1.007e-01
 SSP1,ESC,,,,trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP1,ESC,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.687e-01,1.687e-01,1.687e-01,1.687e-01,1.687e-01
+SSP1,ESC,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.205e-01,1.125e-01,1.125e-01,1.125e-01,1.125e-01
 SSP1,ESC,,,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,ESC,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,3.942e-01,3.942e-01,3.942e-01,3.942e-01,3.942e-01
-SSP1,ESC,,Large Car and SUV,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,8.712e-01,8.712e-01,8.712e-01,8.712e-01,8.712e-01
-SSP1,ESC,,Midsize Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,2.323e-01,2.323e-01,2.323e-01,2.323e-01,2.323e-01
+SSP1,ESC,,Large Car and SUV,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,8.712e-01,7.840e-01,8.712e-01,8.712e-01,8.712e-01
+SSP1,ESC,,Midsize Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,2.323e-01,2.091e-01,2.323e-01,2.323e-01,2.323e-01
 SSP1,ESC,,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.009e-01,1.009e-01,1.009e-01,1.009e-01,1.009e-01
 SSP1,ESC,,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,6.375e-02,6.375e-02,6.375e-02,6.375e-02,6.375e-02
 SSP1,ESC,,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
@@ -6118,24 +6118,24 @@ SSP1,ESC,,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_sub
 SSP1,ESC,,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,2.234e-01,2.234e-01,2.234e-01,2.234e-01,2.234e-01
 SSP1,ESC,,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,2.172e-01,2.172e-01,2.172e-01,2.172e-01,2.172e-01
 SSP1,ESC,,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP1,ESC,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP1,ESC,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP1,ESC,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP1,ESC,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.423e-01,4.034e-01,9.526e-01,9.526e-01
+SSP1,ESC,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.000e-02,2.200e-01,4.200e-01,4.200e-01
+SSP1,ESC,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.000e-02,2.200e-01,4.200e-01,4.200e-01
+SSP1,ESC,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.000e-02,2.200e-01,4.200e-01,4.200e-01
+SSP1,ESC,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.359e-01,3.816e-01,8.448e-01,8.448e-01
 SSP1,ESC,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,ESC,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,ESC,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP1,ESC,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.384e-01,5.000e-01,9.820e-01,9.820e-01
-SSP1,ESC,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,9.485e-02,2.689e-01,9.526e-01,9.526e-01
-SSP1,ESC,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,9.485e-02,2.689e-01,9.526e-01,9.526e-01
-SSP1,ESC,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,9.485e-02,2.689e-01,9.526e-01,9.526e-01
-SSP1,ESC,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.384e-01,5.000e-01,9.820e-01,9.820e-01
-SSP1,ESC,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.236e-02,5.396e-02,1.000e-01,1.000e-01
-SSP1,ESC,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.693e-02,4.743e-02,1.462e-01,1.462e-01
-SSP1,ESC,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-02,1.799e-02,1.000e-01,1.000e-01
-SSP1,ESC,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-02,1.799e-02,1.000e-01,1.000e-01
-SSP1,ESC,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-02,1.799e-02,1.000e-01,1.000e-01
-SSP1,ESC,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.693e-02,4.743e-02,1.462e-01,1.462e-01
+SSP1,ESC,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.819e-01,5.321e-01,7.741e-01,7.741e-01
+SSP1,ESC,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.122e-01,2.862e-01,7.509e-01,7.509e-01
+SSP1,ESC,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.122e-01,2.862e-01,7.509e-01,7.509e-01
+SSP1,ESC,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.122e-01,2.862e-01,7.509e-01,7.509e-01
+SSP1,ESC,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.819e-01,5.321e-01,7.741e-01,7.741e-01
+SSP1,ESC,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.124e-02,6.380e-02,7.883e-02,7.883e-02
+SSP1,ESC,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,7.914e-02,5.608e-02,1.441e-01,1.441e-01
+SSP1,ESC,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.924e-02,2.127e-02,9.854e-02,9.854e-02
+SSP1,ESC,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.924e-02,2.127e-02,9.854e-02,9.854e-02
+SSP1,ESC,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.924e-02,2.127e-02,9.854e-02,9.854e-02
+SSP1,ESC,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,7.914e-02,5.608e-02,1.441e-01,1.441e-01
 SSP1,ESC,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0.000e+00,8.315e-07,4.540e-05,1.192e-01,1.192e-01
 SSP1,ESC,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,ESC,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
@@ -6152,57 +6152,57 @@ SSP1,ESC,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_
 SSP1,ESC,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,ESC,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,ESC,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP1,ESC,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,2.742e-02,5.301e-02,1.042e-01,2.066e-01,2.066e-01
-SSP1,ESC,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SSP1,ESC,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SSP1,ESC,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SSP1,ESC,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SSP1,ESC,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
+SSP1,ESC,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,2.742e-02,4.078e-02,1.042e-01,1.721e-01,1.721e-01
+SSP1,ESC,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.535e-01,1.535e-01
+SSP1,ESC,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.535e-01,1.535e-01
+SSP1,ESC,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.535e-01,1.535e-01
+SSP1,ESC,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.535e-01,1.535e-01
+SSP1,ESC,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.535e-01,1.535e-01
 SSP1,ESW,,,,,Cycle,trn_pass,S3S,linear,1.942e-02,3.884e-02,5.825e-02,1.019e-01,1.019e-01
-SSP1,ESW,,,,,Domestic Aviation,trn_pass,S3S,linear,7.179e-04,7.179e-04,5.744e-04,1.346e-04,1.346e-04
-SSP1,ESW,,,,,Domestic Ship,trn_freight,S3S,linear,6.018e-03,6.018e-03,6.018e-03,6.018e-03,6.018e-03
-SSP1,ESW,,,,,Freight Rail,trn_freight,S3S,linear,1.394e-02,1.394e-02,1.394e-02,1.394e-02,1.394e-02
+SSP1,ESW,,,,,Domestic Aviation,trn_pass,S3S,linear,6.852e-04,6.852e-04,5.482e-04,1.285e-04,1.285e-04
+SSP1,ESW,,,,,Domestic Ship,trn_freight,S3S,linear,6.130e-03,6.130e-03,6.130e-03,6.130e-03,6.130e-03
+SSP1,ESW,,,,,Freight Rail,trn_freight,S3S,linear,1.420e-02,1.420e-02,1.420e-02,1.420e-02,1.420e-02
 SSP1,ESW,,,,,HSR,trn_pass,S3S,linear,9.579e-04,9.579e-04,9.579e-04,3.592e-04,3.592e-04
 SSP1,ESW,,,,,International Aviation,trn_aviation_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,ESW,,,,,International Ship,trn_shipping_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,ESW,,,,,Passenger Rail,trn_pass,S3S,linear,3.621e-03,3.621e-03,5.432e-03,2.037e-03,2.037e-03
 SSP1,ESW,,,,,Walk,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,ESW,,,,,trn_freight_road,trn_freight,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP1,ESW,,,,,trn_pass_road,trn_pass,S3S,linear,1.411e-01,1.129e-01,1.129e-01,3.175e-02,3.175e-02
-SSP1,ESW,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,5.667e-02,5.667e-02,7.083e-02,1.063e-01,1.063e-01
+SSP1,ESW,,,,,trn_pass_road,trn_pass,S3S,linear,1.385e-01,1.108e-01,1.108e-01,3.117e-02,3.117e-02
+SSP1,ESW,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,5.772e-02,5.772e-02,7.215e-02,1.082e-01,1.082e-01
 SSP1,ESW,,,,trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP1,ESW,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,8.570e-02,8.570e-02,8.570e-02,8.570e-02,8.570e-02
+SSP1,ESW,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,7.141e-02,7.141e-02,7.141e-02,6.592e-02,6.592e-02
 SSP1,ESW,,,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP1,ESW,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,5.153e-01,5.153e-01,5.153e-01,5.153e-01,5.153e-01
+SSP1,ESW,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,5.725e-01,5.725e-01,5.725e-01,5.725e-01,5.725e-01
 SSP1,ESW,,Large Car and SUV,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,ESW,,Midsize Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,2.963e-01,2.963e-01,2.963e-01,2.963e-01,2.963e-01
 SSP1,ESW,,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,9.741e-02,9.741e-02,9.741e-02,9.741e-02,9.741e-02
 SSP1,ESW,,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.669e-01,1.669e-01,1.669e-01,1.669e-01,1.669e-01
 SSP1,ESW,,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP1,ESW,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,4.003e-01,4.003e-01,4.003e-01,4.003e-01,4.003e-01
+SSP1,ESW,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,4.448e-01,4.448e-01,4.448e-01,4.448e-01,4.448e-01
 SSP1,ESW,,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,2.850e-01,2.850e-01,2.850e-01,2.850e-01,2.850e-01
 SSP1,ESW,,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,6.043e-02,6.043e-02,6.043e-02,6.043e-02,6.043e-02
 SSP1,ESW,,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,8.424e-02,8.424e-02,8.424e-02,8.424e-02,8.424e-02
 SSP1,ESW,,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,4.041e-01,4.041e-01,4.041e-01,4.041e-01,4.041e-01
 SSP1,ESW,,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP1,ESW,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP1,ESW,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP1,ESW,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP1,ESW,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.186e-01,2.689e-01,6.668e-01,6.668e-01
+SSP1,ESW,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.800e-02,2.160e-01,4.200e-01,4.200e-01
+SSP1,ESW,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.800e-02,2.160e-01,4.200e-01,4.200e-01
+SSP1,ESW,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.800e-02,2.160e-01,4.200e-01,4.200e-01
+SSP1,ESW,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.078e-02,1.164e-01,2.935e-01,6.237e-01,6.237e-01
 SSP1,ESW,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,7.295e-01,7.633e-01,8.309e-01,9.662e-01,9.662e-01
 SSP1,ESW,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,ESW,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP1,ESW,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.576e-01,7.000e-01,9.820e-01,9.820e-01
-SSP1,ESW,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.423e-01,3.765e-01,9.526e-01,9.526e-01
-SSP1,ESW,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.423e-01,3.765e-01,9.526e-01,9.526e-01
-SSP1,ESW,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.423e-01,3.765e-01,9.526e-01,9.526e-01
-SSP1,ESW,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.576e-01,7.000e-01,9.820e-01,9.820e-01
-SSP1,ESW,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.473e-03,1.799e-02,7.500e-02,7.500e-02
-SSP1,ESW,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.693e-02,2.371e-01,1.462e-01,1.462e-01
-SSP1,ESW,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-02,8.993e-02,1.000e-01,1.000e-01
-SSP1,ESW,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-02,8.993e-02,1.000e-01,1.000e-01
-SSP1,ESW,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-02,8.993e-02,1.000e-01,1.000e-01
-SSP1,ESW,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.693e-02,2.371e-01,1.462e-01,1.462e-01
+SSP1,ESW,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.902e-01,6.875e-01,1.000e+00,1.000e+00
+SSP1,ESW,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.553e-01,3.698e-01,1.000e+00,1.000e+00
+SSP1,ESW,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.553e-01,3.698e-01,1.000e+00,1.000e+00
+SSP1,ESW,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.553e-01,3.698e-01,1.000e+00,1.000e+00
+SSP1,ESW,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.902e-01,6.875e-01,1.000e+00,1.000e+00
+SSP1,ESW,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,2.248e-03,2.698e-03,1.963e-02,5.846e-02,5.846e-02
+SSP1,ESW,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,7.303e-02,2.588e-01,1.489e-01,1.489e-01
+SSP1,ESW,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.698e-02,9.813e-02,1.050e-01,1.050e-01
+SSP1,ESW,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.698e-02,9.813e-02,1.050e-01,1.050e-01
+SSP1,ESW,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.698e-02,9.813e-02,1.050e-01,1.050e-01
+SSP1,ESW,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,7.303e-02,2.588e-01,1.489e-01,1.489e-01
 SSP1,ESW,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0.000e+00,8.315e-07,4.540e-05,1.192e-01,1.192e-01
 SSP1,ESW,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,ESW,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
@@ -6214,39 +6214,39 @@ SSP1,ESW,Liquids,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_
 SSP1,ESW,Liquids,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,ESW,Liquids,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,ESW,Liquids,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,5.162e-01,5.162e-01,5.162e-01,5.162e-01,5.162e-01
-SSP1,ESW,Liquids,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP1,ESW,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP1,ESW,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP1,ESW,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP1,ESW,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP1,ESW,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SSP1,ESW,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SSP1,ESW,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SSP1,ESW,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SSP1,ESW,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SSP1,ESW,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
+SSP1,ESW,Liquids,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,9.332e-01,9.332e-01
+SSP1,ESW,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,9.620e-01,9.620e-01
+SSP1,ESW,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,9.620e-01,9.620e-01
+SSP1,ESW,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,9.620e-01,9.620e-01
+SSP1,ESW,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,9.332e-01,9.332e-01
+SSP1,ESW,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.754e-02,2.632e-02,7.895e-02,1.316e-01,1.316e-01
+SSP1,ESW,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.719e-01,1.719e-01
+SSP1,ESW,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.772e-01,1.772e-01
+SSP1,ESW,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.772e-01,1.772e-01
+SSP1,ESW,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.772e-01,1.772e-01
+SSP1,ESW,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.719e-01,1.719e-01
 SSP1,EWN,,,,,Cycle,trn_pass,S3S,linear,1.000e-02,1.000e-02,5.000e-02,1.000e-01,1.000e-01
-SSP1,EWN,,,,,Domestic Aviation,trn_pass,S3S,linear,5.000e-05,5.000e-05,5.000e-05,5.000e-06,5.000e-06
-SSP1,EWN,,,,,Domestic Ship,trn_freight,S3S,linear,6.147e-03,6.830e-03,6.147e-03,6.147e-03,6.147e-03
-SSP1,EWN,,,,,Freight Rail,trn_freight,S3S,linear,1.246e-02,1.385e-02,1.246e-02,1.246e-02,1.246e-02
+SSP1,EWN,,,,,Domestic Aviation,trn_pass,S3S,linear,4.772e-05,4.772e-05,4.772e-05,4.772e-06,4.772e-06
+SSP1,EWN,,,,,Domestic Ship,trn_freight,S3S,linear,6.261e-03,6.957e-03,6.261e-03,6.261e-03,6.261e-03
+SSP1,EWN,,,,,Freight Rail,trn_freight,S3S,linear,1.270e-02,1.411e-02,1.270e-02,1.270e-02,1.270e-02
 SSP1,EWN,,,,,HSR,trn_pass,S3S,linear,1.000e-04,1.000e-04,4.000e-04,2.000e-04,2.000e-04
 SSP1,EWN,,,,,International Aviation,trn_aviation_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,EWN,,,,,International Ship,trn_shipping_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,EWN,,,,,Passenger Rail,trn_pass,S3S,linear,2.000e-03,3.000e-03,3.000e-03,2.000e-03,2.000e-03
 SSP1,EWN,,,,,Walk,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,EWN,,,,,trn_freight_road,trn_freight,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP1,EWN,,,,,trn_pass_road,trn_pass,S3S,linear,6.000e-02,6.000e-02,6.000e-02,3.000e-02,3.000e-02
-SSP1,EWN,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,1.000e-01,1.000e-01,1.000e-01,1.500e-01,1.500e-01
+SSP1,EWN,,,,,trn_pass_road,trn_pass,S3S,linear,5.891e-02,5.891e-02,5.891e-02,2.945e-02,2.945e-02
+SSP1,EWN,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,1.019e-01,1.019e-01,1.019e-01,1.528e-01,1.528e-01
 SSP1,EWN,,,,trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,EWN,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,4.166e-02,4.166e-02,4.166e-02,4.166e-02,4.166e-02
 SSP1,EWN,,,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP1,EWN,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,3.886e-01,3.886e-01,3.886e-01,3.886e-01,3.886e-01
+SSP1,EWN,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,4.317e-01,4.317e-01,3.886e-01,3.886e-01,3.886e-01
 SSP1,EWN,,Large Car and SUV,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,EWN,,Midsize Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,2.283e-01,2.283e-01,2.283e-01,2.283e-01,2.283e-01
 SSP1,EWN,,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.183e-01,1.183e-01,1.183e-01,1.183e-01,1.183e-01
 SSP1,EWN,,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,4.339e-02,4.339e-02,4.339e-02,4.339e-02,4.339e-02
 SSP1,EWN,,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP1,EWN,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,4.377e-01,4.377e-01,4.377e-01,4.377e-01,4.377e-01
+SSP1,EWN,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,4.864e-01,4.864e-01,4.377e-01,4.377e-01,4.377e-01
 SSP1,EWN,,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,EWN,,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.164e-01,1.164e-01,1.164e-01,1.164e-01,1.164e-01
 SSP1,EWN,,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,5.225e-01,5.225e-01,5.225e-01,5.225e-01,5.225e-01
@@ -6255,21 +6255,21 @@ SSP1,EWN,,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_su
 SSP1,EWN,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1.000e-03,6.000e-02,2.450e-01,4.500e-01,4.500e-01
 SSP1,EWN,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1.000e-03,6.000e-02,2.450e-01,4.500e-01,4.500e-01
 SSP1,EWN,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1.000e-03,6.000e-02,2.450e-01,4.500e-01,4.500e-01
-SSP1,EWN,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.958e-02,2.323e-01,4.763e-01,4.763e-01
+SSP1,EWN,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,8.794e-02,2.197e-01,5.006e-01,5.006e-01
 SSP1,EWN,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,EWN,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,EWN,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP1,EWN,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.550e-01,6.500e-01,8.729e-01,8.729e-01
-SSP1,EWN,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.165e-02,3.496e-01,8.467e-01,8.467e-01
-SSP1,EWN,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.165e-02,3.496e-01,8.467e-01,8.467e-01
-SSP1,EWN,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.165e-02,3.496e-01,8.467e-01,8.467e-01
-SSP1,EWN,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.550e-01,6.500e-01,8.729e-01,8.729e-01
-SSP1,EWN,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.573e-03,6.540e-03,1.667e-02,1.667e-02
-SSP1,EWN,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,9.370e-03,4.743e-02,4.061e-02,4.061e-02
-SSP1,EWN,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.462e-03,1.799e-02,2.778e-02,2.778e-02
-SSP1,EWN,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.462e-03,1.799e-02,2.778e-02,2.778e-02
-SSP1,EWN,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.462e-03,1.799e-02,2.778e-02,2.778e-02
-SSP1,EWN,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,9.370e-03,4.743e-02,4.061e-02,4.061e-02
+SSP1,EWN,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.436e-01,6.405e-01,9.031e-01,9.031e-01
+SSP1,EWN,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.367e-01,3.445e-01,8.760e-01,8.760e-01
+SSP1,EWN,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.367e-01,3.445e-01,8.760e-01,8.760e-01
+SSP1,EWN,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.367e-01,3.445e-01,8.760e-01,8.760e-01
+SSP1,EWN,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.436e-01,6.405e-01,9.031e-01,9.031e-01
+SSP1,EWN,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.861e-03,7.734e-03,2.190e-02,2.190e-02
+SSP1,EWN,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.385e-02,1.059e-01,6.003e-02,6.003e-02
+SSP1,EWN,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.116e-03,4.017e-02,4.106e-02,4.106e-02
+SSP1,EWN,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.116e-03,4.017e-02,4.106e-02,4.106e-02
+SSP1,EWN,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.116e-03,4.017e-02,4.106e-02,4.106e-02
+SSP1,EWN,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.385e-02,1.059e-01,6.003e-02,6.003e-02
 SSP1,EWN,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0.000e+00,8.315e-07,4.540e-05,1.192e-01,1.192e-01
 SSP1,EWN,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,EWN,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
@@ -6286,26 +6286,26 @@ SSP1,EWN,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_
 SSP1,EWN,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,EWN,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,EWN,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP1,EWN,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,8.070e-03,3.107e-02,6.282e-02,8.745e-02,8.745e-02
-SSP1,EWN,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,8.171e-04,2.711e-02,7.970e-02,1.027e-01,1.027e-01
-SSP1,EWN,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.023e-01,1.023e-01
-SSP1,EWN,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.023e-01,1.023e-01
-SSP1,EWN,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.023e-01,1.023e-01
-SSP1,EWN,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.023e-01,1.023e-01
+SSP1,EWN,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,8.070e-03,3.107e-02,6.282e-02,9.716e-02,9.716e-02
+SSP1,EWN,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,8.171e-04,3.389e-02,8.856e-02,1.284e-01,1.284e-01
+SSP1,EWN,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.289e-02,8.772e-02,1.279e-01,1.279e-01
+SSP1,EWN,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.289e-02,8.772e-02,1.279e-01,1.279e-01
+SSP1,EWN,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.289e-02,8.772e-02,1.279e-01,1.279e-01
+SSP1,EWN,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.289e-02,8.772e-02,1.279e-01,1.279e-01
 SSP1,FRA,,,,,Cycle,trn_pass,S3S,linear,1.942e-02,2.184e-02,3.641e-02,1.019e-01,1.019e-01
-SSP1,FRA,,,,,Domestic Aviation,trn_pass,S3S,linear,1.225e-04,6.891e-05,4.594e-05,2.297e-05,2.297e-05
-SSP1,FRA,,,,,Domestic Ship,trn_freight,S3S,linear,3.357e-03,3.357e-03,3.357e-03,3.357e-03,3.357e-03
-SSP1,FRA,,,,,Freight Rail,trn_freight,S3S,linear,1.766e-02,1.766e-02,1.766e-02,1.766e-02,1.766e-02
+SSP1,FRA,,,,,Domestic Aviation,trn_pass,S3S,linear,1.169e-04,6.577e-05,4.385e-05,2.192e-05,2.192e-05
+SSP1,FRA,,,,,Domestic Ship,trn_freight,S3S,linear,3.419e-03,3.419e-03,3.419e-03,3.419e-03,3.419e-03
+SSP1,FRA,,,,,Freight Rail,trn_freight,S3S,linear,1.799e-02,1.799e-02,1.799e-02,1.799e-02,1.799e-02
 SSP1,FRA,,,,,HSR,trn_pass,S3S,linear,3.359e-04,2.267e-04,2.015e-04,2.015e-04,2.015e-04
 SSP1,FRA,,,,,International Aviation,trn_aviation_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,FRA,,,,,International Ship,trn_shipping_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,FRA,,,,,Passenger Rail,trn_pass,S3S,linear,3.972e-03,2.979e-03,1.986e-03,1.986e-03,1.986e-03
 SSP1,FRA,,,,,Walk,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,FRA,,,,,trn_freight_road,trn_freight,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP1,FRA,,,,,trn_pass_road,trn_pass,S3S,linear,9.224e-02,5.188e-02,3.459e-02,2.767e-02,2.767e-02
-SSP1,FRA,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,7.788e-02,8.566e-02,9.345e-02,1.402e-01,1.402e-01
+SSP1,FRA,,,,,trn_pass_road,trn_pass,S3S,linear,9.055e-02,5.094e-02,3.396e-02,2.717e-02,2.717e-02
+SSP1,FRA,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,7.932e-02,8.726e-02,9.519e-02,1.428e-01,1.428e-01
 SSP1,FRA,,,,trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP1,FRA,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,9.470e-02,9.470e-02,9.470e-02,9.470e-02,9.470e-02
+SSP1,FRA,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,7.285e-02,7.285e-02,7.285e-02,6.764e-02,6.764e-02
 SSP1,FRA,,,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,FRA,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,6.352e-01,6.352e-01,6.352e-01,6.352e-01,6.352e-01
 SSP1,FRA,,Large Car and SUV,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
@@ -6319,26 +6319,26 @@ SSP1,FRA,,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_sub
 SSP1,FRA,,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.602e-01,1.602e-01,1.602e-01,1.602e-01,1.602e-01
 SSP1,FRA,,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,4.011e-01,4.011e-01,4.011e-01,4.011e-01,4.011e-01
 SSP1,FRA,,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,3.755e-01,3.755e-01,3.755e-01,3.755e-01,3.755e-01
-SSP1,FRA,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP1,FRA,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP1,FRA,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP1,FRA,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.423e-01,4.303e-01,1.000e+00,1.000e+00
+SSP1,FRA,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.000e-02,2.400e-01,4.200e-01,4.200e-01
+SSP1,FRA,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.000e-02,2.400e-01,4.200e-01,4.200e-01
+SSP1,FRA,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.000e-02,2.400e-01,4.200e-01,4.200e-01
+SSP1,FRA,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.402e-02,1.682e-01,4.579e-01,9.531e-01,9.531e-01
 SSP1,FRA,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,FRA,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,FRA,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP1,FRA,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.980e-01,7.500e-01,9.820e-01,9.820e-01
-SSP1,FRA,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.186e-01,4.034e-01,9.526e-01,9.526e-01
-SSP1,FRA,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.186e-01,4.034e-01,9.526e-01,9.526e-01
-SSP1,FRA,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.186e-01,4.034e-01,9.526e-01,9.526e-01
-SSP1,FRA,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.980e-01,7.500e-01,9.820e-01,9.820e-01
-SSP1,FRA,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.236e-02,1.799e-02,9.544e-02,9.544e-02
-SSP1,FRA,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.693e-02,4.743e-02,1.462e-01,1.462e-01
-SSP1,FRA,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-02,1.799e-02,1.000e-01,1.000e-01
-SSP1,FRA,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-02,1.799e-02,1.000e-01,1.000e-01
-SSP1,FRA,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-02,1.799e-02,1.000e-01,1.000e-01
-SSP1,FRA,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.693e-02,4.743e-02,1.462e-01,1.462e-01
+SSP1,FRA,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.171e-01,6.651e-01,9.087e-01,9.087e-01
+SSP1,FRA,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.262e-01,3.578e-01,8.815e-01,8.815e-01
+SSP1,FRA,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.262e-01,3.578e-01,8.815e-01,8.815e-01
+SSP1,FRA,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.262e-01,3.578e-01,8.815e-01,8.815e-01
+SSP1,FRA,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.171e-01,6.651e-01,9.087e-01,9.087e-01
+SSP1,FRA,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.218e-02,1.462e-02,2.127e-02,8.186e-02,8.186e-02
+SSP1,FRA,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,7.914e-02,2.337e-01,1.503e-01,1.503e-01
+SSP1,FRA,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.924e-02,8.861e-02,1.028e-01,1.028e-01
+SSP1,FRA,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.924e-02,8.861e-02,1.028e-01,1.028e-01
+SSP1,FRA,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.924e-02,8.861e-02,1.028e-01,1.028e-01
+SSP1,FRA,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,7.914e-02,2.337e-01,1.503e-01,1.503e-01
 SSP1,FRA,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0.000e+00,8.315e-07,4.540e-05,1.192e-01,1.192e-01
-SSP1,FRA,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,9.544e-01,9.544e-01
+SSP1,FRA,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,FRA,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,FRA,Liquids,Domestic Ship_tmp_vehicletype,Domestic Ship_tmp_subsector_L1,Domestic Ship_tmp_subsector_L2,Domestic Ship,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,FRA,Liquids,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1.608e-01,1.608e-01,1.608e-01,1.608e-01,1.608e-01
@@ -6353,26 +6353,26 @@ SSP1,FRA,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_
 SSP1,FRA,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,FRA,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,FRA,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP1,FRA,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.758e-01,1.758e-01
-SSP1,FRA,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SSP1,FRA,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SSP1,FRA,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SSP1,FRA,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SSP1,FRA,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SSP1,IND,,,,,Cycle,trn_pass,S3S,linear,2.632e-03,4.364e-03,9.091e-03,1.000e-01,1.000e-01
-SSP1,IND,,,,,Domestic Aviation,trn_pass,S3S,linear,9.589e-02,1.091e-01,1.000e-01,2.000e-01,2.000e-01
-SSP1,IND,,,,,Domestic Ship,trn_freight,S3S,linear,1.180e-03,1.180e-03,1.073e-03,9.075e-04,9.075e-04
-SSP1,IND,,,,,Freight Rail,trn_freight,S3S,linear,1.889e-01,1.889e-01,1.717e-01,1.453e-01,1.453e-01
-SSP1,IND,,,,,HSR,trn_pass,S3S,linear,0.000e+00,4.364e-05,1.000e-04,3.000e-04,3.000e-04
+SSP1,FRA,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.535e-02,2.632e-02,7.895e-02,1.417e-01,1.417e-01
+SSP1,FRA,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,6.579e-02,1.602e-01,1.602e-01
+SSP1,FRA,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,6.579e-02,1.602e-01,1.602e-01
+SSP1,FRA,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,6.579e-02,1.602e-01,1.602e-01
+SSP1,FRA,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,6.579e-02,1.602e-01,1.602e-01
+SSP1,FRA,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,6.579e-02,1.602e-01,1.602e-01
+SSP1,IND,,,,,Cycle,trn_pass,S3S,linear,1.915e-02,3.175e-02,4.630e-02,1.000e-01,1.000e-01
+SSP1,IND,,,,,Domestic Aviation,trn_pass,S3S,linear,6.659e-01,7.575e-01,4.861e-01,1.909e-01,1.909e-01
+SSP1,IND,,,,,Domestic Ship,trn_freight,S3S,linear,1.202e-03,1.202e-03,1.092e-03,9.244e-04,9.244e-04
+SSP1,IND,,,,,Freight Rail,trn_freight,S3S,linear,1.924e-01,1.924e-01,1.574e-01,1.332e-01,1.332e-01
+SSP1,IND,,,,,HSR,trn_pass,S3S,linear,0.000e+00,3.175e-04,5.093e-04,3.000e-04,3.000e-04
 SSP1,IND,,,,,International Aviation,trn_aviation_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,IND,,,,,International Ship,trn_shipping_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP1,IND,,,,,Passenger Rail,trn_pass,S3S,linear,6.842e-04,8.000e-04,1.091e-03,4.000e-03,4.000e-03
-SSP1,IND,,,,,Walk,trn_pass,S3S,linear,1.316e-01,9.455e-02,1.818e-01,1.000e+00,1.000e+00
+SSP1,IND,,,,,Passenger Rail,trn_pass,S3S,linear,4.978e-03,5.820e-03,5.556e-03,4.000e-03,4.000e-03
+SSP1,IND,,,,,Walk,trn_pass,S3S,linear,9.573e-01,6.879e-01,9.260e-01,1.000e+00,1.000e+00
 SSP1,IND,,,,,trn_freight_road,trn_freight,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP1,IND,,,,,trn_pass_road,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP1,IND,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,1.188e-01,7.143e-02,3.231e-02,3.231e-02,3.231e-02
-SSP1,IND,,,,trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP1,IND,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,3.027e-03,2.668e-03,1.949e-03,5.108e-04,5.108e-04
+SSP1,IND,,,,,trn_pass_road,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,2.945e-01,2.945e-01
+SSP1,IND,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,1.000e+00,3.638e-01,1.645e-01,9.872e-02,9.872e-02
+SSP1,IND,,,,trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,9.180e-01,1.000e+00,1.000e+00,1.000e+00,1.000e+00
+SSP1,IND,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.816e-02,1.867e-02,2.923e-02,5.108e-02,5.108e-02
 SSP1,IND,,,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,IND,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,IND,,Mini Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,6.374e-03,6.374e-03,6.374e-03,6.374e-03,6.374e-03
@@ -6383,24 +6383,24 @@ SSP1,IND,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,tr
 SSP1,IND,,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.853e-01,1.853e-01,1.853e-01,1.853e-01,1.853e-01
 SSP1,IND,,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.987e-01,1.987e-01,1.987e-01,1.987e-01,1.987e-01
 SSP1,IND,,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP1,IND,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP1,IND,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP1,IND,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP1,IND,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.743e-02,2.689e-01,7.621e-01,7.621e-01
+SSP1,IND,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.000e-01,3.600e-01,3.780e-01,3.780e-01
+SSP1,IND,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.000e-01,3.600e-01,3.780e-01,3.780e-01
+SSP1,IND,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.000e-01,3.600e-01,3.780e-01,3.780e-01
+SSP1,IND,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,5.175e-02,2.935e-01,6.653e-01,6.653e-01
 SSP1,IND,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,IND,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,IND,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,8.340e-01,8.547e-01,8.962e-01,9.792e-01,9.792e-01
-SSP1,IND,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.576e-02,1.000e-01,9.820e-02,9.820e-02
-SSP1,IND,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.423e-02,5.379e-02,9.526e-02,9.526e-02
-SSP1,IND,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,3.000e-01,2.000e-01,1.000e-01,1.000e-01
-SSP1,IND,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,3.000e-01,2.000e-01,1.000e-01,1.000e-01
-SSP1,IND,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.576e-02,1.000e-01,9.820e-02,9.820e-02
-SSP1,IND,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.473e-03,1.799e-02,5.000e-02,5.000e-02
-SSP1,IND,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.693e-03,9.485e-03,1.462e-02,1.462e-02
-SSP1,IND,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-03,3.597e-03,1.000e-02,1.000e-02
-SSP1,IND,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,2.000e-01,2.000e-02,2.000e-02
-SSP1,IND,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,2.000e-01,2.000e-02,2.000e-02
-SSP1,IND,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.693e-03,9.485e-03,1.462e-02,1.462e-02
+SSP1,IND,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.787e-02,6.365e-02,6.430e-02,6.430e-02
+SSP1,IND,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.109e-02,3.424e-02,6.237e-02,6.237e-02
+SSP1,IND,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,2.338e-01,1.273e-01,6.547e-02,6.547e-02
+SSP1,IND,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,2.338e-01,1.273e-01,6.547e-02,6.547e-02
+SSP1,IND,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.787e-02,6.365e-02,6.430e-02,6.430e-02
+SSP1,IND,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.698e-03,1.963e-02,5.456e-02,5.456e-02
+SSP1,IND,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.217e-03,8.625e-03,1.595e-03,1.595e-03
+SSP1,IND,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.927e-03,3.271e-03,1.091e-03,1.091e-03
+SSP1,IND,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,7.794e-01,1.819e-01,2.182e-03,2.182e-03
+SSP1,IND,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,7.794e-01,1.819e-01,2.182e-03,2.182e-03
+SSP1,IND,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.217e-03,8.625e-03,1.595e-03,1.595e-03
 SSP1,IND,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0.000e+00,8.315e-07,4.540e-05,1.192e-01,1.192e-01
 SSP1,IND,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,IND,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
@@ -6414,27 +6414,27 @@ SSP1,IND,Liquids,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_
 SSP1,IND,Liquids,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,IND,Liquids,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,IND,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP1,IND,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP1,IND,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
+SSP1,IND,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,9.164e-01,1.000e+00,1.000e+00,1.000e+00,1.000e+00
+SSP1,IND,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,9.164e-01,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,IND,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,IND,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,2.408e-01,2.086e-01,2.105e-01,1.903e-01,1.903e-01
-SSP1,IND,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,8.768e-02,1.117e-01,7.985e-02,2.557e-02,2.557e-02
-SSP1,IND,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,3.947e-02,1.842e-02,1.842e-02
-SSP1,IND,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,5.000e-01,1.000e-01,1.000e-01
-SSP1,IND,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,5.000e-01,1.000e-01,1.000e-01
-SSP1,IND,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,3.947e-02,1.842e-02,1.842e-02
+SSP1,IND,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,8.768e-02,7.978e-02,6.655e-02,2.557e-02,2.557e-02
+SSP1,IND,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.880e-02,3.289e-02,1.842e-02,1.842e-02
+SSP1,IND,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,9.164e-01,7.143e-01,4.167e-01,1.000e-01,1.000e-01
+SSP1,IND,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,9.164e-01,7.143e-01,4.167e-01,1.000e-01,1.000e-01
+SSP1,IND,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.880e-02,3.289e-02,1.842e-02,1.842e-02
 SSP1,JPN,,,,,Cycle,trn_pass,S3S,linear,1.743e-02,1.743e-02,3.486e-02,1.961e-02,1.961e-02
-SSP1,JPN,,,,,Domestic Aviation,trn_pass,S3S,linear,1.811e-04,2.174e-04,3.261e-04,9.170e-05,9.170e-05
-SSP1,JPN,,,,,Domestic Ship,trn_freight,S3S,linear,1.146e-02,1.146e-02,1.146e-02,1.146e-02,1.146e-02
-SSP1,JPN,,,,,Freight Rail,trn_freight,S3S,linear,2.781e-03,2.781e-03,2.781e-03,2.781e-03,2.781e-03
+SSP1,JPN,,,,,Domestic Aviation,trn_pass,S3S,linear,1.729e-04,2.075e-04,3.112e-04,8.752e-05,8.752e-05
+SSP1,JPN,,,,,Domestic Ship,trn_freight,S3S,linear,1.167e-02,1.111e-02,1.167e-02,1.167e-02,1.167e-02
+SSP1,JPN,,,,,Freight Rail,trn_freight,S3S,linear,2.833e-03,2.698e-03,2.833e-03,2.833e-03,2.833e-03
 SSP1,JPN,,,,,HSR,trn_pass,S3S,linear,4.081e-04,4.081e-04,4.591e-04,1.291e-04,1.291e-04
 SSP1,JPN,,,,,International Aviation,trn_aviation_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,JPN,,,,,International Ship,trn_shipping_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,JPN,,,,,Passenger Rail,trn_pass,S3S,linear,6.084e-03,6.084e-03,7.000e-03,2.281e-03,2.281e-03
 SSP1,JPN,,,,,Walk,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,JPN,,,,,trn_freight_road,trn_freight,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP1,JPN,,,,,trn_pass_road,trn_pass,S3S,linear,7.245e-02,7.770e-02,7.770e-02,2.185e-02,2.185e-02
-SSP1,JPN,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,5.971e-02,5.971e-02,5.971e-02,5.971e-02,5.971e-02
+SSP1,JPN,,,,,trn_pass_road,trn_pass,S3S,linear,7.113e-02,7.629e-02,7.629e-02,2.146e-02,2.146e-02
+SSP1,JPN,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,6.081e-02,6.081e-02,6.081e-02,6.081e-02,6.081e-02
 SSP1,JPN,,,,trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,JPN,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,5.491e-02,5.491e-02,5.491e-02,5.491e-02,5.491e-02
 SSP1,JPN,,,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
@@ -6447,24 +6447,24 @@ SSP1,JPN,,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_ro
 SSP1,JPN,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.286e-01,1.286e-01,1.286e-01,1.286e-01,1.286e-01
 SSP1,JPN,,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,JPN,,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,5.896e-01,5.896e-01,5.896e-01,5.896e-01,5.896e-01
-SSP1,JPN,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP1,JPN,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP1,JPN,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP1,JPN,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.091e-01,1.793e-01,3.810e-01,3.810e-01
+SSP1,JPN,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.600e-01,5.280e-01,1.000e+00,1.000e+00
+SSP1,JPN,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.600e-01,5.280e-01,1.000e+00,1.000e+00
+SSP1,JPN,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.600e-01,5.280e-01,1.000e+00,1.000e+00
+SSP1,JPN,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,9.673e-02,1.794e-01,3.754e-01,3.754e-01
 SSP1,JPN,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,JPN,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,JPN,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP1,JPN,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.252e-01,3.529e-01,8.183e-01,8.183e-01
-SSP1,JPN,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,6.364e-02,1.333e-01,8.333e-01,8.333e-01
-SSP1,JPN,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,6.364e-02,1.333e-01,8.333e-01,8.333e-01
-SSP1,JPN,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,6.364e-02,1.333e-01,8.333e-01,8.333e-01
-SSP1,JPN,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.252e-01,3.529e-01,8.183e-01,8.183e-01
-SSP1,JPN,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,6.182e-02,1.319e-01,1.000e-01,1.000e-01
-SSP1,JPN,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.104e-01,2.511e-01,3.046e-01,3.046e-01
-SSP1,JPN,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,4.167e-01,4.167e-01
-SSP1,JPN,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,4.167e-01,4.167e-01
-SSP1,JPN,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,4.167e-01,4.167e-01
-SSP1,JPN,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.104e-01,2.511e-01,3.046e-01,3.046e-01
+SSP1,JPN,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.332e-01,3.414e-01,8.870e-01,8.870e-01
+SSP1,JPN,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,5.727e-02,1.200e-01,9.032e-01,9.032e-01
+SSP1,JPN,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,5.727e-02,1.200e-01,9.032e-01,9.032e-01
+SSP1,JPN,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,5.727e-02,1.200e-01,9.032e-01,9.032e-01
+SSP1,JPN,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.332e-01,3.414e-01,8.870e-01,8.870e-01
+SSP1,JPN,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,6.091e-02,1.200e-01,9.854e-02,9.854e-02
+SSP1,JPN,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.306e-01,2.699e-01,2.701e-01,2.701e-01
+SSP1,JPN,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,3.695e-01,3.695e-01
+SSP1,JPN,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,3.695e-01,3.695e-01
+SSP1,JPN,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,3.695e-01,3.695e-01
+SSP1,JPN,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.306e-01,2.699e-01,2.701e-01,2.701e-01
 SSP1,JPN,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0.000e+00,8.315e-07,4.540e-05,1.192e-01,1.192e-01
 SSP1,JPN,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,JPN,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
@@ -6472,41 +6472,41 @@ SSP1,JPN,Liquids,Domestic Ship_tmp_vehicletype,Domestic Ship_tmp_subsector_L1,Do
 SSP1,JPN,Liquids,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,8.837e-01,8.837e-01,8.837e-01,8.837e-01,8.837e-01
 SSP1,JPN,Liquids,International Aviation_tmp_vehicletype,International Aviation_tmp_subsector_L1,International Aviation_tmp_subsector_L2,International Aviation,trn_aviation_intl,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,JPN,Liquids,International Ship_tmp_vehicletype,International Ship_tmp_subsector_L1,International Ship_tmp_subsector_L2,International Ship,trn_shipping_intl,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP1,JPN,Liquids,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP1,JPN,Liquids,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP1,JPN,Liquids,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
+SSP1,JPN,Liquids,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,9.921e-01,9.921e-01
+SSP1,JPN,Liquids,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,9.921e-01,9.921e-01
+SSP1,JPN,Liquids,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,9.921e-01,9.921e-01
 SSP1,JPN,Liquids,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,3.433e-02,3.433e-02,3.433e-02,3.433e-02,3.433e-02
 SSP1,JPN,Liquids,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP1,JPN,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,6.061e-02,1.889e-01,1.000e+00,1.000e+00
-SSP1,JPN,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,6.061e-02,1.889e-01,1.000e+00,1.000e+00
-SSP1,JPN,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,6.061e-02,1.889e-01,1.000e+00,1.000e+00
+SSP1,JPN,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,8.457e-01,5.126e-02,1.757e-01,1.000e+00,1.000e+00
+SSP1,JPN,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,8.457e-01,5.126e-02,1.757e-01,1.000e+00,1.000e+00
+SSP1,JPN,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,8.457e-01,5.126e-02,1.757e-01,1.000e+00,1.000e+00
 SSP1,JPN,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP1,JPN,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,7.895e-03,1.579e-02,2.303e-02,2.303e-02
-SSP1,JPN,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.316e-02,4.644e-02,4.605e-02,4.605e-02
-SSP1,JPN,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,3.030e-02,1.111e-01,2.500e-01,2.500e-01
-SSP1,JPN,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,3.030e-02,1.111e-01,2.500e-01,2.500e-01
-SSP1,JPN,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,3.030e-02,1.111e-01,2.500e-01,2.500e-01
-SSP1,JPN,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.316e-02,4.644e-02,4.605e-02,4.605e-02
-SSP1,LAM,,,,,Cycle,trn_pass,S3S,linear,9.812e-03,1.852e-02,4.629e-02,2.315e-01,2.315e-01
-SSP1,LAM,,,,,Domestic Aviation,trn_pass,S3S,linear,8.407e-03,1.058e-02,2.644e-02,1.983e-02,1.983e-02
-SSP1,LAM,,,,,Domestic Ship,trn_freight,S3S,linear,9.523e-03,9.523e-03,8.658e-03,7.936e-03,7.936e-03
-SSP1,LAM,,,,,Freight Rail,trn_freight,S3S,linear,4.694e-02,4.694e-02,4.268e-02,3.912e-02,3.912e-02
-SSP1,LAM,,,,,HSR,trn_pass,S3S,linear,4.709e-03,2.465e-01,2.465e-01,2.465e-01,2.465e-01
+SSP1,JPN,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,6.579e-03,1.215e-02,1.919e-02,1.919e-02
+SSP1,JPN,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.316e-02,4.222e-02,3.838e-02,3.838e-02
+SSP1,JPN,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,8.457e-01,2.563e-02,9.397e-02,2.083e-01,2.083e-01
+SSP1,JPN,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,8.457e-01,2.563e-02,9.397e-02,2.083e-01,2.083e-01
+SSP1,JPN,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,8.457e-01,2.563e-02,9.397e-02,2.083e-01,2.083e-01
+SSP1,JPN,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.316e-02,4.222e-02,3.838e-02,3.838e-02
+SSP1,LAM,,,,,Cycle,trn_pass,S3S,linear,1.091e-02,2.182e-02,5.455e-02,2.728e-01,2.728e-01
+SSP1,LAM,,,,,Domestic Aviation,trn_pass,S3S,linear,8.921e-03,1.190e-02,2.974e-02,2.230e-02,2.230e-02
+SSP1,LAM,,,,,Domestic Ship,trn_freight,S3S,linear,9.700e-03,9.700e-03,8.908e-03,6.736e-03,6.736e-03
+SSP1,LAM,,,,,Freight Rail,trn_freight,S3S,linear,4.782e-02,4.782e-02,4.391e-02,3.985e-02,3.985e-02
+SSP1,LAM,,,,,HSR,trn_pass,S3S,linear,5.236e-03,2.905e-01,2.905e-01,2.905e-01,2.905e-01
 SSP1,LAM,,,,,International Aviation,trn_aviation_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,LAM,,,,,International Ship,trn_shipping_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP1,LAM,,,,,Passenger Rail,trn_pass,S3S,linear,1.348e-01,1.272e-01,1.272e-01,8.482e-02,8.482e-02
-SSP1,LAM,,,,,Walk,trn_pass,S3S,linear,8.993e-01,8.486e-01,8.486e-01,8.486e-01,8.486e-01
+SSP1,LAM,,,,,Passenger Rail,trn_pass,S3S,linear,1.499e-01,1.499e-01,1.499e-01,9.996e-02,9.996e-02
+SSP1,LAM,,,,,Walk,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,LAM,,,,,trn_freight_road,trn_freight,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP1,LAM,,,,,trn_pass_road,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP1,LAM,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,1.732e-01,1.083e-01,8.662e-02,8.662e-02,8.662e-02
+SSP1,LAM,,,,,trn_pass_road,trn_pass,S3S,linear,6.550e-01,6.942e-01,6.942e-01,8.099e-01,8.099e-01
+SSP1,LAM,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,2.647e-01,1.654e-01,1.323e-01,1.323e-01,1.323e-01
 SSP1,LAM,,,,trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,LAM,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.377e-01,1.377e-01,1.377e-01,1.377e-01,1.377e-01
 SSP1,LAM,,,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,LAM,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP1,LAM,,Large Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,5.465e-02,5.465e-02,5.465e-02,5.465e-02,5.465e-02
-SSP1,LAM,,Large Car and SUV,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,6.039e-01,6.039e-01,6.039e-01,6.039e-01,6.039e-01
-SSP1,LAM,,Light Truck and SUV,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,2.182e-01,2.182e-01,2.182e-01,2.182e-01,2.182e-01
-SSP1,LAM,,Midsize Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,7.979e-02,7.979e-02,7.979e-02,7.979e-02,7.979e-02
+SSP1,LAM,,Large Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,3.279e-02,3.935e-02,4.099e-02,4.372e-02,4.372e-02
+SSP1,LAM,,Large Car and SUV,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,3.624e-01,4.348e-01,4.529e-01,4.831e-01,4.831e-01
+SSP1,LAM,,Light Truck and SUV,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.309e-01,1.571e-01,1.636e-01,1.745e-01,1.745e-01
+SSP1,LAM,,Midsize Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,4.788e-02,5.745e-02,5.984e-02,6.383e-02,6.383e-02
 SSP1,LAM,,Mini Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.226e-02,1.226e-02,1.226e-02,1.226e-02,1.226e-02
 SSP1,LAM,,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,4.580e-04,4.580e-04,4.580e-04,4.580e-04,4.580e-04
 SSP1,LAM,,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
@@ -6517,27 +6517,27 @@ SSP1,LAM,,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_sub
 SSP1,LAM,,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,LAM,,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,5.079e-04,5.079e-04,5.079e-04,5.079e-04,5.079e-04
 SSP1,LAM,,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.892e-01,1.892e-01,1.892e-01,1.892e-01,1.892e-01
-SSP1,LAM,,Van,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,2.455e-03,2.455e-03,2.455e-03,2.455e-03,2.455e-03
-SSP1,LAM,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP1,LAM,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP1,LAM,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP1,LAM,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.186e-01,5.379e-01,1.000e+00,1.000e+00
+SSP1,LAM,,Van,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.473e-03,1.768e-03,1.842e-03,1.964e-03,1.964e-03
+SSP1,LAM,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,5.600e-02,2.160e-01,5.040e-01,5.040e-01
+SSP1,LAM,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,5.600e-02,2.160e-01,5.040e-01,5.040e-01
+SSP1,LAM,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,5.600e-02,2.160e-01,5.040e-01,5.040e-01
+SSP1,LAM,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.294e-01,5.869e-01,1.000e+00,1.000e+00
 SSP1,LAM,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,6.810e-02,1.846e-01,4.176e-01,8.835e-01,8.835e-01
 SSP1,LAM,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,LAM,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP1,LAM,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,7.947e-02,2.000e-01,2.400e-01,2.400e-01
-SSP1,LAM,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.162e-02,1.076e-01,2.329e-01,2.329e-01
-SSP1,LAM,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.162e-02,1.076e-01,2.329e-01,2.329e-01
-SSP1,LAM,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.162e-02,1.076e-01,2.329e-01,2.329e-01
-SSP1,LAM,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,7.947e-02,2.000e-01,2.400e-01,2.400e-01
-SSP1,LAM,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.473e-03,1.799e-02,6.561e-02,6.561e-02
-SSP1,LAM,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,8.924e-03,5.691e-02,8.123e-02,8.123e-02
-SSP1,LAM,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.297e-03,2.158e-02,5.556e-02,5.556e-02
-SSP1,LAM,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.297e-03,2.158e-02,5.556e-02,5.556e-02
-SSP1,LAM,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.297e-03,2.158e-02,5.556e-02,5.556e-02
-SSP1,LAM,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,8.924e-03,5.691e-02,8.123e-02,8.123e-02
+SSP1,LAM,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.041e-01,1.964e-01,2.357e-01,2.357e-01
+SSP1,LAM,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.140e-02,1.057e-01,2.287e-01,2.287e-01
+SSP1,LAM,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.140e-02,1.057e-01,2.287e-01,2.287e-01
+SSP1,LAM,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.140e-02,1.057e-01,2.287e-01,2.287e-01
+SSP1,LAM,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.041e-01,1.964e-01,2.357e-01,2.357e-01
+SSP1,LAM,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.698e-03,1.963e-02,6.561e-02,6.561e-02
+SSP1,LAM,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,9.738e-03,6.210e-02,8.864e-02,8.864e-02
+SSP1,LAM,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.598e-03,2.355e-02,6.062e-02,6.062e-02
+SSP1,LAM,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.598e-03,2.355e-02,6.062e-02,6.062e-02
+SSP1,LAM,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.598e-03,2.355e-02,6.062e-02,6.062e-02
+SSP1,LAM,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,9.738e-03,6.210e-02,8.864e-02,8.864e-02
 SSP1,LAM,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0.000e+00,8.315e-07,4.540e-05,1.192e-01,1.192e-01
-SSP1,LAM,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,7.217e-01,7.217e-01
+SSP1,LAM,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,7.275e-01,7.275e-01
 SSP1,LAM,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,LAM,Liquids,Domestic Ship_tmp_vehicletype,Domestic Ship_tmp_subsector_L1,Domestic Ship_tmp_subsector_L2,Domestic Ship,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,LAM,Liquids,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
@@ -6552,55 +6552,55 @@ SSP1,LAM,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_
 SSP1,LAM,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,LAM,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,LAM,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP1,LAM,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,2.689e-02,4.725e-02,1.037e-01,1.353e-01,1.353e-01
+SSP1,LAM,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,2.689e-02,4.725e-02,1.037e-01,1.240e-01,1.240e-01
 SSP1,LAM,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.754e-02,3.158e-02,6.140e-02,6.140e-02
 SSP1,LAM,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.754e-02,3.158e-02,6.140e-02,6.140e-02
 SSP1,LAM,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.754e-02,3.158e-02,6.140e-02,6.140e-02
 SSP1,LAM,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.754e-02,3.158e-02,6.140e-02,6.140e-02
 SSP1,LAM,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.754e-02,3.158e-02,6.140e-02,6.140e-02
 SSP1,MEA,,,,,Cycle,trn_pass,S3S,linear,1.660e-02,1.660e-02,1.660e-02,4.149e-02,4.149e-02
-SSP1,MEA,,,,,Domestic Aviation,trn_pass,S3S,linear,8.929e-03,5.953e-03,1.786e-02,2.381e-02,2.381e-02
-SSP1,MEA,,,,,Domestic Ship,trn_freight,S3S,linear,2.022e-03,2.022e-03,2.022e-03,2.022e-03,2.022e-03
-SSP1,MEA,,,,,Freight Rail,trn_freight,S3S,linear,3.143e-03,3.143e-03,3.143e-03,3.143e-03,3.143e-03
+SSP1,MEA,,,,,Domestic Aviation,trn_pass,S3S,linear,8.522e-03,5.681e-03,1.704e-02,2.500e-02,2.500e-02
+SSP1,MEA,,,,,Domestic Ship,trn_freight,S3S,linear,2.060e-03,2.060e-03,2.060e-03,2.060e-03,2.060e-03
+SSP1,MEA,,,,,Freight Rail,trn_freight,S3S,linear,3.202e-03,3.202e-03,3.202e-03,3.202e-03,3.202e-03
 SSP1,MEA,,,,,HSR,trn_pass,S3S,linear,0.000e+00,1.667e-02,1.667e-02,1.667e-02,1.667e-02
 SSP1,MEA,,,,,International Aviation,trn_aviation_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,MEA,,,,,International Ship,trn_shipping_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,MEA,,,,,Passenger Rail,trn_pass,S3S,linear,5.567e-04,1.113e-03,1.113e-03,1.856e-03,1.856e-03
 SSP1,MEA,,,,,Walk,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,MEA,,,,,trn_freight_road,trn_freight,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP1,MEA,,,,,trn_pass_road,trn_pass,S3S,linear,6.395e-01,7.197e-01,7.197e-01,7.197e-01,7.197e-01
-SSP1,MEA,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,2.627e-01,1.226e-01,6.131e-02,4.905e-02,4.905e-02
+SSP1,MEA,,,,,trn_pass_road,trn_pass,S3S,linear,3.767e-01,4.239e-01,3.815e-01,3.815e-01,3.815e-01
+SSP1,MEA,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,2.676e-01,1.873e-01,9.367e-02,7.493e-02,7.493e-02
 SSP1,MEA,,,,trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP1,MEA,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,7.508e-03,7.508e-03,7.508e-03,7.508e-03,7.508e-03
+SSP1,MEA,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.502e-02,1.502e-02,1.502e-02,1.502e-02,1.502e-02
 SSP1,MEA,,,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP1,MEA,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,4.732e-01,4.732e-01,4.732e-01,4.732e-01,4.732e-01
+SSP1,MEA,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,5.257e-01,4.732e-01,4.337e-01,3.943e-01,3.943e-01
 SSP1,MEA,,Large Car and SUV,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP1,MEA,,Mini Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,3.955e-02,3.955e-02,3.955e-02,3.955e-02,3.955e-02
+SSP1,MEA,,Mini Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,4.395e-02,3.955e-02,3.626e-02,3.296e-02,3.296e-02
 SSP1,MEA,,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,MEA,,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,MEA,,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP1,MEA,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.864e-01,1.864e-01,1.864e-01,1.864e-01,1.864e-01
+SSP1,MEA,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,2.071e-01,1.864e-01,1.709e-01,1.553e-01,1.553e-01
 SSP1,MEA,,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.304e-01,1.304e-01,1.304e-01,1.304e-01,1.304e-01
 SSP1,MEA,,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,2.013e-01,2.013e-01,2.013e-01,2.013e-01,2.013e-01
 SSP1,MEA,,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP1,MEA,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP1,MEA,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP1,MEA,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP1,MEA,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.743e-02,2.958e-01,6.549e-01,6.549e-01
+SSP1,MEA,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.200e-01,2.160e-01,2.100e-01,2.100e-01
+SSP1,MEA,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.200e-01,2.160e-01,2.100e-01,2.100e-01
+SSP1,MEA,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.200e-01,2.160e-01,2.100e-01,2.100e-01
+SSP1,MEA,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,5.175e-02,2.935e-01,6.497e-01,6.497e-01
 SSP1,MEA,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,4.021e-01,4.768e-01,6.263e-01,9.253e-01,9.253e-01
 SSP1,MEA,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,MEA,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP1,MEA,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.960e-02,1.000e-01,1.403e-01,1.403e-01
-SSP1,MEA,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.371e-02,5.379e-02,1.361e-01,1.361e-01
-SSP1,MEA,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.429e-01,2.000e-01,1.429e-01,1.429e-01
-SSP1,MEA,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.429e-01,2.000e-01,1.429e-01,1.429e-01
-SSP1,MEA,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.960e-02,1.000e-01,1.403e-01,1.403e-01
-SSP1,MEA,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.473e-03,1.799e-02,6.250e-02,6.250e-02
-SSP1,MEA,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.346e-03,9.485e-03,4.177e-02,4.177e-02
-SSP1,MEA,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.236e-03,3.597e-03,2.857e-02,2.857e-02
-SSP1,MEA,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.429e-01,2.000e-01,5.714e-02,5.714e-02
-SSP1,MEA,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.429e-01,2.000e-01,5.714e-02,5.714e-02
-SSP1,MEA,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.346e-03,9.485e-03,4.177e-02,4.177e-02
+SSP1,MEA,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.504e-02,1.091e-01,1.392e-01,1.392e-01
+SSP1,MEA,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.588e-02,5.869e-02,1.350e-01,1.350e-01
+SSP1,MEA,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.559e-01,2.182e-01,1.417e-01,1.417e-01
+SSP1,MEA,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.559e-01,2.182e-01,1.417e-01,1.417e-01
+SSP1,MEA,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.504e-02,1.091e-01,1.392e-01,1.392e-01
+SSP1,MEA,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.698e-03,1.784e-02,5.580e-02,5.580e-02
+SSP1,MEA,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.652e-03,1.035e-02,4.144e-04,4.144e-04
+SSP1,MEA,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.349e-03,3.925e-03,2.834e-04,2.834e-04
+SSP1,MEA,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.559e-01,2.182e-01,5.669e-04,5.669e-04
+SSP1,MEA,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.559e-01,2.182e-01,5.669e-04,5.669e-04
+SSP1,MEA,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.652e-03,1.035e-02,4.144e-04,4.144e-04
 SSP1,MEA,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0.000e+00,8.315e-07,4.540e-05,1.192e-01,1.192e-01
 SSP1,MEA,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,MEA,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
@@ -6614,27 +6614,27 @@ SSP1,MEA,Liquids,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_
 SSP1,MEA,Liquids,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,7.852e-02,7.852e-02,7.852e-02,7.852e-02,7.852e-02
 SSP1,MEA,Liquids,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,MEA,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP1,MEA,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,2.857e-01,1.000e+00,1.000e+00,1.000e+00
-SSP1,MEA,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,2.857e-01,1.000e+00,1.000e+00,1.000e+00
+SSP1,MEA,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,9.164e-01,2.857e-01,1.000e+00,1.000e+00,1.000e+00
+SSP1,MEA,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,9.164e-01,2.857e-01,1.000e+00,1.000e+00,1.000e+00
 SSP1,MEA,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP1,MEA,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.342e-02,3.938e-02,9.130e-02,1.220e-01,1.220e-01
-SSP1,MEA,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,9.283e-04,9.527e-02,4.788e-02,5.285e-02,5.285e-02
-SSP1,MEA,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,9.211e-02,4.737e-02,5.263e-02,5.263e-02
-SSP1,MEA,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,6.000e-01,2.857e-01,2.857e-01
-SSP1,MEA,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,6.000e-01,2.857e-01,2.857e-01
-SSP1,MEA,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,9.211e-02,4.737e-02,5.263e-02,5.263e-02
+SSP1,MEA,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.342e-02,3.938e-02,8.300e-02,1.109e-01,1.109e-01
+SSP1,MEA,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,9.283e-04,9.527e-02,4.788e-02,4.804e-02,4.804e-02
+SSP1,MEA,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,9.211e-02,4.737e-02,4.785e-02,4.785e-02
+SSP1,MEA,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,9.164e-01,1.000e+00,6.000e-01,2.597e-01,2.597e-01
+SSP1,MEA,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,9.164e-01,1.000e+00,6.000e-01,2.597e-01,2.597e-01
+SSP1,MEA,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,9.211e-02,4.737e-02,4.785e-02,4.785e-02
 SSP1,NEN,,,,,Cycle,trn_pass,S3S,linear,3.033e-03,3.024e-03,2.621e-03,1.820e-02,1.820e-02
-SSP1,NEN,,,,,Domestic Aviation,trn_pass,S3S,linear,7.555e-06,7.895e-06,2.566e-06,1.497e-06,1.497e-06
-SSP1,NEN,,,,,Domestic Ship,trn_freight,S3S,linear,3.117e-02,3.117e-02,3.117e-02,3.117e-02,3.117e-02
-SSP1,NEN,,,,,Freight Rail,trn_freight,S3S,linear,1.890e-02,1.890e-02,1.890e-02,1.890e-02,1.890e-02
+SSP1,NEN,,,,,Domestic Aviation,trn_pass,S3S,linear,7.210e-06,7.535e-06,2.449e-06,1.428e-06,1.428e-06
+SSP1,NEN,,,,,Domestic Ship,trn_freight,S3S,linear,3.175e-02,3.175e-02,3.175e-02,3.175e-02,3.175e-02
+SSP1,NEN,,,,,Freight Rail,trn_freight,S3S,linear,1.925e-02,1.925e-02,1.925e-02,1.925e-02,1.925e-02
 SSP1,NEN,,,,,HSR,trn_pass,S3S,linear,2.000e-05,4.532e-05,7.364e-06,5.523e-06,5.523e-06
 SSP1,NEN,,,,,International Aviation,trn_aviation_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,NEN,,,,,International Ship,trn_shipping_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,NEN,,,,,Passenger Rail,trn_pass,S3S,linear,3.000e-06,2.967e-06,6.751e-07,3.215e-07,3.215e-07
 SSP1,NEN,,,,,Walk,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,NEN,,,,,trn_freight_road,trn_freight,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP1,NEN,,,,,trn_pass_road,trn_pass,S3S,linear,5.052e-02,6.996e-02,2.842e-02,2.368e-02,2.368e-02
-SSP1,NEN,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,1.263e-02,7.897e-03,3.948e-03,1.974e-03,1.974e-03
+SSP1,NEN,,,,,trn_pass_road,trn_pass,S3S,linear,4.960e-02,6.868e-02,2.790e-02,2.325e-02,2.325e-02
+SSP1,NEN,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,1.287e-02,8.044e-03,4.022e-03,2.011e-03,2.011e-03
 SSP1,NEN,,,,trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,NEN,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,3.994e-02,3.994e-02,3.994e-02,3.994e-02,3.994e-02
 SSP1,NEN,,,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
@@ -6652,24 +6652,24 @@ SSP1,NEN,,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_sub
 SSP1,NEN,,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,6.397e-02,6.397e-02,6.397e-02,6.397e-02,6.397e-02
 SSP1,NEN,,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,3.433e-01,3.433e-01,3.433e-01,3.433e-01,3.433e-01
 SSP1,NEN,,Van,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,7.350e-03,7.350e-03,7.350e-03,7.350e-03,7.350e-03
-SSP1,NEN,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP1,NEN,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP1,NEN,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP1,NEN,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.743e-02,2.689e-01,9.526e-01,9.526e-01
+SSP1,NEN,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.000e-02,1.680e-01,2.940e-01,2.940e-01
+SSP1,NEN,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.000e-02,1.680e-01,2.940e-01,2.940e-01
+SSP1,NEN,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.000e-02,1.680e-01,2.940e-01,2.940e-01
+SSP1,NEN,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,5.608e-02,1.402e-01,4.134e-01,9.856e-01,9.856e-01
 SSP1,NEN,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,NEN,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,NEN,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP1,NEN,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.192e-01,5.000e-01,9.820e-01,9.820e-01
-SSP1,NEN,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.743e-02,2.689e-01,9.526e-01,9.526e-01
-SSP1,NEN,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.743e-02,2.689e-01,9.526e-01,9.526e-01
-SSP1,NEN,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.743e-02,2.689e-01,9.526e-01,9.526e-01
-SSP1,NEN,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.192e-01,5.000e-01,9.820e-01,9.820e-01
-SSP1,NEN,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.473e-03,1.799e-02,5.000e-01,5.000e-01
-SSP1,NEN,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.693e-03,4.743e-02,7.311e-01,7.311e-01
-SSP1,NEN,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-03,1.799e-02,5.000e-01,5.000e-01
-SSP1,NEN,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-03,1.799e-02,5.000e-01,5.000e-01
-SSP1,NEN,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-03,1.799e-02,5.000e-01,5.000e-01
-SSP1,NEN,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.693e-03,4.743e-02,7.311e-01,7.311e-01
+SSP1,NEN,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.537e-01,5.912e-01,8.932e-01,8.932e-01
+SSP1,NEN,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.009e-01,3.180e-01,8.664e-01,8.664e-01
+SSP1,NEN,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.009e-01,3.180e-01,8.664e-01,8.664e-01
+SSP1,NEN,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.009e-01,3.180e-01,8.664e-01,8.664e-01
+SSP1,NEN,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.537e-01,5.912e-01,8.932e-01,8.932e-01
+SSP1,NEN,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.924e-03,2.127e-02,5.543e-02,5.543e-02
+SSP1,NEN,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,7.914e-03,1.682e-01,9.974e-02,9.974e-02
+SSP1,NEN,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.924e-03,6.380e-02,6.822e-02,6.822e-02
+SSP1,NEN,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.924e-03,6.380e-02,6.822e-02,6.822e-02
+SSP1,NEN,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.924e-03,6.380e-02,6.822e-02,6.822e-02
+SSP1,NEN,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,7.914e-03,1.682e-01,9.974e-02,9.974e-02
 SSP1,NEN,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0.000e+00,8.315e-07,4.540e-05,1.192e-01,1.192e-01
 SSP1,NEN,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,NEN,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
@@ -6686,59 +6686,59 @@ SSP1,NEN,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_
 SSP1,NEN,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,NEN,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,NEN,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP1,NEN,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,2.147e-02,4.722e-02,9.872e-02,2.017e-01,2.017e-01
-SSP1,NEN,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,6.427e-03,3.257e-02,8.487e-02,1.895e-01,1.895e-01
-SSP1,NEN,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SSP1,NEN,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SSP1,NEN,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SSP1,NEN,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
+SSP1,NEN,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,2.362e-02,3.778e-02,9.872e-02,1.261e-01,1.261e-01
+SSP1,NEN,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,6.427e-03,3.257e-02,8.487e-02,1.457e-01,1.457e-01
+SSP1,NEN,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.417e-01,1.417e-01
+SSP1,NEN,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.417e-01,1.417e-01
+SSP1,NEN,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.417e-01,1.417e-01
+SSP1,NEN,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.417e-01,1.417e-01
 SSP1,NES,,,,,Cycle,trn_pass,S3S,linear,8.738e-03,7.802e-03,9.929e-03,1.365e-02,1.365e-02
-SSP1,NES,,,,,Domestic Aviation,trn_pass,S3S,linear,4.947e-03,3.534e-03,1.499e-03,4.123e-04,4.123e-04
-SSP1,NES,,,,,Domestic Ship,trn_freight,S3S,linear,1.442e-02,1.442e-02,1.442e-02,1.442e-02,1.442e-02
-SSP1,NES,,,,,Freight Rail,trn_freight,S3S,linear,1.666e-02,1.666e-02,1.666e-02,1.666e-02,1.666e-02
+SSP1,NES,,,,,Domestic Aviation,trn_pass,S3S,linear,4.721e-03,3.372e-03,1.431e-03,3.935e-04,3.935e-04
+SSP1,NES,,,,,Domestic Ship,trn_freight,S3S,linear,1.468e-02,1.468e-02,1.468e-02,1.322e-02,1.322e-02
+SSP1,NES,,,,,Freight Rail,trn_freight,S3S,linear,1.697e-02,1.697e-02,1.697e-02,1.697e-02,1.697e-02
 SSP1,NES,,,,,HSR,trn_pass,S3S,linear,5.085e-04,3.632e-04,2.311e-04,1.271e-04,1.271e-04
 SSP1,NES,,,,,International Aviation,trn_aviation_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,NES,,,,,International Ship,trn_shipping_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,NES,,,,,Passenger Rail,trn_pass,S3S,linear,1.607e-03,1.148e-03,7.303e-04,4.017e-04,4.017e-04
 SSP1,NES,,,,,Walk,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,NES,,,,,trn_freight_road,trn_freight,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP1,NES,,,,,trn_pass_road,trn_pass,S3S,linear,9.258e-01,7.176e-01,4.566e-01,2.512e-01,2.512e-01
-SSP1,NES,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,5.499e-02,2.199e-02,1.100e-02,1.100e-02,1.100e-02
+SSP1,NES,,,,,trn_pass_road,trn_pass,S3S,linear,2.727e-01,2.818e-01,2.242e-01,1.233e-01,1.233e-01
+SSP1,NES,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,8.401e-02,3.734e-02,2.240e-02,2.240e-02,2.240e-02
 SSP1,NES,,,,trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,NES,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,4.923e-03,4.923e-03,4.923e-03,4.923e-03,4.923e-03
 SSP1,NES,,,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP1,NES,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,4.608e-01,4.608e-01,4.608e-01,4.608e-01,4.608e-01
+SSP1,NES,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,5.760e-01,5.760e-01,6.144e-01,6.144e-01,6.144e-01
 SSP1,NES,,Large Car and SUV,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,NES,,Midsize Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,2.352e-01,2.352e-01,2.352e-01,2.352e-01,2.352e-01
-SSP1,NES,,Mini Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.509e-03,1.509e-03,1.509e-03,1.509e-03,1.509e-03
+SSP1,NES,,Mini Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.886e-03,1.886e-03,2.012e-03,2.012e-03,2.012e-03
 SSP1,NES,,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.148e-02,1.148e-02,1.148e-02,1.148e-02,1.148e-02
 SSP1,NES,,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.337e-01,1.337e-01,1.337e-01,1.337e-01,1.337e-01
 SSP1,NES,,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP1,NES,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,7.460e-02,7.460e-02,7.460e-02,7.460e-02,7.460e-02
+SSP1,NES,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,9.325e-02,9.325e-02,9.946e-02,9.946e-02,9.946e-02
 SSP1,NES,,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,NES,,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,6.299e-02,6.299e-02,6.299e-02,6.299e-02,6.299e-02
 SSP1,NES,,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,3.651e-01,3.651e-01,3.651e-01,3.651e-01,3.651e-01
 SSP1,NES,,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,5.704e-01,5.704e-01,5.704e-01,5.704e-01,5.704e-01
 SSP1,NES,,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,4.799e-01,4.799e-01,4.799e-01,4.799e-01,4.799e-01
 SSP1,NES,,Van,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,2.880e-03,2.880e-03,2.880e-03,2.880e-03,2.880e-03
-SSP1,NES,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP1,NES,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP1,NES,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP1,NES,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.743e-02,2.689e-01,9.526e-01,9.526e-01
+SSP1,NES,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.000e-02,1.680e-01,3.360e-01,3.360e-01
+SSP1,NES,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.000e-02,1.680e-01,3.360e-01,3.360e-01
+SSP1,NES,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.000e-02,1.680e-01,3.360e-01,3.360e-01
+SSP1,NES,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,5.175e-02,1.739e-01,3.465e-01,3.465e-01
 SSP1,NES,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,2.081e-01,3.071e-01,5.050e-01,9.010e-01,9.010e-01
 SSP1,NES,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,NES,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP1,NES,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.192e-01,5.000e-01,9.820e-01,9.820e-01
-SSP1,NES,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.743e-02,2.689e-01,9.526e-01,9.526e-01
-SSP1,NES,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.743e-02,2.689e-01,9.526e-01,9.526e-01
-SSP1,NES,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.743e-02,2.689e-01,9.526e-01,9.526e-01
-SSP1,NES,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.192e-01,5.000e-01,9.820e-01,9.820e-01
-SSP1,NES,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.473e-03,1.799e-02,5.000e-01,5.000e-01
-SSP1,NES,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.693e-03,4.743e-02,7.311e-01,7.311e-01
-SSP1,NES,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-03,1.799e-02,5.000e-01,5.000e-01
-SSP1,NES,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-03,1.799e-02,5.000e-01,5.000e-01
-SSP1,NES,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-03,1.799e-02,5.000e-01,5.000e-01
-SSP1,NES,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.693e-03,4.743e-02,7.311e-01,7.311e-01
+SSP1,NES,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.138e-01,2.182e-01,3.215e-01,3.215e-01
+SSP1,NES,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.528e-02,1.174e-01,3.118e-01,3.118e-01
+SSP1,NES,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.528e-02,1.174e-01,3.118e-01,3.118e-01
+SSP1,NES,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.528e-02,1.174e-01,3.118e-01,3.118e-01
+SSP1,NES,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.138e-01,2.182e-01,3.215e-01,3.215e-01
+SSP1,NES,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.698e-03,1.454e-02,3.637e-02,3.637e-02
+SSP1,NES,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,9.129e-03,3.833e-02,8.376e-02,8.376e-02
+SSP1,NES,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.373e-03,1.454e-02,5.729e-02,5.729e-02
+SSP1,NES,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.373e-03,1.454e-02,5.729e-02,5.729e-02
+SSP1,NES,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.373e-03,1.454e-02,5.729e-02,5.729e-02
+SSP1,NES,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,9.129e-03,3.833e-02,8.376e-02,8.376e-02
 SSP1,NES,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0.000e+00,8.315e-07,4.540e-05,1.192e-01,1.192e-01
 SSP1,NES,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,NES,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
@@ -6755,63 +6755,63 @@ SSP1,NES,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_
 SSP1,NES,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,NES,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,NES,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP1,NES,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,3.476e-03,2.970e-02,8.215e-02,1.870e-01,1.870e-01
-SSP1,NES,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SSP1,NES,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SSP1,NES,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SSP1,NES,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SSP1,NES,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SSP1,OAS,,,,,Cycle,trn_pass,S3S,linear,1.256e-02,2.493e-02,3.323e-02,8.309e-02,8.309e-02
-SSP1,OAS,,,,,Domestic Aviation,trn_pass,S3S,linear,2.574e-02,2.661e-02,3.726e-02,7.983e-02,7.983e-02
-SSP1,OAS,,,,,Domestic Ship,trn_freight,S3S,linear,3.645e-02,3.645e-02,2.804e-02,3.645e-02,3.645e-02
-SSP1,OAS,,,,,Freight Rail,trn_freight,S3S,linear,4.649e-02,4.649e-02,3.576e-02,4.649e-02,4.649e-02
-SSP1,OAS,,,,,HSR,trn_pass,S3S,linear,9.660e-04,2.997e-03,2.997e-03,3.995e-03,3.995e-03
+SSP1,NES,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,3.476e-03,2.970e-02,6.085e-02,7.482e-02,7.482e-02
+SSP1,NES,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.289e-02,8.772e-02,1.289e-01,1.289e-01
+SSP1,NES,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.289e-02,8.772e-02,1.289e-01,1.289e-01
+SSP1,NES,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.289e-02,8.772e-02,1.289e-01,1.289e-01
+SSP1,NES,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.289e-02,8.772e-02,1.289e-01,1.289e-01
+SSP1,NES,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.289e-02,8.772e-02,1.289e-01,1.289e-01
+SSP1,OAS,,,,,Cycle,trn_pass,S3S,linear,1.256e-02,3.616e-02,4.821e-02,1.205e-01,1.205e-01
+SSP1,OAS,,,,,Domestic Aviation,trn_pass,S3S,linear,2.456e-02,3.684e-02,5.158e-02,1.326e-01,1.326e-01
+SSP1,OAS,,,,,Domestic Ship,trn_freight,S3S,linear,3.712e-02,3.375e-02,2.856e-02,2.700e-02,2.700e-02
+SSP1,OAS,,,,,Freight Rail,trn_freight,S3S,linear,4.736e-02,4.305e-02,3.643e-02,3.444e-02,3.444e-02
+SSP1,OAS,,,,,HSR,trn_pass,S3S,linear,9.660e-04,4.347e-03,4.347e-03,5.796e-03,5.796e-03
 SSP1,OAS,,,,,International Aviation,trn_aviation_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,OAS,,,,,International Ship,trn_shipping_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP1,OAS,,,,,Passenger Rail,trn_pass,S3S,linear,7.701e-04,7.963e-04,1.194e-03,1.593e-03,1.593e-03
-SSP1,OAS,,,,,Walk,trn_pass,S3S,linear,1.000e+00,6.893e-01,6.893e-01,6.893e-01,6.893e-01
+SSP1,OAS,,,,,Passenger Rail,trn_pass,S3S,linear,7.701e-04,1.155e-03,1.733e-03,2.310e-03,2.310e-03
+SSP1,OAS,,,,,Walk,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,OAS,,,,,trn_freight_road,trn_freight,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP1,OAS,,,,,trn_pass_road,trn_pass,S3S,linear,8.721e-01,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP1,OAS,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,2.403e-01,1.402e-01,5.510e-02,5.510e-02,5.510e-02
+SSP1,OAS,,,,,trn_pass_road,trn_pass,S3S,linear,4.452e-01,5.697e-01,5.697e-01,7.121e-01,7.121e-01
+SSP1,OAS,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,4.352e-01,2.571e-01,1.122e-01,9.620e-02,9.620e-02
 SSP1,OAS,,,,trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP1,OAS,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,2.534e-02,2.233e-02,1.631e-02,4.276e-03,4.276e-03
+SSP1,OAS,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,3.520e-01,1.718e-01,1.631e-01,9.503e-02,9.503e-02
 SSP1,OAS,,,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP1,OAS,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,6.745e-03,6.745e-03,6.745e-03,6.745e-03,6.745e-03
+SSP1,OAS,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,2.698e-03,2.811e-03,4.216e-03,5.621e-03,5.621e-03
 SSP1,OAS,,Large Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,3.018e-01,3.018e-01,3.018e-01,3.018e-01,3.018e-01
 SSP1,OAS,,Large Car and SUV,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,6.459e-04,6.459e-04,6.459e-04,6.459e-04,6.459e-04
 SSP1,OAS,,Light Truck and SUV,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,OAS,,Midsize Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,2.500e-04,2.500e-04,2.500e-04,2.500e-04,2.500e-04
-SSP1,OAS,,Mini Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,6.938e-05,6.938e-05,6.938e-05,6.938e-05,6.938e-05
+SSP1,OAS,,Mini Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,2.775e-05,2.891e-05,4.336e-05,5.782e-05,5.782e-05
 SSP1,OAS,,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,7.762e-03,7.762e-03,7.762e-03,7.762e-03,7.762e-03
 SSP1,OAS,,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,OAS,,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,6.391e-03,6.391e-03,6.391e-03,6.391e-03,6.391e-03
-SSP1,OAS,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,8.508e-03,8.508e-03,8.508e-03,8.508e-03,8.508e-03
+SSP1,OAS,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,3.403e-03,3.545e-03,5.318e-03,7.090e-03,7.090e-03
 SSP1,OAS,,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,3.765e-01,3.765e-01,3.765e-01,3.765e-01,3.765e-01
 SSP1,OAS,,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,4.784e-01,4.784e-01,4.784e-01,4.784e-01,4.784e-01
 SSP1,OAS,,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.365e-03,1.365e-03,1.365e-03,1.365e-03,1.365e-03
 SSP1,OAS,,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,7.361e-04,7.361e-04,7.361e-04,7.361e-04,7.361e-04
 SSP1,OAS,,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,OAS,,Van,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.027e-05,1.027e-05,1.027e-05,1.027e-05,1.027e-05
-SSP1,OAS,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP1,OAS,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1.452e-05,1.452e-05,1.452e-05,1.452e-05,1.452e-05
-SSP1,OAS,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP1,OAS,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.423e-01,6.724e-01,1.000e+00,1.000e+00
+SSP1,OAS,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.400e-02,1.680e-01,2.940e-01,2.940e-01
+SSP1,OAS,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.400e-02,1.680e-01,2.940e-01,2.940e-01
+SSP1,OAS,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.400e-02,1.680e-01,2.940e-01,2.940e-01
+SSP1,OAS,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.411e-01,6.670e-01,1.000e+00,1.000e+00
 SSP1,OAS,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1.733e-01,2.767e-01,4.833e-01,8.967e-01,8.967e-01
 SSP1,OAS,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,OAS,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,3.530e-01,4.338e-01,5.956e-01,9.191e-01,9.191e-01
-SSP1,OAS,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.973e-02,6.250e-02,7.856e-02,7.856e-02
-SSP1,OAS,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.581e-02,3.362e-02,7.621e-02,7.621e-02
-SSP1,OAS,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.581e-02,3.362e-02,7.621e-02,7.621e-02
-SSP1,OAS,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.581e-02,3.362e-02,7.621e-02,7.621e-02
-SSP1,OAS,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.973e-02,6.250e-02,7.856e-02,7.856e-02
-SSP1,OAS,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.473e-03,1.799e-02,6.561e-02,6.561e-02
-SSP1,OAS,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.115e-02,1.186e-02,2.924e-02,2.924e-02
-SSP1,OAS,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.121e-03,4.497e-03,2.000e-02,2.000e-02
-SSP1,OAS,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.121e-03,4.497e-03,2.000e-02,2.000e-02
-SSP1,OAS,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.121e-03,4.497e-03,2.000e-02,2.000e-02
-SSP1,OAS,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.115e-02,1.186e-02,2.924e-02,2.924e-02
+SSP1,OAS,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.469e-02,5.456e-02,7.144e-02,7.144e-02
+SSP1,OAS,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.380e-02,2.935e-02,6.930e-02,6.930e-02
+SSP1,OAS,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.380e-02,2.935e-02,6.930e-02,6.930e-02
+SSP1,OAS,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.380e-02,2.935e-02,6.930e-02,6.930e-02
+SSP1,OAS,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.469e-02,5.456e-02,7.144e-02,7.144e-02
+SSP1,OAS,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.453e-03,1.784e-02,7.290e-02,7.290e-02
+SSP1,OAS,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.217e-02,1.294e-02,2.127e-02,2.127e-02
+SSP1,OAS,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.497e-03,4.907e-03,1.455e-02,1.455e-02
+SSP1,OAS,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.497e-03,4.907e-03,1.455e-02,1.455e-02
+SSP1,OAS,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.497e-03,4.907e-03,1.455e-02,1.455e-02
+SSP1,OAS,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.217e-02,1.294e-02,2.127e-02,2.127e-02
 SSP1,OAS,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0.000e+00,8.315e-07,4.540e-05,1.192e-01,1.192e-01
-SSP1,OAS,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,6.561e-01,6.561e-01
+SSP1,OAS,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,6.681e-01,6.681e-01
 SSP1,OAS,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,OAS,Liquids,Domestic Ship_tmp_vehicletype,Domestic Ship_tmp_subsector_L1,Domestic Ship_tmp_subsector_L2,Domestic Ship,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,OAS,Liquids,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
@@ -6826,58 +6826,58 @@ SSP1,OAS,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_
 SSP1,OAS,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,OAS,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,OAS,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP1,OAS,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.967e-01,2.178e-01,2.601e-01,2.261e-01,2.261e-01
-SSP1,OAS,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,4.535e-04,8.919e-03,3.968e-02,7.383e-02,7.383e-02
-SSP1,OAS,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,8.772e-03,3.947e-02,7.368e-02,7.368e-02
-SSP1,OAS,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.395e-01,5.404e-02,1.037e-01,1.192e-01,1.192e-01
-SSP1,OAS,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,2.466e-01,8.882e-02,1.531e-01,1.542e-01,1.542e-01
-SSP1,OAS,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,8.772e-03,3.947e-02,7.368e-02,7.368e-02
-SSP1,REF,,,,,Cycle,trn_pass,S3S,linear,4.737e-03,4.737e-03,2.369e-02,7.824e-02,7.824e-02
-SSP1,REF,,,,,Domestic Aviation,trn_pass,S3S,linear,1.287e-02,1.232e-02,1.540e-02,1.454e-02,1.454e-02
-SSP1,REF,,,,,Domestic Ship,trn_freight,S3S,linear,7.096e-03,7.096e-03,7.096e-03,7.096e-03,7.096e-03
-SSP1,REF,,,,,Freight Rail,trn_freight,S3S,linear,1.272e-01,1.272e-01,1.272e-01,1.272e-01,1.272e-01
-SSP1,REF,,,,,HSR,trn_pass,S3S,linear,0.000e+00,8.000e-04,8.000e-04,7.550e-04,7.550e-04
+SSP1,OAS,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.967e-01,1.980e-01,2.365e-01,2.303e-01,2.303e-01
+SSP1,OAS,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,4.535e-04,8.919e-03,3.968e-02,6.153e-02,6.153e-02
+SSP1,OAS,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,8.772e-03,3.947e-02,6.140e-02,6.140e-02
+SSP1,OAS,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.395e-01,5.404e-02,1.037e-01,9.933e-02,9.933e-02
+SSP1,OAS,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,2.466e-01,8.882e-02,1.531e-01,1.285e-01,1.285e-01
+SSP1,OAS,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,8.772e-03,3.947e-02,6.140e-02,6.140e-02
+SSP1,REF,,,,,Cycle,trn_pass,S3S,linear,1.379e-02,1.206e-02,6.031e-02,7.824e-02,7.824e-02
+SSP1,REF,,,,,Domestic Aviation,trn_pass,S3S,linear,3.574e-02,2.995e-02,3.743e-02,1.387e-02,1.387e-02
+SSP1,REF,,,,,Domestic Ship,trn_freight,S3S,linear,7.227e-03,7.227e-03,7.227e-03,7.227e-03,7.227e-03
+SSP1,REF,,,,,Freight Rail,trn_freight,S3S,linear,1.296e-01,1.296e-01,1.296e-01,1.296e-01,1.296e-01
+SSP1,REF,,,,,HSR,trn_pass,S3S,linear,0.000e+00,2.037e-03,2.037e-03,7.550e-04,7.550e-04
 SSP1,REF,,,,,International Aviation,trn_aviation_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,REF,,,,,International Ship,trn_shipping_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP1,REF,,,,,Passenger Rail,trn_pass,S3S,linear,2.366e-03,4.731e-03,5.914e-03,1.116e-02,1.116e-02
-SSP1,REF,,,,,Walk,trn_pass,S3S,linear,3.179e-01,3.179e-01,3.179e-01,1.000e+00,1.000e+00
+SSP1,REF,,,,,Passenger Rail,trn_pass,S3S,linear,6.884e-03,1.205e-02,1.506e-02,1.116e-02,1.116e-02
+SSP1,REF,,,,,Walk,trn_pass,S3S,linear,9.251e-01,8.095e-01,8.095e-01,1.000e+00,1.000e+00
 SSP1,REF,,,,,trn_freight_road,trn_freight,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP1,REF,,,,,trn_pass_road,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,9.437e-01,9.437e-01
-SSP1,REF,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,1.186e-01,9.148e-02,7.623e-02,6.099e-02,6.099e-02
+SSP1,REF,,,,,trn_pass_road,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,4.633e-01,4.633e-01
+SSP1,REF,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,2.684e-01,1.864e-01,1.553e-01,1.242e-01,1.242e-01
 SSP1,REF,,,,trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,REF,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,3.698e-01,3.698e-01,3.698e-01,3.698e-01,3.698e-01
 SSP1,REF,,,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP1,REF,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,2.227e-01,2.227e-01,2.227e-01,2.227e-01,2.227e-01
+SSP1,REF,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,4.455e-01,4.176e-01,4.176e-01,3.818e-01,3.818e-01
 SSP1,REF,,Large Car and SUV,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,REF,,Midsize Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.842e-01,1.842e-01,1.842e-01,1.842e-01,1.842e-01
-SSP1,REF,,Mini Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,7.127e-05,7.127e-05,7.127e-05,7.127e-05,7.127e-05
+SSP1,REF,,Mini Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.425e-04,1.336e-04,1.336e-04,1.222e-04,1.222e-04
 SSP1,REF,,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,3.376e-03,3.376e-03,3.376e-03,3.376e-03,3.376e-03
 SSP1,REF,,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,REF,,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,4.141e-01,4.141e-01,4.141e-01,4.141e-01,4.141e-01
-SSP1,REF,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.254e-02,1.254e-02,1.254e-02,1.254e-02,1.254e-02
+SSP1,REF,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,2.508e-02,2.351e-02,2.351e-02,2.150e-02,2.150e-02
 SSP1,REF,,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,REF,,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,5.081e-03,5.081e-03,5.081e-03,5.081e-03,5.081e-03
 SSP1,REF,,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,5.837e-01,5.837e-01,5.837e-01,5.837e-01,5.837e-01
 SSP1,REF,,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.888e-01,1.888e-01,1.888e-01,1.888e-01,1.888e-01
 SSP1,REF,,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.676e-02,1.676e-02,1.676e-02,1.676e-02,1.676e-02
-SSP1,REF,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP1,REF,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,6.589e-03,6.589e-03,6.589e-03,6.589e-03,6.589e-03
-SSP1,REF,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP1,REF,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.743e-02,3.227e-01,9.526e-01,9.526e-01
+SSP1,REF,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.000e-02,1.680e-01,3.360e-01,3.360e-01
+SSP1,REF,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.000e-02,1.680e-01,3.360e-01,3.360e-01
+SSP1,REF,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.000e-02,1.680e-01,3.360e-01,3.360e-01
+SSP1,REF,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,7.245e-02,3.202e-01,7.425e-01,7.425e-01
 SSP1,REF,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,REF,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,REF,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP1,REF,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.192e-01,3.000e-01,3.928e-01,3.928e-01
-SSP1,REF,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.743e-02,1.614e-01,3.810e-01,3.810e-01
-SSP1,REF,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.743e-02,1.614e-01,3.810e-01,3.810e-01
-SSP1,REF,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.743e-02,1.614e-01,3.810e-01,3.810e-01
-SSP1,REF,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.192e-01,3.000e-01,3.928e-01,3.928e-01
-SSP1,REF,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.473e-03,3.597e-02,1.000e-01,1.000e-01
-SSP1,REF,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.024e-02,4.743e-02,7.311e-02,7.311e-02
-SSP1,REF,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.225e-02,1.799e-02,5.000e-02,5.000e-02
-SSP1,REF,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.225e-02,1.799e-02,5.000e-02,5.000e-02
-SSP1,REF,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.225e-02,1.799e-02,5.000e-02,5.000e-02
-SSP1,REF,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.024e-02,4.743e-02,7.311e-02,7.311e-02
+SSP1,REF,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.183e-01,2.678e-01,3.957e-01,3.957e-01
+SSP1,REF,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.705e-02,1.441e-01,3.838e-01,3.838e-01
+SSP1,REF,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.705e-02,1.441e-01,3.838e-01,3.838e-01
+SSP1,REF,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.705e-02,1.441e-01,3.838e-01,3.838e-01
+SSP1,REF,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.183e-01,2.678e-01,3.957e-01,3.957e-01
+SSP1,REF,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.698e-03,3.569e-02,6.236e-02,6.236e-02
+SSP1,REF,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.975e-02,4.705e-02,5.523e-02,5.523e-02
+SSP1,REF,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.208e-02,1.784e-02,3.777e-02,3.777e-02
+SSP1,REF,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.208e-02,1.784e-02,3.777e-02,3.777e-02
+SSP1,REF,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.208e-02,1.784e-02,3.777e-02,3.777e-02
+SSP1,REF,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.975e-02,4.705e-02,5.523e-02,5.523e-02
 SSP1,REF,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0.000e+00,8.315e-07,4.540e-05,1.192e-01,1.192e-01
 SSP1,REF,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,REF,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
@@ -6894,26 +6894,26 @@ SSP1,REF,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_
 SSP1,REF,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,REF,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,REF,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP1,REF,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.400e-02,3.994e-02,7.347e-02,1.369e-01,1.369e-01
-SSP1,REF,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,4.158e-02,6.680e-02,1.172e-01,1.745e-01,1.745e-01
-SSP1,REF,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.474e-01,1.474e-01
-SSP1,REF,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,6.311e-02,8.776e-02,1.371e-01,1.886e-01,1.886e-01
-SSP1,REF,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,3.048e-02,5.599e-02,1.070e-01,1.673e-01,1.673e-01
-SSP1,REF,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.474e-01,1.474e-01
-SSP1,SSA,,,,,Cycle,trn_pass,S3S,linear,1.388e-02,1.795e-02,2.915e-02,3.279e-02,3.279e-02
-SSP1,SSA,,,,,Domestic Aviation,trn_pass,S3S,linear,9.013e-03,5.100e-02,4.140e-02,6.209e-03,6.209e-03
-SSP1,SSA,,,,,Domestic Ship,trn_freight,S3S,linear,1.467e-03,1.467e-03,1.467e-03,1.467e-03,1.467e-03
-SSP1,SSA,,,,,Freight Rail,trn_freight,S3S,linear,1.634e-02,1.634e-02,1.634e-02,1.634e-02,1.634e-02
-SSP1,SSA,,,,,HSR,trn_pass,S3S,linear,1.475e-05,2.003e-05,6.504e-02,9.756e-03,9.756e-03
+SSP1,REF,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.400e-02,3.195e-02,6.011e-02,7.825e-02,7.825e-02
+SSP1,REF,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,3.465e-02,6.073e-02,9.593e-02,1.342e-01,1.342e-01
+SSP1,REF,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.392e-02,6.459e-02,1.134e-01,1.134e-01
+SSP1,REF,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,5.259e-02,7.979e-02,1.122e-01,1.450e-01,1.450e-01
+SSP1,REF,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,2.540e-02,5.090e-02,8.756e-02,1.287e-01,1.287e-01
+SSP1,REF,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.392e-02,6.459e-02,1.134e-01,1.134e-01
+SSP1,SSA,,,,,Cycle,trn_pass,S3S,linear,1.388e-02,1.987e-02,2.915e-02,3.279e-02,3.279e-02
+SSP1,SSA,,,,,Domestic Aviation,trn_pass,S3S,linear,8.602e-03,5.387e-02,3.951e-02,5.926e-03,5.926e-03
+SSP1,SSA,,,,,Domestic Ship,trn_freight,S3S,linear,1.495e-03,1.495e-03,1.495e-03,1.495e-03,1.495e-03
+SSP1,SSA,,,,,Freight Rail,trn_freight,S3S,linear,1.665e-02,1.665e-02,1.665e-02,1.498e-02,1.498e-02
+SSP1,SSA,,,,,HSR,trn_pass,S3S,linear,1.475e-05,2.217e-05,6.504e-02,9.756e-03,9.756e-03
 SSP1,SSA,,,,,International Aviation,trn_aviation_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,SSA,,,,,International Ship,trn_shipping_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP1,SSA,,,,,Passenger Rail,trn_pass,S3S,linear,6.024e-04,1.559e-03,2.530e-03,5.693e-04,5.693e-04
-SSP1,SSA,,,,,Walk,trn_pass,S3S,linear,1.000e+00,9.034e-01,1.000e+00,1.000e+00,1.000e+00
+SSP1,SSA,,,,,Passenger Rail,trn_pass,S3S,linear,6.024e-04,1.725e-03,2.530e-03,5.693e-04,5.693e-04
+SSP1,SSA,,,,,Walk,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,SSA,,,,,trn_freight_road,trn_freight,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP1,SSA,,,,,trn_pass_road,trn_pass,S3S,linear,8.902e-01,1.000e+00,9.741e-01,9.741e-02,9.741e-02
-SSP1,SSA,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,2.477e-01,1.270e-01,7.328e-02,9.526e-02,9.526e-02
+SSP1,SSA,,,,,trn_pass_road,trn_pass,S3S,linear,2.622e-01,3.260e-01,2.869e-01,4.781e-02,4.781e-02
+SSP1,SSA,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,7.568e-01,3.234e-01,1.493e-01,9.703e-02,9.703e-02
 SSP1,SSA,,,,trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP1,SSA,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,3.928e-02,3.928e-02,3.928e-02,3.928e-02,3.928e-02
+SSP1,SSA,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,2.619e-02,2.619e-02,2.619e-02,3.928e-02,3.928e-02
 SSP1,SSA,,,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,SSA,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,SSA,,Large Car and SUV,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,3.022e-03,3.022e-03,3.022e-03,3.022e-03,3.022e-03
@@ -6928,24 +6928,24 @@ SSP1,SSA,,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_sub
 SSP1,SSA,,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,4.207e-06,4.207e-06,4.207e-06,4.207e-06,4.207e-06
 SSP1,SSA,,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,SSA,,Van,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,7.570e-05,7.570e-05,7.570e-05,7.570e-05,7.570e-05
-SSP1,SSA,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP1,SSA,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP1,SSA,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP1,SSA,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.743e-02,4.034e-01,9.526e-01,9.526e-01
+SSP1,SSA,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.000e-01,2.160e-01,3.360e-01,3.360e-01
+SSP1,SSA,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.000e-01,2.160e-01,3.360e-01,3.360e-01
+SSP1,SSA,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.000e-01,2.160e-01,3.360e-01,3.360e-01
+SSP1,SSA,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,6.210e-02,3.962e-01,8.470e-01,8.470e-01
 SSP1,SSA,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,SSA,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,SSA,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP1,SSA,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.384e-02,1.000e-01,1.511e-01,1.511e-01
-SSP1,SSA,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,9.485e-03,5.379e-02,1.465e-01,1.465e-01
-SSP1,SSA,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,9.485e-03,5.379e-02,1.465e-01,1.465e-01
-SSP1,SSA,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,9.485e-03,5.379e-02,1.465e-01,1.465e-01
-SSP1,SSA,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.384e-02,1.000e-01,1.511e-01,1.511e-01
-SSP1,SSA,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.473e-03,1.799e-02,7.500e-02,7.500e-02
-SSP1,SSA,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.693e-03,4.743e-02,2.812e-02,2.812e-02
-SSP1,SSA,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-03,1.799e-02,1.923e-02,1.923e-02
-SSP1,SSA,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-03,1.799e-02,1.923e-02,1.923e-02
-SSP1,SSA,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-03,1.799e-02,1.923e-02,1.923e-02
-SSP1,SSA,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.693e-03,4.743e-02,2.812e-02,2.812e-02
+SSP1,SSA,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.602e-02,1.007e-01,1.511e-01,1.511e-01
+SSP1,SSA,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.035e-02,5.418e-02,1.466e-01,1.466e-01
+SSP1,SSA,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.035e-02,5.418e-02,1.466e-01,1.466e-01
+SSP1,SSA,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.035e-02,5.418e-02,1.466e-01,1.466e-01
+SSP1,SSA,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.602e-02,1.007e-01,1.511e-01,1.511e-01
+SSP1,SSA,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.698e-03,1.963e-02,4.850e-02,4.850e-02
+SSP1,SSA,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,7.303e-03,1.194e-02,2.045e-02,2.045e-02
+SSP1,SSA,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.698e-03,4.529e-03,1.399e-02,1.399e-02
+SSP1,SSA,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.698e-03,4.529e-03,1.399e-02,1.399e-02
+SSP1,SSA,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.698e-03,4.529e-03,1.399e-02,1.399e-02
+SSP1,SSA,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,7.303e-03,1.194e-02,2.045e-02,2.045e-02
 SSP1,SSA,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0.000e+00,8.315e-07,4.540e-05,1.192e-01,1.192e-01
 SSP1,SSA,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,SSA,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
@@ -6962,59 +6962,59 @@ SSP1,SSA,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_
 SSP1,SSA,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,SSA,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,SSA,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP1,SSA,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,3.981e-04,2.670e-02,5.552e-02,9.227e-02,9.227e-02
-SSP1,SSA,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,7.085e-02,7.085e-02
-SSP1,SSA,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,7.085e-02,7.085e-02
-SSP1,SSA,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,7.085e-02,7.085e-02
-SSP1,SSA,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,7.085e-02,7.085e-02
-SSP1,SSA,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,7.085e-02,7.085e-02
+SSP1,SSA,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,3.981e-04,2.670e-02,4.997e-02,6.835e-02,6.835e-02
+SSP1,SSA,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,4.251e-02,5.904e-02,5.904e-02
+SSP1,SSA,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,4.251e-02,5.904e-02,5.904e-02
+SSP1,SSA,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,4.251e-02,5.904e-02,5.904e-02
+SSP1,SSA,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,4.251e-02,5.904e-02,5.904e-02
+SSP1,SSA,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,4.251e-02,5.904e-02,5.904e-02
 SSP1,UKI,,,,,Cycle,trn_pass,S3S,linear,2.500e-02,1.092e-02,3.277e-02,6.553e-02,6.553e-02
-SSP1,UKI,,,,,Domestic Aviation,trn_pass,S3S,linear,6.250e-05,9.365e-06,9.365e-06,9.365e-06,9.365e-06
-SSP1,UKI,,,,,Domestic Ship,trn_freight,S3S,linear,8.512e-03,8.512e-03,8.512e-03,8.512e-03,8.512e-03
-SSP1,UKI,,,,,Freight Rail,trn_freight,S3S,linear,6.067e-03,6.067e-03,6.067e-03,6.067e-03,6.067e-03
+SSP1,UKI,,,,,Domestic Aviation,trn_pass,S3S,linear,5.965e-05,8.938e-06,8.938e-06,8.938e-06,8.938e-06
+SSP1,UKI,,,,,Domestic Ship,trn_freight,S3S,linear,8.670e-03,8.670e-03,8.670e-03,8.670e-03,8.670e-03
+SSP1,UKI,,,,,Freight Rail,trn_freight,S3S,linear,6.180e-03,6.180e-03,6.180e-03,6.180e-03,6.180e-03
 SSP1,UKI,,,,,HSR,trn_pass,S3S,linear,1.250e-04,1.334e-04,1.779e-04,2.224e-04,2.224e-04
 SSP1,UKI,,,,,International Aviation,trn_aviation_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,UKI,,,,,International Ship,trn_shipping_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,UKI,,,,,Passenger Rail,trn_pass,S3S,linear,3.125e-03,2.502e-03,1.876e-03,1.876e-03,1.876e-03
 SSP1,UKI,,,,,Walk,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,UKI,,,,,trn_freight_road,trn_freight,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP1,UKI,,,,,trn_pass_road,trn_pass,S3S,linear,7.500e-02,5.325e-02,3.408e-02,3.408e-02,3.408e-02
-SSP1,UKI,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,2.500e-01,2.010e-01,1.843e-01,1.675e-01,1.675e-01
+SSP1,UKI,,,,,trn_pass_road,trn_pass,S3S,linear,7.363e-02,5.228e-02,3.346e-02,3.346e-02,3.346e-02
+SSP1,UKI,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,2.546e-01,2.048e-01,1.877e-01,1.706e-01,1.706e-01
 SSP1,UKI,,,,trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,UKI,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,3.935e-02,3.935e-02,3.935e-02,3.935e-02,3.935e-02
 SSP1,UKI,,,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP1,UKI,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,4.864e-01,4.864e-01,4.864e-01,4.864e-01,4.864e-01
+SSP1,UKI,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,5.404e-01,5.404e-01,4.864e-01,4.864e-01,4.864e-01
 SSP1,UKI,,Large Car and SUV,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,UKI,,Midsize Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,2.616e-01,2.616e-01,2.616e-01,2.616e-01,2.616e-01
-SSP1,UKI,,Mini Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,4.751e-07,4.751e-07,4.751e-07,4.751e-07,4.751e-07
+SSP1,UKI,,Mini Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,5.279e-07,5.279e-07,4.751e-07,4.751e-07,4.751e-07
 SSP1,UKI,,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,2.088e-02,2.088e-02,2.088e-02,2.088e-02,2.088e-02
 SSP1,UKI,,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,3.798e-03,3.798e-03,3.798e-03,3.798e-03,3.798e-03
 SSP1,UKI,,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP1,UKI,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,5.119e-01,5.119e-01,5.119e-01,5.119e-01,5.119e-01
+SSP1,UKI,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,5.688e-01,5.688e-01,5.119e-01,5.119e-01,5.119e-01
 SSP1,UKI,,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,UKI,,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,4.528e-02,4.528e-02,4.528e-02,4.528e-02,4.528e-02
 SSP1,UKI,,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,9.437e-02,9.437e-02,9.437e-02,9.437e-02,9.437e-02
 SSP1,UKI,,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,5.696e-01,5.696e-01,5.696e-01,5.696e-01,5.696e-01
 SSP1,UKI,,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,7.765e-01,7.765e-01,7.765e-01,7.765e-01,7.765e-01
 SSP1,UKI,,Van,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,2.681e-03,2.681e-03,2.681e-03,2.681e-03,2.681e-03
-SSP1,UKI,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP1,UKI,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP1,UKI,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP1,UKI,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.186e-01,3.227e-01,8.573e-01,8.573e-01
+SSP1,UKI,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,5.000e-02,2.000e-01,3.700e-01,3.700e-01
+SSP1,UKI,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,5.000e-02,2.000e-01,3.700e-01,3.700e-01
+SSP1,UKI,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,5.000e-02,2.000e-01,3.700e-01,3.700e-01
+SSP1,UKI,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,2.500e-02,1.168e-01,3.434e-01,7.434e-01,7.434e-01
 SSP1,UKI,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,8.260e-01,8.478e-01,8.913e-01,9.783e-01,9.783e-01
 SSP1,UKI,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,UKI,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP1,UKI,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.384e-01,5.500e-01,8.838e-01,8.838e-01
-SSP1,UKI,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,9.485e-02,2.958e-01,8.573e-01,8.573e-01
-SSP1,UKI,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,9.485e-02,2.958e-01,8.573e-01,8.573e-01
-SSP1,UKI,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,9.485e-02,2.958e-01,8.573e-01,8.573e-01
-SSP1,UKI,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.384e-01,5.500e-01,8.838e-01,8.838e-01
-SSP1,UKI,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.236e-02,1.799e-02,1.000e-01,1.000e-01
-SSP1,UKI,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.693e-02,1.897e-01,1.462e-01,1.462e-01
-SSP1,UKI,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-02,7.194e-02,1.000e-01,1.000e-01
-SSP1,UKI,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-02,7.194e-02,1.000e-01,1.000e-01
-SSP1,UKI,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-02,7.194e-02,1.000e-01,1.000e-01
-SSP1,UKI,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.693e-02,1.897e-01,1.462e-01,1.462e-01
+SSP1,UKI,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.819e-01,5.853e-01,8.360e-01,8.360e-01
+SSP1,UKI,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.122e-01,3.148e-01,8.110e-01,8.110e-01
+SSP1,UKI,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.122e-01,3.148e-01,8.110e-01,8.110e-01
+SSP1,UKI,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.122e-01,3.148e-01,8.110e-01,8.110e-01
+SSP1,UKI,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.819e-01,5.853e-01,8.360e-01,8.360e-01
+SSP1,UKI,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,2.500e-05,1.218e-02,2.127e-02,7.883e-02,7.883e-02
+SSP1,UKI,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,7.914e-02,2.243e-01,1.729e-01,1.729e-01
+SSP1,UKI,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.924e-02,8.507e-02,1.182e-01,1.182e-01
+SSP1,UKI,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.924e-02,8.507e-02,1.182e-01,1.182e-01
+SSP1,UKI,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.924e-02,8.507e-02,1.182e-01,1.182e-01
+SSP1,UKI,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,7.914e-02,2.243e-01,1.729e-01,1.729e-01
 SSP1,UKI,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0.000e+00,8.315e-07,4.540e-05,1.192e-01,1.192e-01
 SSP1,UKI,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,UKI,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
@@ -7031,24 +7031,24 @@ SSP1,UKI,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_
 SSP1,UKI,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,UKI,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,UKI,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP1,UKI,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,3.616e-04,2.667e-02,7.928e-02,1.845e-01,1.845e-01
+SSP1,UKI,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,9.040e-04,2.222e-02,7.928e-02,1.230e-01,1.230e-01
 SSP1,UKI,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
 SSP1,UKI,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
 SSP1,UKI,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
 SSP1,UKI,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
 SSP1,UKI,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
 SSP1,USA,,,,,Cycle,trn_pass,S3S,linear,8.197e-03,8.197e-03,8.197e-03,4.098e-02,4.098e-02
-SSP1,USA,,,,,Domestic Aviation,trn_pass,S3S,linear,1.057e-03,1.600e-03,1.800e-03,1.100e-03,1.100e-03
-SSP1,USA,,,,,Domestic Ship,trn_freight,S3S,linear,3.208e-03,3.208e-03,3.208e-03,3.208e-03,3.208e-03
-SSP1,USA,,,,,Freight Rail,trn_freight,S3S,linear,3.364e-02,3.364e-02,3.364e-02,3.364e-02,3.364e-02
+SSP1,USA,,,,,Domestic Aviation,trn_pass,S3S,linear,1.009e-03,1.527e-03,1.718e-03,1.050e-03,1.050e-03
+SSP1,USA,,,,,Domestic Ship,trn_freight,S3S,linear,3.267e-03,3.267e-03,3.267e-03,3.267e-03,3.267e-03
+SSP1,USA,,,,,Freight Rail,trn_freight,S3S,linear,3.427e-02,3.427e-02,3.427e-02,3.427e-02,3.427e-02
 SSP1,USA,,,,,HSR,trn_pass,S3S,linear,4.530e-06,4.530e-06,4.530e-06,2.265e-04,2.265e-04
 SSP1,USA,,,,,International Aviation,trn_aviation_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,USA,,,,,International Ship,trn_shipping_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,USA,,,,,Passenger Rail,trn_pass,S3S,linear,1.933e-03,1.933e-03,1.933e-03,9.665e-04,9.665e-04
 SSP1,USA,,,,,Walk,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,USA,,,,,trn_freight_road,trn_freight,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP1,USA,,,,,trn_pass_road,trn_pass,S3S,linear,1.329e-01,1.329e-01,1.276e-01,6.647e-02,6.647e-02
-SSP1,USA,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,8.561e-02,1.070e-01,1.070e-01,1.213e-01,1.213e-01
+SSP1,USA,,,,,trn_pass_road,trn_pass,S3S,linear,1.305e-01,1.305e-01,1.253e-01,6.526e-02,6.526e-02
+SSP1,USA,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,8.720e-02,1.090e-01,1.090e-01,1.235e-01,1.235e-01
 SSP1,USA,,,,trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,USA,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,3.805e-02,3.805e-02,3.805e-02,3.805e-02,3.805e-02
 SSP1,USA,,,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
@@ -7061,29 +7061,29 @@ SSP1,USA,,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_
 SSP1,USA,,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,USA,,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,7.057e-01,7.057e-01,7.057e-01,7.057e-01,7.057e-01
 SSP1,USA,,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP1,USA,,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP1,USA,,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
+SSP1,USA,,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,9.000e-01,1.000e+00,1.000e+00,1.000e+00,1.000e+00
+SSP1,USA,,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,9.000e-01,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,USA,,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,6.263e-01,6.263e-01,6.263e-01,6.263e-01,6.263e-01
-SSP1,USA,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP1,USA,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP1,USA,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP1,USA,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.423e-01,5.379e-01,1.000e+00,1.000e+00
+SSP1,USA,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.400e-02,2.160e-01,3.780e-01,3.780e-01
+SSP1,USA,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.400e-02,2.160e-01,3.780e-01,3.780e-01
+SSP1,USA,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.400e-02,2.160e-01,3.780e-01,3.780e-01
+SSP1,USA,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.122e-01,5.382e-01,1.000e+00,1.000e+00
 SSP1,USA,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,0.000e+00,1.250e-01,3.750e-01,8.750e-01,8.750e-01
 SSP1,USA,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,USA,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP1,USA,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.980e-02,2.500e-01,7.856e-01,7.856e-01
-SSP1,USA,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.186e-02,1.345e-01,7.621e-01,7.621e-01
-SSP1,USA,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,3.000e-02,2.500e-01,5.000e-01,8.000e-01,8.000e-01
-SSP1,USA,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,3.000e-02,2.500e-01,5.000e-01,8.000e-01,8.000e-01
-SSP1,USA,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.980e-02,2.500e-01,7.856e-01,7.856e-01
-SSP1,USA,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.473e-02,1.799e-02,6.999e-02,6.999e-02
-SSP1,USA,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.339e-03,1.423e-02,1.462e-01,1.462e-01
-SSP1,USA,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.945e-04,5.396e-03,1.000e-01,1.000e-01
-SSP1,USA,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,5.000e-02,2.000e-01,3.000e-01,2.000e-01,2.000e-01
-SSP1,USA,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,5.000e-02,2.000e-01,3.000e-01,2.000e-01,2.000e-01
-SSP1,USA,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.339e-03,1.423e-02,1.462e-01,1.462e-01
+SSP1,USA,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.626e-02,2.323e-01,6.967e-01,6.967e-01
+SSP1,USA,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.470e-03,1.249e-01,6.758e-01,6.758e-01
+SSP1,USA,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,3.547e-02,1.364e-01,4.645e-01,7.095e-01,7.095e-01
+SSP1,USA,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,3.547e-02,1.364e-01,4.645e-01,7.095e-01,7.095e-01
+SSP1,USA,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.626e-02,2.323e-01,6.967e-01,6.967e-01
+SSP1,USA,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.436e-02,1.636e-02,7.776e-02,7.776e-02
+SSP1,USA,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.218e-03,1.202e-02,1.008e-01,1.008e-01
+SSP1,USA,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.498e-04,4.557e-03,6.897e-02,6.897e-02
+SSP1,USA,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,5.912e-02,1.819e-01,2.534e-01,1.379e-01,1.379e-01
+SSP1,USA,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,5.912e-02,1.819e-01,2.534e-01,1.379e-01,1.379e-01
+SSP1,USA,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.218e-03,1.202e-02,1.008e-01,1.008e-01
 SSP1,USA,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0.000e+00,8.315e-07,4.540e-05,1.192e-01,1.192e-01
-SSP1,USA,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,6.999e-01,6.999e-01
+SSP1,USA,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,7.892e-01,7.892e-01
 SSP1,USA,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,USA,Liquids,Domestic Ship_tmp_vehicletype,Domestic Ship_tmp_subsector_L1,Domestic Ship_tmp_subsector_L2,Domestic Ship,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,USA,Liquids,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
@@ -7098,12 +7098,12 @@ SSP1,USA,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_
 SSP1,USA,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,USA,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP1,USA,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP1,USA,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,8.478e-02,1.089e-01,1.570e-01,1.773e-01,1.773e-01
-SSP1,USA,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.263e-03,3.158e-02,7.368e-02,7.368e-02
-SSP1,USA,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.263e-03,3.158e-02,7.368e-02,7.368e-02
-SSP1,USA,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e-01,2.000e-01,4.000e-01,4.000e-01,4.000e-01
-SSP1,USA,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e-01,2.000e-01,4.000e-01,4.000e-01,4.000e-01
-SSP1,USA,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.263e-03,3.158e-02,7.368e-02,7.368e-02
+SSP1,USA,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,8.478e-02,9.072e-02,1.208e-01,1.666e-01,1.666e-01
+SSP1,USA,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.049e-03,2.256e-02,6.140e-02,6.140e-02
+SSP1,USA,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.049e-03,2.256e-02,6.140e-02,6.140e-02
+SSP1,USA,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,5.000e-03,1.538e-01,2.857e-01,3.333e-01,3.333e-01
+SSP1,USA,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,5.000e-03,1.538e-01,2.857e-01,3.333e-01,3.333e-01
+SSP1,USA,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.049e-03,2.256e-02,6.140e-02,6.140e-02
 SSP2,CAZ,,,,,Cycle,trn_pass,S3S,linear,1.911e-02,3.822e-02,3.822e-02,7.645e-02,7.645e-02
 SSP2,CAZ,,,,,Domestic Aviation,trn_pass,S3S,linear,1.432e-03,1.527e-03,1.813e-03,1.909e-03,1.909e-03
 SSP2,CAZ,,,,,Domestic Ship,trn_freight,S3S,linear,1.583e-02,1.583e-02,1.583e-02,1.583e-02,1.583e-02

--- a/inst/extdata/sw_trends.csv
+++ b/inst/extdata/sw_trends.csv
@@ -2842,17 +2842,17 @@ SDP_EI,USA,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp
 SDP_EI,USA,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,5.000e-03,1.538e-01,2.857e-01,3.333e-01,3.333e-01
 SDP_EI,USA,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.049e-03,2.256e-02,6.140e-02,6.140e-02
 SDP_MC,CAZ,,,,,Cycle,trn_pass,S3S,linear,1.911e-02,3.822e-02,3.822e-02,7.645e-02,7.645e-02
-SDP_MC,CAZ,,,,,Domestic Aviation,trn_pass,S3S,linear,1.500e-03,1.600e-03,1.900e-03,2.000e-03,2.000e-03
-SDP_MC,CAZ,,,,,Domestic Ship,trn_freight,S3S,linear,1.554e-02,1.554e-02,1.554e-02,1.554e-02,1.554e-02
-SDP_MC,CAZ,,,,,Freight Rail,trn_freight,S3S,linear,1.051e-01,1.051e-01,1.051e-01,1.051e-01,1.051e-01
+SDP_MC,CAZ,,,,,Domestic Aviation,trn_pass,S3S,linear,1.432e-03,1.527e-03,1.813e-03,1.909e-03,1.909e-03
+SDP_MC,CAZ,,,,,Domestic Ship,trn_freight,S3S,linear,1.583e-02,1.583e-02,1.583e-02,1.583e-02,1.583e-02
+SDP_MC,CAZ,,,,,Freight Rail,trn_freight,S3S,linear,1.070e-01,1.070e-01,1.070e-01,9.633e-02,9.633e-02
 SDP_MC,CAZ,,,,,HSR,trn_pass,S3S,linear,8.792e-08,8.792e-05,2.638e-04,2.638e-04,2.638e-04
 SDP_MC,CAZ,,,,,International Aviation,trn_aviation_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,CAZ,,,,,International Ship,trn_shipping_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,CAZ,,,,,Passenger Rail,trn_pass,S3S,linear,8.785e-04,8.785e-04,8.785e-04,8.785e-04,8.785e-04
 SDP_MC,CAZ,,,,,Walk,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,CAZ,,,,,trn_freight_road,trn_freight,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_MC,CAZ,,,,,trn_pass_road,trn_pass,S3S,linear,1.537e-01,1.537e-01,1.537e-01,1.537e-01,1.537e-01
-SDP_MC,CAZ,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,8.691e-02,8.691e-02,1.086e-01,1.376e-01,1.376e-01
+SDP_MC,CAZ,,,,,trn_pass_road,trn_pass,S3S,linear,1.509e-01,1.509e-01,1.509e-01,1.509e-01,1.509e-01
+SDP_MC,CAZ,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,8.852e-02,8.852e-02,1.107e-01,1.402e-01,1.402e-01
 SDP_MC,CAZ,,,,trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,CAZ,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.939e-02,1.939e-02,1.939e-02,1.939e-02,1.939e-02
 SDP_MC,CAZ,,,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
@@ -2872,26 +2872,26 @@ SDP_MC,CAZ,,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_s
 SDP_MC,CAZ,,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,3.497e-05,3.497e-05,3.497e-05,3.497e-05,3.497e-05
 SDP_MC,CAZ,,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,6.282e-01,6.282e-01,6.282e-01,6.282e-01,6.282e-01
 SDP_MC,CAZ,,Van,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,2.082e-01,2.082e-01,2.082e-01,2.082e-01,2.082e-01
-SDP_MC,CAZ,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_MC,CAZ,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_MC,CAZ,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_MC,CAZ,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,9.485e-02,4.572e-01,1.000e+00,1.000e+00
+SDP_MC,CAZ,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.400e-02,1.920e-01,3.360e-01,3.360e-01
+SDP_MC,CAZ,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.400e-02,1.920e-01,3.360e-01,3.360e-01
+SDP_MC,CAZ,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.400e-02,1.920e-01,3.360e-01,3.360e-01
+SDP_MC,CAZ,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.122e-01,4.423e-01,9.735e-01,9.735e-01
 SDP_MC,CAZ,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,9.074e-02,2.044e-01,4.317e-01,8.863e-01,8.863e-01
 SDP_MC,CAZ,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,CAZ,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_MC,CAZ,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.192e-01,3.500e-01,4.910e-01,4.910e-01
-SDP_MC,CAZ,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.743e-02,1.883e-01,4.763e-01,4.763e-01
-SDP_MC,CAZ,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.743e-02,1.883e-01,4.763e-01,4.763e-01
-SDP_MC,CAZ,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.743e-02,1.883e-01,4.763e-01,4.763e-01
-SDP_MC,CAZ,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.192e-01,3.500e-01,4.910e-01,4.910e-01
-SDP_MC,CAZ,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.236e-02,1.799e-02,9.544e-02,9.544e-02
-SDP_MC,CAZ,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.346e-02,4.743e-02,1.462e-01,1.462e-01
-SDP_MC,CAZ,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.236e-02,1.799e-02,1.000e-01,1.000e-01
-SDP_MC,CAZ,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.236e-02,1.799e-02,1.000e-01,1.000e-01
-SDP_MC,CAZ,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.236e-02,1.799e-02,1.000e-01,1.000e-01
-SDP_MC,CAZ,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.346e-02,4.743e-02,1.462e-01,1.462e-01
+SDP_MC,CAZ,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.409e-01,3.311e-01,4.354e-01,4.354e-01
+SDP_MC,CAZ,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.608e-02,1.781e-01,4.224e-01,4.224e-01
+SDP_MC,CAZ,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.608e-02,1.781e-01,4.224e-01,4.224e-01
+SDP_MC,CAZ,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.608e-02,1.781e-01,4.224e-01,4.224e-01
+SDP_MC,CAZ,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.409e-01,3.311e-01,4.354e-01,4.354e-01
+SDP_MC,CAZ,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.462e-02,1.933e-02,7.601e-02,7.601e-02
+SDP_MC,CAZ,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.957e-02,5.608e-02,1.153e-01,1.153e-01
+SDP_MC,CAZ,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.462e-02,2.127e-02,7.883e-02,7.883e-02
+SDP_MC,CAZ,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.462e-02,2.127e-02,7.883e-02,7.883e-02
+SDP_MC,CAZ,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.462e-02,2.127e-02,7.883e-02,7.883e-02
+SDP_MC,CAZ,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.957e-02,5.608e-02,1.153e-01,1.153e-01
 SDP_MC,CAZ,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0.000e+00,8.315e-07,4.540e-05,1.192e-01,1.192e-01
-SDP_MC,CAZ,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,9.544e-01,9.544e-01
+SDP_MC,CAZ,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,CAZ,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,CAZ,Liquids,Domestic Ship_tmp_vehicletype,Domestic Ship_tmp_subsector_L1,Domestic Ship_tmp_subsector_L2,Domestic Ship,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,CAZ,Liquids,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
@@ -2906,124 +2906,124 @@ SDP_MC,CAZ,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_roa
 SDP_MC,CAZ,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,CAZ,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,CAZ,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_MC,CAZ,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,3.104e-02,5.654e-02,1.075e-01,2.000e-01,2.000e-01
-SDP_MC,CAZ,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SDP_MC,CAZ,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SDP_MC,CAZ,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SDP_MC,CAZ,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SDP_MC,CAZ,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SDP_MC,CHA,,,,,Cycle,trn_pass,S3S,linear,8.298e-02,4.412e-02,3.782e-02,4.848e-02,4.848e-02
-SDP_MC,CHA,,,,,Domestic Aviation,trn_pass,S3S,linear,1.104e-01,2.842e-02,1.829e-02,3.517e-03,3.517e-03
-SDP_MC,CHA,,,,,Domestic Ship,trn_freight,S3S,linear,2.849e-02,8.548e-02,8.548e-02,8.548e-02,8.548e-02
-SDP_MC,CHA,,,,,Freight Rail,trn_freight,S3S,linear,6.920e-02,2.076e-01,2.076e-01,2.076e-01,2.076e-01
-SDP_MC,CHA,,,,,HSR,trn_pass,S3S,linear,2.108e-01,8.143e-02,1.916e-02,3.695e-03,3.695e-03
+SDP_MC,CAZ,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,3.104e-02,5.654e-02,9.776e-02,1.497e-01,1.497e-01
+SDP_MC,CAZ,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.535e-01,1.535e-01
+SDP_MC,CAZ,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.535e-01,1.535e-01
+SDP_MC,CAZ,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.535e-01,1.535e-01
+SDP_MC,CAZ,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.535e-01,1.535e-01
+SDP_MC,CAZ,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.535e-01,1.535e-01
+SDP_MC,CHA,,,,,Cycle,trn_pass,S3S,linear,9.454e-02,4.412e-02,3.782e-02,4.848e-02,4.848e-02
+SDP_MC,CHA,,,,,Domestic Aviation,trn_pass,S3S,linear,1.200e-01,2.712e-02,1.745e-02,3.357e-03,3.357e-03
+SDP_MC,CHA,,,,,Domestic Ship,trn_freight,S3S,linear,1.847e-02,1.922e-02,2.232e-02,2.232e-02,2.232e-02
+SDP_MC,CHA,,,,,Freight Rail,trn_freight,S3S,linear,3.204e-02,3.570e-02,3.795e-02,3.795e-02,3.795e-02
+SDP_MC,CHA,,,,,HSR,trn_pass,S3S,linear,2.402e-01,8.143e-02,1.916e-02,3.695e-03,3.695e-03
 SDP_MC,CHA,,,,,International Aviation,trn_aviation_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,CHA,,,,,International Ship,trn_shipping_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_MC,CHA,,,,,Passenger Rail,trn_pass,S3S,linear,5.461e-03,3.111e-03,1.867e-03,9.572e-04,9.572e-04
-SDP_MC,CHA,,,,,Walk,trn_pass,S3S,linear,8.777e-01,1.000e+00,1.000e+00,1.000e+00,1.000e+00
+SDP_MC,CHA,,,,,Passenger Rail,trn_pass,S3S,linear,6.222e-03,3.111e-03,1.867e-03,9.572e-04,9.572e-04
+SDP_MC,CHA,,,,,Walk,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,CHA,,,,,trn_freight_road,trn_freight,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_MC,CHA,,,,,trn_pass_road,trn_pass,S3S,linear,1.000e+00,4.557e-01,2.279e-01,5.843e-02,5.843e-02
-SDP_MC,CHA,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,3.816e-01,1.915e-01,1.705e-01,1.895e-01,1.895e-01
+SDP_MC,CHA,,,,,trn_pass_road,trn_pass,S3S,linear,6.711e-01,2.684e-01,1.342e-01,4.015e-02,4.015e-02
+SDP_MC,CHA,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,6.609e-01,2.927e-01,2.084e-01,9.649e-02,9.649e-02
 SDP_MC,CHA,,,,trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_MC,CHA,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.081e-02,9.523e-03,6.956e-03,1.824e-03,1.824e-03
+SDP_MC,CHA,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,2.702e-01,2.116e-01,1.391e-01,1.459e-01,1.459e-01
 SDP_MC,CHA,,,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_MC,CHA,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,3.616e-01,3.616e-01,3.616e-01,3.616e-01,3.616e-01
+SDP_MC,CHA,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,8.035e-01,7.232e-01,6.574e-01,5.563e-01,5.563e-01
 SDP_MC,CHA,,Large Car and SUV,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_MC,CHA,,Mini Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,8.023e-03,8.023e-03,8.023e-03,8.023e-03,8.023e-03
+SDP_MC,CHA,,Mini Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.783e-02,1.605e-02,1.459e-02,1.234e-02,1.234e-02
 SDP_MC,CHA,,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,4.044e-02,4.044e-02,4.044e-02,4.044e-02,4.044e-02
 SDP_MC,CHA,,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,CHA,,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_MC,CHA,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,3.898e-02,3.898e-02,3.898e-02,3.898e-02,3.898e-02
+SDP_MC,CHA,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,8.662e-02,7.795e-02,7.087e-02,5.996e-02,5.996e-02
 SDP_MC,CHA,,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,CHA,,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,2.234e-01,2.234e-01,2.234e-01,2.234e-01,2.234e-01
-SDP_MC,CHA,,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,4.469e-01,3.352e-01,3.352e-01,3.352e-01,3.352e-01
-SDP_MC,CHA,,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,4.469e-01,3.352e-01,3.352e-01,3.352e-01,3.352e-01
+SDP_MC,CHA,,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,4.022e-01,3.352e-01,3.016e-01,3.352e-01,3.352e-01
+SDP_MC,CHA,,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,4.022e-01,3.352e-01,3.016e-01,3.352e-01,3.352e-01
 SDP_MC,CHA,,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.657e-01,1.657e-01,1.657e-01,1.657e-01,1.657e-01
-SDP_MC,CHA,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_MC,CHA,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,8.402e-02,8.402e-02,8.402e-02,8.402e-02,8.402e-02
-SDP_MC,CHA,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_MC,CHA,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,3.320e-01,1.000e+00,1.000e+00,1.000e+00
+SDP_MC,CHA,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,6.000e-01,1.000e+00,1.000e+00,1.000e+00
+SDP_MC,CHA,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,6.000e-02,6.000e-01,1.000e+00,1.000e+00,1.000e+00
+SDP_MC,CHA,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,6.000e-01,1.000e+00,1.000e+00,1.000e+00
+SDP_MC,CHA,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,3.019e-01,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,CHA,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,4.553e-01,5.234e-01,6.595e-01,9.319e-01,9.319e-01
 SDP_MC,CHA,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,CHA,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,4.158e-01,4.888e-01,6.349e-01,9.270e-01,9.270e-01
-SDP_MC,CHA,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.768e-02,4.500e-01,9.820e-01,9.820e-01
-SDP_MC,CHA,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.897e-02,2.420e-01,9.526e-01,9.526e-01
-SDP_MC,CHA,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e-01,4.000e-01,9.000e-01,1.000e+00,1.000e+00
-SDP_MC,CHA,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e-01,4.000e-01,9.000e-01,1.000e+00,1.000e+00
-SDP_MC,CHA,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.768e-02,4.500e-01,9.820e-01,9.820e-01
-SDP_MC,CHA,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.225e-02,6.688e-02,6.999e-02,6.999e-02
-SDP_MC,CHA,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.339e-03,2.846e-02,1.462e-01,1.462e-01
-SDP_MC,CHA,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.945e-04,1.079e-02,1.000e-01,1.000e-01
-SDP_MC,CHA,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e-02,2.000e-01,6.000e-01,2.000e-01,2.000e-01
-SDP_MC,CHA,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e-02,2.000e-01,6.000e-01,2.000e-01,2.000e-01
-SDP_MC,CHA,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.339e-03,2.846e-02,1.462e-01,1.462e-01
+SDP_MC,CHA,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.002e-02,3.725e-01,8.768e-01,8.768e-01
+SDP_MC,CHA,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.592e-02,2.004e-01,8.505e-01,8.505e-01
+SDP_MC,CHA,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,9.920e-02,3.358e-01,7.450e-01,8.928e-01,8.928e-01
+SDP_MC,CHA,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,9.920e-02,3.358e-01,7.450e-01,8.928e-01,8.928e-01
+SDP_MC,CHA,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.002e-02,3.725e-01,8.768e-01,8.768e-01
+SDP_MC,CHA,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.024e-02,9.554e-02,6.999e-02,6.999e-02
+SDP_MC,CHA,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.124e-03,1.713e-02,1.450e-01,1.450e-01
+SDP_MC,CHA,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.151e-04,6.497e-03,9.920e-02,9.920e-02
+SDP_MC,CHA,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,9.920e-03,1.679e-01,3.612e-01,1.984e-01,1.984e-01
+SDP_MC,CHA,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,9.920e-03,1.679e-01,3.612e-01,1.984e-01,1.984e-01
+SDP_MC,CHA,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.124e-03,1.713e-02,1.450e-01,1.450e-01
 SDP_MC,CHA,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0.000e+00,8.315e-07,4.540e-05,1.192e-01,1.192e-01
-SDP_MC,CHA,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,7.437e-01,3.499e-01,3.499e-01
+SDP_MC,CHA,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,9.736e-01,3.527e-01,3.527e-01
 SDP_MC,CHA,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,CHA,Liquids,Domestic Ship_tmp_vehicletype,Domestic Ship_tmp_subsector_L1,Domestic Ship_tmp_subsector_L2,Domestic Ship,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,CHA,Liquids,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,CHA,Liquids,International Aviation_tmp_vehicletype,International Aviation_tmp_subsector_L1,International Aviation_tmp_subsector_L2,International Aviation,trn_aviation_intl,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,CHA,Liquids,International Ship_tmp_vehicletype,International Ship_tmp_subsector_L1,International Ship_tmp_subsector_L2,International Ship,trn_shipping_intl,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_MC,CHA,Liquids,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_MC,CHA,Liquids,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_MC,CHA,Liquids,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
+SDP_MC,CHA,Liquids,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,8.333e-01,6.803e-01,6.803e-01
+SDP_MC,CHA,Liquids,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,8.333e-01,6.803e-01,6.803e-01
+SDP_MC,CHA,Liquids,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,8.333e-01,6.803e-01,6.803e-01
 SDP_MC,CHA,Liquids,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,CHA,Liquids,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,CHA,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,CHA,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,CHA,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,CHA,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_MC,CHA,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.421e-01,1.594e-01,9.020e-02,1.152e-01,1.152e-01
-SDP_MC,CHA,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.878e-05,1.319e-02,5.530e-02,9.213e-02,9.213e-02
-SDP_MC,CHA,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,7.854e-04,1.443e-02,5.695e-02,9.317e-02,9.317e-02
-SDP_MC,CHA,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,3.000e-01,5.000e-01,7.000e-01,5.000e-01,5.000e-01
-SDP_MC,CHA,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,3.000e-01,5.000e-01,7.000e-01,5.000e-01,5.000e-01
-SDP_MC,CHA,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,3.309e-04,1.369e-02,5.597e-02,9.256e-02,9.256e-02
+SDP_MC,CHA,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.421e-01,1.329e-01,1.181e-01,1.055e-01,1.055e-01
+SDP_MC,CHA,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.707e-05,1.014e-02,3.814e-02,8.376e-02,8.376e-02
+SDP_MC,CHA,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,7.140e-04,1.110e-02,3.928e-02,8.470e-02,8.470e-02
+SDP_MC,CHA,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,2.727e-01,3.846e-01,4.828e-01,4.545e-01,4.545e-01
+SDP_MC,CHA,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,2.727e-01,3.846e-01,4.828e-01,4.545e-01,4.545e-01
+SDP_MC,CHA,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,3.008e-04,1.053e-02,3.860e-02,8.414e-02,8.414e-02
 SDP_MC,DEU,,,,,Cycle,trn_pass,S3S,linear,2.500e-02,2.500e-02,2.500e-02,1.875e-01,1.875e-01
-SDP_MC,DEU,,,,,Domestic Aviation,trn_pass,S3S,linear,6.250e-05,6.250e-05,6.250e-05,6.250e-05,6.250e-05
-SDP_MC,DEU,,,,,Domestic Ship,trn_freight,S3S,linear,2.088e-03,2.088e-03,2.088e-03,2.088e-03,2.088e-03
-SDP_MC,DEU,,,,,Freight Rail,trn_freight,S3S,linear,2.749e-02,2.749e-02,2.749e-02,2.749e-02,2.749e-02
+SDP_MC,DEU,,,,,Domestic Aviation,trn_pass,S3S,linear,5.965e-05,5.965e-05,5.965e-05,5.965e-05,5.965e-05
+SDP_MC,DEU,,,,,Domestic Ship,trn_freight,S3S,linear,2.127e-03,2.127e-03,2.127e-03,2.127e-03,2.127e-03
+SDP_MC,DEU,,,,,Freight Rail,trn_freight,S3S,linear,2.800e-02,2.800e-02,2.800e-02,2.800e-02,2.800e-02
 SDP_MC,DEU,,,,,HSR,trn_pass,S3S,linear,1.250e-04,2.500e-04,6.250e-04,6.250e-04,6.250e-04
 SDP_MC,DEU,,,,,International Aviation,trn_aviation_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,DEU,,,,,International Ship,trn_shipping_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,DEU,,,,,Passenger Rail,trn_pass,S3S,linear,2.500e-03,3.750e-03,3.750e-03,3.750e-03,3.750e-03
 SDP_MC,DEU,,,,,Walk,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,DEU,,,,,trn_freight_road,trn_freight,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_MC,DEU,,,,,trn_pass_road,trn_pass,S3S,linear,7.500e-02,7.500e-02,7.500e-02,7.500e-02,7.500e-02
-SDP_MC,DEU,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,8.000e-02,8.000e-02,8.000e-02,1.500e-01,1.500e-01
+SDP_MC,DEU,,,,,trn_pass_road,trn_pass,S3S,linear,7.363e-02,7.363e-02,7.363e-02,7.363e-02,7.363e-02
+SDP_MC,DEU,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,8.149e-02,8.149e-02,8.149e-02,1.528e-01,1.528e-01
 SDP_MC,DEU,,,,trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,DEU,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,3.054e-02,3.054e-02,3.054e-02,3.054e-02,3.054e-02
 SDP_MC,DEU,,,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_MC,DEU,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,4.724e-01,4.724e-01,4.724e-01,4.724e-01,4.724e-01
+SDP_MC,DEU,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,5.249e-01,5.249e-01,4.724e-01,4.724e-01,4.724e-01
 SDP_MC,DEU,,Large Car and SUV,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,DEU,,Midsize Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,2.716e-01,2.716e-01,2.716e-01,2.716e-01,2.716e-01
 SDP_MC,DEU,,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,2.183e-01,2.183e-01,2.183e-01,2.183e-01,2.183e-01
 SDP_MC,DEU,,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,6.630e-03,6.630e-03,6.630e-03,6.630e-03,6.630e-03
 SDP_MC,DEU,,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_MC,DEU,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,4.803e-01,4.803e-01,4.803e-01,4.803e-01,4.803e-01
+SDP_MC,DEU,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,5.337e-01,5.337e-01,4.803e-01,4.803e-01,4.803e-01
 SDP_MC,DEU,,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,4.427e-01,4.427e-01,4.427e-01,4.427e-01,4.427e-01
 SDP_MC,DEU,,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,8.345e-02,8.345e-02,8.345e-02,8.345e-02,8.345e-02
 SDP_MC,DEU,,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,2.127e-01,2.127e-01,2.127e-01,2.127e-01,2.127e-01
 SDP_MC,DEU,,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,4.934e-01,4.934e-01,4.934e-01,4.934e-01,4.934e-01
 SDP_MC,DEU,,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_MC,DEU,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_MC,DEU,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_MC,DEU,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_MC,DEU,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.423e-01,4.034e-01,8.573e-01,8.573e-01
+SDP_MC,DEU,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.000e-02,2.500e-01,4.500e-01,4.500e-01
+SDP_MC,DEU,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.000e-02,2.500e-01,4.500e-01,4.500e-01
+SDP_MC,DEU,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.000e-02,2.500e-01,4.500e-01,4.500e-01
+SDP_MC,DEU,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.294e-01,3.669e-01,7.798e-01,7.798e-01
 SDP_MC,DEU,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,DEU,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,DEU,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_MC,DEU,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.980e-01,6.750e-01,9.820e-01,9.820e-01
-SDP_MC,DEU,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.186e-01,3.631e-01,9.526e-01,9.526e-01
-SDP_MC,DEU,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.186e-01,3.631e-01,9.526e-01,9.526e-01
-SDP_MC,DEU,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.186e-01,3.631e-01,9.526e-01,9.526e-01
-SDP_MC,DEU,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.980e-01,6.750e-01,9.820e-01,9.820e-01
-SDP_MC,DEU,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.473e-03,1.799e-02,5.000e-02,5.000e-02
-SDP_MC,DEU,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,8.031e-02,3.320e-01,2.193e-01,2.193e-01
-SDP_MC,DEU,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.967e-02,1.259e-01,1.500e-01,1.500e-01
-SDP_MC,DEU,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.967e-02,1.259e-01,1.500e-01,1.500e-01
-SDP_MC,DEU,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.967e-02,1.259e-01,1.500e-01,1.500e-01
-SDP_MC,DEU,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,8.031e-02,3.320e-01,2.193e-01,2.193e-01
+SDP_MC,DEU,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.524e-01,6.784e-01,8.709e-01,8.709e-01
+SDP_MC,DEU,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.402e-01,3.649e-01,8.448e-01,8.448e-01
+SDP_MC,DEU,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.402e-01,3.649e-01,8.448e-01,8.448e-01
+SDP_MC,DEU,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.402e-01,3.649e-01,8.448e-01,8.448e-01
+SDP_MC,DEU,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.524e-01,6.784e-01,8.709e-01,8.709e-01
+SDP_MC,DEU,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.249e-03,1.636e-02,4.548e-02,4.548e-02
+SDP_MC,DEU,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,9.497e-02,3.925e-01,1.837e-01,1.837e-01
+SDP_MC,DEU,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.508e-02,1.489e-01,1.257e-01,1.257e-01
+SDP_MC,DEU,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.508e-02,1.489e-01,1.257e-01,1.257e-01
+SDP_MC,DEU,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.508e-02,1.489e-01,1.257e-01,1.257e-01
+SDP_MC,DEU,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,9.497e-02,3.925e-01,1.837e-01,1.837e-01
 SDP_MC,DEU,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0.000e+00,8.315e-07,4.540e-05,1.192e-01,1.192e-01
 SDP_MC,DEU,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,DEU,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
@@ -3040,59 +3040,59 @@ SDP_MC,DEU,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_roa
 SDP_MC,DEU,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,DEU,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,DEU,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_MC,DEU,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,3.948e-02,6.475e-02,1.153e-01,1.731e-01,1.731e-01
-SDP_MC,DEU,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,2.615e-02,4.142e-02,1.030e-01,2.055e-01,2.055e-01
-SDP_MC,DEU,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.105e-02,7.895e-02,1.842e-01,1.842e-01
-SDP_MC,DEU,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.105e-02,7.895e-02,1.842e-01,1.842e-01
-SDP_MC,DEU,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.105e-02,7.895e-02,1.842e-01,1.842e-01
-SDP_MC,DEU,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.105e-02,7.895e-02,1.842e-01,1.842e-01
+SDP_MC,DEU,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,3.948e-02,4.981e-02,8.870e-02,1.332e-01,1.332e-01
+SDP_MC,DEU,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,2.615e-02,4.142e-02,1.030e-01,1.713e-01,1.713e-01
+SDP_MC,DEU,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.105e-02,7.895e-02,1.535e-01,1.535e-01
+SDP_MC,DEU,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.105e-02,7.895e-02,1.535e-01,1.535e-01
+SDP_MC,DEU,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.105e-02,7.895e-02,1.535e-01,1.535e-01
+SDP_MC,DEU,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.105e-02,7.895e-02,1.535e-01,1.535e-01
 SDP_MC,ECE,,,,,Cycle,trn_pass,S3S,linear,1.942e-02,1.942e-02,9.709e-02,1.092e-01,1.092e-01
-SDP_MC,ECE,,,,,Domestic Aviation,trn_pass,S3S,linear,7.313e-05,7.313e-05,7.313e-05,2.057e-05,2.057e-05
-SDP_MC,ECE,,,,,Domestic Ship,trn_freight,S3S,linear,3.893e-04,3.893e-04,3.893e-04,3.893e-04,3.893e-04
-SDP_MC,ECE,,,,,Freight Rail,trn_freight,S3S,linear,5.909e-02,5.909e-02,5.909e-02,5.909e-02,5.909e-02
+SDP_MC,ECE,,,,,Domestic Aviation,trn_pass,S3S,linear,6.979e-05,6.979e-05,6.979e-05,1.963e-05,1.963e-05
+SDP_MC,ECE,,,,,Domestic Ship,trn_freight,S3S,linear,3.966e-04,3.966e-04,3.966e-04,3.966e-04,3.966e-04
+SDP_MC,ECE,,,,,Freight Rail,trn_freight,S3S,linear,6.019e-02,6.019e-02,5.417e-02,5.417e-02,5.417e-02
 SDP_MC,ECE,,,,,HSR,trn_pass,S3S,linear,1.139e-04,1.708e-04,4.555e-04,3.202e-04,3.202e-04
 SDP_MC,ECE,,,,,International Aviation,trn_aviation_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,ECE,,,,,International Ship,trn_shipping_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,ECE,,,,,Passenger Rail,trn_pass,S3S,linear,6.799e-03,6.799e-03,9.065e-03,3.824e-03,3.824e-03
 SDP_MC,ECE,,,,,Walk,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,ECE,,,,,trn_freight_road,trn_freight,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_MC,ECE,,,,,trn_pass_road,trn_pass,S3S,linear,8.972e-01,8.972e-01,7.177e-01,1.615e-01,1.615e-01
-SDP_MC,ECE,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,1.664e-01,1.664e-01,1.109e-01,1.109e-01,1.109e-01
+SDP_MC,ECE,,,,,trn_pass_road,trn_pass,S3S,linear,6.166e-01,6.166e-01,4.933e-01,1.268e-01,1.268e-01
+SDP_MC,ECE,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,2.712e-01,2.543e-01,1.469e-01,1.130e-01,1.130e-01
 SDP_MC,ECE,,,,trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,ECE,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,6.159e-03,6.159e-03,6.159e-03,6.159e-03,6.159e-03
 SDP_MC,ECE,,,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_MC,ECE,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,3.451e-01,3.451e-01,3.451e-01,3.451e-01,3.451e-01
+SDP_MC,ECE,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,4.706e-01,4.706e-01,4.601e-01,4.314e-01,4.314e-01
 SDP_MC,ECE,,Large Car and SUV,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,7.825e-01,7.825e-01,7.825e-01,7.825e-01,7.825e-01
 SDP_MC,ECE,,Midsize Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,ECE,,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,5.321e-02,5.321e-02,5.321e-02,5.321e-02,5.321e-02
 SDP_MC,ECE,,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,4.728e-04,4.728e-04,4.728e-04,4.728e-04,4.728e-04
 SDP_MC,ECE,,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_MC,ECE,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,4.683e-01,4.683e-01,4.683e-01,4.683e-01,4.683e-01
+SDP_MC,ECE,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,6.386e-01,6.386e-01,6.244e-01,5.854e-01,5.854e-01
 SDP_MC,ECE,,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,6.161e-01,6.161e-01,6.161e-01,6.161e-01,6.161e-01
 SDP_MC,ECE,,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.384e-01,1.384e-01,1.384e-01,1.384e-01,1.384e-01
 SDP_MC,ECE,,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.370e-01,1.370e-01,1.370e-01,1.370e-01,1.370e-01
 SDP_MC,ECE,,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.691e-01,1.691e-01,1.691e-01,1.691e-01,1.691e-01
 SDP_MC,ECE,,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_MC,ECE,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_MC,ECE,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_MC,ECE,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_MC,ECE,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.423e-01,5.379e-01,1.000e+00,1.000e+00
+SDP_MC,ECE,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.000e-02,1.900e-01,4.300e-01,4.300e-01
+SDP_MC,ECE,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.000e-02,1.900e-01,4.300e-01,4.300e-01
+SDP_MC,ECE,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.000e-02,1.900e-01,4.300e-01,4.300e-01
+SDP_MC,ECE,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.553e-01,5.283e-01,1.000e+00,1.000e+00
 SDP_MC,ECE,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,ECE,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,ECE,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_MC,ECE,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.960e-02,1.500e-01,2.946e-01,2.946e-01
-SDP_MC,ECE,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.371e-02,8.068e-02,2.858e-01,2.858e-01
-SDP_MC,ECE,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.371e-02,8.068e-02,2.858e-01,2.858e-01
-SDP_MC,ECE,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.371e-02,8.068e-02,2.858e-01,2.858e-01
-SDP_MC,ECE,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.960e-02,1.500e-01,2.946e-01,2.946e-01
-SDP_MC,ECE,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.236e-02,1.799e-02,8.748e-02,8.748e-02
-SDP_MC,ECE,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.339e-02,4.743e-02,1.462e-01,1.462e-01
-SDP_MC,ECE,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.945e-03,1.799e-02,1.000e-01,1.000e-01
-SDP_MC,ECE,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.945e-03,1.799e-02,1.000e-01,1.000e-01
-SDP_MC,ECE,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.945e-03,1.799e-02,1.000e-01,1.000e-01
-SDP_MC,ECE,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.339e-02,4.743e-02,1.462e-01,1.462e-01
+SDP_MC,ECE,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.504e-02,1.455e-01,2.786e-01,2.786e-01
+SDP_MC,ECE,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.588e-02,7.826e-02,2.703e-01,2.703e-01
+SDP_MC,ECE,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.588e-02,7.826e-02,2.703e-01,2.703e-01
+SDP_MC,ECE,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.588e-02,7.826e-02,2.703e-01,2.703e-01
+SDP_MC,ECE,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.504e-02,1.455e-01,2.786e-01,2.786e-01
+SDP_MC,ECE,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.349e-02,1.963e-02,8.748e-02,8.748e-02
+SDP_MC,ECE,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.461e-02,5.750e-02,6.382e-02,6.382e-02
+SDP_MC,ECE,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.396e-03,2.181e-02,4.365e-02,4.365e-02
+SDP_MC,ECE,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.396e-03,2.181e-02,4.365e-02,4.365e-02
+SDP_MC,ECE,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.396e-03,2.181e-02,4.365e-02,4.365e-02
+SDP_MC,ECE,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.461e-02,5.750e-02,6.382e-02,6.382e-02
 SDP_MC,ECE,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0.000e+00,8.315e-07,4.540e-05,1.192e-01,1.192e-01
-SDP_MC,ECE,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,8.748e-01,8.748e-01
+SDP_MC,ECE,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,8.017e-01,8.017e-01
 SDP_MC,ECE,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,ECE,Liquids,Domestic Ship_tmp_vehicletype,Domestic Ship_tmp_subsector_L1,Domestic Ship_tmp_subsector_L2,Domestic Ship,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,ECE,Liquids,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,5.870e-01,5.870e-01,5.870e-01,5.870e-01,5.870e-01
@@ -3107,57 +3107,57 @@ SDP_MC,ECE,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_roa
 SDP_MC,ECE,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,ECE,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,ECE,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_MC,ECE,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_MC,ECE,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_MC,ECE,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_MC,ECE,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
+SDP_MC,ECE,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e-02,2.000e-02,7.000e-02,9.000e-02,9.000e-02
+SDP_MC,ECE,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.000e-02,1.111e-01,1.867e-01,1.867e-01
+SDP_MC,ECE,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.000e-02,1.111e-01,1.867e-01,1.867e-01
+SDP_MC,ECE,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.000e-02,1.111e-01,1.867e-01,1.867e-01
 SDP_MC,ECE,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_MC,ECE,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_MC,ECS,,,,,Cycle,trn_pass,S3S,linear,7.196e-03,2.159e-02,8.635e-02,8.738e-02,8.738e-02
-SDP_MC,ECS,,,,,Domestic Aviation,trn_pass,S3S,linear,2.566e-03,2.566e-03,2.566e-03,3.895e-04,3.895e-04
-SDP_MC,ECS,,,,,Domestic Ship,trn_freight,S3S,linear,3.878e-03,3.878e-03,3.878e-03,3.878e-03,3.878e-03
-SDP_MC,ECS,,,,,Freight Rail,trn_freight,S3S,linear,5.867e-02,5.867e-02,5.867e-02,5.867e-02,5.867e-02
-SDP_MC,ECS,,,,,HSR,trn_pass,S3S,linear,1.956e-04,1.956e-04,5.216e-04,4.000e-04,4.000e-04
+SDP_MC,ECE,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.000e-02,1.111e-01,1.867e-01,1.867e-01
+SDP_MC,ECS,,,,,Cycle,trn_pass,S3S,linear,1.092e-02,3.277e-02,1.311e-01,8.738e-02,8.738e-02
+SDP_MC,ECS,,,,,Domestic Aviation,trn_pass,S3S,linear,3.717e-03,3.717e-03,3.717e-03,3.717e-04,3.717e-04
+SDP_MC,ECS,,,,,Domestic Ship,trn_freight,S3S,linear,3.950e-03,3.950e-03,3.591e-03,3.950e-03,3.950e-03
+SDP_MC,ECS,,,,,Freight Rail,trn_freight,S3S,linear,5.976e-02,5.976e-02,5.433e-02,5.379e-02,5.379e-02
+SDP_MC,ECS,,,,,HSR,trn_pass,S3S,linear,2.969e-04,2.969e-04,7.917e-04,4.000e-04,4.000e-04
 SDP_MC,ECS,,,,,International Aviation,trn_aviation_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,ECS,,,,,International Ship,trn_shipping_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_MC,ECS,,,,,Passenger Rail,trn_pass,S3S,linear,5.215e-03,6.953e-03,8.691e-03,2.638e-03,2.638e-03
-SDP_MC,ECS,,,,,Walk,trn_pass,S3S,linear,6.588e-01,6.588e-01,6.588e-01,1.000e+00,1.000e+00
+SDP_MC,ECS,,,,,Passenger Rail,trn_pass,S3S,linear,7.915e-03,1.055e-02,1.319e-02,2.638e-03,2.638e-03
+SDP_MC,ECS,,,,,Walk,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,ECS,,,,,trn_freight_road,trn_freight,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_MC,ECS,,,,,trn_pass_road,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.518e-01,1.518e-01
-SDP_MC,ECS,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,1.140e-01,1.140e-01,7.980e-02,6.840e-02,6.840e-02
+SDP_MC,ECS,,,,,trn_pass_road,trn_pass,S3S,linear,7.451e-01,7.451e-01,7.451e-01,8.941e-02,8.941e-02
+SDP_MC,ECS,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,2.090e-01,1.742e-01,1.219e-01,1.045e-01,1.045e-01
 SDP_MC,ECS,,,,trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,ECS,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,2.175e-03,2.175e-03,2.175e-03,2.175e-03,2.175e-03
 SDP_MC,ECS,,,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_MC,ECS,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,3.336e-01,3.336e-01,3.336e-01,3.336e-01,3.336e-01
+SDP_MC,ECS,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,5.004e-01,5.004e-01,5.004e-01,4.549e-01,4.549e-01
 SDP_MC,ECS,,Large Car and SUV,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,ECS,,Midsize Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,9.609e-01,9.609e-01,9.609e-01,9.609e-01,9.609e-01
 SDP_MC,ECS,,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.125e-01,1.125e-01,1.125e-01,1.125e-01,1.125e-01
 SDP_MC,ECS,,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,3.579e-02,3.579e-02,3.579e-02,3.579e-02,3.579e-02
 SDP_MC,ECS,,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_MC,ECS,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,6.520e-01,6.520e-01,6.520e-01,6.520e-01,6.520e-01
+SDP_MC,ECS,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,9.780e-01,9.780e-01,9.780e-01,8.891e-01,8.891e-01
 SDP_MC,ECS,,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,ECS,,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,2.555e-01,2.555e-01,2.555e-01,2.555e-01,2.555e-01
 SDP_MC,ECS,,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,3.104e-01,3.104e-01,3.104e-01,3.104e-01,3.104e-01
 SDP_MC,ECS,,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.282e-01,1.282e-01,1.282e-01,1.282e-01,1.282e-01
 SDP_MC,ECS,,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,4.409e-01,4.409e-01,4.409e-01,4.409e-01,4.409e-01
-SDP_MC,ECS,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_MC,ECS,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_MC,ECS,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_MC,ECS,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.743e-02,3.496e-01,8.573e-01,8.573e-01
+SDP_MC,ECS,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,3.200e-02,1.920e-01,4.200e-01,4.200e-01
+SDP_MC,ECS,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,3.200e-02,1.920e-01,4.200e-01,4.200e-01
+SDP_MC,ECS,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,3.200e-02,1.920e-01,4.200e-01,4.200e-01
+SDP_MC,ECS,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,9.315e-02,3.815e-01,8.420e-01,8.420e-01
 SDP_MC,ECS,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,ECS,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,ECS,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_MC,ECS,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.192e-01,2.500e-01,2.946e-01,2.946e-01
-SDP_MC,ECS,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.743e-02,1.345e-01,2.858e-01,2.858e-01
-SDP_MC,ECS,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.743e-02,1.345e-01,2.858e-01,2.858e-01
-SDP_MC,ECS,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.743e-02,1.345e-01,2.858e-01,2.858e-01
-SDP_MC,ECS,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.192e-01,2.500e-01,2.946e-01,2.946e-01
-SDP_MC,ECS,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.473e-03,5.396e-02,1.000e-01,1.000e-01
-SDP_MC,ECS,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.339e-02,4.743e-02,7.311e-02,7.311e-02
-SDP_MC,ECS,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.945e-03,1.799e-02,5.000e-02,5.000e-02
-SDP_MC,ECS,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.945e-03,1.799e-02,5.000e-02,5.000e-02
-SDP_MC,ECS,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.945e-03,1.799e-02,5.000e-02,5.000e-02
-SDP_MC,ECS,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.339e-02,4.743e-02,7.311e-02,7.311e-02
+SDP_MC,ECS,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.041e-01,2.182e-01,2.893e-01,2.893e-01
+SDP_MC,ECS,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.140e-02,1.174e-01,2.807e-01,2.807e-01
+SDP_MC,ECS,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.140e-02,1.174e-01,2.807e-01,2.807e-01
+SDP_MC,ECS,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.140e-02,1.174e-01,2.807e-01,2.807e-01
+SDP_MC,ECS,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.041e-01,2.182e-01,2.893e-01,2.893e-01
+SDP_MC,ECS,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.698e-03,7.360e-02,1.091e-01,1.091e-01
+SDP_MC,ECS,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.461e-02,6.900e-02,7.977e-02,7.977e-02
+SDP_MC,ECS,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.396e-03,2.617e-02,5.456e-02,5.456e-02
+SDP_MC,ECS,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.396e-03,2.617e-02,5.456e-02,5.456e-02
+SDP_MC,ECS,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.396e-03,2.617e-02,5.456e-02,5.456e-02
+SDP_MC,ECS,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.461e-02,6.900e-02,7.977e-02,7.977e-02
 SDP_MC,ECS,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0.000e+00,8.315e-07,4.540e-05,1.192e-01,1.192e-01
 SDP_MC,ECS,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,ECS,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
@@ -3174,61 +3174,61 @@ SDP_MC,ECS,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_roa
 SDP_MC,ECS,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,ECS,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,ECS,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_MC,ECS,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_MC,ECS,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_MC,ECS,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_MC,ECS,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_MC,ECS,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_MC,ECS,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
+SDP_MC,ECS,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e-02,2.000e-02,6.250e-02,1.000e-01,1.000e-01
+SDP_MC,ECS,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e-05,1.300e-02,6.667e-02,1.400e-01,1.400e-01
+SDP_MC,ECS,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e-05,1.300e-02,6.667e-02,1.400e-01,1.400e-01
+SDP_MC,ECS,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e-05,1.300e-02,6.667e-02,1.400e-01,1.400e-01
+SDP_MC,ECS,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e-05,1.300e-02,6.667e-02,1.400e-01,1.400e-01
+SDP_MC,ECS,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e-05,1.300e-02,6.667e-02,1.400e-01,1.400e-01
 SDP_MC,ENC,,,,,Cycle,trn_pass,S3S,linear,2.500e-02,2.500e-02,5.556e-02,1.000e-01,1.000e-01
-SDP_MC,ENC,,,,,Domestic Aviation,trn_pass,S3S,linear,6.250e-05,6.250e-05,5.556e-05,2.500e-05,2.500e-05
-SDP_MC,ENC,,,,,Domestic Ship,trn_freight,S3S,linear,1.223e-02,1.223e-02,1.223e-02,1.223e-02,1.223e-02
-SDP_MC,ENC,,,,,Freight Rail,trn_freight,S3S,linear,2.875e-02,2.875e-02,2.875e-02,2.875e-02,2.875e-02
+SDP_MC,ENC,,,,,Domestic Aviation,trn_pass,S3S,linear,5.965e-05,5.965e-05,5.302e-05,2.386e-05,2.386e-05
+SDP_MC,ENC,,,,,Domestic Ship,trn_freight,S3S,linear,1.246e-02,1.246e-02,1.246e-02,1.246e-02,1.246e-02
+SDP_MC,ENC,,,,,Freight Rail,trn_freight,S3S,linear,2.928e-02,2.928e-02,2.928e-02,2.928e-02,2.928e-02
 SDP_MC,ENC,,,,,HSR,trn_pass,S3S,linear,1.250e-04,2.500e-04,2.222e-04,2.000e-04,2.000e-04
 SDP_MC,ENC,,,,,International Aviation,trn_aviation_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,ENC,,,,,International Ship,trn_shipping_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,ENC,,,,,Passenger Rail,trn_pass,S3S,linear,3.125e-03,3.125e-03,3.333e-03,2.000e-03,2.000e-03
 SDP_MC,ENC,,,,,Walk,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,ENC,,,,,trn_freight_road,trn_freight,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_MC,ENC,,,,,trn_pass_road,trn_pass,S3S,linear,7.500e-02,7.500e-02,6.667e-02,3.000e-02,3.000e-02
-SDP_MC,ENC,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,2.000e-01,1.500e-01,1.500e-01,1.500e-01,1.500e-01
+SDP_MC,ENC,,,,,trn_pass_road,trn_pass,S3S,linear,7.363e-02,7.363e-02,6.545e-02,2.945e-02,2.945e-02
+SDP_MC,ENC,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,2.037e-01,1.528e-01,1.528e-01,1.528e-01,1.528e-01
 SDP_MC,ENC,,,,trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,ENC,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,3.014e-02,3.014e-02,3.014e-02,3.014e-02,3.014e-02
 SDP_MC,ENC,,,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_MC,ENC,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,3.559e-01,3.559e-01,3.559e-01,3.559e-01,3.559e-01
+SDP_MC,ENC,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,3.955e-01,3.955e-01,3.955e-01,3.559e-01,3.559e-01
 SDP_MC,ENC,,Large Car and SUV,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,ENC,,Midsize Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.960e-01,1.960e-01,1.960e-01,1.960e-01,1.960e-01
-SDP_MC,ENC,,Mini Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,2.357e-07,2.357e-07,2.357e-07,2.357e-07,2.357e-07
+SDP_MC,ENC,,Mini Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,2.619e-07,2.619e-07,2.619e-07,2.357e-07,2.357e-07
 SDP_MC,ENC,,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.576e-01,1.576e-01,1.576e-01,1.576e-01,1.576e-01
 SDP_MC,ENC,,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,3.751e-02,3.751e-02,3.751e-02,3.751e-02,3.751e-02
 SDP_MC,ENC,,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_MC,ENC,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.963e-01,1.963e-01,1.963e-01,1.963e-01,1.963e-01
+SDP_MC,ENC,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,2.181e-01,2.181e-01,2.181e-01,1.963e-01,1.963e-01
 SDP_MC,ENC,,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,ENC,,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.002e-01,1.002e-01,1.002e-01,1.002e-01,1.002e-01
 SDP_MC,ENC,,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,3.593e-01,3.593e-01,3.593e-01,3.593e-01,3.593e-01
 SDP_MC,ENC,,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,4.374e-01,4.374e-01,4.374e-01,4.374e-01,4.374e-01
 SDP_MC,ENC,,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,4.946e-01,4.946e-01,4.946e-01,4.946e-01,4.946e-01
 SDP_MC,ENC,,Van,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.049e-03,1.049e-03,1.049e-03,1.049e-03,1.049e-03
-SDP_MC,ENC,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_MC,ENC,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_MC,ENC,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_MC,ENC,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.371e-01,6.724e-01,1.000e+00,1.000e+00
+SDP_MC,ENC,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,5.000e-02,2.300e-01,5.000e-01,5.000e-01
+SDP_MC,ENC,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,5.000e-02,2.300e-01,5.000e-01,5.000e-01
+SDP_MC,ENC,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,5.000e-02,2.300e-01,5.000e-01,5.000e-01
+SDP_MC,ENC,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.157e-01,7.227e-01,1.000e+00,1.000e+00
 SDP_MC,ENC,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,ENC,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,ENC,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_MC,ENC,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.622e-01,6.000e-01,9.820e-01,9.820e-01
-SDP_MC,ENC,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.043e-01,3.227e-01,9.526e-01,9.526e-01
-SDP_MC,ENC,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.043e-01,3.227e-01,9.526e-01,9.526e-01
-SDP_MC,ENC,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.043e-01,3.227e-01,9.526e-01,9.526e-01
-SDP_MC,ENC,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.622e-01,6.000e-01,9.820e-01,9.820e-01
-SDP_MC,ENC,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.236e-02,5.396e-02,1.312e-01,1.312e-01
-SDP_MC,ENC,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.693e-02,2.371e-01,1.462e-01,1.462e-01
-SDP_MC,ENC,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-02,8.993e-02,1.000e-01,1.000e-01
-SDP_MC,ENC,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-02,8.993e-02,1.000e-01,1.000e-01
-SDP_MC,ENC,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-02,8.993e-02,1.000e-01,1.000e-01
-SDP_MC,ENC,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.693e-02,2.371e-01,1.462e-01,1.462e-01
+SDP_MC,ENC,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.101e-01,6.386e-01,9.289e-01,9.289e-01
+SDP_MC,ENC,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.234e-01,3.434e-01,9.011e-01,9.011e-01
+SDP_MC,ENC,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.234e-01,3.434e-01,9.011e-01,9.011e-01
+SDP_MC,ENC,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.234e-01,3.434e-01,9.011e-01,9.011e-01
+SDP_MC,ENC,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.101e-01,6.386e-01,9.289e-01,9.289e-01
+SDP_MC,ENC,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.124e-02,5.800e-02,1.021e-01,1.021e-01
+SDP_MC,ENC,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,7.914e-02,2.804e-01,1.729e-01,1.729e-01
+SDP_MC,ENC,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.924e-02,1.063e-01,1.183e-01,1.183e-01
+SDP_MC,ENC,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.924e-02,1.063e-01,1.183e-01,1.183e-01
+SDP_MC,ENC,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.924e-02,1.063e-01,1.183e-01,1.183e-01
+SDP_MC,ENC,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,7.914e-02,2.804e-01,1.729e-01,1.729e-01
 SDP_MC,ENC,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0.000e+00,8.315e-07,4.540e-05,1.192e-01,1.192e-01
-SDP_MC,ENC,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,5.249e-01,5.249e-01
+SDP_MC,ENC,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,5.426e-01,5.426e-01
 SDP_MC,ENC,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,ENC,Liquids,Domestic Ship_tmp_vehicletype,Domestic Ship_tmp_subsector_L1,Domestic Ship_tmp_subsector_L2,Domestic Ship,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,ENC,Liquids,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1.341e-01,1.341e-01,1.341e-01,1.341e-01,1.341e-01
@@ -3243,30 +3243,30 @@ SDP_MC,ENC,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_roa
 SDP_MC,ENC,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,ENC,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,ENC,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_MC,ENC,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,2.533e-02,5.098e-02,1.023e-01,1.075e-01,1.075e-01
+SDP_MC,ENC,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,2.533e-02,3.921e-02,9.298e-02,1.011e-01,1.011e-01
 SDP_MC,ENC,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
 SDP_MC,ENC,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
 SDP_MC,ENC,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
 SDP_MC,ENC,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
 SDP_MC,ENC,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
 SDP_MC,ESC,,,,,Cycle,trn_pass,S3S,linear,1.942e-02,2.184e-02,4.369e-02,1.638e-01,1.638e-01
-SDP_MC,ESC,,,,,Domestic Aviation,trn_pass,S3S,linear,1.347e-04,3.789e-05,3.789e-05,7.579e-05,7.579e-05
-SDP_MC,ESC,,,,,Domestic Ship,trn_freight,S3S,linear,1.187e-02,1.187e-02,1.187e-02,1.187e-02,1.187e-02
-SDP_MC,ESC,,,,,Freight Rail,trn_freight,S3S,linear,4.020e-03,4.020e-03,4.020e-03,4.020e-03,4.020e-03
+SDP_MC,ESC,,,,,Domestic Aviation,trn_pass,S3S,linear,1.286e-04,3.616e-05,3.616e-05,7.233e-05,7.233e-05
+SDP_MC,ESC,,,,,Domestic Ship,trn_freight,S3S,linear,1.209e-02,1.209e-02,1.209e-02,1.209e-02,1.209e-02
+SDP_MC,ESC,,,,,Freight Rail,trn_freight,S3S,linear,4.094e-03,4.094e-03,4.094e-03,4.094e-03,4.094e-03
 SDP_MC,ESC,,,,,HSR,trn_pass,S3S,linear,6.613e-04,1.860e-04,6.200e-04,6.200e-04,6.200e-04
 SDP_MC,ESC,,,,,International Aviation,trn_aviation_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,ESC,,,,,International Ship,trn_shipping_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,ESC,,,,,Passenger Rail,trn_pass,S3S,linear,3.195e-03,2.696e-03,2.696e-03,4.044e-03,4.044e-03
 SDP_MC,ESC,,,,,Walk,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,ESC,,,,,trn_freight_road,trn_freight,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_MC,ESC,,,,,trn_pass_road,trn_pass,S3S,linear,1.832e-01,1.030e-01,8.242e-02,6.594e-02,6.594e-02
-SDP_MC,ESC,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,6.591e-02,6.591e-02,6.591e-02,9.887e-02,9.887e-02
+SDP_MC,ESC,,,,,trn_pass_road,trn_pass,S3S,linear,1.798e-01,1.011e-01,8.092e-02,6.473e-02,6.473e-02
+SDP_MC,ESC,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,6.714e-02,6.714e-02,6.714e-02,1.007e-01,1.007e-01
 SDP_MC,ESC,,,,trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_MC,ESC,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.687e-01,1.687e-01,1.687e-01,1.687e-01,1.687e-01
+SDP_MC,ESC,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.205e-01,1.125e-01,1.125e-01,1.125e-01,1.125e-01
 SDP_MC,ESC,,,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,ESC,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,3.942e-01,3.942e-01,3.942e-01,3.942e-01,3.942e-01
-SDP_MC,ESC,,Large Car and SUV,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,8.712e-01,8.712e-01,8.712e-01,8.712e-01,8.712e-01
-SDP_MC,ESC,,Midsize Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,2.323e-01,2.323e-01,2.323e-01,2.323e-01,2.323e-01
+SDP_MC,ESC,,Large Car and SUV,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,8.712e-01,7.840e-01,8.712e-01,8.712e-01,8.712e-01
+SDP_MC,ESC,,Midsize Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,2.323e-01,2.091e-01,2.323e-01,2.323e-01,2.323e-01
 SDP_MC,ESC,,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.009e-01,1.009e-01,1.009e-01,1.009e-01,1.009e-01
 SDP_MC,ESC,,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,6.375e-02,6.375e-02,6.375e-02,6.375e-02,6.375e-02
 SDP_MC,ESC,,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
@@ -3276,24 +3276,24 @@ SDP_MC,ESC,,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_s
 SDP_MC,ESC,,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,2.234e-01,2.234e-01,2.234e-01,2.234e-01,2.234e-01
 SDP_MC,ESC,,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,2.172e-01,2.172e-01,2.172e-01,2.172e-01,2.172e-01
 SDP_MC,ESC,,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_MC,ESC,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_MC,ESC,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_MC,ESC,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_MC,ESC,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.423e-01,4.034e-01,9.526e-01,9.526e-01
+SDP_MC,ESC,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.000e-02,2.200e-01,4.200e-01,4.200e-01
+SDP_MC,ESC,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.000e-02,2.200e-01,4.200e-01,4.200e-01
+SDP_MC,ESC,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.000e-02,2.200e-01,4.200e-01,4.200e-01
+SDP_MC,ESC,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.359e-01,3.816e-01,8.448e-01,8.448e-01
 SDP_MC,ESC,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,ESC,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,ESC,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_MC,ESC,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.384e-01,5.000e-01,9.820e-01,9.820e-01
-SDP_MC,ESC,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,9.485e-02,2.689e-01,9.526e-01,9.526e-01
-SDP_MC,ESC,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,9.485e-02,2.689e-01,9.526e-01,9.526e-01
-SDP_MC,ESC,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,9.485e-02,2.689e-01,9.526e-01,9.526e-01
-SDP_MC,ESC,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.384e-01,5.000e-01,9.820e-01,9.820e-01
-SDP_MC,ESC,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.236e-02,5.396e-02,1.000e-01,1.000e-01
-SDP_MC,ESC,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.693e-02,4.743e-02,1.462e-01,1.462e-01
-SDP_MC,ESC,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-02,1.799e-02,1.000e-01,1.000e-01
-SDP_MC,ESC,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-02,1.799e-02,1.000e-01,1.000e-01
-SDP_MC,ESC,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-02,1.799e-02,1.000e-01,1.000e-01
-SDP_MC,ESC,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.693e-02,4.743e-02,1.462e-01,1.462e-01
+SDP_MC,ESC,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.819e-01,5.321e-01,7.741e-01,7.741e-01
+SDP_MC,ESC,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.122e-01,2.862e-01,7.509e-01,7.509e-01
+SDP_MC,ESC,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.122e-01,2.862e-01,7.509e-01,7.509e-01
+SDP_MC,ESC,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.122e-01,2.862e-01,7.509e-01,7.509e-01
+SDP_MC,ESC,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.819e-01,5.321e-01,7.741e-01,7.741e-01
+SDP_MC,ESC,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.124e-02,6.380e-02,7.883e-02,7.883e-02
+SDP_MC,ESC,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,7.914e-02,5.608e-02,1.441e-01,1.441e-01
+SDP_MC,ESC,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.924e-02,2.127e-02,9.854e-02,9.854e-02
+SDP_MC,ESC,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.924e-02,2.127e-02,9.854e-02,9.854e-02
+SDP_MC,ESC,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.924e-02,2.127e-02,9.854e-02,9.854e-02
+SDP_MC,ESC,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,7.914e-02,5.608e-02,1.441e-01,1.441e-01
 SDP_MC,ESC,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0.000e+00,8.315e-07,4.540e-05,1.192e-01,1.192e-01
 SDP_MC,ESC,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,ESC,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
@@ -3310,57 +3310,57 @@ SDP_MC,ESC,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_roa
 SDP_MC,ESC,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,ESC,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,ESC,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_MC,ESC,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,2.742e-02,5.301e-02,1.042e-01,2.066e-01,2.066e-01
-SDP_MC,ESC,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SDP_MC,ESC,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SDP_MC,ESC,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SDP_MC,ESC,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SDP_MC,ESC,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
+SDP_MC,ESC,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,2.742e-02,4.078e-02,1.042e-01,1.721e-01,1.721e-01
+SDP_MC,ESC,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.535e-01,1.535e-01
+SDP_MC,ESC,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.535e-01,1.535e-01
+SDP_MC,ESC,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.535e-01,1.535e-01
+SDP_MC,ESC,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.535e-01,1.535e-01
+SDP_MC,ESC,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.535e-01,1.535e-01
 SDP_MC,ESW,,,,,Cycle,trn_pass,S3S,linear,1.942e-02,3.884e-02,5.825e-02,1.019e-01,1.019e-01
-SDP_MC,ESW,,,,,Domestic Aviation,trn_pass,S3S,linear,7.179e-04,7.179e-04,5.744e-04,1.346e-04,1.346e-04
-SDP_MC,ESW,,,,,Domestic Ship,trn_freight,S3S,linear,6.018e-03,6.018e-03,6.018e-03,6.018e-03,6.018e-03
-SDP_MC,ESW,,,,,Freight Rail,trn_freight,S3S,linear,1.394e-02,1.394e-02,1.394e-02,1.394e-02,1.394e-02
+SDP_MC,ESW,,,,,Domestic Aviation,trn_pass,S3S,linear,6.852e-04,6.852e-04,5.482e-04,1.285e-04,1.285e-04
+SDP_MC,ESW,,,,,Domestic Ship,trn_freight,S3S,linear,6.130e-03,6.130e-03,6.130e-03,6.130e-03,6.130e-03
+SDP_MC,ESW,,,,,Freight Rail,trn_freight,S3S,linear,1.420e-02,1.420e-02,1.420e-02,1.420e-02,1.420e-02
 SDP_MC,ESW,,,,,HSR,trn_pass,S3S,linear,9.579e-04,9.579e-04,9.579e-04,3.592e-04,3.592e-04
 SDP_MC,ESW,,,,,International Aviation,trn_aviation_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,ESW,,,,,International Ship,trn_shipping_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,ESW,,,,,Passenger Rail,trn_pass,S3S,linear,3.621e-03,3.621e-03,5.432e-03,2.037e-03,2.037e-03
 SDP_MC,ESW,,,,,Walk,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,ESW,,,,,trn_freight_road,trn_freight,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_MC,ESW,,,,,trn_pass_road,trn_pass,S3S,linear,1.411e-01,1.129e-01,1.129e-01,3.175e-02,3.175e-02
-SDP_MC,ESW,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,5.667e-02,5.667e-02,7.083e-02,1.063e-01,1.063e-01
+SDP_MC,ESW,,,,,trn_pass_road,trn_pass,S3S,linear,1.385e-01,1.108e-01,1.108e-01,3.117e-02,3.117e-02
+SDP_MC,ESW,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,5.772e-02,5.772e-02,7.215e-02,1.082e-01,1.082e-01
 SDP_MC,ESW,,,,trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_MC,ESW,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,8.570e-02,8.570e-02,8.570e-02,8.570e-02,8.570e-02
+SDP_MC,ESW,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,7.141e-02,7.141e-02,7.141e-02,6.592e-02,6.592e-02
 SDP_MC,ESW,,,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_MC,ESW,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,5.153e-01,5.153e-01,5.153e-01,5.153e-01,5.153e-01
+SDP_MC,ESW,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,5.725e-01,5.725e-01,5.725e-01,5.725e-01,5.725e-01
 SDP_MC,ESW,,Large Car and SUV,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,ESW,,Midsize Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,2.963e-01,2.963e-01,2.963e-01,2.963e-01,2.963e-01
 SDP_MC,ESW,,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,9.741e-02,9.741e-02,9.741e-02,9.741e-02,9.741e-02
 SDP_MC,ESW,,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.669e-01,1.669e-01,1.669e-01,1.669e-01,1.669e-01
 SDP_MC,ESW,,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_MC,ESW,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,4.003e-01,4.003e-01,4.003e-01,4.003e-01,4.003e-01
+SDP_MC,ESW,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,4.448e-01,4.448e-01,4.448e-01,4.448e-01,4.448e-01
 SDP_MC,ESW,,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,2.850e-01,2.850e-01,2.850e-01,2.850e-01,2.850e-01
 SDP_MC,ESW,,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,6.043e-02,6.043e-02,6.043e-02,6.043e-02,6.043e-02
 SDP_MC,ESW,,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,8.424e-02,8.424e-02,8.424e-02,8.424e-02,8.424e-02
 SDP_MC,ESW,,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,4.041e-01,4.041e-01,4.041e-01,4.041e-01,4.041e-01
 SDP_MC,ESW,,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_MC,ESW,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_MC,ESW,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_MC,ESW,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_MC,ESW,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.186e-01,2.689e-01,6.668e-01,6.668e-01
+SDP_MC,ESW,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.800e-02,2.160e-01,4.200e-01,4.200e-01
+SDP_MC,ESW,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.800e-02,2.160e-01,4.200e-01,4.200e-01
+SDP_MC,ESW,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.800e-02,2.160e-01,4.200e-01,4.200e-01
+SDP_MC,ESW,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.078e-02,1.164e-01,2.935e-01,6.237e-01,6.237e-01
 SDP_MC,ESW,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,7.295e-01,7.633e-01,8.309e-01,9.662e-01,9.662e-01
 SDP_MC,ESW,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,ESW,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_MC,ESW,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.576e-01,7.000e-01,9.820e-01,9.820e-01
-SDP_MC,ESW,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.423e-01,3.765e-01,9.526e-01,9.526e-01
-SDP_MC,ESW,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.423e-01,3.765e-01,9.526e-01,9.526e-01
-SDP_MC,ESW,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.423e-01,3.765e-01,9.526e-01,9.526e-01
-SDP_MC,ESW,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.576e-01,7.000e-01,9.820e-01,9.820e-01
-SDP_MC,ESW,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.473e-03,1.799e-02,7.500e-02,7.500e-02
-SDP_MC,ESW,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.693e-02,2.371e-01,1.462e-01,1.462e-01
-SDP_MC,ESW,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-02,8.993e-02,1.000e-01,1.000e-01
-SDP_MC,ESW,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-02,8.993e-02,1.000e-01,1.000e-01
-SDP_MC,ESW,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-02,8.993e-02,1.000e-01,1.000e-01
-SDP_MC,ESW,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.693e-02,2.371e-01,1.462e-01,1.462e-01
+SDP_MC,ESW,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.902e-01,6.875e-01,1.000e+00,1.000e+00
+SDP_MC,ESW,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.553e-01,3.698e-01,1.000e+00,1.000e+00
+SDP_MC,ESW,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.553e-01,3.698e-01,1.000e+00,1.000e+00
+SDP_MC,ESW,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.553e-01,3.698e-01,1.000e+00,1.000e+00
+SDP_MC,ESW,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.902e-01,6.875e-01,1.000e+00,1.000e+00
+SDP_MC,ESW,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,2.248e-03,2.698e-03,1.963e-02,5.846e-02,5.846e-02
+SDP_MC,ESW,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,7.303e-02,2.588e-01,1.489e-01,1.489e-01
+SDP_MC,ESW,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.698e-02,9.813e-02,1.050e-01,1.050e-01
+SDP_MC,ESW,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.698e-02,9.813e-02,1.050e-01,1.050e-01
+SDP_MC,ESW,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.698e-02,9.813e-02,1.050e-01,1.050e-01
+SDP_MC,ESW,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,7.303e-02,2.588e-01,1.489e-01,1.489e-01
 SDP_MC,ESW,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0.000e+00,8.315e-07,4.540e-05,1.192e-01,1.192e-01
 SDP_MC,ESW,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,ESW,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
@@ -3372,39 +3372,39 @@ SDP_MC,ESW,Liquids,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,tr
 SDP_MC,ESW,Liquids,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,ESW,Liquids,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,ESW,Liquids,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,5.162e-01,5.162e-01,5.162e-01,5.162e-01,5.162e-01
-SDP_MC,ESW,Liquids,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_MC,ESW,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_MC,ESW,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_MC,ESW,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_MC,ESW,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_MC,ESW,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SDP_MC,ESW,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SDP_MC,ESW,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SDP_MC,ESW,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SDP_MC,ESW,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SDP_MC,ESW,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
+SDP_MC,ESW,Liquids,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,9.332e-01,9.332e-01
+SDP_MC,ESW,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,9.620e-01,9.620e-01
+SDP_MC,ESW,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,9.620e-01,9.620e-01
+SDP_MC,ESW,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,9.620e-01,9.620e-01
+SDP_MC,ESW,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,9.332e-01,9.332e-01
+SDP_MC,ESW,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.754e-02,2.632e-02,7.895e-02,1.316e-01,1.316e-01
+SDP_MC,ESW,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.719e-01,1.719e-01
+SDP_MC,ESW,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.772e-01,1.772e-01
+SDP_MC,ESW,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.772e-01,1.772e-01
+SDP_MC,ESW,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.772e-01,1.772e-01
+SDP_MC,ESW,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.719e-01,1.719e-01
 SDP_MC,EWN,,,,,Cycle,trn_pass,S3S,linear,1.000e-02,1.000e-02,5.000e-02,1.000e-01,1.000e-01
-SDP_MC,EWN,,,,,Domestic Aviation,trn_pass,S3S,linear,5.000e-05,5.000e-05,5.000e-05,5.000e-06,5.000e-06
-SDP_MC,EWN,,,,,Domestic Ship,trn_freight,S3S,linear,6.147e-03,6.830e-03,6.147e-03,6.147e-03,6.147e-03
-SDP_MC,EWN,,,,,Freight Rail,trn_freight,S3S,linear,1.246e-02,1.385e-02,1.246e-02,1.246e-02,1.246e-02
+SDP_MC,EWN,,,,,Domestic Aviation,trn_pass,S3S,linear,4.772e-05,4.772e-05,4.772e-05,4.772e-06,4.772e-06
+SDP_MC,EWN,,,,,Domestic Ship,trn_freight,S3S,linear,6.261e-03,6.957e-03,6.261e-03,6.261e-03,6.261e-03
+SDP_MC,EWN,,,,,Freight Rail,trn_freight,S3S,linear,1.270e-02,1.411e-02,1.270e-02,1.270e-02,1.270e-02
 SDP_MC,EWN,,,,,HSR,trn_pass,S3S,linear,1.000e-04,1.000e-04,4.000e-04,2.000e-04,2.000e-04
 SDP_MC,EWN,,,,,International Aviation,trn_aviation_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,EWN,,,,,International Ship,trn_shipping_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,EWN,,,,,Passenger Rail,trn_pass,S3S,linear,2.000e-03,3.000e-03,3.000e-03,2.000e-03,2.000e-03
 SDP_MC,EWN,,,,,Walk,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,EWN,,,,,trn_freight_road,trn_freight,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_MC,EWN,,,,,trn_pass_road,trn_pass,S3S,linear,6.000e-02,6.000e-02,6.000e-02,3.000e-02,3.000e-02
-SDP_MC,EWN,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,1.000e-01,1.000e-01,1.000e-01,1.500e-01,1.500e-01
+SDP_MC,EWN,,,,,trn_pass_road,trn_pass,S3S,linear,5.891e-02,5.891e-02,5.891e-02,2.945e-02,2.945e-02
+SDP_MC,EWN,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,1.019e-01,1.019e-01,1.019e-01,1.528e-01,1.528e-01
 SDP_MC,EWN,,,,trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,EWN,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,4.166e-02,4.166e-02,4.166e-02,4.166e-02,4.166e-02
 SDP_MC,EWN,,,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_MC,EWN,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,3.886e-01,3.886e-01,3.886e-01,3.886e-01,3.886e-01
+SDP_MC,EWN,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,4.317e-01,4.317e-01,3.886e-01,3.886e-01,3.886e-01
 SDP_MC,EWN,,Large Car and SUV,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,EWN,,Midsize Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,2.283e-01,2.283e-01,2.283e-01,2.283e-01,2.283e-01
 SDP_MC,EWN,,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.183e-01,1.183e-01,1.183e-01,1.183e-01,1.183e-01
 SDP_MC,EWN,,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,4.339e-02,4.339e-02,4.339e-02,4.339e-02,4.339e-02
 SDP_MC,EWN,,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_MC,EWN,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,4.377e-01,4.377e-01,4.377e-01,4.377e-01,4.377e-01
+SDP_MC,EWN,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,4.864e-01,4.864e-01,4.377e-01,4.377e-01,4.377e-01
 SDP_MC,EWN,,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,EWN,,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.164e-01,1.164e-01,1.164e-01,1.164e-01,1.164e-01
 SDP_MC,EWN,,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,5.225e-01,5.225e-01,5.225e-01,5.225e-01,5.225e-01
@@ -3413,21 +3413,21 @@ SDP_MC,EWN,,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_
 SDP_MC,EWN,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1.000e-03,6.000e-02,2.450e-01,4.500e-01,4.500e-01
 SDP_MC,EWN,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1.000e-03,6.000e-02,2.450e-01,4.500e-01,4.500e-01
 SDP_MC,EWN,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1.000e-03,6.000e-02,2.450e-01,4.500e-01,4.500e-01
-SDP_MC,EWN,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.958e-02,2.323e-01,4.763e-01,4.763e-01
+SDP_MC,EWN,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,8.794e-02,2.197e-01,5.006e-01,5.006e-01
 SDP_MC,EWN,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,EWN,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,EWN,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_MC,EWN,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.550e-01,6.500e-01,8.729e-01,8.729e-01
-SDP_MC,EWN,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.165e-02,3.496e-01,8.467e-01,8.467e-01
-SDP_MC,EWN,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.165e-02,3.496e-01,8.467e-01,8.467e-01
-SDP_MC,EWN,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.165e-02,3.496e-01,8.467e-01,8.467e-01
-SDP_MC,EWN,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.550e-01,6.500e-01,8.729e-01,8.729e-01
-SDP_MC,EWN,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.573e-03,6.540e-03,1.667e-02,1.667e-02
-SDP_MC,EWN,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,9.370e-03,4.743e-02,4.061e-02,4.061e-02
-SDP_MC,EWN,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.462e-03,1.799e-02,2.778e-02,2.778e-02
-SDP_MC,EWN,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.462e-03,1.799e-02,2.778e-02,2.778e-02
-SDP_MC,EWN,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.462e-03,1.799e-02,2.778e-02,2.778e-02
-SDP_MC,EWN,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,9.370e-03,4.743e-02,4.061e-02,4.061e-02
+SDP_MC,EWN,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.436e-01,6.405e-01,9.031e-01,9.031e-01
+SDP_MC,EWN,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.367e-01,3.445e-01,8.760e-01,8.760e-01
+SDP_MC,EWN,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.367e-01,3.445e-01,8.760e-01,8.760e-01
+SDP_MC,EWN,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.367e-01,3.445e-01,8.760e-01,8.760e-01
+SDP_MC,EWN,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.436e-01,6.405e-01,9.031e-01,9.031e-01
+SDP_MC,EWN,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.861e-03,7.734e-03,2.190e-02,2.190e-02
+SDP_MC,EWN,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.385e-02,1.059e-01,6.003e-02,6.003e-02
+SDP_MC,EWN,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.116e-03,4.017e-02,4.106e-02,4.106e-02
+SDP_MC,EWN,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.116e-03,4.017e-02,4.106e-02,4.106e-02
+SDP_MC,EWN,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.116e-03,4.017e-02,4.106e-02,4.106e-02
+SDP_MC,EWN,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.385e-02,1.059e-01,6.003e-02,6.003e-02
 SDP_MC,EWN,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0.000e+00,8.315e-07,4.540e-05,1.192e-01,1.192e-01
 SDP_MC,EWN,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,EWN,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
@@ -3444,26 +3444,26 @@ SDP_MC,EWN,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_roa
 SDP_MC,EWN,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,EWN,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,EWN,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_MC,EWN,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,8.070e-03,3.107e-02,6.282e-02,8.745e-02,8.745e-02
-SDP_MC,EWN,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,8.171e-04,2.711e-02,7.970e-02,1.027e-01,1.027e-01
-SDP_MC,EWN,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.023e-01,1.023e-01
-SDP_MC,EWN,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.023e-01,1.023e-01
-SDP_MC,EWN,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.023e-01,1.023e-01
-SDP_MC,EWN,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.023e-01,1.023e-01
+SDP_MC,EWN,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,8.070e-03,3.107e-02,6.282e-02,9.716e-02,9.716e-02
+SDP_MC,EWN,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,8.171e-04,3.389e-02,8.856e-02,1.284e-01,1.284e-01
+SDP_MC,EWN,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.289e-02,8.772e-02,1.279e-01,1.279e-01
+SDP_MC,EWN,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.289e-02,8.772e-02,1.279e-01,1.279e-01
+SDP_MC,EWN,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.289e-02,8.772e-02,1.279e-01,1.279e-01
+SDP_MC,EWN,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.289e-02,8.772e-02,1.279e-01,1.279e-01
 SDP_MC,FRA,,,,,Cycle,trn_pass,S3S,linear,1.942e-02,2.184e-02,3.641e-02,1.019e-01,1.019e-01
-SDP_MC,FRA,,,,,Domestic Aviation,trn_pass,S3S,linear,1.225e-04,6.891e-05,4.594e-05,2.297e-05,2.297e-05
-SDP_MC,FRA,,,,,Domestic Ship,trn_freight,S3S,linear,3.357e-03,3.357e-03,3.357e-03,3.357e-03,3.357e-03
-SDP_MC,FRA,,,,,Freight Rail,trn_freight,S3S,linear,1.766e-02,1.766e-02,1.766e-02,1.766e-02,1.766e-02
+SDP_MC,FRA,,,,,Domestic Aviation,trn_pass,S3S,linear,1.169e-04,6.577e-05,4.385e-05,2.192e-05,2.192e-05
+SDP_MC,FRA,,,,,Domestic Ship,trn_freight,S3S,linear,3.419e-03,3.419e-03,3.419e-03,3.419e-03,3.419e-03
+SDP_MC,FRA,,,,,Freight Rail,trn_freight,S3S,linear,1.799e-02,1.799e-02,1.799e-02,1.799e-02,1.799e-02
 SDP_MC,FRA,,,,,HSR,trn_pass,S3S,linear,3.359e-04,2.267e-04,2.015e-04,2.015e-04,2.015e-04
 SDP_MC,FRA,,,,,International Aviation,trn_aviation_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,FRA,,,,,International Ship,trn_shipping_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,FRA,,,,,Passenger Rail,trn_pass,S3S,linear,3.972e-03,2.979e-03,1.986e-03,1.986e-03,1.986e-03
 SDP_MC,FRA,,,,,Walk,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,FRA,,,,,trn_freight_road,trn_freight,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_MC,FRA,,,,,trn_pass_road,trn_pass,S3S,linear,9.224e-02,5.188e-02,3.459e-02,2.767e-02,2.767e-02
-SDP_MC,FRA,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,7.788e-02,8.566e-02,9.345e-02,1.402e-01,1.402e-01
+SDP_MC,FRA,,,,,trn_pass_road,trn_pass,S3S,linear,9.055e-02,5.094e-02,3.396e-02,2.717e-02,2.717e-02
+SDP_MC,FRA,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,7.932e-02,8.726e-02,9.519e-02,1.428e-01,1.428e-01
 SDP_MC,FRA,,,,trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_MC,FRA,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,9.470e-02,9.470e-02,9.470e-02,9.470e-02,9.470e-02
+SDP_MC,FRA,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,7.285e-02,7.285e-02,7.285e-02,6.764e-02,6.764e-02
 SDP_MC,FRA,,,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,FRA,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,6.352e-01,6.352e-01,6.352e-01,6.352e-01,6.352e-01
 SDP_MC,FRA,,Large Car and SUV,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
@@ -3477,26 +3477,26 @@ SDP_MC,FRA,,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_s
 SDP_MC,FRA,,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.602e-01,1.602e-01,1.602e-01,1.602e-01,1.602e-01
 SDP_MC,FRA,,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,4.011e-01,4.011e-01,4.011e-01,4.011e-01,4.011e-01
 SDP_MC,FRA,,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,3.755e-01,3.755e-01,3.755e-01,3.755e-01,3.755e-01
-SDP_MC,FRA,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_MC,FRA,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_MC,FRA,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_MC,FRA,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.423e-01,4.303e-01,1.000e+00,1.000e+00
+SDP_MC,FRA,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.000e-02,2.400e-01,4.200e-01,4.200e-01
+SDP_MC,FRA,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.000e-02,2.400e-01,4.200e-01,4.200e-01
+SDP_MC,FRA,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.000e-02,2.400e-01,4.200e-01,4.200e-01
+SDP_MC,FRA,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.402e-02,1.682e-01,4.579e-01,9.531e-01,9.531e-01
 SDP_MC,FRA,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,FRA,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,FRA,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_MC,FRA,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.980e-01,7.500e-01,9.820e-01,9.820e-01
-SDP_MC,FRA,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.186e-01,4.034e-01,9.526e-01,9.526e-01
-SDP_MC,FRA,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.186e-01,4.034e-01,9.526e-01,9.526e-01
-SDP_MC,FRA,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.186e-01,4.034e-01,9.526e-01,9.526e-01
-SDP_MC,FRA,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.980e-01,7.500e-01,9.820e-01,9.820e-01
-SDP_MC,FRA,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.236e-02,1.799e-02,9.544e-02,9.544e-02
-SDP_MC,FRA,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.693e-02,4.743e-02,1.462e-01,1.462e-01
-SDP_MC,FRA,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-02,1.799e-02,1.000e-01,1.000e-01
-SDP_MC,FRA,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-02,1.799e-02,1.000e-01,1.000e-01
-SDP_MC,FRA,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-02,1.799e-02,1.000e-01,1.000e-01
-SDP_MC,FRA,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.693e-02,4.743e-02,1.462e-01,1.462e-01
+SDP_MC,FRA,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.171e-01,6.651e-01,9.087e-01,9.087e-01
+SDP_MC,FRA,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.262e-01,3.578e-01,8.815e-01,8.815e-01
+SDP_MC,FRA,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.262e-01,3.578e-01,8.815e-01,8.815e-01
+SDP_MC,FRA,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.262e-01,3.578e-01,8.815e-01,8.815e-01
+SDP_MC,FRA,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.171e-01,6.651e-01,9.087e-01,9.087e-01
+SDP_MC,FRA,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.218e-02,1.462e-02,2.127e-02,8.186e-02,8.186e-02
+SDP_MC,FRA,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,7.914e-02,2.337e-01,1.503e-01,1.503e-01
+SDP_MC,FRA,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.924e-02,8.861e-02,1.028e-01,1.028e-01
+SDP_MC,FRA,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.924e-02,8.861e-02,1.028e-01,1.028e-01
+SDP_MC,FRA,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.924e-02,8.861e-02,1.028e-01,1.028e-01
+SDP_MC,FRA,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,7.914e-02,2.337e-01,1.503e-01,1.503e-01
 SDP_MC,FRA,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0.000e+00,8.315e-07,4.540e-05,1.192e-01,1.192e-01
-SDP_MC,FRA,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,9.544e-01,9.544e-01
+SDP_MC,FRA,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,FRA,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,FRA,Liquids,Domestic Ship_tmp_vehicletype,Domestic Ship_tmp_subsector_L1,Domestic Ship_tmp_subsector_L2,Domestic Ship,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,FRA,Liquids,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1.608e-01,1.608e-01,1.608e-01,1.608e-01,1.608e-01
@@ -3511,26 +3511,26 @@ SDP_MC,FRA,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_roa
 SDP_MC,FRA,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,FRA,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,FRA,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_MC,FRA,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.758e-01,1.758e-01
-SDP_MC,FRA,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SDP_MC,FRA,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SDP_MC,FRA,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SDP_MC,FRA,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SDP_MC,FRA,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SDP_MC,IND,,,,,Cycle,trn_pass,S3S,linear,2.632e-03,4.364e-03,9.091e-03,1.000e-01,1.000e-01
-SDP_MC,IND,,,,,Domestic Aviation,trn_pass,S3S,linear,9.589e-02,1.091e-01,1.000e-01,2.000e-01,2.000e-01
-SDP_MC,IND,,,,,Domestic Ship,trn_freight,S3S,linear,1.180e-03,1.180e-03,1.073e-03,9.075e-04,9.075e-04
-SDP_MC,IND,,,,,Freight Rail,trn_freight,S3S,linear,1.889e-01,1.889e-01,1.717e-01,1.453e-01,1.453e-01
-SDP_MC,IND,,,,,HSR,trn_pass,S3S,linear,0.000e+00,4.364e-05,1.000e-04,3.000e-04,3.000e-04
+SDP_MC,FRA,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.535e-02,2.632e-02,7.895e-02,1.417e-01,1.417e-01
+SDP_MC,FRA,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,6.579e-02,1.602e-01,1.602e-01
+SDP_MC,FRA,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,6.579e-02,1.602e-01,1.602e-01
+SDP_MC,FRA,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,6.579e-02,1.602e-01,1.602e-01
+SDP_MC,FRA,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,6.579e-02,1.602e-01,1.602e-01
+SDP_MC,FRA,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,6.579e-02,1.602e-01,1.602e-01
+SDP_MC,IND,,,,,Cycle,trn_pass,S3S,linear,1.915e-02,3.175e-02,4.630e-02,1.000e-01,1.000e-01
+SDP_MC,IND,,,,,Domestic Aviation,trn_pass,S3S,linear,6.659e-01,7.575e-01,4.861e-01,1.909e-01,1.909e-01
+SDP_MC,IND,,,,,Domestic Ship,trn_freight,S3S,linear,1.202e-03,1.202e-03,1.092e-03,9.244e-04,9.244e-04
+SDP_MC,IND,,,,,Freight Rail,trn_freight,S3S,linear,1.924e-01,1.924e-01,1.574e-01,1.332e-01,1.332e-01
+SDP_MC,IND,,,,,HSR,trn_pass,S3S,linear,0.000e+00,3.175e-04,5.093e-04,3.000e-04,3.000e-04
 SDP_MC,IND,,,,,International Aviation,trn_aviation_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,IND,,,,,International Ship,trn_shipping_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_MC,IND,,,,,Passenger Rail,trn_pass,S3S,linear,6.842e-04,8.000e-04,1.091e-03,4.000e-03,4.000e-03
-SDP_MC,IND,,,,,Walk,trn_pass,S3S,linear,1.316e-01,9.455e-02,1.818e-01,1.000e+00,1.000e+00
+SDP_MC,IND,,,,,Passenger Rail,trn_pass,S3S,linear,4.978e-03,5.820e-03,5.556e-03,4.000e-03,4.000e-03
+SDP_MC,IND,,,,,Walk,trn_pass,S3S,linear,9.573e-01,6.879e-01,9.260e-01,1.000e+00,1.000e+00
 SDP_MC,IND,,,,,trn_freight_road,trn_freight,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_MC,IND,,,,,trn_pass_road,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_MC,IND,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,1.188e-01,7.143e-02,3.231e-02,3.231e-02,3.231e-02
-SDP_MC,IND,,,,trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_MC,IND,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,3.027e-03,2.668e-03,1.949e-03,5.108e-04,5.108e-04
+SDP_MC,IND,,,,,trn_pass_road,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,2.945e-01,2.945e-01
+SDP_MC,IND,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,1.000e+00,3.638e-01,1.645e-01,9.872e-02,9.872e-02
+SDP_MC,IND,,,,trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,9.180e-01,1.000e+00,1.000e+00,1.000e+00,1.000e+00
+SDP_MC,IND,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.816e-02,1.867e-02,2.923e-02,5.108e-02,5.108e-02
 SDP_MC,IND,,,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,IND,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,IND,,Mini Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,6.374e-03,6.374e-03,6.374e-03,6.374e-03,6.374e-03
@@ -3541,24 +3541,24 @@ SDP_MC,IND,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,
 SDP_MC,IND,,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.853e-01,1.853e-01,1.853e-01,1.853e-01,1.853e-01
 SDP_MC,IND,,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.987e-01,1.987e-01,1.987e-01,1.987e-01,1.987e-01
 SDP_MC,IND,,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_MC,IND,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_MC,IND,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_MC,IND,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_MC,IND,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.743e-02,2.689e-01,7.621e-01,7.621e-01
+SDP_MC,IND,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.000e-01,3.600e-01,3.780e-01,3.780e-01
+SDP_MC,IND,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.000e-01,3.600e-01,3.780e-01,3.780e-01
+SDP_MC,IND,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.000e-01,3.600e-01,3.780e-01,3.780e-01
+SDP_MC,IND,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,5.175e-02,2.935e-01,6.653e-01,6.653e-01
 SDP_MC,IND,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,IND,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,IND,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,8.340e-01,8.547e-01,8.962e-01,9.792e-01,9.792e-01
-SDP_MC,IND,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.576e-02,1.000e-01,9.820e-02,9.820e-02
-SDP_MC,IND,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.423e-02,5.379e-02,9.526e-02,9.526e-02
-SDP_MC,IND,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,3.000e-01,2.000e-01,1.000e-01,1.000e-01
-SDP_MC,IND,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,3.000e-01,2.000e-01,1.000e-01,1.000e-01
-SDP_MC,IND,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.576e-02,1.000e-01,9.820e-02,9.820e-02
-SDP_MC,IND,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.473e-03,1.799e-02,5.000e-02,5.000e-02
-SDP_MC,IND,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.693e-03,9.485e-03,1.462e-02,1.462e-02
-SDP_MC,IND,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-03,3.597e-03,1.000e-02,1.000e-02
-SDP_MC,IND,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,2.000e-01,2.000e-02,2.000e-02
-SDP_MC,IND,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,2.000e-01,2.000e-02,2.000e-02
-SDP_MC,IND,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.693e-03,9.485e-03,1.462e-02,1.462e-02
+SDP_MC,IND,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.787e-02,6.365e-02,6.430e-02,6.430e-02
+SDP_MC,IND,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.109e-02,3.424e-02,6.237e-02,6.237e-02
+SDP_MC,IND,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,2.338e-01,1.273e-01,6.547e-02,6.547e-02
+SDP_MC,IND,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,2.338e-01,1.273e-01,6.547e-02,6.547e-02
+SDP_MC,IND,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.787e-02,6.365e-02,6.430e-02,6.430e-02
+SDP_MC,IND,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.698e-03,1.963e-02,5.456e-02,5.456e-02
+SDP_MC,IND,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.217e-03,8.625e-03,1.595e-03,1.595e-03
+SDP_MC,IND,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.927e-03,3.271e-03,1.091e-03,1.091e-03
+SDP_MC,IND,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,7.794e-01,1.819e-01,2.182e-03,2.182e-03
+SDP_MC,IND,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,7.794e-01,1.819e-01,2.182e-03,2.182e-03
+SDP_MC,IND,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.217e-03,8.625e-03,1.595e-03,1.595e-03
 SDP_MC,IND,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0.000e+00,8.315e-07,4.540e-05,1.192e-01,1.192e-01
 SDP_MC,IND,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,IND,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
@@ -3572,27 +3572,27 @@ SDP_MC,IND,Liquids,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,tr
 SDP_MC,IND,Liquids,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,IND,Liquids,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,IND,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_MC,IND,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_MC,IND,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
+SDP_MC,IND,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,9.164e-01,1.000e+00,1.000e+00,1.000e+00,1.000e+00
+SDP_MC,IND,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,9.164e-01,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,IND,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,IND,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,2.408e-01,2.086e-01,2.105e-01,1.903e-01,1.903e-01
-SDP_MC,IND,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,8.768e-02,1.117e-01,7.985e-02,2.557e-02,2.557e-02
-SDP_MC,IND,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,3.947e-02,1.842e-02,1.842e-02
-SDP_MC,IND,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,5.000e-01,1.000e-01,1.000e-01
-SDP_MC,IND,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,5.000e-01,1.000e-01,1.000e-01
-SDP_MC,IND,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,3.947e-02,1.842e-02,1.842e-02
+SDP_MC,IND,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,8.768e-02,7.978e-02,6.655e-02,2.557e-02,2.557e-02
+SDP_MC,IND,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.880e-02,3.289e-02,1.842e-02,1.842e-02
+SDP_MC,IND,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,9.164e-01,7.143e-01,4.167e-01,1.000e-01,1.000e-01
+SDP_MC,IND,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,9.164e-01,7.143e-01,4.167e-01,1.000e-01,1.000e-01
+SDP_MC,IND,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.880e-02,3.289e-02,1.842e-02,1.842e-02
 SDP_MC,JPN,,,,,Cycle,trn_pass,S3S,linear,1.743e-02,1.743e-02,3.486e-02,1.961e-02,1.961e-02
-SDP_MC,JPN,,,,,Domestic Aviation,trn_pass,S3S,linear,1.811e-04,2.174e-04,3.261e-04,9.170e-05,9.170e-05
-SDP_MC,JPN,,,,,Domestic Ship,trn_freight,S3S,linear,1.146e-02,1.146e-02,1.146e-02,1.146e-02,1.146e-02
-SDP_MC,JPN,,,,,Freight Rail,trn_freight,S3S,linear,2.781e-03,2.781e-03,2.781e-03,2.781e-03,2.781e-03
+SDP_MC,JPN,,,,,Domestic Aviation,trn_pass,S3S,linear,1.729e-04,2.075e-04,3.112e-04,8.752e-05,8.752e-05
+SDP_MC,JPN,,,,,Domestic Ship,trn_freight,S3S,linear,1.167e-02,1.111e-02,1.167e-02,1.167e-02,1.167e-02
+SDP_MC,JPN,,,,,Freight Rail,trn_freight,S3S,linear,2.833e-03,2.698e-03,2.833e-03,2.833e-03,2.833e-03
 SDP_MC,JPN,,,,,HSR,trn_pass,S3S,linear,4.081e-04,4.081e-04,4.591e-04,1.291e-04,1.291e-04
 SDP_MC,JPN,,,,,International Aviation,trn_aviation_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,JPN,,,,,International Ship,trn_shipping_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,JPN,,,,,Passenger Rail,trn_pass,S3S,linear,6.084e-03,6.084e-03,7.000e-03,2.281e-03,2.281e-03
 SDP_MC,JPN,,,,,Walk,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,JPN,,,,,trn_freight_road,trn_freight,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_MC,JPN,,,,,trn_pass_road,trn_pass,S3S,linear,7.245e-02,7.770e-02,7.770e-02,2.185e-02,2.185e-02
-SDP_MC,JPN,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,5.971e-02,5.971e-02,5.971e-02,5.971e-02,5.971e-02
+SDP_MC,JPN,,,,,trn_pass_road,trn_pass,S3S,linear,7.113e-02,7.629e-02,7.629e-02,2.146e-02,2.146e-02
+SDP_MC,JPN,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,6.081e-02,6.081e-02,6.081e-02,6.081e-02,6.081e-02
 SDP_MC,JPN,,,,trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,JPN,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,5.491e-02,5.491e-02,5.491e-02,5.491e-02,5.491e-02
 SDP_MC,JPN,,,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
@@ -3605,24 +3605,24 @@ SDP_MC,JPN,,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_
 SDP_MC,JPN,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.286e-01,1.286e-01,1.286e-01,1.286e-01,1.286e-01
 SDP_MC,JPN,,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,JPN,,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,5.896e-01,5.896e-01,5.896e-01,5.896e-01,5.896e-01
-SDP_MC,JPN,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_MC,JPN,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_MC,JPN,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_MC,JPN,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.091e-01,1.793e-01,3.810e-01,3.810e-01
+SDP_MC,JPN,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.600e-01,5.280e-01,1.000e+00,1.000e+00
+SDP_MC,JPN,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.600e-01,5.280e-01,1.000e+00,1.000e+00
+SDP_MC,JPN,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.600e-01,5.280e-01,1.000e+00,1.000e+00
+SDP_MC,JPN,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,9.673e-02,1.794e-01,3.754e-01,3.754e-01
 SDP_MC,JPN,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,JPN,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,JPN,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_MC,JPN,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.252e-01,3.529e-01,8.183e-01,8.183e-01
-SDP_MC,JPN,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,6.364e-02,1.333e-01,8.333e-01,8.333e-01
-SDP_MC,JPN,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,6.364e-02,1.333e-01,8.333e-01,8.333e-01
-SDP_MC,JPN,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,6.364e-02,1.333e-01,8.333e-01,8.333e-01
-SDP_MC,JPN,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.252e-01,3.529e-01,8.183e-01,8.183e-01
-SDP_MC,JPN,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,6.182e-02,1.319e-01,1.000e-01,1.000e-01
-SDP_MC,JPN,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.104e-01,2.511e-01,3.046e-01,3.046e-01
-SDP_MC,JPN,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,4.167e-01,4.167e-01
-SDP_MC,JPN,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,4.167e-01,4.167e-01
-SDP_MC,JPN,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,4.167e-01,4.167e-01
-SDP_MC,JPN,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.104e-01,2.511e-01,3.046e-01,3.046e-01
+SDP_MC,JPN,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.332e-01,3.414e-01,8.870e-01,8.870e-01
+SDP_MC,JPN,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,5.727e-02,1.200e-01,9.032e-01,9.032e-01
+SDP_MC,JPN,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,5.727e-02,1.200e-01,9.032e-01,9.032e-01
+SDP_MC,JPN,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,5.727e-02,1.200e-01,9.032e-01,9.032e-01
+SDP_MC,JPN,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.332e-01,3.414e-01,8.870e-01,8.870e-01
+SDP_MC,JPN,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,6.091e-02,1.200e-01,9.854e-02,9.854e-02
+SDP_MC,JPN,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.306e-01,2.699e-01,2.701e-01,2.701e-01
+SDP_MC,JPN,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,3.695e-01,3.695e-01
+SDP_MC,JPN,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,3.695e-01,3.695e-01
+SDP_MC,JPN,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,3.695e-01,3.695e-01
+SDP_MC,JPN,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.306e-01,2.699e-01,2.701e-01,2.701e-01
 SDP_MC,JPN,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0.000e+00,8.315e-07,4.540e-05,1.192e-01,1.192e-01
 SDP_MC,JPN,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,JPN,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
@@ -3630,41 +3630,41 @@ SDP_MC,JPN,Liquids,Domestic Ship_tmp_vehicletype,Domestic Ship_tmp_subsector_L1,
 SDP_MC,JPN,Liquids,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,8.837e-01,8.837e-01,8.837e-01,8.837e-01,8.837e-01
 SDP_MC,JPN,Liquids,International Aviation_tmp_vehicletype,International Aviation_tmp_subsector_L1,International Aviation_tmp_subsector_L2,International Aviation,trn_aviation_intl,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,JPN,Liquids,International Ship_tmp_vehicletype,International Ship_tmp_subsector_L1,International Ship_tmp_subsector_L2,International Ship,trn_shipping_intl,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_MC,JPN,Liquids,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_MC,JPN,Liquids,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_MC,JPN,Liquids,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
+SDP_MC,JPN,Liquids,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,9.921e-01,9.921e-01
+SDP_MC,JPN,Liquids,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,9.921e-01,9.921e-01
+SDP_MC,JPN,Liquids,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,9.921e-01,9.921e-01
 SDP_MC,JPN,Liquids,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,3.433e-02,3.433e-02,3.433e-02,3.433e-02,3.433e-02
 SDP_MC,JPN,Liquids,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_MC,JPN,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,6.061e-02,1.889e-01,1.000e+00,1.000e+00
-SDP_MC,JPN,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,6.061e-02,1.889e-01,1.000e+00,1.000e+00
-SDP_MC,JPN,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,6.061e-02,1.889e-01,1.000e+00,1.000e+00
+SDP_MC,JPN,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,8.457e-01,5.126e-02,1.757e-01,1.000e+00,1.000e+00
+SDP_MC,JPN,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,8.457e-01,5.126e-02,1.757e-01,1.000e+00,1.000e+00
+SDP_MC,JPN,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,8.457e-01,5.126e-02,1.757e-01,1.000e+00,1.000e+00
 SDP_MC,JPN,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_MC,JPN,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,7.895e-03,1.579e-02,2.303e-02,2.303e-02
-SDP_MC,JPN,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.316e-02,4.644e-02,4.605e-02,4.605e-02
-SDP_MC,JPN,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,3.030e-02,1.111e-01,2.500e-01,2.500e-01
-SDP_MC,JPN,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,3.030e-02,1.111e-01,2.500e-01,2.500e-01
-SDP_MC,JPN,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,3.030e-02,1.111e-01,2.500e-01,2.500e-01
-SDP_MC,JPN,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.316e-02,4.644e-02,4.605e-02,4.605e-02
-SDP_MC,LAM,,,,,Cycle,trn_pass,S3S,linear,9.812e-03,1.852e-02,4.629e-02,2.315e-01,2.315e-01
-SDP_MC,LAM,,,,,Domestic Aviation,trn_pass,S3S,linear,8.407e-03,1.058e-02,2.644e-02,1.983e-02,1.983e-02
-SDP_MC,LAM,,,,,Domestic Ship,trn_freight,S3S,linear,9.523e-03,9.523e-03,8.658e-03,7.936e-03,7.936e-03
-SDP_MC,LAM,,,,,Freight Rail,trn_freight,S3S,linear,4.694e-02,4.694e-02,4.268e-02,3.912e-02,3.912e-02
-SDP_MC,LAM,,,,,HSR,trn_pass,S3S,linear,4.709e-03,2.465e-01,2.465e-01,2.465e-01,2.465e-01
+SDP_MC,JPN,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,6.579e-03,1.215e-02,1.919e-02,1.919e-02
+SDP_MC,JPN,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.316e-02,4.222e-02,3.838e-02,3.838e-02
+SDP_MC,JPN,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,8.457e-01,2.563e-02,9.397e-02,2.083e-01,2.083e-01
+SDP_MC,JPN,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,8.457e-01,2.563e-02,9.397e-02,2.083e-01,2.083e-01
+SDP_MC,JPN,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,8.457e-01,2.563e-02,9.397e-02,2.083e-01,2.083e-01
+SDP_MC,JPN,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.316e-02,4.222e-02,3.838e-02,3.838e-02
+SDP_MC,LAM,,,,,Cycle,trn_pass,S3S,linear,1.091e-02,2.182e-02,5.455e-02,2.728e-01,2.728e-01
+SDP_MC,LAM,,,,,Domestic Aviation,trn_pass,S3S,linear,8.921e-03,1.190e-02,2.974e-02,2.230e-02,2.230e-02
+SDP_MC,LAM,,,,,Domestic Ship,trn_freight,S3S,linear,9.700e-03,9.700e-03,8.908e-03,6.736e-03,6.736e-03
+SDP_MC,LAM,,,,,Freight Rail,trn_freight,S3S,linear,4.782e-02,4.782e-02,4.391e-02,3.985e-02,3.985e-02
+SDP_MC,LAM,,,,,HSR,trn_pass,S3S,linear,5.236e-03,2.905e-01,2.905e-01,2.905e-01,2.905e-01
 SDP_MC,LAM,,,,,International Aviation,trn_aviation_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,LAM,,,,,International Ship,trn_shipping_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_MC,LAM,,,,,Passenger Rail,trn_pass,S3S,linear,1.348e-01,1.272e-01,1.272e-01,8.482e-02,8.482e-02
-SDP_MC,LAM,,,,,Walk,trn_pass,S3S,linear,8.993e-01,8.486e-01,8.486e-01,8.486e-01,8.486e-01
+SDP_MC,LAM,,,,,Passenger Rail,trn_pass,S3S,linear,1.499e-01,1.499e-01,1.499e-01,9.996e-02,9.996e-02
+SDP_MC,LAM,,,,,Walk,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,LAM,,,,,trn_freight_road,trn_freight,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_MC,LAM,,,,,trn_pass_road,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_MC,LAM,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,1.732e-01,1.083e-01,8.662e-02,8.662e-02,8.662e-02
+SDP_MC,LAM,,,,,trn_pass_road,trn_pass,S3S,linear,6.550e-01,6.942e-01,6.942e-01,8.099e-01,8.099e-01
+SDP_MC,LAM,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,2.647e-01,1.654e-01,1.323e-01,1.323e-01,1.323e-01
 SDP_MC,LAM,,,,trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,LAM,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.377e-01,1.377e-01,1.377e-01,1.377e-01,1.377e-01
 SDP_MC,LAM,,,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,LAM,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_MC,LAM,,Large Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,5.465e-02,5.465e-02,5.465e-02,5.465e-02,5.465e-02
-SDP_MC,LAM,,Large Car and SUV,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,6.039e-01,6.039e-01,6.039e-01,6.039e-01,6.039e-01
-SDP_MC,LAM,,Light Truck and SUV,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,2.182e-01,2.182e-01,2.182e-01,2.182e-01,2.182e-01
-SDP_MC,LAM,,Midsize Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,7.979e-02,7.979e-02,7.979e-02,7.979e-02,7.979e-02
+SDP_MC,LAM,,Large Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,3.279e-02,3.935e-02,4.099e-02,4.372e-02,4.372e-02
+SDP_MC,LAM,,Large Car and SUV,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,3.624e-01,4.348e-01,4.529e-01,4.831e-01,4.831e-01
+SDP_MC,LAM,,Light Truck and SUV,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.309e-01,1.571e-01,1.636e-01,1.745e-01,1.745e-01
+SDP_MC,LAM,,Midsize Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,4.788e-02,5.745e-02,5.984e-02,6.383e-02,6.383e-02
 SDP_MC,LAM,,Mini Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.226e-02,1.226e-02,1.226e-02,1.226e-02,1.226e-02
 SDP_MC,LAM,,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,4.580e-04,4.580e-04,4.580e-04,4.580e-04,4.580e-04
 SDP_MC,LAM,,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
@@ -3675,27 +3675,27 @@ SDP_MC,LAM,,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_s
 SDP_MC,LAM,,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,LAM,,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,5.079e-04,5.079e-04,5.079e-04,5.079e-04,5.079e-04
 SDP_MC,LAM,,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.892e-01,1.892e-01,1.892e-01,1.892e-01,1.892e-01
-SDP_MC,LAM,,Van,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,2.455e-03,2.455e-03,2.455e-03,2.455e-03,2.455e-03
-SDP_MC,LAM,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_MC,LAM,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_MC,LAM,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_MC,LAM,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.186e-01,5.379e-01,1.000e+00,1.000e+00
+SDP_MC,LAM,,Van,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.473e-03,1.768e-03,1.842e-03,1.964e-03,1.964e-03
+SDP_MC,LAM,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,5.600e-02,2.160e-01,5.040e-01,5.040e-01
+SDP_MC,LAM,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,5.600e-02,2.160e-01,5.040e-01,5.040e-01
+SDP_MC,LAM,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,5.600e-02,2.160e-01,5.040e-01,5.040e-01
+SDP_MC,LAM,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.294e-01,5.869e-01,1.000e+00,1.000e+00
 SDP_MC,LAM,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,6.810e-02,1.846e-01,4.176e-01,8.835e-01,8.835e-01
 SDP_MC,LAM,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,LAM,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_MC,LAM,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,7.947e-02,2.000e-01,2.400e-01,2.400e-01
-SDP_MC,LAM,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.162e-02,1.076e-01,2.329e-01,2.329e-01
-SDP_MC,LAM,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.162e-02,1.076e-01,2.329e-01,2.329e-01
-SDP_MC,LAM,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.162e-02,1.076e-01,2.329e-01,2.329e-01
-SDP_MC,LAM,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,7.947e-02,2.000e-01,2.400e-01,2.400e-01
-SDP_MC,LAM,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.473e-03,1.799e-02,6.561e-02,6.561e-02
-SDP_MC,LAM,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,8.924e-03,5.691e-02,8.123e-02,8.123e-02
-SDP_MC,LAM,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.297e-03,2.158e-02,5.556e-02,5.556e-02
-SDP_MC,LAM,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.297e-03,2.158e-02,5.556e-02,5.556e-02
-SDP_MC,LAM,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.297e-03,2.158e-02,5.556e-02,5.556e-02
-SDP_MC,LAM,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,8.924e-03,5.691e-02,8.123e-02,8.123e-02
+SDP_MC,LAM,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.041e-01,1.964e-01,2.357e-01,2.357e-01
+SDP_MC,LAM,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.140e-02,1.057e-01,2.287e-01,2.287e-01
+SDP_MC,LAM,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.140e-02,1.057e-01,2.287e-01,2.287e-01
+SDP_MC,LAM,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.140e-02,1.057e-01,2.287e-01,2.287e-01
+SDP_MC,LAM,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.041e-01,1.964e-01,2.357e-01,2.357e-01
+SDP_MC,LAM,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.698e-03,1.963e-02,6.561e-02,6.561e-02
+SDP_MC,LAM,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,9.738e-03,6.210e-02,8.864e-02,8.864e-02
+SDP_MC,LAM,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.598e-03,2.355e-02,6.062e-02,6.062e-02
+SDP_MC,LAM,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.598e-03,2.355e-02,6.062e-02,6.062e-02
+SDP_MC,LAM,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.598e-03,2.355e-02,6.062e-02,6.062e-02
+SDP_MC,LAM,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,9.738e-03,6.210e-02,8.864e-02,8.864e-02
 SDP_MC,LAM,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0.000e+00,8.315e-07,4.540e-05,1.192e-01,1.192e-01
-SDP_MC,LAM,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,7.217e-01,7.217e-01
+SDP_MC,LAM,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,7.275e-01,7.275e-01
 SDP_MC,LAM,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,LAM,Liquids,Domestic Ship_tmp_vehicletype,Domestic Ship_tmp_subsector_L1,Domestic Ship_tmp_subsector_L2,Domestic Ship,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,LAM,Liquids,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
@@ -3710,55 +3710,55 @@ SDP_MC,LAM,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_roa
 SDP_MC,LAM,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,LAM,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,LAM,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_MC,LAM,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,2.689e-02,4.725e-02,1.037e-01,1.353e-01,1.353e-01
+SDP_MC,LAM,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,2.689e-02,4.725e-02,1.037e-01,1.240e-01,1.240e-01
 SDP_MC,LAM,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.754e-02,3.158e-02,6.140e-02,6.140e-02
 SDP_MC,LAM,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.754e-02,3.158e-02,6.140e-02,6.140e-02
 SDP_MC,LAM,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.754e-02,3.158e-02,6.140e-02,6.140e-02
 SDP_MC,LAM,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.754e-02,3.158e-02,6.140e-02,6.140e-02
 SDP_MC,LAM,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.754e-02,3.158e-02,6.140e-02,6.140e-02
 SDP_MC,MEA,,,,,Cycle,trn_pass,S3S,linear,1.660e-02,1.660e-02,1.660e-02,4.149e-02,4.149e-02
-SDP_MC,MEA,,,,,Domestic Aviation,trn_pass,S3S,linear,8.929e-03,5.953e-03,1.786e-02,2.381e-02,2.381e-02
-SDP_MC,MEA,,,,,Domestic Ship,trn_freight,S3S,linear,2.022e-03,2.022e-03,2.022e-03,2.022e-03,2.022e-03
-SDP_MC,MEA,,,,,Freight Rail,trn_freight,S3S,linear,3.143e-03,3.143e-03,3.143e-03,3.143e-03,3.143e-03
+SDP_MC,MEA,,,,,Domestic Aviation,trn_pass,S3S,linear,8.522e-03,5.681e-03,1.704e-02,2.500e-02,2.500e-02
+SDP_MC,MEA,,,,,Domestic Ship,trn_freight,S3S,linear,2.060e-03,2.060e-03,2.060e-03,2.060e-03,2.060e-03
+SDP_MC,MEA,,,,,Freight Rail,trn_freight,S3S,linear,3.202e-03,3.202e-03,3.202e-03,3.202e-03,3.202e-03
 SDP_MC,MEA,,,,,HSR,trn_pass,S3S,linear,0.000e+00,1.667e-02,1.667e-02,1.667e-02,1.667e-02
 SDP_MC,MEA,,,,,International Aviation,trn_aviation_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,MEA,,,,,International Ship,trn_shipping_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,MEA,,,,,Passenger Rail,trn_pass,S3S,linear,5.567e-04,1.113e-03,1.113e-03,1.856e-03,1.856e-03
 SDP_MC,MEA,,,,,Walk,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,MEA,,,,,trn_freight_road,trn_freight,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_MC,MEA,,,,,trn_pass_road,trn_pass,S3S,linear,6.395e-01,7.197e-01,7.197e-01,7.197e-01,7.197e-01
-SDP_MC,MEA,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,2.627e-01,1.226e-01,6.131e-02,4.905e-02,4.905e-02
+SDP_MC,MEA,,,,,trn_pass_road,trn_pass,S3S,linear,3.767e-01,4.239e-01,3.815e-01,3.815e-01,3.815e-01
+SDP_MC,MEA,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,2.676e-01,1.873e-01,9.367e-02,7.493e-02,7.493e-02
 SDP_MC,MEA,,,,trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_MC,MEA,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,7.508e-03,7.508e-03,7.508e-03,7.508e-03,7.508e-03
+SDP_MC,MEA,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.502e-02,1.502e-02,1.502e-02,1.502e-02,1.502e-02
 SDP_MC,MEA,,,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_MC,MEA,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,4.732e-01,4.732e-01,4.732e-01,4.732e-01,4.732e-01
+SDP_MC,MEA,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,5.257e-01,4.732e-01,4.337e-01,3.943e-01,3.943e-01
 SDP_MC,MEA,,Large Car and SUV,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_MC,MEA,,Mini Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,3.955e-02,3.955e-02,3.955e-02,3.955e-02,3.955e-02
+SDP_MC,MEA,,Mini Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,4.395e-02,3.955e-02,3.626e-02,3.296e-02,3.296e-02
 SDP_MC,MEA,,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,MEA,,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,MEA,,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_MC,MEA,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.864e-01,1.864e-01,1.864e-01,1.864e-01,1.864e-01
+SDP_MC,MEA,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,2.071e-01,1.864e-01,1.709e-01,1.553e-01,1.553e-01
 SDP_MC,MEA,,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.304e-01,1.304e-01,1.304e-01,1.304e-01,1.304e-01
 SDP_MC,MEA,,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,2.013e-01,2.013e-01,2.013e-01,2.013e-01,2.013e-01
 SDP_MC,MEA,,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_MC,MEA,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_MC,MEA,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_MC,MEA,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_MC,MEA,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.743e-02,2.958e-01,6.549e-01,6.549e-01
+SDP_MC,MEA,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.200e-01,2.160e-01,2.100e-01,2.100e-01
+SDP_MC,MEA,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.200e-01,2.160e-01,2.100e-01,2.100e-01
+SDP_MC,MEA,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.200e-01,2.160e-01,2.100e-01,2.100e-01
+SDP_MC,MEA,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,5.175e-02,2.935e-01,6.497e-01,6.497e-01
 SDP_MC,MEA,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,4.021e-01,4.768e-01,6.263e-01,9.253e-01,9.253e-01
 SDP_MC,MEA,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,MEA,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_MC,MEA,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.960e-02,1.000e-01,1.403e-01,1.403e-01
-SDP_MC,MEA,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.371e-02,5.379e-02,1.361e-01,1.361e-01
-SDP_MC,MEA,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.429e-01,2.000e-01,1.429e-01,1.429e-01
-SDP_MC,MEA,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.429e-01,2.000e-01,1.429e-01,1.429e-01
-SDP_MC,MEA,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.960e-02,1.000e-01,1.403e-01,1.403e-01
-SDP_MC,MEA,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.473e-03,1.799e-02,6.250e-02,6.250e-02
-SDP_MC,MEA,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.346e-03,9.485e-03,4.177e-02,4.177e-02
-SDP_MC,MEA,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.236e-03,3.597e-03,2.857e-02,2.857e-02
-SDP_MC,MEA,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.429e-01,2.000e-01,5.714e-02,5.714e-02
-SDP_MC,MEA,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.429e-01,2.000e-01,5.714e-02,5.714e-02
-SDP_MC,MEA,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.346e-03,9.485e-03,4.177e-02,4.177e-02
+SDP_MC,MEA,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.504e-02,1.091e-01,1.392e-01,1.392e-01
+SDP_MC,MEA,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.588e-02,5.869e-02,1.350e-01,1.350e-01
+SDP_MC,MEA,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.559e-01,2.182e-01,1.417e-01,1.417e-01
+SDP_MC,MEA,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.559e-01,2.182e-01,1.417e-01,1.417e-01
+SDP_MC,MEA,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.504e-02,1.091e-01,1.392e-01,1.392e-01
+SDP_MC,MEA,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.698e-03,1.784e-02,5.580e-02,5.580e-02
+SDP_MC,MEA,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.652e-03,1.035e-02,4.144e-04,4.144e-04
+SDP_MC,MEA,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.349e-03,3.925e-03,2.834e-04,2.834e-04
+SDP_MC,MEA,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.559e-01,2.182e-01,5.669e-04,5.669e-04
+SDP_MC,MEA,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.559e-01,2.182e-01,5.669e-04,5.669e-04
+SDP_MC,MEA,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.652e-03,1.035e-02,4.144e-04,4.144e-04
 SDP_MC,MEA,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0.000e+00,8.315e-07,4.540e-05,1.192e-01,1.192e-01
 SDP_MC,MEA,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,MEA,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
@@ -3772,27 +3772,27 @@ SDP_MC,MEA,Liquids,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,tr
 SDP_MC,MEA,Liquids,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,7.852e-02,7.852e-02,7.852e-02,7.852e-02,7.852e-02
 SDP_MC,MEA,Liquids,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,MEA,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_MC,MEA,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,2.857e-01,1.000e+00,1.000e+00,1.000e+00
-SDP_MC,MEA,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,2.857e-01,1.000e+00,1.000e+00,1.000e+00
+SDP_MC,MEA,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,9.164e-01,2.857e-01,1.000e+00,1.000e+00,1.000e+00
+SDP_MC,MEA,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,9.164e-01,2.857e-01,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,MEA,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_MC,MEA,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.342e-02,3.938e-02,9.130e-02,1.220e-01,1.220e-01
-SDP_MC,MEA,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,9.283e-04,9.527e-02,4.788e-02,5.285e-02,5.285e-02
-SDP_MC,MEA,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,9.211e-02,4.737e-02,5.263e-02,5.263e-02
-SDP_MC,MEA,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,6.000e-01,2.857e-01,2.857e-01
-SDP_MC,MEA,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,6.000e-01,2.857e-01,2.857e-01
-SDP_MC,MEA,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,9.211e-02,4.737e-02,5.263e-02,5.263e-02
+SDP_MC,MEA,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.342e-02,3.938e-02,8.300e-02,1.109e-01,1.109e-01
+SDP_MC,MEA,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,9.283e-04,9.527e-02,4.788e-02,4.804e-02,4.804e-02
+SDP_MC,MEA,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,9.211e-02,4.737e-02,4.785e-02,4.785e-02
+SDP_MC,MEA,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,9.164e-01,1.000e+00,6.000e-01,2.597e-01,2.597e-01
+SDP_MC,MEA,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,9.164e-01,1.000e+00,6.000e-01,2.597e-01,2.597e-01
+SDP_MC,MEA,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,9.211e-02,4.737e-02,4.785e-02,4.785e-02
 SDP_MC,NEN,,,,,Cycle,trn_pass,S3S,linear,3.033e-03,3.024e-03,2.621e-03,1.820e-02,1.820e-02
-SDP_MC,NEN,,,,,Domestic Aviation,trn_pass,S3S,linear,7.555e-06,7.895e-06,2.566e-06,1.497e-06,1.497e-06
-SDP_MC,NEN,,,,,Domestic Ship,trn_freight,S3S,linear,3.117e-02,3.117e-02,3.117e-02,3.117e-02,3.117e-02
-SDP_MC,NEN,,,,,Freight Rail,trn_freight,S3S,linear,1.890e-02,1.890e-02,1.890e-02,1.890e-02,1.890e-02
+SDP_MC,NEN,,,,,Domestic Aviation,trn_pass,S3S,linear,7.210e-06,7.535e-06,2.449e-06,1.428e-06,1.428e-06
+SDP_MC,NEN,,,,,Domestic Ship,trn_freight,S3S,linear,3.175e-02,3.175e-02,3.175e-02,3.175e-02,3.175e-02
+SDP_MC,NEN,,,,,Freight Rail,trn_freight,S3S,linear,1.925e-02,1.925e-02,1.925e-02,1.925e-02,1.925e-02
 SDP_MC,NEN,,,,,HSR,trn_pass,S3S,linear,2.000e-05,4.532e-05,7.364e-06,5.523e-06,5.523e-06
 SDP_MC,NEN,,,,,International Aviation,trn_aviation_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,NEN,,,,,International Ship,trn_shipping_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,NEN,,,,,Passenger Rail,trn_pass,S3S,linear,3.000e-06,2.967e-06,6.751e-07,3.215e-07,3.215e-07
 SDP_MC,NEN,,,,,Walk,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,NEN,,,,,trn_freight_road,trn_freight,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_MC,NEN,,,,,trn_pass_road,trn_pass,S3S,linear,5.052e-02,6.996e-02,2.842e-02,2.368e-02,2.368e-02
-SDP_MC,NEN,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,1.263e-02,7.897e-03,3.948e-03,1.974e-03,1.974e-03
+SDP_MC,NEN,,,,,trn_pass_road,trn_pass,S3S,linear,4.960e-02,6.868e-02,2.790e-02,2.325e-02,2.325e-02
+SDP_MC,NEN,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,1.287e-02,8.044e-03,4.022e-03,2.011e-03,2.011e-03
 SDP_MC,NEN,,,,trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,NEN,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,3.994e-02,3.994e-02,3.994e-02,3.994e-02,3.994e-02
 SDP_MC,NEN,,,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
@@ -3810,24 +3810,24 @@ SDP_MC,NEN,,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_s
 SDP_MC,NEN,,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,6.397e-02,6.397e-02,6.397e-02,6.397e-02,6.397e-02
 SDP_MC,NEN,,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,3.433e-01,3.433e-01,3.433e-01,3.433e-01,3.433e-01
 SDP_MC,NEN,,Van,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,7.350e-03,7.350e-03,7.350e-03,7.350e-03,7.350e-03
-SDP_MC,NEN,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_MC,NEN,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_MC,NEN,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_MC,NEN,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.743e-02,2.689e-01,9.526e-01,9.526e-01
+SDP_MC,NEN,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.000e-02,1.680e-01,2.940e-01,2.940e-01
+SDP_MC,NEN,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.000e-02,1.680e-01,2.940e-01,2.940e-01
+SDP_MC,NEN,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.000e-02,1.680e-01,2.940e-01,2.940e-01
+SDP_MC,NEN,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,5.608e-02,1.402e-01,4.134e-01,9.856e-01,9.856e-01
 SDP_MC,NEN,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,NEN,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,NEN,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_MC,NEN,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.192e-01,5.000e-01,9.820e-01,9.820e-01
-SDP_MC,NEN,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.743e-02,2.689e-01,9.526e-01,9.526e-01
-SDP_MC,NEN,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.743e-02,2.689e-01,9.526e-01,9.526e-01
-SDP_MC,NEN,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.743e-02,2.689e-01,9.526e-01,9.526e-01
-SDP_MC,NEN,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.192e-01,5.000e-01,9.820e-01,9.820e-01
-SDP_MC,NEN,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.473e-03,1.799e-02,5.000e-01,5.000e-01
-SDP_MC,NEN,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.693e-03,4.743e-02,7.311e-01,7.311e-01
-SDP_MC,NEN,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-03,1.799e-02,5.000e-01,5.000e-01
-SDP_MC,NEN,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-03,1.799e-02,5.000e-01,5.000e-01
-SDP_MC,NEN,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-03,1.799e-02,5.000e-01,5.000e-01
-SDP_MC,NEN,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.693e-03,4.743e-02,7.311e-01,7.311e-01
+SDP_MC,NEN,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.537e-01,5.912e-01,8.932e-01,8.932e-01
+SDP_MC,NEN,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.009e-01,3.180e-01,8.664e-01,8.664e-01
+SDP_MC,NEN,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.009e-01,3.180e-01,8.664e-01,8.664e-01
+SDP_MC,NEN,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.009e-01,3.180e-01,8.664e-01,8.664e-01
+SDP_MC,NEN,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.537e-01,5.912e-01,8.932e-01,8.932e-01
+SDP_MC,NEN,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.924e-03,2.127e-02,5.543e-02,5.543e-02
+SDP_MC,NEN,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,7.914e-03,1.682e-01,9.974e-02,9.974e-02
+SDP_MC,NEN,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.924e-03,6.380e-02,6.822e-02,6.822e-02
+SDP_MC,NEN,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.924e-03,6.380e-02,6.822e-02,6.822e-02
+SDP_MC,NEN,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.924e-03,6.380e-02,6.822e-02,6.822e-02
+SDP_MC,NEN,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,7.914e-03,1.682e-01,9.974e-02,9.974e-02
 SDP_MC,NEN,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0.000e+00,8.315e-07,4.540e-05,1.192e-01,1.192e-01
 SDP_MC,NEN,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,NEN,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
@@ -3844,59 +3844,59 @@ SDP_MC,NEN,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_roa
 SDP_MC,NEN,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,NEN,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,NEN,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_MC,NEN,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,2.147e-02,4.722e-02,9.872e-02,2.017e-01,2.017e-01
-SDP_MC,NEN,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,6.427e-03,3.257e-02,8.487e-02,1.895e-01,1.895e-01
-SDP_MC,NEN,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SDP_MC,NEN,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SDP_MC,NEN,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SDP_MC,NEN,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
+SDP_MC,NEN,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,2.362e-02,3.778e-02,9.872e-02,1.261e-01,1.261e-01
+SDP_MC,NEN,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,6.427e-03,3.257e-02,8.487e-02,1.457e-01,1.457e-01
+SDP_MC,NEN,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.417e-01,1.417e-01
+SDP_MC,NEN,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.417e-01,1.417e-01
+SDP_MC,NEN,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.417e-01,1.417e-01
+SDP_MC,NEN,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.417e-01,1.417e-01
 SDP_MC,NES,,,,,Cycle,trn_pass,S3S,linear,8.738e-03,7.802e-03,9.929e-03,1.365e-02,1.365e-02
-SDP_MC,NES,,,,,Domestic Aviation,trn_pass,S3S,linear,4.947e-03,3.534e-03,1.499e-03,4.123e-04,4.123e-04
-SDP_MC,NES,,,,,Domestic Ship,trn_freight,S3S,linear,1.442e-02,1.442e-02,1.442e-02,1.442e-02,1.442e-02
-SDP_MC,NES,,,,,Freight Rail,trn_freight,S3S,linear,1.666e-02,1.666e-02,1.666e-02,1.666e-02,1.666e-02
+SDP_MC,NES,,,,,Domestic Aviation,trn_pass,S3S,linear,4.721e-03,3.372e-03,1.431e-03,3.935e-04,3.935e-04
+SDP_MC,NES,,,,,Domestic Ship,trn_freight,S3S,linear,1.468e-02,1.468e-02,1.468e-02,1.322e-02,1.322e-02
+SDP_MC,NES,,,,,Freight Rail,trn_freight,S3S,linear,1.697e-02,1.697e-02,1.697e-02,1.697e-02,1.697e-02
 SDP_MC,NES,,,,,HSR,trn_pass,S3S,linear,5.085e-04,3.632e-04,2.311e-04,1.271e-04,1.271e-04
 SDP_MC,NES,,,,,International Aviation,trn_aviation_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,NES,,,,,International Ship,trn_shipping_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,NES,,,,,Passenger Rail,trn_pass,S3S,linear,1.607e-03,1.148e-03,7.303e-04,4.017e-04,4.017e-04
 SDP_MC,NES,,,,,Walk,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,NES,,,,,trn_freight_road,trn_freight,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_MC,NES,,,,,trn_pass_road,trn_pass,S3S,linear,9.258e-01,7.176e-01,4.566e-01,2.512e-01,2.512e-01
-SDP_MC,NES,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,5.499e-02,2.199e-02,1.100e-02,1.100e-02,1.100e-02
+SDP_MC,NES,,,,,trn_pass_road,trn_pass,S3S,linear,2.727e-01,2.818e-01,2.242e-01,1.233e-01,1.233e-01
+SDP_MC,NES,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,8.401e-02,3.734e-02,2.240e-02,2.240e-02,2.240e-02
 SDP_MC,NES,,,,trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,NES,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,4.923e-03,4.923e-03,4.923e-03,4.923e-03,4.923e-03
 SDP_MC,NES,,,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_MC,NES,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,4.608e-01,4.608e-01,4.608e-01,4.608e-01,4.608e-01
+SDP_MC,NES,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,5.760e-01,5.760e-01,6.144e-01,6.144e-01,6.144e-01
 SDP_MC,NES,,Large Car and SUV,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,NES,,Midsize Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,2.352e-01,2.352e-01,2.352e-01,2.352e-01,2.352e-01
-SDP_MC,NES,,Mini Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.509e-03,1.509e-03,1.509e-03,1.509e-03,1.509e-03
+SDP_MC,NES,,Mini Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.886e-03,1.886e-03,2.012e-03,2.012e-03,2.012e-03
 SDP_MC,NES,,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.148e-02,1.148e-02,1.148e-02,1.148e-02,1.148e-02
 SDP_MC,NES,,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.337e-01,1.337e-01,1.337e-01,1.337e-01,1.337e-01
 SDP_MC,NES,,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_MC,NES,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,7.460e-02,7.460e-02,7.460e-02,7.460e-02,7.460e-02
+SDP_MC,NES,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,9.325e-02,9.325e-02,9.946e-02,9.946e-02,9.946e-02
 SDP_MC,NES,,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,NES,,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,6.299e-02,6.299e-02,6.299e-02,6.299e-02,6.299e-02
 SDP_MC,NES,,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,3.651e-01,3.651e-01,3.651e-01,3.651e-01,3.651e-01
 SDP_MC,NES,,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,5.704e-01,5.704e-01,5.704e-01,5.704e-01,5.704e-01
 SDP_MC,NES,,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,4.799e-01,4.799e-01,4.799e-01,4.799e-01,4.799e-01
 SDP_MC,NES,,Van,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,2.880e-03,2.880e-03,2.880e-03,2.880e-03,2.880e-03
-SDP_MC,NES,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_MC,NES,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_MC,NES,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_MC,NES,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.743e-02,2.689e-01,9.526e-01,9.526e-01
+SDP_MC,NES,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.000e-02,1.680e-01,3.360e-01,3.360e-01
+SDP_MC,NES,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.000e-02,1.680e-01,3.360e-01,3.360e-01
+SDP_MC,NES,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.000e-02,1.680e-01,3.360e-01,3.360e-01
+SDP_MC,NES,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,5.175e-02,1.739e-01,3.465e-01,3.465e-01
 SDP_MC,NES,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,2.081e-01,3.071e-01,5.050e-01,9.010e-01,9.010e-01
 SDP_MC,NES,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,NES,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_MC,NES,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.192e-01,5.000e-01,9.820e-01,9.820e-01
-SDP_MC,NES,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.743e-02,2.689e-01,9.526e-01,9.526e-01
-SDP_MC,NES,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.743e-02,2.689e-01,9.526e-01,9.526e-01
-SDP_MC,NES,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.743e-02,2.689e-01,9.526e-01,9.526e-01
-SDP_MC,NES,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.192e-01,5.000e-01,9.820e-01,9.820e-01
-SDP_MC,NES,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.473e-03,1.799e-02,5.000e-01,5.000e-01
-SDP_MC,NES,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.693e-03,4.743e-02,7.311e-01,7.311e-01
-SDP_MC,NES,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-03,1.799e-02,5.000e-01,5.000e-01
-SDP_MC,NES,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-03,1.799e-02,5.000e-01,5.000e-01
-SDP_MC,NES,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-03,1.799e-02,5.000e-01,5.000e-01
-SDP_MC,NES,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.693e-03,4.743e-02,7.311e-01,7.311e-01
+SDP_MC,NES,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.138e-01,2.182e-01,3.215e-01,3.215e-01
+SDP_MC,NES,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.528e-02,1.174e-01,3.118e-01,3.118e-01
+SDP_MC,NES,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.528e-02,1.174e-01,3.118e-01,3.118e-01
+SDP_MC,NES,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.528e-02,1.174e-01,3.118e-01,3.118e-01
+SDP_MC,NES,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.138e-01,2.182e-01,3.215e-01,3.215e-01
+SDP_MC,NES,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.698e-03,1.454e-02,3.637e-02,3.637e-02
+SDP_MC,NES,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,9.129e-03,3.833e-02,8.376e-02,8.376e-02
+SDP_MC,NES,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.373e-03,1.454e-02,5.729e-02,5.729e-02
+SDP_MC,NES,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.373e-03,1.454e-02,5.729e-02,5.729e-02
+SDP_MC,NES,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.373e-03,1.454e-02,5.729e-02,5.729e-02
+SDP_MC,NES,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,9.129e-03,3.833e-02,8.376e-02,8.376e-02
 SDP_MC,NES,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0.000e+00,8.315e-07,4.540e-05,1.192e-01,1.192e-01
 SDP_MC,NES,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,NES,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
@@ -3913,63 +3913,63 @@ SDP_MC,NES,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_roa
 SDP_MC,NES,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,NES,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,NES,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_MC,NES,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,3.476e-03,2.970e-02,8.215e-02,1.870e-01,1.870e-01
-SDP_MC,NES,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SDP_MC,NES,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SDP_MC,NES,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SDP_MC,NES,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SDP_MC,NES,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SDP_MC,OAS,,,,,Cycle,trn_pass,S3S,linear,1.256e-02,2.493e-02,3.323e-02,8.309e-02,8.309e-02
-SDP_MC,OAS,,,,,Domestic Aviation,trn_pass,S3S,linear,2.574e-02,2.661e-02,3.726e-02,7.983e-02,7.983e-02
-SDP_MC,OAS,,,,,Domestic Ship,trn_freight,S3S,linear,3.645e-02,3.645e-02,2.804e-02,3.645e-02,3.645e-02
-SDP_MC,OAS,,,,,Freight Rail,trn_freight,S3S,linear,4.649e-02,4.649e-02,3.576e-02,4.649e-02,4.649e-02
-SDP_MC,OAS,,,,,HSR,trn_pass,S3S,linear,9.660e-04,2.997e-03,2.997e-03,3.995e-03,3.995e-03
+SDP_MC,NES,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,3.476e-03,2.970e-02,6.085e-02,7.482e-02,7.482e-02
+SDP_MC,NES,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.289e-02,8.772e-02,1.289e-01,1.289e-01
+SDP_MC,NES,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.289e-02,8.772e-02,1.289e-01,1.289e-01
+SDP_MC,NES,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.289e-02,8.772e-02,1.289e-01,1.289e-01
+SDP_MC,NES,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.289e-02,8.772e-02,1.289e-01,1.289e-01
+SDP_MC,NES,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.289e-02,8.772e-02,1.289e-01,1.289e-01
+SDP_MC,OAS,,,,,Cycle,trn_pass,S3S,linear,1.256e-02,3.616e-02,4.821e-02,1.205e-01,1.205e-01
+SDP_MC,OAS,,,,,Domestic Aviation,trn_pass,S3S,linear,2.456e-02,3.684e-02,5.158e-02,1.326e-01,1.326e-01
+SDP_MC,OAS,,,,,Domestic Ship,trn_freight,S3S,linear,3.712e-02,3.375e-02,2.856e-02,2.700e-02,2.700e-02
+SDP_MC,OAS,,,,,Freight Rail,trn_freight,S3S,linear,4.736e-02,4.305e-02,3.643e-02,3.444e-02,3.444e-02
+SDP_MC,OAS,,,,,HSR,trn_pass,S3S,linear,9.660e-04,4.347e-03,4.347e-03,5.796e-03,5.796e-03
 SDP_MC,OAS,,,,,International Aviation,trn_aviation_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,OAS,,,,,International Ship,trn_shipping_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_MC,OAS,,,,,Passenger Rail,trn_pass,S3S,linear,7.701e-04,7.963e-04,1.194e-03,1.593e-03,1.593e-03
-SDP_MC,OAS,,,,,Walk,trn_pass,S3S,linear,1.000e+00,6.893e-01,6.893e-01,6.893e-01,6.893e-01
+SDP_MC,OAS,,,,,Passenger Rail,trn_pass,S3S,linear,7.701e-04,1.155e-03,1.733e-03,2.310e-03,2.310e-03
+SDP_MC,OAS,,,,,Walk,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,OAS,,,,,trn_freight_road,trn_freight,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_MC,OAS,,,,,trn_pass_road,trn_pass,S3S,linear,8.721e-01,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_MC,OAS,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,2.403e-01,1.402e-01,5.510e-02,5.510e-02,5.510e-02
+SDP_MC,OAS,,,,,trn_pass_road,trn_pass,S3S,linear,4.452e-01,5.697e-01,5.697e-01,7.121e-01,7.121e-01
+SDP_MC,OAS,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,4.352e-01,2.571e-01,1.122e-01,9.620e-02,9.620e-02
 SDP_MC,OAS,,,,trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_MC,OAS,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,2.534e-02,2.233e-02,1.631e-02,4.276e-03,4.276e-03
+SDP_MC,OAS,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,3.520e-01,1.718e-01,1.631e-01,9.503e-02,9.503e-02
 SDP_MC,OAS,,,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_MC,OAS,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,6.745e-03,6.745e-03,6.745e-03,6.745e-03,6.745e-03
+SDP_MC,OAS,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,2.698e-03,2.811e-03,4.216e-03,5.621e-03,5.621e-03
 SDP_MC,OAS,,Large Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,3.018e-01,3.018e-01,3.018e-01,3.018e-01,3.018e-01
 SDP_MC,OAS,,Large Car and SUV,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,6.459e-04,6.459e-04,6.459e-04,6.459e-04,6.459e-04
 SDP_MC,OAS,,Light Truck and SUV,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,OAS,,Midsize Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,2.500e-04,2.500e-04,2.500e-04,2.500e-04,2.500e-04
-SDP_MC,OAS,,Mini Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,6.938e-05,6.938e-05,6.938e-05,6.938e-05,6.938e-05
+SDP_MC,OAS,,Mini Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,2.775e-05,2.891e-05,4.336e-05,5.782e-05,5.782e-05
 SDP_MC,OAS,,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,7.762e-03,7.762e-03,7.762e-03,7.762e-03,7.762e-03
 SDP_MC,OAS,,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,OAS,,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,6.391e-03,6.391e-03,6.391e-03,6.391e-03,6.391e-03
-SDP_MC,OAS,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,8.508e-03,8.508e-03,8.508e-03,8.508e-03,8.508e-03
+SDP_MC,OAS,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,3.403e-03,3.545e-03,5.318e-03,7.090e-03,7.090e-03
 SDP_MC,OAS,,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,3.765e-01,3.765e-01,3.765e-01,3.765e-01,3.765e-01
 SDP_MC,OAS,,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,4.784e-01,4.784e-01,4.784e-01,4.784e-01,4.784e-01
 SDP_MC,OAS,,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.365e-03,1.365e-03,1.365e-03,1.365e-03,1.365e-03
 SDP_MC,OAS,,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,7.361e-04,7.361e-04,7.361e-04,7.361e-04,7.361e-04
 SDP_MC,OAS,,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,OAS,,Van,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.027e-05,1.027e-05,1.027e-05,1.027e-05,1.027e-05
-SDP_MC,OAS,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_MC,OAS,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1.452e-05,1.452e-05,1.452e-05,1.452e-05,1.452e-05
-SDP_MC,OAS,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_MC,OAS,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.423e-01,6.724e-01,1.000e+00,1.000e+00
+SDP_MC,OAS,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.400e-02,1.680e-01,2.940e-01,2.940e-01
+SDP_MC,OAS,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.400e-02,1.680e-01,2.940e-01,2.940e-01
+SDP_MC,OAS,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.400e-02,1.680e-01,2.940e-01,2.940e-01
+SDP_MC,OAS,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.411e-01,6.670e-01,1.000e+00,1.000e+00
 SDP_MC,OAS,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1.733e-01,2.767e-01,4.833e-01,8.967e-01,8.967e-01
 SDP_MC,OAS,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,OAS,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,3.530e-01,4.338e-01,5.956e-01,9.191e-01,9.191e-01
-SDP_MC,OAS,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.973e-02,6.250e-02,7.856e-02,7.856e-02
-SDP_MC,OAS,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.581e-02,3.362e-02,7.621e-02,7.621e-02
-SDP_MC,OAS,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.581e-02,3.362e-02,7.621e-02,7.621e-02
-SDP_MC,OAS,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.581e-02,3.362e-02,7.621e-02,7.621e-02
-SDP_MC,OAS,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.973e-02,6.250e-02,7.856e-02,7.856e-02
-SDP_MC,OAS,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.473e-03,1.799e-02,6.561e-02,6.561e-02
-SDP_MC,OAS,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.115e-02,1.186e-02,2.924e-02,2.924e-02
-SDP_MC,OAS,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.121e-03,4.497e-03,2.000e-02,2.000e-02
-SDP_MC,OAS,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.121e-03,4.497e-03,2.000e-02,2.000e-02
-SDP_MC,OAS,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.121e-03,4.497e-03,2.000e-02,2.000e-02
-SDP_MC,OAS,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.115e-02,1.186e-02,2.924e-02,2.924e-02
+SDP_MC,OAS,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.469e-02,5.456e-02,7.144e-02,7.144e-02
+SDP_MC,OAS,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.380e-02,2.935e-02,6.930e-02,6.930e-02
+SDP_MC,OAS,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.380e-02,2.935e-02,6.930e-02,6.930e-02
+SDP_MC,OAS,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.380e-02,2.935e-02,6.930e-02,6.930e-02
+SDP_MC,OAS,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.469e-02,5.456e-02,7.144e-02,7.144e-02
+SDP_MC,OAS,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.453e-03,1.784e-02,7.290e-02,7.290e-02
+SDP_MC,OAS,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.217e-02,1.294e-02,2.127e-02,2.127e-02
+SDP_MC,OAS,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.497e-03,4.907e-03,1.455e-02,1.455e-02
+SDP_MC,OAS,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.497e-03,4.907e-03,1.455e-02,1.455e-02
+SDP_MC,OAS,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.497e-03,4.907e-03,1.455e-02,1.455e-02
+SDP_MC,OAS,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.217e-02,1.294e-02,2.127e-02,2.127e-02
 SDP_MC,OAS,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0.000e+00,8.315e-07,4.540e-05,1.192e-01,1.192e-01
-SDP_MC,OAS,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,6.561e-01,6.561e-01
+SDP_MC,OAS,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,6.681e-01,6.681e-01
 SDP_MC,OAS,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,OAS,Liquids,Domestic Ship_tmp_vehicletype,Domestic Ship_tmp_subsector_L1,Domestic Ship_tmp_subsector_L2,Domestic Ship,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,OAS,Liquids,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
@@ -3984,58 +3984,58 @@ SDP_MC,OAS,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_roa
 SDP_MC,OAS,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,OAS,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,OAS,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_MC,OAS,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.967e-01,2.178e-01,2.601e-01,2.261e-01,2.261e-01
-SDP_MC,OAS,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,4.535e-04,8.919e-03,3.968e-02,7.383e-02,7.383e-02
-SDP_MC,OAS,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,8.772e-03,3.947e-02,7.368e-02,7.368e-02
-SDP_MC,OAS,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.395e-01,5.404e-02,1.037e-01,1.192e-01,1.192e-01
-SDP_MC,OAS,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,2.466e-01,8.882e-02,1.531e-01,1.542e-01,1.542e-01
-SDP_MC,OAS,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,8.772e-03,3.947e-02,7.368e-02,7.368e-02
-SDP_MC,REF,,,,,Cycle,trn_pass,S3S,linear,4.737e-03,4.737e-03,2.369e-02,7.824e-02,7.824e-02
-SDP_MC,REF,,,,,Domestic Aviation,trn_pass,S3S,linear,1.287e-02,1.232e-02,1.540e-02,1.454e-02,1.454e-02
-SDP_MC,REF,,,,,Domestic Ship,trn_freight,S3S,linear,7.096e-03,7.096e-03,7.096e-03,7.096e-03,7.096e-03
-SDP_MC,REF,,,,,Freight Rail,trn_freight,S3S,linear,1.272e-01,1.272e-01,1.272e-01,1.272e-01,1.272e-01
-SDP_MC,REF,,,,,HSR,trn_pass,S3S,linear,0.000e+00,8.000e-04,8.000e-04,7.550e-04,7.550e-04
+SDP_MC,OAS,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.967e-01,1.980e-01,2.365e-01,2.303e-01,2.303e-01
+SDP_MC,OAS,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,4.535e-04,8.919e-03,3.968e-02,6.153e-02,6.153e-02
+SDP_MC,OAS,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,8.772e-03,3.947e-02,6.140e-02,6.140e-02
+SDP_MC,OAS,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.395e-01,5.404e-02,1.037e-01,9.933e-02,9.933e-02
+SDP_MC,OAS,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,2.466e-01,8.882e-02,1.531e-01,1.285e-01,1.285e-01
+SDP_MC,OAS,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,8.772e-03,3.947e-02,6.140e-02,6.140e-02
+SDP_MC,REF,,,,,Cycle,trn_pass,S3S,linear,1.379e-02,1.206e-02,6.031e-02,7.824e-02,7.824e-02
+SDP_MC,REF,,,,,Domestic Aviation,trn_pass,S3S,linear,3.574e-02,2.995e-02,3.743e-02,1.387e-02,1.387e-02
+SDP_MC,REF,,,,,Domestic Ship,trn_freight,S3S,linear,7.227e-03,7.227e-03,7.227e-03,7.227e-03,7.227e-03
+SDP_MC,REF,,,,,Freight Rail,trn_freight,S3S,linear,1.296e-01,1.296e-01,1.296e-01,1.296e-01,1.296e-01
+SDP_MC,REF,,,,,HSR,trn_pass,S3S,linear,0.000e+00,2.037e-03,2.037e-03,7.550e-04,7.550e-04
 SDP_MC,REF,,,,,International Aviation,trn_aviation_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,REF,,,,,International Ship,trn_shipping_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_MC,REF,,,,,Passenger Rail,trn_pass,S3S,linear,2.366e-03,4.731e-03,5.914e-03,1.116e-02,1.116e-02
-SDP_MC,REF,,,,,Walk,trn_pass,S3S,linear,3.179e-01,3.179e-01,3.179e-01,1.000e+00,1.000e+00
+SDP_MC,REF,,,,,Passenger Rail,trn_pass,S3S,linear,6.884e-03,1.205e-02,1.506e-02,1.116e-02,1.116e-02
+SDP_MC,REF,,,,,Walk,trn_pass,S3S,linear,9.251e-01,8.095e-01,8.095e-01,1.000e+00,1.000e+00
 SDP_MC,REF,,,,,trn_freight_road,trn_freight,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_MC,REF,,,,,trn_pass_road,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,9.437e-01,9.437e-01
-SDP_MC,REF,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,1.186e-01,9.148e-02,7.623e-02,6.099e-02,6.099e-02
+SDP_MC,REF,,,,,trn_pass_road,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,4.633e-01,4.633e-01
+SDP_MC,REF,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,2.684e-01,1.864e-01,1.553e-01,1.242e-01,1.242e-01
 SDP_MC,REF,,,,trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,REF,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,3.698e-01,3.698e-01,3.698e-01,3.698e-01,3.698e-01
 SDP_MC,REF,,,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_MC,REF,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,2.227e-01,2.227e-01,2.227e-01,2.227e-01,2.227e-01
+SDP_MC,REF,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,4.455e-01,4.176e-01,4.176e-01,3.818e-01,3.818e-01
 SDP_MC,REF,,Large Car and SUV,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,REF,,Midsize Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.842e-01,1.842e-01,1.842e-01,1.842e-01,1.842e-01
-SDP_MC,REF,,Mini Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,7.127e-05,7.127e-05,7.127e-05,7.127e-05,7.127e-05
+SDP_MC,REF,,Mini Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.425e-04,1.336e-04,1.336e-04,1.222e-04,1.222e-04
 SDP_MC,REF,,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,3.376e-03,3.376e-03,3.376e-03,3.376e-03,3.376e-03
 SDP_MC,REF,,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,REF,,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,4.141e-01,4.141e-01,4.141e-01,4.141e-01,4.141e-01
-SDP_MC,REF,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.254e-02,1.254e-02,1.254e-02,1.254e-02,1.254e-02
+SDP_MC,REF,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,2.508e-02,2.351e-02,2.351e-02,2.150e-02,2.150e-02
 SDP_MC,REF,,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,REF,,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,5.081e-03,5.081e-03,5.081e-03,5.081e-03,5.081e-03
 SDP_MC,REF,,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,5.837e-01,5.837e-01,5.837e-01,5.837e-01,5.837e-01
 SDP_MC,REF,,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.888e-01,1.888e-01,1.888e-01,1.888e-01,1.888e-01
 SDP_MC,REF,,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.676e-02,1.676e-02,1.676e-02,1.676e-02,1.676e-02
-SDP_MC,REF,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_MC,REF,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,6.589e-03,6.589e-03,6.589e-03,6.589e-03,6.589e-03
-SDP_MC,REF,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_MC,REF,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.743e-02,3.227e-01,9.526e-01,9.526e-01
+SDP_MC,REF,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.000e-02,1.680e-01,3.360e-01,3.360e-01
+SDP_MC,REF,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.000e-02,1.680e-01,3.360e-01,3.360e-01
+SDP_MC,REF,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.000e-02,1.680e-01,3.360e-01,3.360e-01
+SDP_MC,REF,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,7.245e-02,3.202e-01,7.425e-01,7.425e-01
 SDP_MC,REF,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,REF,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,REF,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_MC,REF,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.192e-01,3.000e-01,3.928e-01,3.928e-01
-SDP_MC,REF,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.743e-02,1.614e-01,3.810e-01,3.810e-01
-SDP_MC,REF,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.743e-02,1.614e-01,3.810e-01,3.810e-01
-SDP_MC,REF,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.743e-02,1.614e-01,3.810e-01,3.810e-01
-SDP_MC,REF,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.192e-01,3.000e-01,3.928e-01,3.928e-01
-SDP_MC,REF,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.473e-03,3.597e-02,1.000e-01,1.000e-01
-SDP_MC,REF,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.024e-02,4.743e-02,7.311e-02,7.311e-02
-SDP_MC,REF,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.225e-02,1.799e-02,5.000e-02,5.000e-02
-SDP_MC,REF,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.225e-02,1.799e-02,5.000e-02,5.000e-02
-SDP_MC,REF,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.225e-02,1.799e-02,5.000e-02,5.000e-02
-SDP_MC,REF,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.024e-02,4.743e-02,7.311e-02,7.311e-02
+SDP_MC,REF,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.183e-01,2.678e-01,3.957e-01,3.957e-01
+SDP_MC,REF,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.705e-02,1.441e-01,3.838e-01,3.838e-01
+SDP_MC,REF,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.705e-02,1.441e-01,3.838e-01,3.838e-01
+SDP_MC,REF,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.705e-02,1.441e-01,3.838e-01,3.838e-01
+SDP_MC,REF,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.183e-01,2.678e-01,3.957e-01,3.957e-01
+SDP_MC,REF,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.698e-03,3.569e-02,6.236e-02,6.236e-02
+SDP_MC,REF,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.975e-02,4.705e-02,5.523e-02,5.523e-02
+SDP_MC,REF,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.208e-02,1.784e-02,3.777e-02,3.777e-02
+SDP_MC,REF,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.208e-02,1.784e-02,3.777e-02,3.777e-02
+SDP_MC,REF,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.208e-02,1.784e-02,3.777e-02,3.777e-02
+SDP_MC,REF,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.975e-02,4.705e-02,5.523e-02,5.523e-02
 SDP_MC,REF,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0.000e+00,8.315e-07,4.540e-05,1.192e-01,1.192e-01
 SDP_MC,REF,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,REF,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
@@ -4052,26 +4052,26 @@ SDP_MC,REF,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_roa
 SDP_MC,REF,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,REF,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,REF,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_MC,REF,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.400e-02,3.994e-02,7.347e-02,1.369e-01,1.369e-01
-SDP_MC,REF,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,4.158e-02,6.680e-02,1.172e-01,1.745e-01,1.745e-01
-SDP_MC,REF,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.474e-01,1.474e-01
-SDP_MC,REF,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,6.311e-02,8.776e-02,1.371e-01,1.886e-01,1.886e-01
-SDP_MC,REF,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,3.048e-02,5.599e-02,1.070e-01,1.673e-01,1.673e-01
-SDP_MC,REF,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.474e-01,1.474e-01
-SDP_MC,SSA,,,,,Cycle,trn_pass,S3S,linear,1.388e-02,1.795e-02,2.915e-02,3.279e-02,3.279e-02
-SDP_MC,SSA,,,,,Domestic Aviation,trn_pass,S3S,linear,9.013e-03,5.100e-02,4.140e-02,6.209e-03,6.209e-03
-SDP_MC,SSA,,,,,Domestic Ship,trn_freight,S3S,linear,1.467e-03,1.467e-03,1.467e-03,1.467e-03,1.467e-03
-SDP_MC,SSA,,,,,Freight Rail,trn_freight,S3S,linear,1.634e-02,1.634e-02,1.634e-02,1.634e-02,1.634e-02
-SDP_MC,SSA,,,,,HSR,trn_pass,S3S,linear,1.475e-05,2.003e-05,6.504e-02,9.756e-03,9.756e-03
+SDP_MC,REF,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.400e-02,3.195e-02,6.011e-02,7.825e-02,7.825e-02
+SDP_MC,REF,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,3.465e-02,6.073e-02,9.593e-02,1.342e-01,1.342e-01
+SDP_MC,REF,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.392e-02,6.459e-02,1.134e-01,1.134e-01
+SDP_MC,REF,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,5.259e-02,7.979e-02,1.122e-01,1.450e-01,1.450e-01
+SDP_MC,REF,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,2.540e-02,5.090e-02,8.756e-02,1.287e-01,1.287e-01
+SDP_MC,REF,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.392e-02,6.459e-02,1.134e-01,1.134e-01
+SDP_MC,SSA,,,,,Cycle,trn_pass,S3S,linear,1.388e-02,1.987e-02,2.915e-02,3.279e-02,3.279e-02
+SDP_MC,SSA,,,,,Domestic Aviation,trn_pass,S3S,linear,8.602e-03,5.387e-02,3.951e-02,5.926e-03,5.926e-03
+SDP_MC,SSA,,,,,Domestic Ship,trn_freight,S3S,linear,1.495e-03,1.495e-03,1.495e-03,1.495e-03,1.495e-03
+SDP_MC,SSA,,,,,Freight Rail,trn_freight,S3S,linear,1.665e-02,1.665e-02,1.665e-02,1.498e-02,1.498e-02
+SDP_MC,SSA,,,,,HSR,trn_pass,S3S,linear,1.475e-05,2.217e-05,6.504e-02,9.756e-03,9.756e-03
 SDP_MC,SSA,,,,,International Aviation,trn_aviation_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,SSA,,,,,International Ship,trn_shipping_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_MC,SSA,,,,,Passenger Rail,trn_pass,S3S,linear,6.024e-04,1.559e-03,2.530e-03,5.693e-04,5.693e-04
-SDP_MC,SSA,,,,,Walk,trn_pass,S3S,linear,1.000e+00,9.034e-01,1.000e+00,1.000e+00,1.000e+00
+SDP_MC,SSA,,,,,Passenger Rail,trn_pass,S3S,linear,6.024e-04,1.725e-03,2.530e-03,5.693e-04,5.693e-04
+SDP_MC,SSA,,,,,Walk,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,SSA,,,,,trn_freight_road,trn_freight,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_MC,SSA,,,,,trn_pass_road,trn_pass,S3S,linear,8.902e-01,1.000e+00,9.741e-01,9.741e-02,9.741e-02
-SDP_MC,SSA,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,2.477e-01,1.270e-01,7.328e-02,9.526e-02,9.526e-02
+SDP_MC,SSA,,,,,trn_pass_road,trn_pass,S3S,linear,2.622e-01,3.260e-01,2.869e-01,4.781e-02,4.781e-02
+SDP_MC,SSA,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,7.568e-01,3.234e-01,1.493e-01,9.703e-02,9.703e-02
 SDP_MC,SSA,,,,trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_MC,SSA,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,3.928e-02,3.928e-02,3.928e-02,3.928e-02,3.928e-02
+SDP_MC,SSA,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,2.619e-02,2.619e-02,2.619e-02,3.928e-02,3.928e-02
 SDP_MC,SSA,,,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,SSA,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,SSA,,Large Car and SUV,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,3.022e-03,3.022e-03,3.022e-03,3.022e-03,3.022e-03
@@ -4086,24 +4086,24 @@ SDP_MC,SSA,,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_s
 SDP_MC,SSA,,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,4.207e-06,4.207e-06,4.207e-06,4.207e-06,4.207e-06
 SDP_MC,SSA,,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,SSA,,Van,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,7.570e-05,7.570e-05,7.570e-05,7.570e-05,7.570e-05
-SDP_MC,SSA,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_MC,SSA,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_MC,SSA,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_MC,SSA,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.743e-02,4.034e-01,9.526e-01,9.526e-01
+SDP_MC,SSA,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.000e-01,2.160e-01,3.360e-01,3.360e-01
+SDP_MC,SSA,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.000e-01,2.160e-01,3.360e-01,3.360e-01
+SDP_MC,SSA,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.000e-01,2.160e-01,3.360e-01,3.360e-01
+SDP_MC,SSA,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,6.210e-02,3.962e-01,8.470e-01,8.470e-01
 SDP_MC,SSA,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,SSA,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,SSA,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_MC,SSA,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.384e-02,1.000e-01,1.511e-01,1.511e-01
-SDP_MC,SSA,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,9.485e-03,5.379e-02,1.465e-01,1.465e-01
-SDP_MC,SSA,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,9.485e-03,5.379e-02,1.465e-01,1.465e-01
-SDP_MC,SSA,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,9.485e-03,5.379e-02,1.465e-01,1.465e-01
-SDP_MC,SSA,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.384e-02,1.000e-01,1.511e-01,1.511e-01
-SDP_MC,SSA,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.473e-03,1.799e-02,7.500e-02,7.500e-02
-SDP_MC,SSA,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.693e-03,4.743e-02,2.812e-02,2.812e-02
-SDP_MC,SSA,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-03,1.799e-02,1.923e-02,1.923e-02
-SDP_MC,SSA,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-03,1.799e-02,1.923e-02,1.923e-02
-SDP_MC,SSA,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-03,1.799e-02,1.923e-02,1.923e-02
-SDP_MC,SSA,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.693e-03,4.743e-02,2.812e-02,2.812e-02
+SDP_MC,SSA,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.602e-02,1.007e-01,1.511e-01,1.511e-01
+SDP_MC,SSA,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.035e-02,5.418e-02,1.466e-01,1.466e-01
+SDP_MC,SSA,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.035e-02,5.418e-02,1.466e-01,1.466e-01
+SDP_MC,SSA,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.035e-02,5.418e-02,1.466e-01,1.466e-01
+SDP_MC,SSA,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.602e-02,1.007e-01,1.511e-01,1.511e-01
+SDP_MC,SSA,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.698e-03,1.963e-02,4.850e-02,4.850e-02
+SDP_MC,SSA,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,7.303e-03,1.194e-02,2.045e-02,2.045e-02
+SDP_MC,SSA,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.698e-03,4.529e-03,1.399e-02,1.399e-02
+SDP_MC,SSA,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.698e-03,4.529e-03,1.399e-02,1.399e-02
+SDP_MC,SSA,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.698e-03,4.529e-03,1.399e-02,1.399e-02
+SDP_MC,SSA,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,7.303e-03,1.194e-02,2.045e-02,2.045e-02
 SDP_MC,SSA,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0.000e+00,8.315e-07,4.540e-05,1.192e-01,1.192e-01
 SDP_MC,SSA,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,SSA,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
@@ -4120,59 +4120,59 @@ SDP_MC,SSA,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_roa
 SDP_MC,SSA,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,SSA,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,SSA,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_MC,SSA,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,3.981e-04,2.670e-02,5.552e-02,9.227e-02,9.227e-02
-SDP_MC,SSA,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,7.085e-02,7.085e-02
-SDP_MC,SSA,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,7.085e-02,7.085e-02
-SDP_MC,SSA,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,7.085e-02,7.085e-02
-SDP_MC,SSA,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,7.085e-02,7.085e-02
-SDP_MC,SSA,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,7.085e-02,7.085e-02
+SDP_MC,SSA,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,3.981e-04,2.670e-02,4.997e-02,6.835e-02,6.835e-02
+SDP_MC,SSA,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,4.251e-02,5.904e-02,5.904e-02
+SDP_MC,SSA,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,4.251e-02,5.904e-02,5.904e-02
+SDP_MC,SSA,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,4.251e-02,5.904e-02,5.904e-02
+SDP_MC,SSA,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,4.251e-02,5.904e-02,5.904e-02
+SDP_MC,SSA,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,4.251e-02,5.904e-02,5.904e-02
 SDP_MC,UKI,,,,,Cycle,trn_pass,S3S,linear,2.500e-02,1.092e-02,3.277e-02,6.553e-02,6.553e-02
-SDP_MC,UKI,,,,,Domestic Aviation,trn_pass,S3S,linear,6.250e-05,9.365e-06,9.365e-06,9.365e-06,9.365e-06
-SDP_MC,UKI,,,,,Domestic Ship,trn_freight,S3S,linear,8.512e-03,8.512e-03,8.512e-03,8.512e-03,8.512e-03
-SDP_MC,UKI,,,,,Freight Rail,trn_freight,S3S,linear,6.067e-03,6.067e-03,6.067e-03,6.067e-03,6.067e-03
+SDP_MC,UKI,,,,,Domestic Aviation,trn_pass,S3S,linear,5.965e-05,8.938e-06,8.938e-06,8.938e-06,8.938e-06
+SDP_MC,UKI,,,,,Domestic Ship,trn_freight,S3S,linear,8.670e-03,8.670e-03,8.670e-03,8.670e-03,8.670e-03
+SDP_MC,UKI,,,,,Freight Rail,trn_freight,S3S,linear,6.180e-03,6.180e-03,6.180e-03,6.180e-03,6.180e-03
 SDP_MC,UKI,,,,,HSR,trn_pass,S3S,linear,1.250e-04,1.334e-04,1.779e-04,2.224e-04,2.224e-04
 SDP_MC,UKI,,,,,International Aviation,trn_aviation_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,UKI,,,,,International Ship,trn_shipping_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,UKI,,,,,Passenger Rail,trn_pass,S3S,linear,3.125e-03,2.502e-03,1.876e-03,1.876e-03,1.876e-03
 SDP_MC,UKI,,,,,Walk,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,UKI,,,,,trn_freight_road,trn_freight,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_MC,UKI,,,,,trn_pass_road,trn_pass,S3S,linear,7.500e-02,5.325e-02,3.408e-02,3.408e-02,3.408e-02
-SDP_MC,UKI,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,2.500e-01,2.010e-01,1.843e-01,1.675e-01,1.675e-01
+SDP_MC,UKI,,,,,trn_pass_road,trn_pass,S3S,linear,7.363e-02,5.228e-02,3.346e-02,3.346e-02,3.346e-02
+SDP_MC,UKI,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,2.546e-01,2.048e-01,1.877e-01,1.706e-01,1.706e-01
 SDP_MC,UKI,,,,trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,UKI,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,3.935e-02,3.935e-02,3.935e-02,3.935e-02,3.935e-02
 SDP_MC,UKI,,,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_MC,UKI,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,4.864e-01,4.864e-01,4.864e-01,4.864e-01,4.864e-01
+SDP_MC,UKI,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,5.404e-01,5.404e-01,4.864e-01,4.864e-01,4.864e-01
 SDP_MC,UKI,,Large Car and SUV,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,UKI,,Midsize Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,2.616e-01,2.616e-01,2.616e-01,2.616e-01,2.616e-01
-SDP_MC,UKI,,Mini Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,4.751e-07,4.751e-07,4.751e-07,4.751e-07,4.751e-07
+SDP_MC,UKI,,Mini Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,5.279e-07,5.279e-07,4.751e-07,4.751e-07,4.751e-07
 SDP_MC,UKI,,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,2.088e-02,2.088e-02,2.088e-02,2.088e-02,2.088e-02
 SDP_MC,UKI,,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,3.798e-03,3.798e-03,3.798e-03,3.798e-03,3.798e-03
 SDP_MC,UKI,,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_MC,UKI,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,5.119e-01,5.119e-01,5.119e-01,5.119e-01,5.119e-01
+SDP_MC,UKI,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,5.688e-01,5.688e-01,5.119e-01,5.119e-01,5.119e-01
 SDP_MC,UKI,,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,UKI,,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,4.528e-02,4.528e-02,4.528e-02,4.528e-02,4.528e-02
 SDP_MC,UKI,,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,9.437e-02,9.437e-02,9.437e-02,9.437e-02,9.437e-02
 SDP_MC,UKI,,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,5.696e-01,5.696e-01,5.696e-01,5.696e-01,5.696e-01
 SDP_MC,UKI,,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,7.765e-01,7.765e-01,7.765e-01,7.765e-01,7.765e-01
 SDP_MC,UKI,,Van,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,2.681e-03,2.681e-03,2.681e-03,2.681e-03,2.681e-03
-SDP_MC,UKI,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_MC,UKI,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_MC,UKI,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_MC,UKI,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.186e-01,3.227e-01,8.573e-01,8.573e-01
+SDP_MC,UKI,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,5.000e-02,2.000e-01,3.700e-01,3.700e-01
+SDP_MC,UKI,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,5.000e-02,2.000e-01,3.700e-01,3.700e-01
+SDP_MC,UKI,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,5.000e-02,2.000e-01,3.700e-01,3.700e-01
+SDP_MC,UKI,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,2.500e-02,1.168e-01,3.434e-01,7.434e-01,7.434e-01
 SDP_MC,UKI,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,8.260e-01,8.478e-01,8.913e-01,9.783e-01,9.783e-01
 SDP_MC,UKI,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,UKI,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_MC,UKI,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.384e-01,5.500e-01,8.838e-01,8.838e-01
-SDP_MC,UKI,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,9.485e-02,2.958e-01,8.573e-01,8.573e-01
-SDP_MC,UKI,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,9.485e-02,2.958e-01,8.573e-01,8.573e-01
-SDP_MC,UKI,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,9.485e-02,2.958e-01,8.573e-01,8.573e-01
-SDP_MC,UKI,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.384e-01,5.500e-01,8.838e-01,8.838e-01
-SDP_MC,UKI,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.236e-02,1.799e-02,1.000e-01,1.000e-01
-SDP_MC,UKI,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.693e-02,1.897e-01,1.462e-01,1.462e-01
-SDP_MC,UKI,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-02,7.194e-02,1.000e-01,1.000e-01
-SDP_MC,UKI,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-02,7.194e-02,1.000e-01,1.000e-01
-SDP_MC,UKI,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-02,7.194e-02,1.000e-01,1.000e-01
-SDP_MC,UKI,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.693e-02,1.897e-01,1.462e-01,1.462e-01
+SDP_MC,UKI,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.819e-01,5.853e-01,8.360e-01,8.360e-01
+SDP_MC,UKI,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.122e-01,3.148e-01,8.110e-01,8.110e-01
+SDP_MC,UKI,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.122e-01,3.148e-01,8.110e-01,8.110e-01
+SDP_MC,UKI,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.122e-01,3.148e-01,8.110e-01,8.110e-01
+SDP_MC,UKI,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.819e-01,5.853e-01,8.360e-01,8.360e-01
+SDP_MC,UKI,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,2.500e-05,1.218e-02,2.127e-02,7.883e-02,7.883e-02
+SDP_MC,UKI,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,7.914e-02,2.243e-01,1.729e-01,1.729e-01
+SDP_MC,UKI,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.924e-02,8.507e-02,1.182e-01,1.182e-01
+SDP_MC,UKI,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.924e-02,8.507e-02,1.182e-01,1.182e-01
+SDP_MC,UKI,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.924e-02,8.507e-02,1.182e-01,1.182e-01
+SDP_MC,UKI,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,7.914e-02,2.243e-01,1.729e-01,1.729e-01
 SDP_MC,UKI,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0.000e+00,8.315e-07,4.540e-05,1.192e-01,1.192e-01
 SDP_MC,UKI,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,UKI,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
@@ -4189,24 +4189,24 @@ SDP_MC,UKI,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_roa
 SDP_MC,UKI,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,UKI,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,UKI,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_MC,UKI,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,3.616e-04,2.667e-02,7.928e-02,1.845e-01,1.845e-01
+SDP_MC,UKI,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,9.040e-04,2.222e-02,7.928e-02,1.230e-01,1.230e-01
 SDP_MC,UKI,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
 SDP_MC,UKI,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
 SDP_MC,UKI,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
 SDP_MC,UKI,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
 SDP_MC,UKI,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
 SDP_MC,USA,,,,,Cycle,trn_pass,S3S,linear,8.197e-03,8.197e-03,8.197e-03,4.098e-02,4.098e-02
-SDP_MC,USA,,,,,Domestic Aviation,trn_pass,S3S,linear,1.057e-03,1.600e-03,1.800e-03,1.100e-03,1.100e-03
-SDP_MC,USA,,,,,Domestic Ship,trn_freight,S3S,linear,3.208e-03,3.208e-03,3.208e-03,3.208e-03,3.208e-03
-SDP_MC,USA,,,,,Freight Rail,trn_freight,S3S,linear,3.364e-02,3.364e-02,3.364e-02,3.364e-02,3.364e-02
+SDP_MC,USA,,,,,Domestic Aviation,trn_pass,S3S,linear,1.009e-03,1.527e-03,1.718e-03,1.050e-03,1.050e-03
+SDP_MC,USA,,,,,Domestic Ship,trn_freight,S3S,linear,3.267e-03,3.267e-03,3.267e-03,3.267e-03,3.267e-03
+SDP_MC,USA,,,,,Freight Rail,trn_freight,S3S,linear,3.427e-02,3.427e-02,3.427e-02,3.427e-02,3.427e-02
 SDP_MC,USA,,,,,HSR,trn_pass,S3S,linear,4.530e-06,4.530e-06,4.530e-06,2.265e-04,2.265e-04
 SDP_MC,USA,,,,,International Aviation,trn_aviation_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,USA,,,,,International Ship,trn_shipping_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,USA,,,,,Passenger Rail,trn_pass,S3S,linear,1.933e-03,1.933e-03,1.933e-03,9.665e-04,9.665e-04
 SDP_MC,USA,,,,,Walk,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,USA,,,,,trn_freight_road,trn_freight,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_MC,USA,,,,,trn_pass_road,trn_pass,S3S,linear,1.329e-01,1.329e-01,1.276e-01,6.647e-02,6.647e-02
-SDP_MC,USA,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,8.561e-02,1.070e-01,1.070e-01,1.213e-01,1.213e-01
+SDP_MC,USA,,,,,trn_pass_road,trn_pass,S3S,linear,1.305e-01,1.305e-01,1.253e-01,6.526e-02,6.526e-02
+SDP_MC,USA,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,8.720e-02,1.090e-01,1.090e-01,1.235e-01,1.235e-01
 SDP_MC,USA,,,,trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,USA,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,3.805e-02,3.805e-02,3.805e-02,3.805e-02,3.805e-02
 SDP_MC,USA,,,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
@@ -4219,29 +4219,29 @@ SDP_MC,USA,,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pas
 SDP_MC,USA,,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,USA,,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,7.057e-01,7.057e-01,7.057e-01,7.057e-01,7.057e-01
 SDP_MC,USA,,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_MC,USA,,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_MC,USA,,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
+SDP_MC,USA,,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,9.000e-01,1.000e+00,1.000e+00,1.000e+00,1.000e+00
+SDP_MC,USA,,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,9.000e-01,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,USA,,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,6.263e-01,6.263e-01,6.263e-01,6.263e-01,6.263e-01
-SDP_MC,USA,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_MC,USA,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_MC,USA,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_MC,USA,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.423e-01,5.379e-01,1.000e+00,1.000e+00
+SDP_MC,USA,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.400e-02,2.160e-01,3.780e-01,3.780e-01
+SDP_MC,USA,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.400e-02,2.160e-01,3.780e-01,3.780e-01
+SDP_MC,USA,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.400e-02,2.160e-01,3.780e-01,3.780e-01
+SDP_MC,USA,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.122e-01,5.382e-01,1.000e+00,1.000e+00
 SDP_MC,USA,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,0.000e+00,1.250e-01,3.750e-01,8.750e-01,8.750e-01
 SDP_MC,USA,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,USA,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_MC,USA,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.980e-02,2.500e-01,7.856e-01,7.856e-01
-SDP_MC,USA,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.186e-02,1.345e-01,7.621e-01,7.621e-01
-SDP_MC,USA,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,3.000e-02,2.500e-01,5.000e-01,8.000e-01,8.000e-01
-SDP_MC,USA,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,3.000e-02,2.500e-01,5.000e-01,8.000e-01,8.000e-01
-SDP_MC,USA,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.980e-02,2.500e-01,7.856e-01,7.856e-01
-SDP_MC,USA,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.473e-02,1.799e-02,6.999e-02,6.999e-02
-SDP_MC,USA,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.339e-03,1.423e-02,1.462e-01,1.462e-01
-SDP_MC,USA,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.945e-04,5.396e-03,1.000e-01,1.000e-01
-SDP_MC,USA,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,5.000e-02,2.000e-01,3.000e-01,2.000e-01,2.000e-01
-SDP_MC,USA,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,5.000e-02,2.000e-01,3.000e-01,2.000e-01,2.000e-01
-SDP_MC,USA,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.339e-03,1.423e-02,1.462e-01,1.462e-01
+SDP_MC,USA,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.626e-02,2.323e-01,6.967e-01,6.967e-01
+SDP_MC,USA,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.470e-03,1.249e-01,6.758e-01,6.758e-01
+SDP_MC,USA,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,3.547e-02,1.364e-01,4.645e-01,7.095e-01,7.095e-01
+SDP_MC,USA,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,3.547e-02,1.364e-01,4.645e-01,7.095e-01,7.095e-01
+SDP_MC,USA,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.626e-02,2.323e-01,6.967e-01,6.967e-01
+SDP_MC,USA,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.436e-02,1.636e-02,7.776e-02,7.776e-02
+SDP_MC,USA,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.218e-03,1.202e-02,1.008e-01,1.008e-01
+SDP_MC,USA,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.498e-04,4.557e-03,6.897e-02,6.897e-02
+SDP_MC,USA,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,5.912e-02,1.819e-01,2.534e-01,1.379e-01,1.379e-01
+SDP_MC,USA,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,5.912e-02,1.819e-01,2.534e-01,1.379e-01,1.379e-01
+SDP_MC,USA,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.218e-03,1.202e-02,1.008e-01,1.008e-01
 SDP_MC,USA,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0.000e+00,8.315e-07,4.540e-05,1.192e-01,1.192e-01
-SDP_MC,USA,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,6.999e-01,6.999e-01
+SDP_MC,USA,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,7.892e-01,7.892e-01
 SDP_MC,USA,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,USA,Liquids,Domestic Ship_tmp_vehicletype,Domestic Ship_tmp_subsector_L1,Domestic Ship_tmp_subsector_L2,Domestic Ship,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,USA,Liquids,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
@@ -4256,12 +4256,12 @@ SDP_MC,USA,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_roa
 SDP_MC,USA,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,USA,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_MC,USA,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_MC,USA,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,8.478e-02,1.089e-01,1.570e-01,1.773e-01,1.773e-01
-SDP_MC,USA,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.263e-03,3.158e-02,7.368e-02,7.368e-02
-SDP_MC,USA,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.263e-03,3.158e-02,7.368e-02,7.368e-02
-SDP_MC,USA,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e-01,2.000e-01,4.000e-01,4.000e-01,4.000e-01
-SDP_MC,USA,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e-01,2.000e-01,4.000e-01,4.000e-01,4.000e-01
-SDP_MC,USA,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.263e-03,3.158e-02,7.368e-02,7.368e-02
+SDP_MC,USA,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,8.478e-02,9.072e-02,1.208e-01,1.666e-01,1.666e-01
+SDP_MC,USA,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.049e-03,2.256e-02,6.140e-02,6.140e-02
+SDP_MC,USA,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.049e-03,2.256e-02,6.140e-02,6.140e-02
+SDP_MC,USA,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,5.000e-03,1.538e-01,2.857e-01,3.333e-01,3.333e-01
+SDP_MC,USA,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,5.000e-03,1.538e-01,2.857e-01,3.333e-01,3.333e-01
+SDP_MC,USA,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.049e-03,2.256e-02,6.140e-02,6.140e-02
 SDP_RC,CAZ,,,,,Cycle,trn_pass,S3S,linear,1.911e-02,3.822e-02,3.822e-02,7.645e-02,7.645e-02
 SDP_RC,CAZ,,,,,Domestic Aviation,trn_pass,S3S,linear,1.500e-03,1.600e-03,1.900e-03,2.000e-03,2.000e-03
 SDP_RC,CAZ,,,,,Domestic Ship,trn_freight,S3S,linear,1.554e-02,1.554e-02,1.554e-02,1.554e-02,1.554e-02

--- a/inst/extdata/sw_trends.csv
+++ b/inst/extdata/sw_trends.csv
@@ -1421,17 +1421,17 @@ SDP,USA,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_su
 SDP,USA,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,5.000e-03,1.538e-01,2.857e-01,3.333e-01,3.333e-01
 SDP,USA,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.049e-03,2.256e-02,6.140e-02,6.140e-02
 SDP_EI,CAZ,,,,,Cycle,trn_pass,S3S,linear,1.911e-02,3.822e-02,3.822e-02,7.645e-02,7.645e-02
-SDP_EI,CAZ,,,,,Domestic Aviation,trn_pass,S3S,linear,1.500e-03,1.600e-03,1.900e-03,2.000e-03,2.000e-03
-SDP_EI,CAZ,,,,,Domestic Ship,trn_freight,S3S,linear,1.554e-02,1.554e-02,1.554e-02,1.554e-02,1.554e-02
-SDP_EI,CAZ,,,,,Freight Rail,trn_freight,S3S,linear,1.051e-01,1.051e-01,1.051e-01,1.051e-01,1.051e-01
+SDP_EI,CAZ,,,,,Domestic Aviation,trn_pass,S3S,linear,1.432e-03,1.527e-03,1.813e-03,1.909e-03,1.909e-03
+SDP_EI,CAZ,,,,,Domestic Ship,trn_freight,S3S,linear,1.583e-02,1.583e-02,1.583e-02,1.583e-02,1.583e-02
+SDP_EI,CAZ,,,,,Freight Rail,trn_freight,S3S,linear,1.070e-01,1.070e-01,1.070e-01,9.633e-02,9.633e-02
 SDP_EI,CAZ,,,,,HSR,trn_pass,S3S,linear,8.792e-08,8.792e-05,2.638e-04,2.638e-04,2.638e-04
 SDP_EI,CAZ,,,,,International Aviation,trn_aviation_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,CAZ,,,,,International Ship,trn_shipping_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,CAZ,,,,,Passenger Rail,trn_pass,S3S,linear,8.785e-04,8.785e-04,8.785e-04,8.785e-04,8.785e-04
 SDP_EI,CAZ,,,,,Walk,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,CAZ,,,,,trn_freight_road,trn_freight,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_EI,CAZ,,,,,trn_pass_road,trn_pass,S3S,linear,1.537e-01,1.537e-01,1.537e-01,1.537e-01,1.537e-01
-SDP_EI,CAZ,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,8.691e-02,8.691e-02,1.086e-01,1.376e-01,1.376e-01
+SDP_EI,CAZ,,,,,trn_pass_road,trn_pass,S3S,linear,1.509e-01,1.509e-01,1.509e-01,1.509e-01,1.509e-01
+SDP_EI,CAZ,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,8.852e-02,8.852e-02,1.107e-01,1.402e-01,1.402e-01
 SDP_EI,CAZ,,,,trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,CAZ,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.939e-02,1.939e-02,1.939e-02,1.939e-02,1.939e-02
 SDP_EI,CAZ,,,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
@@ -1451,26 +1451,26 @@ SDP_EI,CAZ,,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_s
 SDP_EI,CAZ,,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,3.497e-05,3.497e-05,3.497e-05,3.497e-05,3.497e-05
 SDP_EI,CAZ,,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,6.282e-01,6.282e-01,6.282e-01,6.282e-01,6.282e-01
 SDP_EI,CAZ,,Van,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,2.082e-01,2.082e-01,2.082e-01,2.082e-01,2.082e-01
-SDP_EI,CAZ,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_EI,CAZ,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_EI,CAZ,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_EI,CAZ,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,9.485e-02,4.572e-01,1.000e+00,1.000e+00
+SDP_EI,CAZ,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.400e-02,1.920e-01,3.360e-01,3.360e-01
+SDP_EI,CAZ,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.400e-02,1.920e-01,3.360e-01,3.360e-01
+SDP_EI,CAZ,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.400e-02,1.920e-01,3.360e-01,3.360e-01
+SDP_EI,CAZ,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.122e-01,4.423e-01,9.735e-01,9.735e-01
 SDP_EI,CAZ,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,9.074e-02,2.044e-01,4.317e-01,8.863e-01,8.863e-01
 SDP_EI,CAZ,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,CAZ,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_EI,CAZ,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.192e-01,3.500e-01,4.910e-01,4.910e-01
-SDP_EI,CAZ,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.743e-02,1.883e-01,4.763e-01,4.763e-01
-SDP_EI,CAZ,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.743e-02,1.883e-01,4.763e-01,4.763e-01
-SDP_EI,CAZ,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.743e-02,1.883e-01,4.763e-01,4.763e-01
-SDP_EI,CAZ,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.192e-01,3.500e-01,4.910e-01,4.910e-01
-SDP_EI,CAZ,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.236e-02,1.799e-02,9.544e-02,9.544e-02
-SDP_EI,CAZ,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.346e-02,4.743e-02,1.462e-01,1.462e-01
-SDP_EI,CAZ,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.236e-02,1.799e-02,1.000e-01,1.000e-01
-SDP_EI,CAZ,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.236e-02,1.799e-02,1.000e-01,1.000e-01
-SDP_EI,CAZ,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.236e-02,1.799e-02,1.000e-01,1.000e-01
-SDP_EI,CAZ,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.346e-02,4.743e-02,1.462e-01,1.462e-01
+SDP_EI,CAZ,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.409e-01,3.311e-01,4.354e-01,4.354e-01
+SDP_EI,CAZ,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.608e-02,1.781e-01,4.224e-01,4.224e-01
+SDP_EI,CAZ,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.608e-02,1.781e-01,4.224e-01,4.224e-01
+SDP_EI,CAZ,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.608e-02,1.781e-01,4.224e-01,4.224e-01
+SDP_EI,CAZ,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.409e-01,3.311e-01,4.354e-01,4.354e-01
+SDP_EI,CAZ,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.462e-02,1.933e-02,7.601e-02,7.601e-02
+SDP_EI,CAZ,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.957e-02,5.608e-02,1.153e-01,1.153e-01
+SDP_EI,CAZ,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.462e-02,2.127e-02,7.883e-02,7.883e-02
+SDP_EI,CAZ,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.462e-02,2.127e-02,7.883e-02,7.883e-02
+SDP_EI,CAZ,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.462e-02,2.127e-02,7.883e-02,7.883e-02
+SDP_EI,CAZ,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.957e-02,5.608e-02,1.153e-01,1.153e-01
 SDP_EI,CAZ,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0.000e+00,8.315e-07,4.540e-05,1.192e-01,1.192e-01
-SDP_EI,CAZ,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,9.544e-01,9.544e-01
+SDP_EI,CAZ,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,CAZ,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,CAZ,Liquids,Domestic Ship_tmp_vehicletype,Domestic Ship_tmp_subsector_L1,Domestic Ship_tmp_subsector_L2,Domestic Ship,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,CAZ,Liquids,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
@@ -1485,124 +1485,124 @@ SDP_EI,CAZ,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_roa
 SDP_EI,CAZ,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,CAZ,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,CAZ,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_EI,CAZ,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,3.104e-02,5.654e-02,1.075e-01,2.000e-01,2.000e-01
-SDP_EI,CAZ,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SDP_EI,CAZ,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SDP_EI,CAZ,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SDP_EI,CAZ,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SDP_EI,CAZ,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SDP_EI,CHA,,,,,Cycle,trn_pass,S3S,linear,8.298e-02,4.412e-02,3.782e-02,4.848e-02,4.848e-02
-SDP_EI,CHA,,,,,Domestic Aviation,trn_pass,S3S,linear,1.104e-01,2.842e-02,1.829e-02,3.517e-03,3.517e-03
-SDP_EI,CHA,,,,,Domestic Ship,trn_freight,S3S,linear,2.849e-02,8.548e-02,8.548e-02,8.548e-02,8.548e-02
-SDP_EI,CHA,,,,,Freight Rail,trn_freight,S3S,linear,6.920e-02,2.076e-01,2.076e-01,2.076e-01,2.076e-01
-SDP_EI,CHA,,,,,HSR,trn_pass,S3S,linear,2.108e-01,8.143e-02,1.916e-02,3.695e-03,3.695e-03
+SDP_EI,CAZ,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,3.104e-02,5.654e-02,9.776e-02,1.497e-01,1.497e-01
+SDP_EI,CAZ,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.535e-01,1.535e-01
+SDP_EI,CAZ,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.535e-01,1.535e-01
+SDP_EI,CAZ,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.535e-01,1.535e-01
+SDP_EI,CAZ,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.535e-01,1.535e-01
+SDP_EI,CAZ,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.535e-01,1.535e-01
+SDP_EI,CHA,,,,,Cycle,trn_pass,S3S,linear,9.454e-02,4.412e-02,3.782e-02,4.848e-02,4.848e-02
+SDP_EI,CHA,,,,,Domestic Aviation,trn_pass,S3S,linear,1.200e-01,2.712e-02,1.745e-02,3.357e-03,3.357e-03
+SDP_EI,CHA,,,,,Domestic Ship,trn_freight,S3S,linear,1.847e-02,1.922e-02,2.232e-02,2.232e-02,2.232e-02
+SDP_EI,CHA,,,,,Freight Rail,trn_freight,S3S,linear,3.204e-02,3.570e-02,3.795e-02,3.795e-02,3.795e-02
+SDP_EI,CHA,,,,,HSR,trn_pass,S3S,linear,2.402e-01,8.143e-02,1.916e-02,3.695e-03,3.695e-03
 SDP_EI,CHA,,,,,International Aviation,trn_aviation_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,CHA,,,,,International Ship,trn_shipping_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_EI,CHA,,,,,Passenger Rail,trn_pass,S3S,linear,5.461e-03,3.111e-03,1.867e-03,9.572e-04,9.572e-04
-SDP_EI,CHA,,,,,Walk,trn_pass,S3S,linear,8.777e-01,1.000e+00,1.000e+00,1.000e+00,1.000e+00
+SDP_EI,CHA,,,,,Passenger Rail,trn_pass,S3S,linear,6.222e-03,3.111e-03,1.867e-03,9.572e-04,9.572e-04
+SDP_EI,CHA,,,,,Walk,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,CHA,,,,,trn_freight_road,trn_freight,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_EI,CHA,,,,,trn_pass_road,trn_pass,S3S,linear,1.000e+00,4.557e-01,2.279e-01,5.843e-02,5.843e-02
-SDP_EI,CHA,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,3.816e-01,1.915e-01,1.705e-01,1.895e-01,1.895e-01
+SDP_EI,CHA,,,,,trn_pass_road,trn_pass,S3S,linear,6.711e-01,2.684e-01,1.342e-01,4.015e-02,4.015e-02
+SDP_EI,CHA,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,6.609e-01,2.927e-01,2.084e-01,9.649e-02,9.649e-02
 SDP_EI,CHA,,,,trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_EI,CHA,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.081e-02,9.523e-03,6.956e-03,1.824e-03,1.824e-03
+SDP_EI,CHA,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,2.702e-01,2.116e-01,1.391e-01,1.459e-01,1.459e-01
 SDP_EI,CHA,,,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_EI,CHA,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,3.616e-01,3.616e-01,3.616e-01,3.616e-01,3.616e-01
+SDP_EI,CHA,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,8.035e-01,7.232e-01,6.574e-01,5.563e-01,5.563e-01
 SDP_EI,CHA,,Large Car and SUV,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_EI,CHA,,Mini Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,8.023e-03,8.023e-03,8.023e-03,8.023e-03,8.023e-03
+SDP_EI,CHA,,Mini Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.783e-02,1.605e-02,1.459e-02,1.234e-02,1.234e-02
 SDP_EI,CHA,,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,4.044e-02,4.044e-02,4.044e-02,4.044e-02,4.044e-02
 SDP_EI,CHA,,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,CHA,,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_EI,CHA,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,3.898e-02,3.898e-02,3.898e-02,3.898e-02,3.898e-02
+SDP_EI,CHA,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,8.662e-02,7.795e-02,7.087e-02,5.996e-02,5.996e-02
 SDP_EI,CHA,,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,CHA,,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,2.234e-01,2.234e-01,2.234e-01,2.234e-01,2.234e-01
-SDP_EI,CHA,,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,4.469e-01,3.352e-01,3.352e-01,3.352e-01,3.352e-01
-SDP_EI,CHA,,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,4.469e-01,3.352e-01,3.352e-01,3.352e-01,3.352e-01
+SDP_EI,CHA,,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,4.022e-01,3.352e-01,3.016e-01,3.352e-01,3.352e-01
+SDP_EI,CHA,,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,4.022e-01,3.352e-01,3.016e-01,3.352e-01,3.352e-01
 SDP_EI,CHA,,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.657e-01,1.657e-01,1.657e-01,1.657e-01,1.657e-01
-SDP_EI,CHA,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_EI,CHA,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,8.402e-02,8.402e-02,8.402e-02,8.402e-02,8.402e-02
-SDP_EI,CHA,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_EI,CHA,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,3.320e-01,1.000e+00,1.000e+00,1.000e+00
+SDP_EI,CHA,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,6.000e-01,1.000e+00,1.000e+00,1.000e+00
+SDP_EI,CHA,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,6.000e-02,6.000e-01,1.000e+00,1.000e+00,1.000e+00
+SDP_EI,CHA,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,6.000e-01,1.000e+00,1.000e+00,1.000e+00
+SDP_EI,CHA,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,3.019e-01,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,CHA,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,4.553e-01,5.234e-01,6.595e-01,9.319e-01,9.319e-01
 SDP_EI,CHA,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,CHA,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,4.158e-01,4.888e-01,6.349e-01,9.270e-01,9.270e-01
-SDP_EI,CHA,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.768e-02,4.500e-01,9.820e-01,9.820e-01
-SDP_EI,CHA,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.897e-02,2.420e-01,9.526e-01,9.526e-01
-SDP_EI,CHA,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e-01,4.000e-01,9.000e-01,1.000e+00,1.000e+00
-SDP_EI,CHA,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e-01,4.000e-01,9.000e-01,1.000e+00,1.000e+00
-SDP_EI,CHA,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.768e-02,4.500e-01,9.820e-01,9.820e-01
-SDP_EI,CHA,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.225e-02,6.688e-02,6.999e-02,6.999e-02
-SDP_EI,CHA,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.339e-03,2.846e-02,1.462e-01,1.462e-01
-SDP_EI,CHA,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.945e-04,1.079e-02,1.000e-01,1.000e-01
-SDP_EI,CHA,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e-02,2.000e-01,6.000e-01,2.000e-01,2.000e-01
-SDP_EI,CHA,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e-02,2.000e-01,6.000e-01,2.000e-01,2.000e-01
-SDP_EI,CHA,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.339e-03,2.846e-02,1.462e-01,1.462e-01
+SDP_EI,CHA,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.002e-02,3.725e-01,8.768e-01,8.768e-01
+SDP_EI,CHA,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.592e-02,2.004e-01,8.505e-01,8.505e-01
+SDP_EI,CHA,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,9.920e-02,3.358e-01,7.450e-01,8.928e-01,8.928e-01
+SDP_EI,CHA,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,9.920e-02,3.358e-01,7.450e-01,8.928e-01,8.928e-01
+SDP_EI,CHA,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.002e-02,3.725e-01,8.768e-01,8.768e-01
+SDP_EI,CHA,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.024e-02,9.554e-02,6.999e-02,6.999e-02
+SDP_EI,CHA,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.124e-03,1.713e-02,1.450e-01,1.450e-01
+SDP_EI,CHA,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.151e-04,6.497e-03,9.920e-02,9.920e-02
+SDP_EI,CHA,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,9.920e-03,1.679e-01,3.612e-01,1.984e-01,1.984e-01
+SDP_EI,CHA,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,9.920e-03,1.679e-01,3.612e-01,1.984e-01,1.984e-01
+SDP_EI,CHA,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.124e-03,1.713e-02,1.450e-01,1.450e-01
 SDP_EI,CHA,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0.000e+00,8.315e-07,4.540e-05,1.192e-01,1.192e-01
-SDP_EI,CHA,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,7.437e-01,3.499e-01,3.499e-01
+SDP_EI,CHA,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,9.736e-01,3.527e-01,3.527e-01
 SDP_EI,CHA,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,CHA,Liquids,Domestic Ship_tmp_vehicletype,Domestic Ship_tmp_subsector_L1,Domestic Ship_tmp_subsector_L2,Domestic Ship,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,CHA,Liquids,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,CHA,Liquids,International Aviation_tmp_vehicletype,International Aviation_tmp_subsector_L1,International Aviation_tmp_subsector_L2,International Aviation,trn_aviation_intl,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,CHA,Liquids,International Ship_tmp_vehicletype,International Ship_tmp_subsector_L1,International Ship_tmp_subsector_L2,International Ship,trn_shipping_intl,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_EI,CHA,Liquids,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_EI,CHA,Liquids,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_EI,CHA,Liquids,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
+SDP_EI,CHA,Liquids,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,8.333e-01,6.803e-01,6.803e-01
+SDP_EI,CHA,Liquids,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,8.333e-01,6.803e-01,6.803e-01
+SDP_EI,CHA,Liquids,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,8.333e-01,6.803e-01,6.803e-01
 SDP_EI,CHA,Liquids,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,CHA,Liquids,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,CHA,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,CHA,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,CHA,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,CHA,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_EI,CHA,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.421e-01,1.594e-01,9.020e-02,1.152e-01,1.152e-01
-SDP_EI,CHA,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.878e-05,1.319e-02,5.530e-02,9.213e-02,9.213e-02
-SDP_EI,CHA,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,7.854e-04,1.443e-02,5.695e-02,9.317e-02,9.317e-02
-SDP_EI,CHA,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,3.000e-01,5.000e-01,7.000e-01,5.000e-01,5.000e-01
-SDP_EI,CHA,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,3.000e-01,5.000e-01,7.000e-01,5.000e-01,5.000e-01
-SDP_EI,CHA,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,3.309e-04,1.369e-02,5.597e-02,9.256e-02,9.256e-02
+SDP_EI,CHA,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.421e-01,1.329e-01,1.181e-01,1.055e-01,1.055e-01
+SDP_EI,CHA,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.707e-05,1.014e-02,3.814e-02,8.376e-02,8.376e-02
+SDP_EI,CHA,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,7.140e-04,1.110e-02,3.928e-02,8.470e-02,8.470e-02
+SDP_EI,CHA,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,2.727e-01,3.846e-01,4.828e-01,4.545e-01,4.545e-01
+SDP_EI,CHA,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,2.727e-01,3.846e-01,4.828e-01,4.545e-01,4.545e-01
+SDP_EI,CHA,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,3.008e-04,1.053e-02,3.860e-02,8.414e-02,8.414e-02
 SDP_EI,DEU,,,,,Cycle,trn_pass,S3S,linear,2.500e-02,2.500e-02,2.500e-02,1.875e-01,1.875e-01
-SDP_EI,DEU,,,,,Domestic Aviation,trn_pass,S3S,linear,6.250e-05,6.250e-05,6.250e-05,6.250e-05,6.250e-05
-SDP_EI,DEU,,,,,Domestic Ship,trn_freight,S3S,linear,2.088e-03,2.088e-03,2.088e-03,2.088e-03,2.088e-03
-SDP_EI,DEU,,,,,Freight Rail,trn_freight,S3S,linear,2.749e-02,2.749e-02,2.749e-02,2.749e-02,2.749e-02
+SDP_EI,DEU,,,,,Domestic Aviation,trn_pass,S3S,linear,5.965e-05,5.965e-05,5.965e-05,5.965e-05,5.965e-05
+SDP_EI,DEU,,,,,Domestic Ship,trn_freight,S3S,linear,2.127e-03,2.127e-03,2.127e-03,2.127e-03,2.127e-03
+SDP_EI,DEU,,,,,Freight Rail,trn_freight,S3S,linear,2.800e-02,2.800e-02,2.800e-02,2.800e-02,2.800e-02
 SDP_EI,DEU,,,,,HSR,trn_pass,S3S,linear,1.250e-04,2.500e-04,6.250e-04,6.250e-04,6.250e-04
 SDP_EI,DEU,,,,,International Aviation,trn_aviation_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,DEU,,,,,International Ship,trn_shipping_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,DEU,,,,,Passenger Rail,trn_pass,S3S,linear,2.500e-03,3.750e-03,3.750e-03,3.750e-03,3.750e-03
 SDP_EI,DEU,,,,,Walk,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,DEU,,,,,trn_freight_road,trn_freight,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_EI,DEU,,,,,trn_pass_road,trn_pass,S3S,linear,7.500e-02,7.500e-02,7.500e-02,7.500e-02,7.500e-02
-SDP_EI,DEU,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,8.000e-02,8.000e-02,8.000e-02,1.500e-01,1.500e-01
+SDP_EI,DEU,,,,,trn_pass_road,trn_pass,S3S,linear,7.363e-02,7.363e-02,7.363e-02,7.363e-02,7.363e-02
+SDP_EI,DEU,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,8.149e-02,8.149e-02,8.149e-02,1.528e-01,1.528e-01
 SDP_EI,DEU,,,,trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,DEU,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,3.054e-02,3.054e-02,3.054e-02,3.054e-02,3.054e-02
 SDP_EI,DEU,,,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_EI,DEU,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,4.724e-01,4.724e-01,4.724e-01,4.724e-01,4.724e-01
+SDP_EI,DEU,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,5.249e-01,5.249e-01,4.724e-01,4.724e-01,4.724e-01
 SDP_EI,DEU,,Large Car and SUV,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,DEU,,Midsize Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,2.716e-01,2.716e-01,2.716e-01,2.716e-01,2.716e-01
 SDP_EI,DEU,,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,2.183e-01,2.183e-01,2.183e-01,2.183e-01,2.183e-01
 SDP_EI,DEU,,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,6.630e-03,6.630e-03,6.630e-03,6.630e-03,6.630e-03
 SDP_EI,DEU,,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_EI,DEU,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,4.803e-01,4.803e-01,4.803e-01,4.803e-01,4.803e-01
+SDP_EI,DEU,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,5.337e-01,5.337e-01,4.803e-01,4.803e-01,4.803e-01
 SDP_EI,DEU,,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,4.427e-01,4.427e-01,4.427e-01,4.427e-01,4.427e-01
 SDP_EI,DEU,,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,8.345e-02,8.345e-02,8.345e-02,8.345e-02,8.345e-02
 SDP_EI,DEU,,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,2.127e-01,2.127e-01,2.127e-01,2.127e-01,2.127e-01
 SDP_EI,DEU,,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,4.934e-01,4.934e-01,4.934e-01,4.934e-01,4.934e-01
 SDP_EI,DEU,,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_EI,DEU,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_EI,DEU,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_EI,DEU,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_EI,DEU,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.423e-01,4.034e-01,8.573e-01,8.573e-01
+SDP_EI,DEU,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.000e-02,2.500e-01,4.500e-01,4.500e-01
+SDP_EI,DEU,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.000e-02,2.500e-01,4.500e-01,4.500e-01
+SDP_EI,DEU,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.000e-02,2.500e-01,4.500e-01,4.500e-01
+SDP_EI,DEU,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.294e-01,3.669e-01,7.798e-01,7.798e-01
 SDP_EI,DEU,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,DEU,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,DEU,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_EI,DEU,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.980e-01,6.750e-01,9.820e-01,9.820e-01
-SDP_EI,DEU,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.186e-01,3.631e-01,9.526e-01,9.526e-01
-SDP_EI,DEU,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.186e-01,3.631e-01,9.526e-01,9.526e-01
-SDP_EI,DEU,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.186e-01,3.631e-01,9.526e-01,9.526e-01
-SDP_EI,DEU,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.980e-01,6.750e-01,9.820e-01,9.820e-01
-SDP_EI,DEU,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.473e-03,1.799e-02,5.000e-02,5.000e-02
-SDP_EI,DEU,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,8.031e-02,3.320e-01,2.193e-01,2.193e-01
-SDP_EI,DEU,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.967e-02,1.259e-01,1.500e-01,1.500e-01
-SDP_EI,DEU,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.967e-02,1.259e-01,1.500e-01,1.500e-01
-SDP_EI,DEU,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.967e-02,1.259e-01,1.500e-01,1.500e-01
-SDP_EI,DEU,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,8.031e-02,3.320e-01,2.193e-01,2.193e-01
+SDP_EI,DEU,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.524e-01,6.784e-01,8.709e-01,8.709e-01
+SDP_EI,DEU,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.402e-01,3.649e-01,8.448e-01,8.448e-01
+SDP_EI,DEU,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.402e-01,3.649e-01,8.448e-01,8.448e-01
+SDP_EI,DEU,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.402e-01,3.649e-01,8.448e-01,8.448e-01
+SDP_EI,DEU,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.524e-01,6.784e-01,8.709e-01,8.709e-01
+SDP_EI,DEU,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.249e-03,1.636e-02,4.548e-02,4.548e-02
+SDP_EI,DEU,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,9.497e-02,3.925e-01,1.837e-01,1.837e-01
+SDP_EI,DEU,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.508e-02,1.489e-01,1.257e-01,1.257e-01
+SDP_EI,DEU,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.508e-02,1.489e-01,1.257e-01,1.257e-01
+SDP_EI,DEU,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.508e-02,1.489e-01,1.257e-01,1.257e-01
+SDP_EI,DEU,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,9.497e-02,3.925e-01,1.837e-01,1.837e-01
 SDP_EI,DEU,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0.000e+00,8.315e-07,4.540e-05,1.192e-01,1.192e-01
 SDP_EI,DEU,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,DEU,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
@@ -1619,59 +1619,59 @@ SDP_EI,DEU,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_roa
 SDP_EI,DEU,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,DEU,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,DEU,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_EI,DEU,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,3.948e-02,6.475e-02,1.153e-01,1.731e-01,1.731e-01
-SDP_EI,DEU,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,2.615e-02,4.142e-02,1.030e-01,2.055e-01,2.055e-01
-SDP_EI,DEU,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.105e-02,7.895e-02,1.842e-01,1.842e-01
-SDP_EI,DEU,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.105e-02,7.895e-02,1.842e-01,1.842e-01
-SDP_EI,DEU,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.105e-02,7.895e-02,1.842e-01,1.842e-01
-SDP_EI,DEU,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.105e-02,7.895e-02,1.842e-01,1.842e-01
+SDP_EI,DEU,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,3.948e-02,4.981e-02,8.870e-02,1.332e-01,1.332e-01
+SDP_EI,DEU,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,2.615e-02,4.142e-02,1.030e-01,1.713e-01,1.713e-01
+SDP_EI,DEU,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.105e-02,7.895e-02,1.535e-01,1.535e-01
+SDP_EI,DEU,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.105e-02,7.895e-02,1.535e-01,1.535e-01
+SDP_EI,DEU,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.105e-02,7.895e-02,1.535e-01,1.535e-01
+SDP_EI,DEU,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.105e-02,7.895e-02,1.535e-01,1.535e-01
 SDP_EI,ECE,,,,,Cycle,trn_pass,S3S,linear,1.942e-02,1.942e-02,9.709e-02,1.092e-01,1.092e-01
-SDP_EI,ECE,,,,,Domestic Aviation,trn_pass,S3S,linear,7.313e-05,7.313e-05,7.313e-05,2.057e-05,2.057e-05
-SDP_EI,ECE,,,,,Domestic Ship,trn_freight,S3S,linear,3.893e-04,3.893e-04,3.893e-04,3.893e-04,3.893e-04
-SDP_EI,ECE,,,,,Freight Rail,trn_freight,S3S,linear,5.909e-02,5.909e-02,5.909e-02,5.909e-02,5.909e-02
+SDP_EI,ECE,,,,,Domestic Aviation,trn_pass,S3S,linear,6.979e-05,6.979e-05,6.979e-05,1.963e-05,1.963e-05
+SDP_EI,ECE,,,,,Domestic Ship,trn_freight,S3S,linear,3.966e-04,3.966e-04,3.966e-04,3.966e-04,3.966e-04
+SDP_EI,ECE,,,,,Freight Rail,trn_freight,S3S,linear,6.019e-02,6.019e-02,5.417e-02,5.417e-02,5.417e-02
 SDP_EI,ECE,,,,,HSR,trn_pass,S3S,linear,1.139e-04,1.708e-04,4.555e-04,3.202e-04,3.202e-04
 SDP_EI,ECE,,,,,International Aviation,trn_aviation_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,ECE,,,,,International Ship,trn_shipping_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,ECE,,,,,Passenger Rail,trn_pass,S3S,linear,6.799e-03,6.799e-03,9.065e-03,3.824e-03,3.824e-03
 SDP_EI,ECE,,,,,Walk,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,ECE,,,,,trn_freight_road,trn_freight,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_EI,ECE,,,,,trn_pass_road,trn_pass,S3S,linear,8.972e-01,8.972e-01,7.177e-01,1.615e-01,1.615e-01
-SDP_EI,ECE,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,1.664e-01,1.664e-01,1.109e-01,1.109e-01,1.109e-01
+SDP_EI,ECE,,,,,trn_pass_road,trn_pass,S3S,linear,6.166e-01,6.166e-01,4.933e-01,1.268e-01,1.268e-01
+SDP_EI,ECE,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,2.712e-01,2.543e-01,1.469e-01,1.130e-01,1.130e-01
 SDP_EI,ECE,,,,trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,ECE,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,6.159e-03,6.159e-03,6.159e-03,6.159e-03,6.159e-03
 SDP_EI,ECE,,,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_EI,ECE,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,3.451e-01,3.451e-01,3.451e-01,3.451e-01,3.451e-01
+SDP_EI,ECE,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,4.706e-01,4.706e-01,4.601e-01,4.314e-01,4.314e-01
 SDP_EI,ECE,,Large Car and SUV,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,7.825e-01,7.825e-01,7.825e-01,7.825e-01,7.825e-01
 SDP_EI,ECE,,Midsize Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,ECE,,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,5.321e-02,5.321e-02,5.321e-02,5.321e-02,5.321e-02
 SDP_EI,ECE,,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,4.728e-04,4.728e-04,4.728e-04,4.728e-04,4.728e-04
 SDP_EI,ECE,,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_EI,ECE,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,4.683e-01,4.683e-01,4.683e-01,4.683e-01,4.683e-01
+SDP_EI,ECE,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,6.386e-01,6.386e-01,6.244e-01,5.854e-01,5.854e-01
 SDP_EI,ECE,,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,6.161e-01,6.161e-01,6.161e-01,6.161e-01,6.161e-01
 SDP_EI,ECE,,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.384e-01,1.384e-01,1.384e-01,1.384e-01,1.384e-01
 SDP_EI,ECE,,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.370e-01,1.370e-01,1.370e-01,1.370e-01,1.370e-01
 SDP_EI,ECE,,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.691e-01,1.691e-01,1.691e-01,1.691e-01,1.691e-01
 SDP_EI,ECE,,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_EI,ECE,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_EI,ECE,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_EI,ECE,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_EI,ECE,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.423e-01,5.379e-01,1.000e+00,1.000e+00
+SDP_EI,ECE,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.000e-02,1.900e-01,4.300e-01,4.300e-01
+SDP_EI,ECE,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.000e-02,1.900e-01,4.300e-01,4.300e-01
+SDP_EI,ECE,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.000e-02,1.900e-01,4.300e-01,4.300e-01
+SDP_EI,ECE,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.553e-01,5.283e-01,1.000e+00,1.000e+00
 SDP_EI,ECE,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,ECE,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,ECE,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_EI,ECE,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.960e-02,1.500e-01,2.946e-01,2.946e-01
-SDP_EI,ECE,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.371e-02,8.068e-02,2.858e-01,2.858e-01
-SDP_EI,ECE,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.371e-02,8.068e-02,2.858e-01,2.858e-01
-SDP_EI,ECE,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.371e-02,8.068e-02,2.858e-01,2.858e-01
-SDP_EI,ECE,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.960e-02,1.500e-01,2.946e-01,2.946e-01
-SDP_EI,ECE,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.236e-02,1.799e-02,8.748e-02,8.748e-02
-SDP_EI,ECE,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.339e-02,4.743e-02,1.462e-01,1.462e-01
-SDP_EI,ECE,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.945e-03,1.799e-02,1.000e-01,1.000e-01
-SDP_EI,ECE,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.945e-03,1.799e-02,1.000e-01,1.000e-01
-SDP_EI,ECE,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.945e-03,1.799e-02,1.000e-01,1.000e-01
-SDP_EI,ECE,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.339e-02,4.743e-02,1.462e-01,1.462e-01
+SDP_EI,ECE,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.504e-02,1.455e-01,2.786e-01,2.786e-01
+SDP_EI,ECE,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.588e-02,7.826e-02,2.703e-01,2.703e-01
+SDP_EI,ECE,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.588e-02,7.826e-02,2.703e-01,2.703e-01
+SDP_EI,ECE,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.588e-02,7.826e-02,2.703e-01,2.703e-01
+SDP_EI,ECE,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.504e-02,1.455e-01,2.786e-01,2.786e-01
+SDP_EI,ECE,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.349e-02,1.963e-02,8.748e-02,8.748e-02
+SDP_EI,ECE,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.461e-02,5.750e-02,6.382e-02,6.382e-02
+SDP_EI,ECE,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.396e-03,2.181e-02,4.365e-02,4.365e-02
+SDP_EI,ECE,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.396e-03,2.181e-02,4.365e-02,4.365e-02
+SDP_EI,ECE,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.396e-03,2.181e-02,4.365e-02,4.365e-02
+SDP_EI,ECE,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.461e-02,5.750e-02,6.382e-02,6.382e-02
 SDP_EI,ECE,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0.000e+00,8.315e-07,4.540e-05,1.192e-01,1.192e-01
-SDP_EI,ECE,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,8.748e-01,8.748e-01
+SDP_EI,ECE,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,8.017e-01,8.017e-01
 SDP_EI,ECE,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,ECE,Liquids,Domestic Ship_tmp_vehicletype,Domestic Ship_tmp_subsector_L1,Domestic Ship_tmp_subsector_L2,Domestic Ship,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,ECE,Liquids,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,5.870e-01,5.870e-01,5.870e-01,5.870e-01,5.870e-01
@@ -1686,57 +1686,57 @@ SDP_EI,ECE,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_roa
 SDP_EI,ECE,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,ECE,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,ECE,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_EI,ECE,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_EI,ECE,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_EI,ECE,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_EI,ECE,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
+SDP_EI,ECE,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e-02,2.000e-02,7.000e-02,9.000e-02,9.000e-02
+SDP_EI,ECE,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.000e-02,1.111e-01,1.867e-01,1.867e-01
+SDP_EI,ECE,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.000e-02,1.111e-01,1.867e-01,1.867e-01
+SDP_EI,ECE,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.000e-02,1.111e-01,1.867e-01,1.867e-01
 SDP_EI,ECE,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_EI,ECE,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_EI,ECS,,,,,Cycle,trn_pass,S3S,linear,7.196e-03,2.159e-02,8.635e-02,8.738e-02,8.738e-02
-SDP_EI,ECS,,,,,Domestic Aviation,trn_pass,S3S,linear,2.566e-03,2.566e-03,2.566e-03,3.895e-04,3.895e-04
-SDP_EI,ECS,,,,,Domestic Ship,trn_freight,S3S,linear,3.878e-03,3.878e-03,3.878e-03,3.878e-03,3.878e-03
-SDP_EI,ECS,,,,,Freight Rail,trn_freight,S3S,linear,5.867e-02,5.867e-02,5.867e-02,5.867e-02,5.867e-02
-SDP_EI,ECS,,,,,HSR,trn_pass,S3S,linear,1.956e-04,1.956e-04,5.216e-04,4.000e-04,4.000e-04
+SDP_EI,ECE,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.000e-02,1.111e-01,1.867e-01,1.867e-01
+SDP_EI,ECS,,,,,Cycle,trn_pass,S3S,linear,1.092e-02,3.277e-02,1.311e-01,8.738e-02,8.738e-02
+SDP_EI,ECS,,,,,Domestic Aviation,trn_pass,S3S,linear,3.717e-03,3.717e-03,3.717e-03,3.717e-04,3.717e-04
+SDP_EI,ECS,,,,,Domestic Ship,trn_freight,S3S,linear,3.950e-03,3.950e-03,3.591e-03,3.950e-03,3.950e-03
+SDP_EI,ECS,,,,,Freight Rail,trn_freight,S3S,linear,5.976e-02,5.976e-02,5.433e-02,5.379e-02,5.379e-02
+SDP_EI,ECS,,,,,HSR,trn_pass,S3S,linear,2.969e-04,2.969e-04,7.917e-04,4.000e-04,4.000e-04
 SDP_EI,ECS,,,,,International Aviation,trn_aviation_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,ECS,,,,,International Ship,trn_shipping_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_EI,ECS,,,,,Passenger Rail,trn_pass,S3S,linear,5.215e-03,6.953e-03,8.691e-03,2.638e-03,2.638e-03
-SDP_EI,ECS,,,,,Walk,trn_pass,S3S,linear,6.588e-01,6.588e-01,6.588e-01,1.000e+00,1.000e+00
+SDP_EI,ECS,,,,,Passenger Rail,trn_pass,S3S,linear,7.915e-03,1.055e-02,1.319e-02,2.638e-03,2.638e-03
+SDP_EI,ECS,,,,,Walk,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,ECS,,,,,trn_freight_road,trn_freight,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_EI,ECS,,,,,trn_pass_road,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.518e-01,1.518e-01
-SDP_EI,ECS,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,1.140e-01,1.140e-01,7.980e-02,6.840e-02,6.840e-02
+SDP_EI,ECS,,,,,trn_pass_road,trn_pass,S3S,linear,7.451e-01,7.451e-01,7.451e-01,8.941e-02,8.941e-02
+SDP_EI,ECS,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,2.090e-01,1.742e-01,1.219e-01,1.045e-01,1.045e-01
 SDP_EI,ECS,,,,trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,ECS,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,2.175e-03,2.175e-03,2.175e-03,2.175e-03,2.175e-03
 SDP_EI,ECS,,,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_EI,ECS,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,3.336e-01,3.336e-01,3.336e-01,3.336e-01,3.336e-01
+SDP_EI,ECS,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,5.004e-01,5.004e-01,5.004e-01,4.549e-01,4.549e-01
 SDP_EI,ECS,,Large Car and SUV,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,ECS,,Midsize Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,9.609e-01,9.609e-01,9.609e-01,9.609e-01,9.609e-01
 SDP_EI,ECS,,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.125e-01,1.125e-01,1.125e-01,1.125e-01,1.125e-01
 SDP_EI,ECS,,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,3.579e-02,3.579e-02,3.579e-02,3.579e-02,3.579e-02
 SDP_EI,ECS,,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_EI,ECS,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,6.520e-01,6.520e-01,6.520e-01,6.520e-01,6.520e-01
+SDP_EI,ECS,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,9.780e-01,9.780e-01,9.780e-01,8.891e-01,8.891e-01
 SDP_EI,ECS,,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,ECS,,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,2.555e-01,2.555e-01,2.555e-01,2.555e-01,2.555e-01
 SDP_EI,ECS,,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,3.104e-01,3.104e-01,3.104e-01,3.104e-01,3.104e-01
 SDP_EI,ECS,,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.282e-01,1.282e-01,1.282e-01,1.282e-01,1.282e-01
 SDP_EI,ECS,,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,4.409e-01,4.409e-01,4.409e-01,4.409e-01,4.409e-01
-SDP_EI,ECS,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_EI,ECS,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_EI,ECS,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_EI,ECS,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.743e-02,3.496e-01,8.573e-01,8.573e-01
+SDP_EI,ECS,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,3.200e-02,1.920e-01,4.200e-01,4.200e-01
+SDP_EI,ECS,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,3.200e-02,1.920e-01,4.200e-01,4.200e-01
+SDP_EI,ECS,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,3.200e-02,1.920e-01,4.200e-01,4.200e-01
+SDP_EI,ECS,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,9.315e-02,3.815e-01,8.420e-01,8.420e-01
 SDP_EI,ECS,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,ECS,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,ECS,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_EI,ECS,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.192e-01,2.500e-01,2.946e-01,2.946e-01
-SDP_EI,ECS,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.743e-02,1.345e-01,2.858e-01,2.858e-01
-SDP_EI,ECS,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.743e-02,1.345e-01,2.858e-01,2.858e-01
-SDP_EI,ECS,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.743e-02,1.345e-01,2.858e-01,2.858e-01
-SDP_EI,ECS,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.192e-01,2.500e-01,2.946e-01,2.946e-01
-SDP_EI,ECS,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.473e-03,5.396e-02,1.000e-01,1.000e-01
-SDP_EI,ECS,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.339e-02,4.743e-02,7.311e-02,7.311e-02
-SDP_EI,ECS,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.945e-03,1.799e-02,5.000e-02,5.000e-02
-SDP_EI,ECS,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.945e-03,1.799e-02,5.000e-02,5.000e-02
-SDP_EI,ECS,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.945e-03,1.799e-02,5.000e-02,5.000e-02
-SDP_EI,ECS,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.339e-02,4.743e-02,7.311e-02,7.311e-02
+SDP_EI,ECS,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.041e-01,2.182e-01,2.893e-01,2.893e-01
+SDP_EI,ECS,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.140e-02,1.174e-01,2.807e-01,2.807e-01
+SDP_EI,ECS,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.140e-02,1.174e-01,2.807e-01,2.807e-01
+SDP_EI,ECS,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.140e-02,1.174e-01,2.807e-01,2.807e-01
+SDP_EI,ECS,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.041e-01,2.182e-01,2.893e-01,2.893e-01
+SDP_EI,ECS,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.698e-03,7.360e-02,1.091e-01,1.091e-01
+SDP_EI,ECS,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.461e-02,6.900e-02,7.977e-02,7.977e-02
+SDP_EI,ECS,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.396e-03,2.617e-02,5.456e-02,5.456e-02
+SDP_EI,ECS,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.396e-03,2.617e-02,5.456e-02,5.456e-02
+SDP_EI,ECS,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.396e-03,2.617e-02,5.456e-02,5.456e-02
+SDP_EI,ECS,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.461e-02,6.900e-02,7.977e-02,7.977e-02
 SDP_EI,ECS,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0.000e+00,8.315e-07,4.540e-05,1.192e-01,1.192e-01
 SDP_EI,ECS,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,ECS,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
@@ -1753,61 +1753,61 @@ SDP_EI,ECS,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_roa
 SDP_EI,ECS,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,ECS,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,ECS,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_EI,ECS,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_EI,ECS,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_EI,ECS,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_EI,ECS,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_EI,ECS,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_EI,ECS,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
+SDP_EI,ECS,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e-02,2.000e-02,6.250e-02,1.000e-01,1.000e-01
+SDP_EI,ECS,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e-05,1.300e-02,6.667e-02,1.400e-01,1.400e-01
+SDP_EI,ECS,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e-05,1.300e-02,6.667e-02,1.400e-01,1.400e-01
+SDP_EI,ECS,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e-05,1.300e-02,6.667e-02,1.400e-01,1.400e-01
+SDP_EI,ECS,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e-05,1.300e-02,6.667e-02,1.400e-01,1.400e-01
+SDP_EI,ECS,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e-05,1.300e-02,6.667e-02,1.400e-01,1.400e-01
 SDP_EI,ENC,,,,,Cycle,trn_pass,S3S,linear,2.500e-02,2.500e-02,5.556e-02,1.000e-01,1.000e-01
-SDP_EI,ENC,,,,,Domestic Aviation,trn_pass,S3S,linear,6.250e-05,6.250e-05,5.556e-05,2.500e-05,2.500e-05
-SDP_EI,ENC,,,,,Domestic Ship,trn_freight,S3S,linear,1.223e-02,1.223e-02,1.223e-02,1.223e-02,1.223e-02
-SDP_EI,ENC,,,,,Freight Rail,trn_freight,S3S,linear,2.875e-02,2.875e-02,2.875e-02,2.875e-02,2.875e-02
+SDP_EI,ENC,,,,,Domestic Aviation,trn_pass,S3S,linear,5.965e-05,5.965e-05,5.302e-05,2.386e-05,2.386e-05
+SDP_EI,ENC,,,,,Domestic Ship,trn_freight,S3S,linear,1.246e-02,1.246e-02,1.246e-02,1.246e-02,1.246e-02
+SDP_EI,ENC,,,,,Freight Rail,trn_freight,S3S,linear,2.928e-02,2.928e-02,2.928e-02,2.928e-02,2.928e-02
 SDP_EI,ENC,,,,,HSR,trn_pass,S3S,linear,1.250e-04,2.500e-04,2.222e-04,2.000e-04,2.000e-04
 SDP_EI,ENC,,,,,International Aviation,trn_aviation_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,ENC,,,,,International Ship,trn_shipping_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,ENC,,,,,Passenger Rail,trn_pass,S3S,linear,3.125e-03,3.125e-03,3.333e-03,2.000e-03,2.000e-03
 SDP_EI,ENC,,,,,Walk,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,ENC,,,,,trn_freight_road,trn_freight,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_EI,ENC,,,,,trn_pass_road,trn_pass,S3S,linear,7.500e-02,7.500e-02,6.667e-02,3.000e-02,3.000e-02
-SDP_EI,ENC,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,2.000e-01,1.500e-01,1.500e-01,1.500e-01,1.500e-01
+SDP_EI,ENC,,,,,trn_pass_road,trn_pass,S3S,linear,7.363e-02,7.363e-02,6.545e-02,2.945e-02,2.945e-02
+SDP_EI,ENC,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,2.037e-01,1.528e-01,1.528e-01,1.528e-01,1.528e-01
 SDP_EI,ENC,,,,trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,ENC,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,3.014e-02,3.014e-02,3.014e-02,3.014e-02,3.014e-02
 SDP_EI,ENC,,,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_EI,ENC,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,3.559e-01,3.559e-01,3.559e-01,3.559e-01,3.559e-01
+SDP_EI,ENC,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,3.955e-01,3.955e-01,3.955e-01,3.559e-01,3.559e-01
 SDP_EI,ENC,,Large Car and SUV,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,ENC,,Midsize Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.960e-01,1.960e-01,1.960e-01,1.960e-01,1.960e-01
-SDP_EI,ENC,,Mini Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,2.357e-07,2.357e-07,2.357e-07,2.357e-07,2.357e-07
+SDP_EI,ENC,,Mini Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,2.619e-07,2.619e-07,2.619e-07,2.357e-07,2.357e-07
 SDP_EI,ENC,,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.576e-01,1.576e-01,1.576e-01,1.576e-01,1.576e-01
 SDP_EI,ENC,,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,3.751e-02,3.751e-02,3.751e-02,3.751e-02,3.751e-02
 SDP_EI,ENC,,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_EI,ENC,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.963e-01,1.963e-01,1.963e-01,1.963e-01,1.963e-01
+SDP_EI,ENC,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,2.181e-01,2.181e-01,2.181e-01,1.963e-01,1.963e-01
 SDP_EI,ENC,,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,ENC,,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.002e-01,1.002e-01,1.002e-01,1.002e-01,1.002e-01
 SDP_EI,ENC,,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,3.593e-01,3.593e-01,3.593e-01,3.593e-01,3.593e-01
 SDP_EI,ENC,,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,4.374e-01,4.374e-01,4.374e-01,4.374e-01,4.374e-01
 SDP_EI,ENC,,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,4.946e-01,4.946e-01,4.946e-01,4.946e-01,4.946e-01
 SDP_EI,ENC,,Van,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.049e-03,1.049e-03,1.049e-03,1.049e-03,1.049e-03
-SDP_EI,ENC,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_EI,ENC,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_EI,ENC,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_EI,ENC,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.371e-01,6.724e-01,1.000e+00,1.000e+00
+SDP_EI,ENC,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,5.000e-02,2.300e-01,5.000e-01,5.000e-01
+SDP_EI,ENC,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,5.000e-02,2.300e-01,5.000e-01,5.000e-01
+SDP_EI,ENC,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,5.000e-02,2.300e-01,5.000e-01,5.000e-01
+SDP_EI,ENC,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.157e-01,7.227e-01,1.000e+00,1.000e+00
 SDP_EI,ENC,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,ENC,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,ENC,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_EI,ENC,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.622e-01,6.000e-01,9.820e-01,9.820e-01
-SDP_EI,ENC,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.043e-01,3.227e-01,9.526e-01,9.526e-01
-SDP_EI,ENC,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.043e-01,3.227e-01,9.526e-01,9.526e-01
-SDP_EI,ENC,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.043e-01,3.227e-01,9.526e-01,9.526e-01
-SDP_EI,ENC,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.622e-01,6.000e-01,9.820e-01,9.820e-01
-SDP_EI,ENC,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.236e-02,5.396e-02,1.312e-01,1.312e-01
-SDP_EI,ENC,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.693e-02,2.371e-01,1.462e-01,1.462e-01
-SDP_EI,ENC,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-02,8.993e-02,1.000e-01,1.000e-01
-SDP_EI,ENC,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-02,8.993e-02,1.000e-01,1.000e-01
-SDP_EI,ENC,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-02,8.993e-02,1.000e-01,1.000e-01
-SDP_EI,ENC,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.693e-02,2.371e-01,1.462e-01,1.462e-01
+SDP_EI,ENC,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.101e-01,6.386e-01,9.289e-01,9.289e-01
+SDP_EI,ENC,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.234e-01,3.434e-01,9.011e-01,9.011e-01
+SDP_EI,ENC,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.234e-01,3.434e-01,9.011e-01,9.011e-01
+SDP_EI,ENC,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.234e-01,3.434e-01,9.011e-01,9.011e-01
+SDP_EI,ENC,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.101e-01,6.386e-01,9.289e-01,9.289e-01
+SDP_EI,ENC,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.124e-02,5.800e-02,1.021e-01,1.021e-01
+SDP_EI,ENC,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,7.914e-02,2.804e-01,1.729e-01,1.729e-01
+SDP_EI,ENC,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.924e-02,1.063e-01,1.183e-01,1.183e-01
+SDP_EI,ENC,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.924e-02,1.063e-01,1.183e-01,1.183e-01
+SDP_EI,ENC,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.924e-02,1.063e-01,1.183e-01,1.183e-01
+SDP_EI,ENC,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,7.914e-02,2.804e-01,1.729e-01,1.729e-01
 SDP_EI,ENC,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0.000e+00,8.315e-07,4.540e-05,1.192e-01,1.192e-01
-SDP_EI,ENC,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,5.249e-01,5.249e-01
+SDP_EI,ENC,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,5.426e-01,5.426e-01
 SDP_EI,ENC,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,ENC,Liquids,Domestic Ship_tmp_vehicletype,Domestic Ship_tmp_subsector_L1,Domestic Ship_tmp_subsector_L2,Domestic Ship,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,ENC,Liquids,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1.341e-01,1.341e-01,1.341e-01,1.341e-01,1.341e-01
@@ -1822,30 +1822,30 @@ SDP_EI,ENC,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_roa
 SDP_EI,ENC,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,ENC,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,ENC,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_EI,ENC,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,2.533e-02,5.098e-02,1.023e-01,1.075e-01,1.075e-01
+SDP_EI,ENC,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,2.533e-02,3.921e-02,9.298e-02,1.011e-01,1.011e-01
 SDP_EI,ENC,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
 SDP_EI,ENC,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
 SDP_EI,ENC,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
 SDP_EI,ENC,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
 SDP_EI,ENC,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
 SDP_EI,ESC,,,,,Cycle,trn_pass,S3S,linear,1.942e-02,2.184e-02,4.369e-02,1.638e-01,1.638e-01
-SDP_EI,ESC,,,,,Domestic Aviation,trn_pass,S3S,linear,1.347e-04,3.789e-05,3.789e-05,7.579e-05,7.579e-05
-SDP_EI,ESC,,,,,Domestic Ship,trn_freight,S3S,linear,1.187e-02,1.187e-02,1.187e-02,1.187e-02,1.187e-02
-SDP_EI,ESC,,,,,Freight Rail,trn_freight,S3S,linear,4.020e-03,4.020e-03,4.020e-03,4.020e-03,4.020e-03
+SDP_EI,ESC,,,,,Domestic Aviation,trn_pass,S3S,linear,1.286e-04,3.616e-05,3.616e-05,7.233e-05,7.233e-05
+SDP_EI,ESC,,,,,Domestic Ship,trn_freight,S3S,linear,1.209e-02,1.209e-02,1.209e-02,1.209e-02,1.209e-02
+SDP_EI,ESC,,,,,Freight Rail,trn_freight,S3S,linear,4.094e-03,4.094e-03,4.094e-03,4.094e-03,4.094e-03
 SDP_EI,ESC,,,,,HSR,trn_pass,S3S,linear,6.613e-04,1.860e-04,6.200e-04,6.200e-04,6.200e-04
 SDP_EI,ESC,,,,,International Aviation,trn_aviation_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,ESC,,,,,International Ship,trn_shipping_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,ESC,,,,,Passenger Rail,trn_pass,S3S,linear,3.195e-03,2.696e-03,2.696e-03,4.044e-03,4.044e-03
 SDP_EI,ESC,,,,,Walk,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,ESC,,,,,trn_freight_road,trn_freight,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_EI,ESC,,,,,trn_pass_road,trn_pass,S3S,linear,1.832e-01,1.030e-01,8.242e-02,6.594e-02,6.594e-02
-SDP_EI,ESC,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,6.591e-02,6.591e-02,6.591e-02,9.887e-02,9.887e-02
+SDP_EI,ESC,,,,,trn_pass_road,trn_pass,S3S,linear,1.798e-01,1.011e-01,8.092e-02,6.473e-02,6.473e-02
+SDP_EI,ESC,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,6.714e-02,6.714e-02,6.714e-02,1.007e-01,1.007e-01
 SDP_EI,ESC,,,,trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_EI,ESC,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.687e-01,1.687e-01,1.687e-01,1.687e-01,1.687e-01
+SDP_EI,ESC,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.205e-01,1.125e-01,1.125e-01,1.125e-01,1.125e-01
 SDP_EI,ESC,,,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,ESC,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,3.942e-01,3.942e-01,3.942e-01,3.942e-01,3.942e-01
-SDP_EI,ESC,,Large Car and SUV,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,8.712e-01,8.712e-01,8.712e-01,8.712e-01,8.712e-01
-SDP_EI,ESC,,Midsize Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,2.323e-01,2.323e-01,2.323e-01,2.323e-01,2.323e-01
+SDP_EI,ESC,,Large Car and SUV,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,8.712e-01,7.840e-01,8.712e-01,8.712e-01,8.712e-01
+SDP_EI,ESC,,Midsize Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,2.323e-01,2.091e-01,2.323e-01,2.323e-01,2.323e-01
 SDP_EI,ESC,,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.009e-01,1.009e-01,1.009e-01,1.009e-01,1.009e-01
 SDP_EI,ESC,,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,6.375e-02,6.375e-02,6.375e-02,6.375e-02,6.375e-02
 SDP_EI,ESC,,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
@@ -1855,24 +1855,24 @@ SDP_EI,ESC,,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_s
 SDP_EI,ESC,,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,2.234e-01,2.234e-01,2.234e-01,2.234e-01,2.234e-01
 SDP_EI,ESC,,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,2.172e-01,2.172e-01,2.172e-01,2.172e-01,2.172e-01
 SDP_EI,ESC,,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_EI,ESC,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_EI,ESC,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_EI,ESC,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_EI,ESC,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.423e-01,4.034e-01,9.526e-01,9.526e-01
+SDP_EI,ESC,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.000e-02,2.200e-01,4.200e-01,4.200e-01
+SDP_EI,ESC,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.000e-02,2.200e-01,4.200e-01,4.200e-01
+SDP_EI,ESC,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.000e-02,2.200e-01,4.200e-01,4.200e-01
+SDP_EI,ESC,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.359e-01,3.816e-01,8.448e-01,8.448e-01
 SDP_EI,ESC,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,ESC,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,ESC,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_EI,ESC,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.384e-01,5.000e-01,9.820e-01,9.820e-01
-SDP_EI,ESC,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,9.485e-02,2.689e-01,9.526e-01,9.526e-01
-SDP_EI,ESC,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,9.485e-02,2.689e-01,9.526e-01,9.526e-01
-SDP_EI,ESC,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,9.485e-02,2.689e-01,9.526e-01,9.526e-01
-SDP_EI,ESC,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.384e-01,5.000e-01,9.820e-01,9.820e-01
-SDP_EI,ESC,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.236e-02,5.396e-02,1.000e-01,1.000e-01
-SDP_EI,ESC,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.693e-02,4.743e-02,1.462e-01,1.462e-01
-SDP_EI,ESC,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-02,1.799e-02,1.000e-01,1.000e-01
-SDP_EI,ESC,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-02,1.799e-02,1.000e-01,1.000e-01
-SDP_EI,ESC,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-02,1.799e-02,1.000e-01,1.000e-01
-SDP_EI,ESC,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.693e-02,4.743e-02,1.462e-01,1.462e-01
+SDP_EI,ESC,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.819e-01,5.321e-01,7.741e-01,7.741e-01
+SDP_EI,ESC,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.122e-01,2.862e-01,7.509e-01,7.509e-01
+SDP_EI,ESC,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.122e-01,2.862e-01,7.509e-01,7.509e-01
+SDP_EI,ESC,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.122e-01,2.862e-01,7.509e-01,7.509e-01
+SDP_EI,ESC,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.819e-01,5.321e-01,7.741e-01,7.741e-01
+SDP_EI,ESC,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.124e-02,6.380e-02,7.883e-02,7.883e-02
+SDP_EI,ESC,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,7.914e-02,5.608e-02,1.441e-01,1.441e-01
+SDP_EI,ESC,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.924e-02,2.127e-02,9.854e-02,9.854e-02
+SDP_EI,ESC,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.924e-02,2.127e-02,9.854e-02,9.854e-02
+SDP_EI,ESC,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.924e-02,2.127e-02,9.854e-02,9.854e-02
+SDP_EI,ESC,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,7.914e-02,5.608e-02,1.441e-01,1.441e-01
 SDP_EI,ESC,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0.000e+00,8.315e-07,4.540e-05,1.192e-01,1.192e-01
 SDP_EI,ESC,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,ESC,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
@@ -1889,57 +1889,57 @@ SDP_EI,ESC,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_roa
 SDP_EI,ESC,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,ESC,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,ESC,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_EI,ESC,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,2.742e-02,5.301e-02,1.042e-01,2.066e-01,2.066e-01
-SDP_EI,ESC,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SDP_EI,ESC,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SDP_EI,ESC,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SDP_EI,ESC,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SDP_EI,ESC,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
+SDP_EI,ESC,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,2.742e-02,4.078e-02,1.042e-01,1.721e-01,1.721e-01
+SDP_EI,ESC,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.535e-01,1.535e-01
+SDP_EI,ESC,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.535e-01,1.535e-01
+SDP_EI,ESC,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.535e-01,1.535e-01
+SDP_EI,ESC,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.535e-01,1.535e-01
+SDP_EI,ESC,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.535e-01,1.535e-01
 SDP_EI,ESW,,,,,Cycle,trn_pass,S3S,linear,1.942e-02,3.884e-02,5.825e-02,1.019e-01,1.019e-01
-SDP_EI,ESW,,,,,Domestic Aviation,trn_pass,S3S,linear,7.179e-04,7.179e-04,5.744e-04,1.346e-04,1.346e-04
-SDP_EI,ESW,,,,,Domestic Ship,trn_freight,S3S,linear,6.018e-03,6.018e-03,6.018e-03,6.018e-03,6.018e-03
-SDP_EI,ESW,,,,,Freight Rail,trn_freight,S3S,linear,1.394e-02,1.394e-02,1.394e-02,1.394e-02,1.394e-02
+SDP_EI,ESW,,,,,Domestic Aviation,trn_pass,S3S,linear,6.852e-04,6.852e-04,5.482e-04,1.285e-04,1.285e-04
+SDP_EI,ESW,,,,,Domestic Ship,trn_freight,S3S,linear,6.130e-03,6.130e-03,6.130e-03,6.130e-03,6.130e-03
+SDP_EI,ESW,,,,,Freight Rail,trn_freight,S3S,linear,1.420e-02,1.420e-02,1.420e-02,1.420e-02,1.420e-02
 SDP_EI,ESW,,,,,HSR,trn_pass,S3S,linear,9.579e-04,9.579e-04,9.579e-04,3.592e-04,3.592e-04
 SDP_EI,ESW,,,,,International Aviation,trn_aviation_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,ESW,,,,,International Ship,trn_shipping_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,ESW,,,,,Passenger Rail,trn_pass,S3S,linear,3.621e-03,3.621e-03,5.432e-03,2.037e-03,2.037e-03
 SDP_EI,ESW,,,,,Walk,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,ESW,,,,,trn_freight_road,trn_freight,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_EI,ESW,,,,,trn_pass_road,trn_pass,S3S,linear,1.411e-01,1.129e-01,1.129e-01,3.175e-02,3.175e-02
-SDP_EI,ESW,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,5.667e-02,5.667e-02,7.083e-02,1.063e-01,1.063e-01
+SDP_EI,ESW,,,,,trn_pass_road,trn_pass,S3S,linear,1.385e-01,1.108e-01,1.108e-01,3.117e-02,3.117e-02
+SDP_EI,ESW,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,5.772e-02,5.772e-02,7.215e-02,1.082e-01,1.082e-01
 SDP_EI,ESW,,,,trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_EI,ESW,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,8.570e-02,8.570e-02,8.570e-02,8.570e-02,8.570e-02
+SDP_EI,ESW,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,7.141e-02,7.141e-02,7.141e-02,6.592e-02,6.592e-02
 SDP_EI,ESW,,,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_EI,ESW,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,5.153e-01,5.153e-01,5.153e-01,5.153e-01,5.153e-01
+SDP_EI,ESW,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,5.725e-01,5.725e-01,5.725e-01,5.725e-01,5.725e-01
 SDP_EI,ESW,,Large Car and SUV,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,ESW,,Midsize Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,2.963e-01,2.963e-01,2.963e-01,2.963e-01,2.963e-01
 SDP_EI,ESW,,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,9.741e-02,9.741e-02,9.741e-02,9.741e-02,9.741e-02
 SDP_EI,ESW,,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.669e-01,1.669e-01,1.669e-01,1.669e-01,1.669e-01
 SDP_EI,ESW,,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_EI,ESW,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,4.003e-01,4.003e-01,4.003e-01,4.003e-01,4.003e-01
+SDP_EI,ESW,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,4.448e-01,4.448e-01,4.448e-01,4.448e-01,4.448e-01
 SDP_EI,ESW,,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,2.850e-01,2.850e-01,2.850e-01,2.850e-01,2.850e-01
 SDP_EI,ESW,,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,6.043e-02,6.043e-02,6.043e-02,6.043e-02,6.043e-02
 SDP_EI,ESW,,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,8.424e-02,8.424e-02,8.424e-02,8.424e-02,8.424e-02
 SDP_EI,ESW,,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,4.041e-01,4.041e-01,4.041e-01,4.041e-01,4.041e-01
 SDP_EI,ESW,,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_EI,ESW,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_EI,ESW,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_EI,ESW,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_EI,ESW,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.186e-01,2.689e-01,6.668e-01,6.668e-01
+SDP_EI,ESW,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.800e-02,2.160e-01,4.200e-01,4.200e-01
+SDP_EI,ESW,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.800e-02,2.160e-01,4.200e-01,4.200e-01
+SDP_EI,ESW,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.800e-02,2.160e-01,4.200e-01,4.200e-01
+SDP_EI,ESW,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.078e-02,1.164e-01,2.935e-01,6.237e-01,6.237e-01
 SDP_EI,ESW,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,7.295e-01,7.633e-01,8.309e-01,9.662e-01,9.662e-01
 SDP_EI,ESW,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,ESW,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_EI,ESW,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.576e-01,7.000e-01,9.820e-01,9.820e-01
-SDP_EI,ESW,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.423e-01,3.765e-01,9.526e-01,9.526e-01
-SDP_EI,ESW,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.423e-01,3.765e-01,9.526e-01,9.526e-01
-SDP_EI,ESW,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.423e-01,3.765e-01,9.526e-01,9.526e-01
-SDP_EI,ESW,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.576e-01,7.000e-01,9.820e-01,9.820e-01
-SDP_EI,ESW,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.473e-03,1.799e-02,7.500e-02,7.500e-02
-SDP_EI,ESW,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.693e-02,2.371e-01,1.462e-01,1.462e-01
-SDP_EI,ESW,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-02,8.993e-02,1.000e-01,1.000e-01
-SDP_EI,ESW,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-02,8.993e-02,1.000e-01,1.000e-01
-SDP_EI,ESW,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-02,8.993e-02,1.000e-01,1.000e-01
-SDP_EI,ESW,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.693e-02,2.371e-01,1.462e-01,1.462e-01
+SDP_EI,ESW,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.902e-01,6.875e-01,1.000e+00,1.000e+00
+SDP_EI,ESW,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.553e-01,3.698e-01,1.000e+00,1.000e+00
+SDP_EI,ESW,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.553e-01,3.698e-01,1.000e+00,1.000e+00
+SDP_EI,ESW,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.553e-01,3.698e-01,1.000e+00,1.000e+00
+SDP_EI,ESW,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.902e-01,6.875e-01,1.000e+00,1.000e+00
+SDP_EI,ESW,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,2.248e-03,2.698e-03,1.963e-02,5.846e-02,5.846e-02
+SDP_EI,ESW,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,7.303e-02,2.588e-01,1.489e-01,1.489e-01
+SDP_EI,ESW,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.698e-02,9.813e-02,1.050e-01,1.050e-01
+SDP_EI,ESW,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.698e-02,9.813e-02,1.050e-01,1.050e-01
+SDP_EI,ESW,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.698e-02,9.813e-02,1.050e-01,1.050e-01
+SDP_EI,ESW,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,7.303e-02,2.588e-01,1.489e-01,1.489e-01
 SDP_EI,ESW,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0.000e+00,8.315e-07,4.540e-05,1.192e-01,1.192e-01
 SDP_EI,ESW,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,ESW,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
@@ -1951,39 +1951,39 @@ SDP_EI,ESW,Liquids,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,tr
 SDP_EI,ESW,Liquids,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,ESW,Liquids,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,ESW,Liquids,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,5.162e-01,5.162e-01,5.162e-01,5.162e-01,5.162e-01
-SDP_EI,ESW,Liquids,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_EI,ESW,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_EI,ESW,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_EI,ESW,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_EI,ESW,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_EI,ESW,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SDP_EI,ESW,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SDP_EI,ESW,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SDP_EI,ESW,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SDP_EI,ESW,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SDP_EI,ESW,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
+SDP_EI,ESW,Liquids,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,9.332e-01,9.332e-01
+SDP_EI,ESW,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,9.620e-01,9.620e-01
+SDP_EI,ESW,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,9.620e-01,9.620e-01
+SDP_EI,ESW,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,9.620e-01,9.620e-01
+SDP_EI,ESW,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,9.332e-01,9.332e-01
+SDP_EI,ESW,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.754e-02,2.632e-02,7.895e-02,1.316e-01,1.316e-01
+SDP_EI,ESW,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.719e-01,1.719e-01
+SDP_EI,ESW,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.772e-01,1.772e-01
+SDP_EI,ESW,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.772e-01,1.772e-01
+SDP_EI,ESW,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.772e-01,1.772e-01
+SDP_EI,ESW,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.719e-01,1.719e-01
 SDP_EI,EWN,,,,,Cycle,trn_pass,S3S,linear,1.000e-02,1.000e-02,5.000e-02,1.000e-01,1.000e-01
-SDP_EI,EWN,,,,,Domestic Aviation,trn_pass,S3S,linear,5.000e-05,5.000e-05,5.000e-05,5.000e-06,5.000e-06
-SDP_EI,EWN,,,,,Domestic Ship,trn_freight,S3S,linear,6.147e-03,6.830e-03,6.147e-03,6.147e-03,6.147e-03
-SDP_EI,EWN,,,,,Freight Rail,trn_freight,S3S,linear,1.246e-02,1.385e-02,1.246e-02,1.246e-02,1.246e-02
+SDP_EI,EWN,,,,,Domestic Aviation,trn_pass,S3S,linear,4.772e-05,4.772e-05,4.772e-05,4.772e-06,4.772e-06
+SDP_EI,EWN,,,,,Domestic Ship,trn_freight,S3S,linear,6.261e-03,6.957e-03,6.261e-03,6.261e-03,6.261e-03
+SDP_EI,EWN,,,,,Freight Rail,trn_freight,S3S,linear,1.270e-02,1.411e-02,1.270e-02,1.270e-02,1.270e-02
 SDP_EI,EWN,,,,,HSR,trn_pass,S3S,linear,1.000e-04,1.000e-04,4.000e-04,2.000e-04,2.000e-04
 SDP_EI,EWN,,,,,International Aviation,trn_aviation_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,EWN,,,,,International Ship,trn_shipping_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,EWN,,,,,Passenger Rail,trn_pass,S3S,linear,2.000e-03,3.000e-03,3.000e-03,2.000e-03,2.000e-03
 SDP_EI,EWN,,,,,Walk,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,EWN,,,,,trn_freight_road,trn_freight,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_EI,EWN,,,,,trn_pass_road,trn_pass,S3S,linear,6.000e-02,6.000e-02,6.000e-02,3.000e-02,3.000e-02
-SDP_EI,EWN,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,1.000e-01,1.000e-01,1.000e-01,1.500e-01,1.500e-01
+SDP_EI,EWN,,,,,trn_pass_road,trn_pass,S3S,linear,5.891e-02,5.891e-02,5.891e-02,2.945e-02,2.945e-02
+SDP_EI,EWN,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,1.019e-01,1.019e-01,1.019e-01,1.528e-01,1.528e-01
 SDP_EI,EWN,,,,trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,EWN,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,4.166e-02,4.166e-02,4.166e-02,4.166e-02,4.166e-02
 SDP_EI,EWN,,,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_EI,EWN,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,3.886e-01,3.886e-01,3.886e-01,3.886e-01,3.886e-01
+SDP_EI,EWN,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,4.317e-01,4.317e-01,3.886e-01,3.886e-01,3.886e-01
 SDP_EI,EWN,,Large Car and SUV,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,EWN,,Midsize Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,2.283e-01,2.283e-01,2.283e-01,2.283e-01,2.283e-01
 SDP_EI,EWN,,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.183e-01,1.183e-01,1.183e-01,1.183e-01,1.183e-01
 SDP_EI,EWN,,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,4.339e-02,4.339e-02,4.339e-02,4.339e-02,4.339e-02
 SDP_EI,EWN,,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_EI,EWN,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,4.377e-01,4.377e-01,4.377e-01,4.377e-01,4.377e-01
+SDP_EI,EWN,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,4.864e-01,4.864e-01,4.377e-01,4.377e-01,4.377e-01
 SDP_EI,EWN,,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,EWN,,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.164e-01,1.164e-01,1.164e-01,1.164e-01,1.164e-01
 SDP_EI,EWN,,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,5.225e-01,5.225e-01,5.225e-01,5.225e-01,5.225e-01
@@ -1992,21 +1992,21 @@ SDP_EI,EWN,,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_
 SDP_EI,EWN,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1.000e-03,6.000e-02,2.450e-01,4.500e-01,4.500e-01
 SDP_EI,EWN,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1.000e-03,6.000e-02,2.450e-01,4.500e-01,4.500e-01
 SDP_EI,EWN,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1.000e-03,6.000e-02,2.450e-01,4.500e-01,4.500e-01
-SDP_EI,EWN,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.958e-02,2.323e-01,4.763e-01,4.763e-01
+SDP_EI,EWN,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,8.794e-02,2.197e-01,5.006e-01,5.006e-01
 SDP_EI,EWN,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,EWN,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,EWN,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_EI,EWN,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.550e-01,6.500e-01,8.729e-01,8.729e-01
-SDP_EI,EWN,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.165e-02,3.496e-01,8.467e-01,8.467e-01
-SDP_EI,EWN,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.165e-02,3.496e-01,8.467e-01,8.467e-01
-SDP_EI,EWN,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.165e-02,3.496e-01,8.467e-01,8.467e-01
-SDP_EI,EWN,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.550e-01,6.500e-01,8.729e-01,8.729e-01
-SDP_EI,EWN,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.573e-03,6.540e-03,1.667e-02,1.667e-02
-SDP_EI,EWN,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,9.370e-03,4.743e-02,4.061e-02,4.061e-02
-SDP_EI,EWN,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.462e-03,1.799e-02,2.778e-02,2.778e-02
-SDP_EI,EWN,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.462e-03,1.799e-02,2.778e-02,2.778e-02
-SDP_EI,EWN,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.462e-03,1.799e-02,2.778e-02,2.778e-02
-SDP_EI,EWN,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,9.370e-03,4.743e-02,4.061e-02,4.061e-02
+SDP_EI,EWN,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.436e-01,6.405e-01,9.031e-01,9.031e-01
+SDP_EI,EWN,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.367e-01,3.445e-01,8.760e-01,8.760e-01
+SDP_EI,EWN,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.367e-01,3.445e-01,8.760e-01,8.760e-01
+SDP_EI,EWN,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.367e-01,3.445e-01,8.760e-01,8.760e-01
+SDP_EI,EWN,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.436e-01,6.405e-01,9.031e-01,9.031e-01
+SDP_EI,EWN,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.861e-03,7.734e-03,2.190e-02,2.190e-02
+SDP_EI,EWN,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.385e-02,1.059e-01,6.003e-02,6.003e-02
+SDP_EI,EWN,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.116e-03,4.017e-02,4.106e-02,4.106e-02
+SDP_EI,EWN,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.116e-03,4.017e-02,4.106e-02,4.106e-02
+SDP_EI,EWN,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.116e-03,4.017e-02,4.106e-02,4.106e-02
+SDP_EI,EWN,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.385e-02,1.059e-01,6.003e-02,6.003e-02
 SDP_EI,EWN,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0.000e+00,8.315e-07,4.540e-05,1.192e-01,1.192e-01
 SDP_EI,EWN,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,EWN,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
@@ -2023,26 +2023,26 @@ SDP_EI,EWN,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_roa
 SDP_EI,EWN,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,EWN,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,EWN,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_EI,EWN,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,8.070e-03,3.107e-02,6.282e-02,8.745e-02,8.745e-02
-SDP_EI,EWN,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,8.171e-04,2.711e-02,7.970e-02,1.027e-01,1.027e-01
-SDP_EI,EWN,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.023e-01,1.023e-01
-SDP_EI,EWN,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.023e-01,1.023e-01
-SDP_EI,EWN,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.023e-01,1.023e-01
-SDP_EI,EWN,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.023e-01,1.023e-01
+SDP_EI,EWN,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,8.070e-03,3.107e-02,6.282e-02,9.716e-02,9.716e-02
+SDP_EI,EWN,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,8.171e-04,3.389e-02,8.856e-02,1.284e-01,1.284e-01
+SDP_EI,EWN,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.289e-02,8.772e-02,1.279e-01,1.279e-01
+SDP_EI,EWN,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.289e-02,8.772e-02,1.279e-01,1.279e-01
+SDP_EI,EWN,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.289e-02,8.772e-02,1.279e-01,1.279e-01
+SDP_EI,EWN,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.289e-02,8.772e-02,1.279e-01,1.279e-01
 SDP_EI,FRA,,,,,Cycle,trn_pass,S3S,linear,1.942e-02,2.184e-02,3.641e-02,1.019e-01,1.019e-01
-SDP_EI,FRA,,,,,Domestic Aviation,trn_pass,S3S,linear,1.225e-04,6.891e-05,4.594e-05,2.297e-05,2.297e-05
-SDP_EI,FRA,,,,,Domestic Ship,trn_freight,S3S,linear,3.357e-03,3.357e-03,3.357e-03,3.357e-03,3.357e-03
-SDP_EI,FRA,,,,,Freight Rail,trn_freight,S3S,linear,1.766e-02,1.766e-02,1.766e-02,1.766e-02,1.766e-02
+SDP_EI,FRA,,,,,Domestic Aviation,trn_pass,S3S,linear,1.169e-04,6.577e-05,4.385e-05,2.192e-05,2.192e-05
+SDP_EI,FRA,,,,,Domestic Ship,trn_freight,S3S,linear,3.419e-03,3.419e-03,3.419e-03,3.419e-03,3.419e-03
+SDP_EI,FRA,,,,,Freight Rail,trn_freight,S3S,linear,1.799e-02,1.799e-02,1.799e-02,1.799e-02,1.799e-02
 SDP_EI,FRA,,,,,HSR,trn_pass,S3S,linear,3.359e-04,2.267e-04,2.015e-04,2.015e-04,2.015e-04
 SDP_EI,FRA,,,,,International Aviation,trn_aviation_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,FRA,,,,,International Ship,trn_shipping_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,FRA,,,,,Passenger Rail,trn_pass,S3S,linear,3.972e-03,2.979e-03,1.986e-03,1.986e-03,1.986e-03
 SDP_EI,FRA,,,,,Walk,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,FRA,,,,,trn_freight_road,trn_freight,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_EI,FRA,,,,,trn_pass_road,trn_pass,S3S,linear,9.224e-02,5.188e-02,3.459e-02,2.767e-02,2.767e-02
-SDP_EI,FRA,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,7.788e-02,8.566e-02,9.345e-02,1.402e-01,1.402e-01
+SDP_EI,FRA,,,,,trn_pass_road,trn_pass,S3S,linear,9.055e-02,5.094e-02,3.396e-02,2.717e-02,2.717e-02
+SDP_EI,FRA,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,7.932e-02,8.726e-02,9.519e-02,1.428e-01,1.428e-01
 SDP_EI,FRA,,,,trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_EI,FRA,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,9.470e-02,9.470e-02,9.470e-02,9.470e-02,9.470e-02
+SDP_EI,FRA,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,7.285e-02,7.285e-02,7.285e-02,6.764e-02,6.764e-02
 SDP_EI,FRA,,,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,FRA,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,6.352e-01,6.352e-01,6.352e-01,6.352e-01,6.352e-01
 SDP_EI,FRA,,Large Car and SUV,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
@@ -2056,26 +2056,26 @@ SDP_EI,FRA,,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_s
 SDP_EI,FRA,,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.602e-01,1.602e-01,1.602e-01,1.602e-01,1.602e-01
 SDP_EI,FRA,,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,4.011e-01,4.011e-01,4.011e-01,4.011e-01,4.011e-01
 SDP_EI,FRA,,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,3.755e-01,3.755e-01,3.755e-01,3.755e-01,3.755e-01
-SDP_EI,FRA,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_EI,FRA,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_EI,FRA,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_EI,FRA,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.423e-01,4.303e-01,1.000e+00,1.000e+00
+SDP_EI,FRA,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.000e-02,2.400e-01,4.200e-01,4.200e-01
+SDP_EI,FRA,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.000e-02,2.400e-01,4.200e-01,4.200e-01
+SDP_EI,FRA,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.000e-02,2.400e-01,4.200e-01,4.200e-01
+SDP_EI,FRA,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.402e-02,1.682e-01,4.579e-01,9.531e-01,9.531e-01
 SDP_EI,FRA,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,FRA,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,FRA,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_EI,FRA,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.980e-01,7.500e-01,9.820e-01,9.820e-01
-SDP_EI,FRA,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.186e-01,4.034e-01,9.526e-01,9.526e-01
-SDP_EI,FRA,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.186e-01,4.034e-01,9.526e-01,9.526e-01
-SDP_EI,FRA,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.186e-01,4.034e-01,9.526e-01,9.526e-01
-SDP_EI,FRA,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.980e-01,7.500e-01,9.820e-01,9.820e-01
-SDP_EI,FRA,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.236e-02,1.799e-02,9.544e-02,9.544e-02
-SDP_EI,FRA,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.693e-02,4.743e-02,1.462e-01,1.462e-01
-SDP_EI,FRA,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-02,1.799e-02,1.000e-01,1.000e-01
-SDP_EI,FRA,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-02,1.799e-02,1.000e-01,1.000e-01
-SDP_EI,FRA,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-02,1.799e-02,1.000e-01,1.000e-01
-SDP_EI,FRA,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.693e-02,4.743e-02,1.462e-01,1.462e-01
+SDP_EI,FRA,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.171e-01,6.651e-01,9.087e-01,9.087e-01
+SDP_EI,FRA,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.262e-01,3.578e-01,8.815e-01,8.815e-01
+SDP_EI,FRA,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.262e-01,3.578e-01,8.815e-01,8.815e-01
+SDP_EI,FRA,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.262e-01,3.578e-01,8.815e-01,8.815e-01
+SDP_EI,FRA,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.171e-01,6.651e-01,9.087e-01,9.087e-01
+SDP_EI,FRA,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.218e-02,1.462e-02,2.127e-02,8.186e-02,8.186e-02
+SDP_EI,FRA,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,7.914e-02,2.337e-01,1.503e-01,1.503e-01
+SDP_EI,FRA,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.924e-02,8.861e-02,1.028e-01,1.028e-01
+SDP_EI,FRA,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.924e-02,8.861e-02,1.028e-01,1.028e-01
+SDP_EI,FRA,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.924e-02,8.861e-02,1.028e-01,1.028e-01
+SDP_EI,FRA,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,7.914e-02,2.337e-01,1.503e-01,1.503e-01
 SDP_EI,FRA,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0.000e+00,8.315e-07,4.540e-05,1.192e-01,1.192e-01
-SDP_EI,FRA,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,9.544e-01,9.544e-01
+SDP_EI,FRA,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,FRA,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,FRA,Liquids,Domestic Ship_tmp_vehicletype,Domestic Ship_tmp_subsector_L1,Domestic Ship_tmp_subsector_L2,Domestic Ship,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,FRA,Liquids,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1.608e-01,1.608e-01,1.608e-01,1.608e-01,1.608e-01
@@ -2090,26 +2090,26 @@ SDP_EI,FRA,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_roa
 SDP_EI,FRA,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,FRA,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,FRA,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_EI,FRA,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.758e-01,1.758e-01
-SDP_EI,FRA,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SDP_EI,FRA,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SDP_EI,FRA,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SDP_EI,FRA,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SDP_EI,FRA,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SDP_EI,IND,,,,,Cycle,trn_pass,S3S,linear,2.632e-03,4.364e-03,9.091e-03,1.000e-01,1.000e-01
-SDP_EI,IND,,,,,Domestic Aviation,trn_pass,S3S,linear,9.589e-02,1.091e-01,1.000e-01,2.000e-01,2.000e-01
-SDP_EI,IND,,,,,Domestic Ship,trn_freight,S3S,linear,1.180e-03,1.180e-03,1.073e-03,9.075e-04,9.075e-04
-SDP_EI,IND,,,,,Freight Rail,trn_freight,S3S,linear,1.889e-01,1.889e-01,1.717e-01,1.453e-01,1.453e-01
-SDP_EI,IND,,,,,HSR,trn_pass,S3S,linear,0.000e+00,4.364e-05,1.000e-04,3.000e-04,3.000e-04
+SDP_EI,FRA,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.535e-02,2.632e-02,7.895e-02,1.417e-01,1.417e-01
+SDP_EI,FRA,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,6.579e-02,1.602e-01,1.602e-01
+SDP_EI,FRA,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,6.579e-02,1.602e-01,1.602e-01
+SDP_EI,FRA,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,6.579e-02,1.602e-01,1.602e-01
+SDP_EI,FRA,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,6.579e-02,1.602e-01,1.602e-01
+SDP_EI,FRA,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,6.579e-02,1.602e-01,1.602e-01
+SDP_EI,IND,,,,,Cycle,trn_pass,S3S,linear,1.915e-02,3.175e-02,4.630e-02,1.000e-01,1.000e-01
+SDP_EI,IND,,,,,Domestic Aviation,trn_pass,S3S,linear,6.659e-01,7.575e-01,4.861e-01,1.909e-01,1.909e-01
+SDP_EI,IND,,,,,Domestic Ship,trn_freight,S3S,linear,1.202e-03,1.202e-03,1.092e-03,9.244e-04,9.244e-04
+SDP_EI,IND,,,,,Freight Rail,trn_freight,S3S,linear,1.924e-01,1.924e-01,1.574e-01,1.332e-01,1.332e-01
+SDP_EI,IND,,,,,HSR,trn_pass,S3S,linear,0.000e+00,3.175e-04,5.093e-04,3.000e-04,3.000e-04
 SDP_EI,IND,,,,,International Aviation,trn_aviation_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,IND,,,,,International Ship,trn_shipping_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_EI,IND,,,,,Passenger Rail,trn_pass,S3S,linear,6.842e-04,8.000e-04,1.091e-03,4.000e-03,4.000e-03
-SDP_EI,IND,,,,,Walk,trn_pass,S3S,linear,1.316e-01,9.455e-02,1.818e-01,1.000e+00,1.000e+00
+SDP_EI,IND,,,,,Passenger Rail,trn_pass,S3S,linear,4.978e-03,5.820e-03,5.556e-03,4.000e-03,4.000e-03
+SDP_EI,IND,,,,,Walk,trn_pass,S3S,linear,9.573e-01,6.879e-01,9.260e-01,1.000e+00,1.000e+00
 SDP_EI,IND,,,,,trn_freight_road,trn_freight,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_EI,IND,,,,,trn_pass_road,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_EI,IND,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,1.188e-01,7.143e-02,3.231e-02,3.231e-02,3.231e-02
-SDP_EI,IND,,,,trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_EI,IND,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,3.027e-03,2.668e-03,1.949e-03,5.108e-04,5.108e-04
+SDP_EI,IND,,,,,trn_pass_road,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,2.945e-01,2.945e-01
+SDP_EI,IND,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,1.000e+00,3.638e-01,1.645e-01,9.872e-02,9.872e-02
+SDP_EI,IND,,,,trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,9.180e-01,1.000e+00,1.000e+00,1.000e+00,1.000e+00
+SDP_EI,IND,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.816e-02,1.867e-02,2.923e-02,5.108e-02,5.108e-02
 SDP_EI,IND,,,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,IND,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,IND,,Mini Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,6.374e-03,6.374e-03,6.374e-03,6.374e-03,6.374e-03
@@ -2120,24 +2120,24 @@ SDP_EI,IND,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,
 SDP_EI,IND,,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.853e-01,1.853e-01,1.853e-01,1.853e-01,1.853e-01
 SDP_EI,IND,,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.987e-01,1.987e-01,1.987e-01,1.987e-01,1.987e-01
 SDP_EI,IND,,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_EI,IND,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_EI,IND,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_EI,IND,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_EI,IND,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.743e-02,2.689e-01,7.621e-01,7.621e-01
+SDP_EI,IND,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.000e-01,3.600e-01,3.780e-01,3.780e-01
+SDP_EI,IND,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.000e-01,3.600e-01,3.780e-01,3.780e-01
+SDP_EI,IND,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.000e-01,3.600e-01,3.780e-01,3.780e-01
+SDP_EI,IND,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,5.175e-02,2.935e-01,6.653e-01,6.653e-01
 SDP_EI,IND,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,IND,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,IND,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,8.340e-01,8.547e-01,8.962e-01,9.792e-01,9.792e-01
-SDP_EI,IND,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.576e-02,1.000e-01,9.820e-02,9.820e-02
-SDP_EI,IND,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.423e-02,5.379e-02,9.526e-02,9.526e-02
-SDP_EI,IND,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,3.000e-01,2.000e-01,1.000e-01,1.000e-01
-SDP_EI,IND,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,3.000e-01,2.000e-01,1.000e-01,1.000e-01
-SDP_EI,IND,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.576e-02,1.000e-01,9.820e-02,9.820e-02
-SDP_EI,IND,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.473e-03,1.799e-02,5.000e-02,5.000e-02
-SDP_EI,IND,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.693e-03,9.485e-03,1.462e-02,1.462e-02
-SDP_EI,IND,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-03,3.597e-03,1.000e-02,1.000e-02
-SDP_EI,IND,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,2.000e-01,2.000e-02,2.000e-02
-SDP_EI,IND,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,2.000e-01,2.000e-02,2.000e-02
-SDP_EI,IND,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.693e-03,9.485e-03,1.462e-02,1.462e-02
+SDP_EI,IND,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.787e-02,6.365e-02,6.430e-02,6.430e-02
+SDP_EI,IND,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.109e-02,3.424e-02,6.237e-02,6.237e-02
+SDP_EI,IND,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,2.338e-01,1.273e-01,6.547e-02,6.547e-02
+SDP_EI,IND,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,2.338e-01,1.273e-01,6.547e-02,6.547e-02
+SDP_EI,IND,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.787e-02,6.365e-02,6.430e-02,6.430e-02
+SDP_EI,IND,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.698e-03,1.963e-02,5.456e-02,5.456e-02
+SDP_EI,IND,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.217e-03,8.625e-03,1.595e-03,1.595e-03
+SDP_EI,IND,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.927e-03,3.271e-03,1.091e-03,1.091e-03
+SDP_EI,IND,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,7.794e-01,1.819e-01,2.182e-03,2.182e-03
+SDP_EI,IND,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,7.794e-01,1.819e-01,2.182e-03,2.182e-03
+SDP_EI,IND,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.217e-03,8.625e-03,1.595e-03,1.595e-03
 SDP_EI,IND,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0.000e+00,8.315e-07,4.540e-05,1.192e-01,1.192e-01
 SDP_EI,IND,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,IND,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
@@ -2151,27 +2151,27 @@ SDP_EI,IND,Liquids,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,tr
 SDP_EI,IND,Liquids,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,IND,Liquids,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,IND,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_EI,IND,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_EI,IND,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
+SDP_EI,IND,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,9.164e-01,1.000e+00,1.000e+00,1.000e+00,1.000e+00
+SDP_EI,IND,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,9.164e-01,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,IND,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,IND,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,2.408e-01,2.086e-01,2.105e-01,1.903e-01,1.903e-01
-SDP_EI,IND,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,8.768e-02,1.117e-01,7.985e-02,2.557e-02,2.557e-02
-SDP_EI,IND,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,3.947e-02,1.842e-02,1.842e-02
-SDP_EI,IND,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,5.000e-01,1.000e-01,1.000e-01
-SDP_EI,IND,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,5.000e-01,1.000e-01,1.000e-01
-SDP_EI,IND,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,3.947e-02,1.842e-02,1.842e-02
+SDP_EI,IND,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,8.768e-02,7.978e-02,6.655e-02,2.557e-02,2.557e-02
+SDP_EI,IND,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.880e-02,3.289e-02,1.842e-02,1.842e-02
+SDP_EI,IND,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,9.164e-01,7.143e-01,4.167e-01,1.000e-01,1.000e-01
+SDP_EI,IND,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,9.164e-01,7.143e-01,4.167e-01,1.000e-01,1.000e-01
+SDP_EI,IND,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.880e-02,3.289e-02,1.842e-02,1.842e-02
 SDP_EI,JPN,,,,,Cycle,trn_pass,S3S,linear,1.743e-02,1.743e-02,3.486e-02,1.961e-02,1.961e-02
-SDP_EI,JPN,,,,,Domestic Aviation,trn_pass,S3S,linear,1.811e-04,2.174e-04,3.261e-04,9.170e-05,9.170e-05
-SDP_EI,JPN,,,,,Domestic Ship,trn_freight,S3S,linear,1.146e-02,1.146e-02,1.146e-02,1.146e-02,1.146e-02
-SDP_EI,JPN,,,,,Freight Rail,trn_freight,S3S,linear,2.781e-03,2.781e-03,2.781e-03,2.781e-03,2.781e-03
+SDP_EI,JPN,,,,,Domestic Aviation,trn_pass,S3S,linear,1.729e-04,2.075e-04,3.112e-04,8.752e-05,8.752e-05
+SDP_EI,JPN,,,,,Domestic Ship,trn_freight,S3S,linear,1.167e-02,1.111e-02,1.167e-02,1.167e-02,1.167e-02
+SDP_EI,JPN,,,,,Freight Rail,trn_freight,S3S,linear,2.833e-03,2.698e-03,2.833e-03,2.833e-03,2.833e-03
 SDP_EI,JPN,,,,,HSR,trn_pass,S3S,linear,4.081e-04,4.081e-04,4.591e-04,1.291e-04,1.291e-04
 SDP_EI,JPN,,,,,International Aviation,trn_aviation_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,JPN,,,,,International Ship,trn_shipping_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,JPN,,,,,Passenger Rail,trn_pass,S3S,linear,6.084e-03,6.084e-03,7.000e-03,2.281e-03,2.281e-03
 SDP_EI,JPN,,,,,Walk,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,JPN,,,,,trn_freight_road,trn_freight,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_EI,JPN,,,,,trn_pass_road,trn_pass,S3S,linear,7.245e-02,7.770e-02,7.770e-02,2.185e-02,2.185e-02
-SDP_EI,JPN,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,5.971e-02,5.971e-02,5.971e-02,5.971e-02,5.971e-02
+SDP_EI,JPN,,,,,trn_pass_road,trn_pass,S3S,linear,7.113e-02,7.629e-02,7.629e-02,2.146e-02,2.146e-02
+SDP_EI,JPN,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,6.081e-02,6.081e-02,6.081e-02,6.081e-02,6.081e-02
 SDP_EI,JPN,,,,trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,JPN,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,5.491e-02,5.491e-02,5.491e-02,5.491e-02,5.491e-02
 SDP_EI,JPN,,,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
@@ -2184,24 +2184,24 @@ SDP_EI,JPN,,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_
 SDP_EI,JPN,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.286e-01,1.286e-01,1.286e-01,1.286e-01,1.286e-01
 SDP_EI,JPN,,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,JPN,,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,5.896e-01,5.896e-01,5.896e-01,5.896e-01,5.896e-01
-SDP_EI,JPN,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_EI,JPN,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_EI,JPN,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_EI,JPN,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.091e-01,1.793e-01,3.810e-01,3.810e-01
+SDP_EI,JPN,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.600e-01,5.280e-01,1.000e+00,1.000e+00
+SDP_EI,JPN,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.600e-01,5.280e-01,1.000e+00,1.000e+00
+SDP_EI,JPN,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.600e-01,5.280e-01,1.000e+00,1.000e+00
+SDP_EI,JPN,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,9.673e-02,1.794e-01,3.754e-01,3.754e-01
 SDP_EI,JPN,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,JPN,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,JPN,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_EI,JPN,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.252e-01,3.529e-01,8.183e-01,8.183e-01
-SDP_EI,JPN,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,6.364e-02,1.333e-01,8.333e-01,8.333e-01
-SDP_EI,JPN,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,6.364e-02,1.333e-01,8.333e-01,8.333e-01
-SDP_EI,JPN,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,6.364e-02,1.333e-01,8.333e-01,8.333e-01
-SDP_EI,JPN,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.252e-01,3.529e-01,8.183e-01,8.183e-01
-SDP_EI,JPN,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,6.182e-02,1.319e-01,1.000e-01,1.000e-01
-SDP_EI,JPN,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.104e-01,2.511e-01,3.046e-01,3.046e-01
-SDP_EI,JPN,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,4.167e-01,4.167e-01
-SDP_EI,JPN,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,4.167e-01,4.167e-01
-SDP_EI,JPN,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,4.167e-01,4.167e-01
-SDP_EI,JPN,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.104e-01,2.511e-01,3.046e-01,3.046e-01
+SDP_EI,JPN,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.332e-01,3.414e-01,8.870e-01,8.870e-01
+SDP_EI,JPN,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,5.727e-02,1.200e-01,9.032e-01,9.032e-01
+SDP_EI,JPN,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,5.727e-02,1.200e-01,9.032e-01,9.032e-01
+SDP_EI,JPN,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,5.727e-02,1.200e-01,9.032e-01,9.032e-01
+SDP_EI,JPN,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.332e-01,3.414e-01,8.870e-01,8.870e-01
+SDP_EI,JPN,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,6.091e-02,1.200e-01,9.854e-02,9.854e-02
+SDP_EI,JPN,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.306e-01,2.699e-01,2.701e-01,2.701e-01
+SDP_EI,JPN,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,3.695e-01,3.695e-01
+SDP_EI,JPN,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,3.695e-01,3.695e-01
+SDP_EI,JPN,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,3.695e-01,3.695e-01
+SDP_EI,JPN,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.306e-01,2.699e-01,2.701e-01,2.701e-01
 SDP_EI,JPN,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0.000e+00,8.315e-07,4.540e-05,1.192e-01,1.192e-01
 SDP_EI,JPN,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,JPN,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
@@ -2209,41 +2209,41 @@ SDP_EI,JPN,Liquids,Domestic Ship_tmp_vehicletype,Domestic Ship_tmp_subsector_L1,
 SDP_EI,JPN,Liquids,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,8.837e-01,8.837e-01,8.837e-01,8.837e-01,8.837e-01
 SDP_EI,JPN,Liquids,International Aviation_tmp_vehicletype,International Aviation_tmp_subsector_L1,International Aviation_tmp_subsector_L2,International Aviation,trn_aviation_intl,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,JPN,Liquids,International Ship_tmp_vehicletype,International Ship_tmp_subsector_L1,International Ship_tmp_subsector_L2,International Ship,trn_shipping_intl,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_EI,JPN,Liquids,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_EI,JPN,Liquids,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_EI,JPN,Liquids,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
+SDP_EI,JPN,Liquids,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,9.921e-01,9.921e-01
+SDP_EI,JPN,Liquids,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,9.921e-01,9.921e-01
+SDP_EI,JPN,Liquids,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,9.921e-01,9.921e-01
 SDP_EI,JPN,Liquids,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,3.433e-02,3.433e-02,3.433e-02,3.433e-02,3.433e-02
 SDP_EI,JPN,Liquids,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_EI,JPN,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,6.061e-02,1.889e-01,1.000e+00,1.000e+00
-SDP_EI,JPN,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,6.061e-02,1.889e-01,1.000e+00,1.000e+00
-SDP_EI,JPN,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,6.061e-02,1.889e-01,1.000e+00,1.000e+00
+SDP_EI,JPN,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,8.457e-01,5.126e-02,1.757e-01,1.000e+00,1.000e+00
+SDP_EI,JPN,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,8.457e-01,5.126e-02,1.757e-01,1.000e+00,1.000e+00
+SDP_EI,JPN,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,8.457e-01,5.126e-02,1.757e-01,1.000e+00,1.000e+00
 SDP_EI,JPN,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_EI,JPN,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,7.895e-03,1.579e-02,2.303e-02,2.303e-02
-SDP_EI,JPN,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.316e-02,4.644e-02,4.605e-02,4.605e-02
-SDP_EI,JPN,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,3.030e-02,1.111e-01,2.500e-01,2.500e-01
-SDP_EI,JPN,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,3.030e-02,1.111e-01,2.500e-01,2.500e-01
-SDP_EI,JPN,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,3.030e-02,1.111e-01,2.500e-01,2.500e-01
-SDP_EI,JPN,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.316e-02,4.644e-02,4.605e-02,4.605e-02
-SDP_EI,LAM,,,,,Cycle,trn_pass,S3S,linear,9.812e-03,1.852e-02,4.629e-02,2.315e-01,2.315e-01
-SDP_EI,LAM,,,,,Domestic Aviation,trn_pass,S3S,linear,8.407e-03,1.058e-02,2.644e-02,1.983e-02,1.983e-02
-SDP_EI,LAM,,,,,Domestic Ship,trn_freight,S3S,linear,9.523e-03,9.523e-03,8.658e-03,7.936e-03,7.936e-03
-SDP_EI,LAM,,,,,Freight Rail,trn_freight,S3S,linear,4.694e-02,4.694e-02,4.268e-02,3.912e-02,3.912e-02
-SDP_EI,LAM,,,,,HSR,trn_pass,S3S,linear,4.709e-03,2.465e-01,2.465e-01,2.465e-01,2.465e-01
+SDP_EI,JPN,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,6.579e-03,1.215e-02,1.919e-02,1.919e-02
+SDP_EI,JPN,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.316e-02,4.222e-02,3.838e-02,3.838e-02
+SDP_EI,JPN,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,8.457e-01,2.563e-02,9.397e-02,2.083e-01,2.083e-01
+SDP_EI,JPN,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,8.457e-01,2.563e-02,9.397e-02,2.083e-01,2.083e-01
+SDP_EI,JPN,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,8.457e-01,2.563e-02,9.397e-02,2.083e-01,2.083e-01
+SDP_EI,JPN,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.316e-02,4.222e-02,3.838e-02,3.838e-02
+SDP_EI,LAM,,,,,Cycle,trn_pass,S3S,linear,1.091e-02,2.182e-02,5.455e-02,2.728e-01,2.728e-01
+SDP_EI,LAM,,,,,Domestic Aviation,trn_pass,S3S,linear,8.921e-03,1.190e-02,2.974e-02,2.230e-02,2.230e-02
+SDP_EI,LAM,,,,,Domestic Ship,trn_freight,S3S,linear,9.700e-03,9.700e-03,8.908e-03,6.736e-03,6.736e-03
+SDP_EI,LAM,,,,,Freight Rail,trn_freight,S3S,linear,4.782e-02,4.782e-02,4.391e-02,3.985e-02,3.985e-02
+SDP_EI,LAM,,,,,HSR,trn_pass,S3S,linear,5.236e-03,2.905e-01,2.905e-01,2.905e-01,2.905e-01
 SDP_EI,LAM,,,,,International Aviation,trn_aviation_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,LAM,,,,,International Ship,trn_shipping_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_EI,LAM,,,,,Passenger Rail,trn_pass,S3S,linear,1.348e-01,1.272e-01,1.272e-01,8.482e-02,8.482e-02
-SDP_EI,LAM,,,,,Walk,trn_pass,S3S,linear,8.993e-01,8.486e-01,8.486e-01,8.486e-01,8.486e-01
+SDP_EI,LAM,,,,,Passenger Rail,trn_pass,S3S,linear,1.499e-01,1.499e-01,1.499e-01,9.996e-02,9.996e-02
+SDP_EI,LAM,,,,,Walk,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,LAM,,,,,trn_freight_road,trn_freight,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_EI,LAM,,,,,trn_pass_road,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_EI,LAM,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,1.732e-01,1.083e-01,8.662e-02,8.662e-02,8.662e-02
+SDP_EI,LAM,,,,,trn_pass_road,trn_pass,S3S,linear,6.550e-01,6.942e-01,6.942e-01,8.099e-01,8.099e-01
+SDP_EI,LAM,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,2.647e-01,1.654e-01,1.323e-01,1.323e-01,1.323e-01
 SDP_EI,LAM,,,,trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,LAM,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.377e-01,1.377e-01,1.377e-01,1.377e-01,1.377e-01
 SDP_EI,LAM,,,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,LAM,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_EI,LAM,,Large Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,5.465e-02,5.465e-02,5.465e-02,5.465e-02,5.465e-02
-SDP_EI,LAM,,Large Car and SUV,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,6.039e-01,6.039e-01,6.039e-01,6.039e-01,6.039e-01
-SDP_EI,LAM,,Light Truck and SUV,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,2.182e-01,2.182e-01,2.182e-01,2.182e-01,2.182e-01
-SDP_EI,LAM,,Midsize Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,7.979e-02,7.979e-02,7.979e-02,7.979e-02,7.979e-02
+SDP_EI,LAM,,Large Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,3.279e-02,3.935e-02,4.099e-02,4.372e-02,4.372e-02
+SDP_EI,LAM,,Large Car and SUV,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,3.624e-01,4.348e-01,4.529e-01,4.831e-01,4.831e-01
+SDP_EI,LAM,,Light Truck and SUV,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.309e-01,1.571e-01,1.636e-01,1.745e-01,1.745e-01
+SDP_EI,LAM,,Midsize Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,4.788e-02,5.745e-02,5.984e-02,6.383e-02,6.383e-02
 SDP_EI,LAM,,Mini Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.226e-02,1.226e-02,1.226e-02,1.226e-02,1.226e-02
 SDP_EI,LAM,,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,4.580e-04,4.580e-04,4.580e-04,4.580e-04,4.580e-04
 SDP_EI,LAM,,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
@@ -2254,27 +2254,27 @@ SDP_EI,LAM,,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_s
 SDP_EI,LAM,,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,LAM,,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,5.079e-04,5.079e-04,5.079e-04,5.079e-04,5.079e-04
 SDP_EI,LAM,,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.892e-01,1.892e-01,1.892e-01,1.892e-01,1.892e-01
-SDP_EI,LAM,,Van,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,2.455e-03,2.455e-03,2.455e-03,2.455e-03,2.455e-03
-SDP_EI,LAM,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_EI,LAM,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_EI,LAM,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_EI,LAM,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.186e-01,5.379e-01,1.000e+00,1.000e+00
+SDP_EI,LAM,,Van,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.473e-03,1.768e-03,1.842e-03,1.964e-03,1.964e-03
+SDP_EI,LAM,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,5.600e-02,2.160e-01,5.040e-01,5.040e-01
+SDP_EI,LAM,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,5.600e-02,2.160e-01,5.040e-01,5.040e-01
+SDP_EI,LAM,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,5.600e-02,2.160e-01,5.040e-01,5.040e-01
+SDP_EI,LAM,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.294e-01,5.869e-01,1.000e+00,1.000e+00
 SDP_EI,LAM,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,6.810e-02,1.846e-01,4.176e-01,8.835e-01,8.835e-01
 SDP_EI,LAM,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,LAM,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_EI,LAM,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,7.947e-02,2.000e-01,2.400e-01,2.400e-01
-SDP_EI,LAM,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.162e-02,1.076e-01,2.329e-01,2.329e-01
-SDP_EI,LAM,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.162e-02,1.076e-01,2.329e-01,2.329e-01
-SDP_EI,LAM,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.162e-02,1.076e-01,2.329e-01,2.329e-01
-SDP_EI,LAM,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,7.947e-02,2.000e-01,2.400e-01,2.400e-01
-SDP_EI,LAM,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.473e-03,1.799e-02,6.561e-02,6.561e-02
-SDP_EI,LAM,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,8.924e-03,5.691e-02,8.123e-02,8.123e-02
-SDP_EI,LAM,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.297e-03,2.158e-02,5.556e-02,5.556e-02
-SDP_EI,LAM,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.297e-03,2.158e-02,5.556e-02,5.556e-02
-SDP_EI,LAM,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.297e-03,2.158e-02,5.556e-02,5.556e-02
-SDP_EI,LAM,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,8.924e-03,5.691e-02,8.123e-02,8.123e-02
+SDP_EI,LAM,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.041e-01,1.964e-01,2.357e-01,2.357e-01
+SDP_EI,LAM,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.140e-02,1.057e-01,2.287e-01,2.287e-01
+SDP_EI,LAM,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.140e-02,1.057e-01,2.287e-01,2.287e-01
+SDP_EI,LAM,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.140e-02,1.057e-01,2.287e-01,2.287e-01
+SDP_EI,LAM,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.041e-01,1.964e-01,2.357e-01,2.357e-01
+SDP_EI,LAM,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.698e-03,1.963e-02,6.561e-02,6.561e-02
+SDP_EI,LAM,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,9.738e-03,6.210e-02,8.864e-02,8.864e-02
+SDP_EI,LAM,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.598e-03,2.355e-02,6.062e-02,6.062e-02
+SDP_EI,LAM,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.598e-03,2.355e-02,6.062e-02,6.062e-02
+SDP_EI,LAM,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.598e-03,2.355e-02,6.062e-02,6.062e-02
+SDP_EI,LAM,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,9.738e-03,6.210e-02,8.864e-02,8.864e-02
 SDP_EI,LAM,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0.000e+00,8.315e-07,4.540e-05,1.192e-01,1.192e-01
-SDP_EI,LAM,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,7.217e-01,7.217e-01
+SDP_EI,LAM,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,7.275e-01,7.275e-01
 SDP_EI,LAM,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,LAM,Liquids,Domestic Ship_tmp_vehicletype,Domestic Ship_tmp_subsector_L1,Domestic Ship_tmp_subsector_L2,Domestic Ship,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,LAM,Liquids,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
@@ -2289,55 +2289,55 @@ SDP_EI,LAM,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_roa
 SDP_EI,LAM,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,LAM,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,LAM,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_EI,LAM,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,2.689e-02,4.725e-02,1.037e-01,1.353e-01,1.353e-01
+SDP_EI,LAM,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,2.689e-02,4.725e-02,1.037e-01,1.240e-01,1.240e-01
 SDP_EI,LAM,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.754e-02,3.158e-02,6.140e-02,6.140e-02
 SDP_EI,LAM,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.754e-02,3.158e-02,6.140e-02,6.140e-02
 SDP_EI,LAM,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.754e-02,3.158e-02,6.140e-02,6.140e-02
 SDP_EI,LAM,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.754e-02,3.158e-02,6.140e-02,6.140e-02
 SDP_EI,LAM,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.754e-02,3.158e-02,6.140e-02,6.140e-02
 SDP_EI,MEA,,,,,Cycle,trn_pass,S3S,linear,1.660e-02,1.660e-02,1.660e-02,4.149e-02,4.149e-02
-SDP_EI,MEA,,,,,Domestic Aviation,trn_pass,S3S,linear,8.929e-03,5.953e-03,1.786e-02,2.381e-02,2.381e-02
-SDP_EI,MEA,,,,,Domestic Ship,trn_freight,S3S,linear,2.022e-03,2.022e-03,2.022e-03,2.022e-03,2.022e-03
-SDP_EI,MEA,,,,,Freight Rail,trn_freight,S3S,linear,3.143e-03,3.143e-03,3.143e-03,3.143e-03,3.143e-03
+SDP_EI,MEA,,,,,Domestic Aviation,trn_pass,S3S,linear,8.522e-03,5.681e-03,1.704e-02,2.500e-02,2.500e-02
+SDP_EI,MEA,,,,,Domestic Ship,trn_freight,S3S,linear,2.060e-03,2.060e-03,2.060e-03,2.060e-03,2.060e-03
+SDP_EI,MEA,,,,,Freight Rail,trn_freight,S3S,linear,3.202e-03,3.202e-03,3.202e-03,3.202e-03,3.202e-03
 SDP_EI,MEA,,,,,HSR,trn_pass,S3S,linear,0.000e+00,1.667e-02,1.667e-02,1.667e-02,1.667e-02
 SDP_EI,MEA,,,,,International Aviation,trn_aviation_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,MEA,,,,,International Ship,trn_shipping_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,MEA,,,,,Passenger Rail,trn_pass,S3S,linear,5.567e-04,1.113e-03,1.113e-03,1.856e-03,1.856e-03
 SDP_EI,MEA,,,,,Walk,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,MEA,,,,,trn_freight_road,trn_freight,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_EI,MEA,,,,,trn_pass_road,trn_pass,S3S,linear,6.395e-01,7.197e-01,7.197e-01,7.197e-01,7.197e-01
-SDP_EI,MEA,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,2.627e-01,1.226e-01,6.131e-02,4.905e-02,4.905e-02
+SDP_EI,MEA,,,,,trn_pass_road,trn_pass,S3S,linear,3.767e-01,4.239e-01,3.815e-01,3.815e-01,3.815e-01
+SDP_EI,MEA,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,2.676e-01,1.873e-01,9.367e-02,7.493e-02,7.493e-02
 SDP_EI,MEA,,,,trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_EI,MEA,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,7.508e-03,7.508e-03,7.508e-03,7.508e-03,7.508e-03
+SDP_EI,MEA,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.502e-02,1.502e-02,1.502e-02,1.502e-02,1.502e-02
 SDP_EI,MEA,,,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_EI,MEA,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,4.732e-01,4.732e-01,4.732e-01,4.732e-01,4.732e-01
+SDP_EI,MEA,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,5.257e-01,4.732e-01,4.337e-01,3.943e-01,3.943e-01
 SDP_EI,MEA,,Large Car and SUV,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_EI,MEA,,Mini Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,3.955e-02,3.955e-02,3.955e-02,3.955e-02,3.955e-02
+SDP_EI,MEA,,Mini Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,4.395e-02,3.955e-02,3.626e-02,3.296e-02,3.296e-02
 SDP_EI,MEA,,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,MEA,,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,MEA,,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_EI,MEA,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.864e-01,1.864e-01,1.864e-01,1.864e-01,1.864e-01
+SDP_EI,MEA,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,2.071e-01,1.864e-01,1.709e-01,1.553e-01,1.553e-01
 SDP_EI,MEA,,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.304e-01,1.304e-01,1.304e-01,1.304e-01,1.304e-01
 SDP_EI,MEA,,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,2.013e-01,2.013e-01,2.013e-01,2.013e-01,2.013e-01
 SDP_EI,MEA,,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_EI,MEA,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_EI,MEA,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_EI,MEA,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_EI,MEA,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.743e-02,2.958e-01,6.549e-01,6.549e-01
+SDP_EI,MEA,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.200e-01,2.160e-01,2.100e-01,2.100e-01
+SDP_EI,MEA,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.200e-01,2.160e-01,2.100e-01,2.100e-01
+SDP_EI,MEA,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.200e-01,2.160e-01,2.100e-01,2.100e-01
+SDP_EI,MEA,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,5.175e-02,2.935e-01,6.497e-01,6.497e-01
 SDP_EI,MEA,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,4.021e-01,4.768e-01,6.263e-01,9.253e-01,9.253e-01
 SDP_EI,MEA,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,MEA,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_EI,MEA,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.960e-02,1.000e-01,1.403e-01,1.403e-01
-SDP_EI,MEA,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.371e-02,5.379e-02,1.361e-01,1.361e-01
-SDP_EI,MEA,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.429e-01,2.000e-01,1.429e-01,1.429e-01
-SDP_EI,MEA,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.429e-01,2.000e-01,1.429e-01,1.429e-01
-SDP_EI,MEA,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.960e-02,1.000e-01,1.403e-01,1.403e-01
-SDP_EI,MEA,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.473e-03,1.799e-02,6.250e-02,6.250e-02
-SDP_EI,MEA,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.346e-03,9.485e-03,4.177e-02,4.177e-02
-SDP_EI,MEA,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.236e-03,3.597e-03,2.857e-02,2.857e-02
-SDP_EI,MEA,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.429e-01,2.000e-01,5.714e-02,5.714e-02
-SDP_EI,MEA,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.429e-01,2.000e-01,5.714e-02,5.714e-02
-SDP_EI,MEA,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.346e-03,9.485e-03,4.177e-02,4.177e-02
+SDP_EI,MEA,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.504e-02,1.091e-01,1.392e-01,1.392e-01
+SDP_EI,MEA,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.588e-02,5.869e-02,1.350e-01,1.350e-01
+SDP_EI,MEA,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.559e-01,2.182e-01,1.417e-01,1.417e-01
+SDP_EI,MEA,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.559e-01,2.182e-01,1.417e-01,1.417e-01
+SDP_EI,MEA,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.504e-02,1.091e-01,1.392e-01,1.392e-01
+SDP_EI,MEA,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.698e-03,1.784e-02,5.580e-02,5.580e-02
+SDP_EI,MEA,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.652e-03,1.035e-02,4.144e-04,4.144e-04
+SDP_EI,MEA,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.349e-03,3.925e-03,2.834e-04,2.834e-04
+SDP_EI,MEA,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.559e-01,2.182e-01,5.669e-04,5.669e-04
+SDP_EI,MEA,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.559e-01,2.182e-01,5.669e-04,5.669e-04
+SDP_EI,MEA,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.652e-03,1.035e-02,4.144e-04,4.144e-04
 SDP_EI,MEA,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0.000e+00,8.315e-07,4.540e-05,1.192e-01,1.192e-01
 SDP_EI,MEA,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,MEA,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
@@ -2351,27 +2351,27 @@ SDP_EI,MEA,Liquids,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,tr
 SDP_EI,MEA,Liquids,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,7.852e-02,7.852e-02,7.852e-02,7.852e-02,7.852e-02
 SDP_EI,MEA,Liquids,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,MEA,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_EI,MEA,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,2.857e-01,1.000e+00,1.000e+00,1.000e+00
-SDP_EI,MEA,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,2.857e-01,1.000e+00,1.000e+00,1.000e+00
+SDP_EI,MEA,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,9.164e-01,2.857e-01,1.000e+00,1.000e+00,1.000e+00
+SDP_EI,MEA,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,9.164e-01,2.857e-01,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,MEA,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_EI,MEA,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.342e-02,3.938e-02,9.130e-02,1.220e-01,1.220e-01
-SDP_EI,MEA,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,9.283e-04,9.527e-02,4.788e-02,5.285e-02,5.285e-02
-SDP_EI,MEA,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,9.211e-02,4.737e-02,5.263e-02,5.263e-02
-SDP_EI,MEA,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,6.000e-01,2.857e-01,2.857e-01
-SDP_EI,MEA,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,6.000e-01,2.857e-01,2.857e-01
-SDP_EI,MEA,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,9.211e-02,4.737e-02,5.263e-02,5.263e-02
+SDP_EI,MEA,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.342e-02,3.938e-02,8.300e-02,1.109e-01,1.109e-01
+SDP_EI,MEA,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,9.283e-04,9.527e-02,4.788e-02,4.804e-02,4.804e-02
+SDP_EI,MEA,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,9.211e-02,4.737e-02,4.785e-02,4.785e-02
+SDP_EI,MEA,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,9.164e-01,1.000e+00,6.000e-01,2.597e-01,2.597e-01
+SDP_EI,MEA,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,9.164e-01,1.000e+00,6.000e-01,2.597e-01,2.597e-01
+SDP_EI,MEA,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,9.211e-02,4.737e-02,4.785e-02,4.785e-02
 SDP_EI,NEN,,,,,Cycle,trn_pass,S3S,linear,3.033e-03,3.024e-03,2.621e-03,1.820e-02,1.820e-02
-SDP_EI,NEN,,,,,Domestic Aviation,trn_pass,S3S,linear,7.555e-06,7.895e-06,2.566e-06,1.497e-06,1.497e-06
-SDP_EI,NEN,,,,,Domestic Ship,trn_freight,S3S,linear,3.117e-02,3.117e-02,3.117e-02,3.117e-02,3.117e-02
-SDP_EI,NEN,,,,,Freight Rail,trn_freight,S3S,linear,1.890e-02,1.890e-02,1.890e-02,1.890e-02,1.890e-02
+SDP_EI,NEN,,,,,Domestic Aviation,trn_pass,S3S,linear,7.210e-06,7.535e-06,2.449e-06,1.428e-06,1.428e-06
+SDP_EI,NEN,,,,,Domestic Ship,trn_freight,S3S,linear,3.175e-02,3.175e-02,3.175e-02,3.175e-02,3.175e-02
+SDP_EI,NEN,,,,,Freight Rail,trn_freight,S3S,linear,1.925e-02,1.925e-02,1.925e-02,1.925e-02,1.925e-02
 SDP_EI,NEN,,,,,HSR,trn_pass,S3S,linear,2.000e-05,4.532e-05,7.364e-06,5.523e-06,5.523e-06
 SDP_EI,NEN,,,,,International Aviation,trn_aviation_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,NEN,,,,,International Ship,trn_shipping_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,NEN,,,,,Passenger Rail,trn_pass,S3S,linear,3.000e-06,2.967e-06,6.751e-07,3.215e-07,3.215e-07
 SDP_EI,NEN,,,,,Walk,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,NEN,,,,,trn_freight_road,trn_freight,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_EI,NEN,,,,,trn_pass_road,trn_pass,S3S,linear,5.052e-02,6.996e-02,2.842e-02,2.368e-02,2.368e-02
-SDP_EI,NEN,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,1.263e-02,7.897e-03,3.948e-03,1.974e-03,1.974e-03
+SDP_EI,NEN,,,,,trn_pass_road,trn_pass,S3S,linear,4.960e-02,6.868e-02,2.790e-02,2.325e-02,2.325e-02
+SDP_EI,NEN,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,1.287e-02,8.044e-03,4.022e-03,2.011e-03,2.011e-03
 SDP_EI,NEN,,,,trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,NEN,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,3.994e-02,3.994e-02,3.994e-02,3.994e-02,3.994e-02
 SDP_EI,NEN,,,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
@@ -2389,24 +2389,24 @@ SDP_EI,NEN,,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_s
 SDP_EI,NEN,,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,6.397e-02,6.397e-02,6.397e-02,6.397e-02,6.397e-02
 SDP_EI,NEN,,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,3.433e-01,3.433e-01,3.433e-01,3.433e-01,3.433e-01
 SDP_EI,NEN,,Van,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,7.350e-03,7.350e-03,7.350e-03,7.350e-03,7.350e-03
-SDP_EI,NEN,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_EI,NEN,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_EI,NEN,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_EI,NEN,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.743e-02,2.689e-01,9.526e-01,9.526e-01
+SDP_EI,NEN,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.000e-02,1.680e-01,2.940e-01,2.940e-01
+SDP_EI,NEN,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.000e-02,1.680e-01,2.940e-01,2.940e-01
+SDP_EI,NEN,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.000e-02,1.680e-01,2.940e-01,2.940e-01
+SDP_EI,NEN,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,5.608e-02,1.402e-01,4.134e-01,9.856e-01,9.856e-01
 SDP_EI,NEN,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,NEN,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,NEN,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_EI,NEN,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.192e-01,5.000e-01,9.820e-01,9.820e-01
-SDP_EI,NEN,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.743e-02,2.689e-01,9.526e-01,9.526e-01
-SDP_EI,NEN,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.743e-02,2.689e-01,9.526e-01,9.526e-01
-SDP_EI,NEN,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.743e-02,2.689e-01,9.526e-01,9.526e-01
-SDP_EI,NEN,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.192e-01,5.000e-01,9.820e-01,9.820e-01
-SDP_EI,NEN,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.473e-03,1.799e-02,5.000e-01,5.000e-01
-SDP_EI,NEN,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.693e-03,4.743e-02,7.311e-01,7.311e-01
-SDP_EI,NEN,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-03,1.799e-02,5.000e-01,5.000e-01
-SDP_EI,NEN,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-03,1.799e-02,5.000e-01,5.000e-01
-SDP_EI,NEN,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-03,1.799e-02,5.000e-01,5.000e-01
-SDP_EI,NEN,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.693e-03,4.743e-02,7.311e-01,7.311e-01
+SDP_EI,NEN,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.537e-01,5.912e-01,8.932e-01,8.932e-01
+SDP_EI,NEN,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.009e-01,3.180e-01,8.664e-01,8.664e-01
+SDP_EI,NEN,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.009e-01,3.180e-01,8.664e-01,8.664e-01
+SDP_EI,NEN,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.009e-01,3.180e-01,8.664e-01,8.664e-01
+SDP_EI,NEN,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.537e-01,5.912e-01,8.932e-01,8.932e-01
+SDP_EI,NEN,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.924e-03,2.127e-02,5.543e-02,5.543e-02
+SDP_EI,NEN,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,7.914e-03,1.682e-01,9.974e-02,9.974e-02
+SDP_EI,NEN,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.924e-03,6.380e-02,6.822e-02,6.822e-02
+SDP_EI,NEN,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.924e-03,6.380e-02,6.822e-02,6.822e-02
+SDP_EI,NEN,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.924e-03,6.380e-02,6.822e-02,6.822e-02
+SDP_EI,NEN,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,7.914e-03,1.682e-01,9.974e-02,9.974e-02
 SDP_EI,NEN,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0.000e+00,8.315e-07,4.540e-05,1.192e-01,1.192e-01
 SDP_EI,NEN,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,NEN,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
@@ -2423,59 +2423,59 @@ SDP_EI,NEN,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_roa
 SDP_EI,NEN,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,NEN,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,NEN,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_EI,NEN,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,2.147e-02,4.722e-02,9.872e-02,2.017e-01,2.017e-01
-SDP_EI,NEN,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,6.427e-03,3.257e-02,8.487e-02,1.895e-01,1.895e-01
-SDP_EI,NEN,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SDP_EI,NEN,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SDP_EI,NEN,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SDP_EI,NEN,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
+SDP_EI,NEN,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,2.362e-02,3.778e-02,9.872e-02,1.261e-01,1.261e-01
+SDP_EI,NEN,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,6.427e-03,3.257e-02,8.487e-02,1.457e-01,1.457e-01
+SDP_EI,NEN,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.417e-01,1.417e-01
+SDP_EI,NEN,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.417e-01,1.417e-01
+SDP_EI,NEN,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.417e-01,1.417e-01
+SDP_EI,NEN,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.417e-01,1.417e-01
 SDP_EI,NES,,,,,Cycle,trn_pass,S3S,linear,8.738e-03,7.802e-03,9.929e-03,1.365e-02,1.365e-02
-SDP_EI,NES,,,,,Domestic Aviation,trn_pass,S3S,linear,4.947e-03,3.534e-03,1.499e-03,4.123e-04,4.123e-04
-SDP_EI,NES,,,,,Domestic Ship,trn_freight,S3S,linear,1.442e-02,1.442e-02,1.442e-02,1.442e-02,1.442e-02
-SDP_EI,NES,,,,,Freight Rail,trn_freight,S3S,linear,1.666e-02,1.666e-02,1.666e-02,1.666e-02,1.666e-02
+SDP_EI,NES,,,,,Domestic Aviation,trn_pass,S3S,linear,4.721e-03,3.372e-03,1.431e-03,3.935e-04,3.935e-04
+SDP_EI,NES,,,,,Domestic Ship,trn_freight,S3S,linear,1.468e-02,1.468e-02,1.468e-02,1.322e-02,1.322e-02
+SDP_EI,NES,,,,,Freight Rail,trn_freight,S3S,linear,1.697e-02,1.697e-02,1.697e-02,1.697e-02,1.697e-02
 SDP_EI,NES,,,,,HSR,trn_pass,S3S,linear,5.085e-04,3.632e-04,2.311e-04,1.271e-04,1.271e-04
 SDP_EI,NES,,,,,International Aviation,trn_aviation_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,NES,,,,,International Ship,trn_shipping_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,NES,,,,,Passenger Rail,trn_pass,S3S,linear,1.607e-03,1.148e-03,7.303e-04,4.017e-04,4.017e-04
 SDP_EI,NES,,,,,Walk,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,NES,,,,,trn_freight_road,trn_freight,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_EI,NES,,,,,trn_pass_road,trn_pass,S3S,linear,9.258e-01,7.176e-01,4.566e-01,2.512e-01,2.512e-01
-SDP_EI,NES,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,5.499e-02,2.199e-02,1.100e-02,1.100e-02,1.100e-02
+SDP_EI,NES,,,,,trn_pass_road,trn_pass,S3S,linear,2.727e-01,2.818e-01,2.242e-01,1.233e-01,1.233e-01
+SDP_EI,NES,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,8.401e-02,3.734e-02,2.240e-02,2.240e-02,2.240e-02
 SDP_EI,NES,,,,trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,NES,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,4.923e-03,4.923e-03,4.923e-03,4.923e-03,4.923e-03
 SDP_EI,NES,,,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_EI,NES,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,4.608e-01,4.608e-01,4.608e-01,4.608e-01,4.608e-01
+SDP_EI,NES,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,5.760e-01,5.760e-01,6.144e-01,6.144e-01,6.144e-01
 SDP_EI,NES,,Large Car and SUV,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,NES,,Midsize Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,2.352e-01,2.352e-01,2.352e-01,2.352e-01,2.352e-01
-SDP_EI,NES,,Mini Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.509e-03,1.509e-03,1.509e-03,1.509e-03,1.509e-03
+SDP_EI,NES,,Mini Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.886e-03,1.886e-03,2.012e-03,2.012e-03,2.012e-03
 SDP_EI,NES,,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.148e-02,1.148e-02,1.148e-02,1.148e-02,1.148e-02
 SDP_EI,NES,,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.337e-01,1.337e-01,1.337e-01,1.337e-01,1.337e-01
 SDP_EI,NES,,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_EI,NES,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,7.460e-02,7.460e-02,7.460e-02,7.460e-02,7.460e-02
+SDP_EI,NES,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,9.325e-02,9.325e-02,9.946e-02,9.946e-02,9.946e-02
 SDP_EI,NES,,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,NES,,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,6.299e-02,6.299e-02,6.299e-02,6.299e-02,6.299e-02
 SDP_EI,NES,,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,3.651e-01,3.651e-01,3.651e-01,3.651e-01,3.651e-01
 SDP_EI,NES,,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,5.704e-01,5.704e-01,5.704e-01,5.704e-01,5.704e-01
 SDP_EI,NES,,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,4.799e-01,4.799e-01,4.799e-01,4.799e-01,4.799e-01
 SDP_EI,NES,,Van,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,2.880e-03,2.880e-03,2.880e-03,2.880e-03,2.880e-03
-SDP_EI,NES,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_EI,NES,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_EI,NES,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_EI,NES,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.743e-02,2.689e-01,9.526e-01,9.526e-01
+SDP_EI,NES,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.000e-02,1.680e-01,3.360e-01,3.360e-01
+SDP_EI,NES,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.000e-02,1.680e-01,3.360e-01,3.360e-01
+SDP_EI,NES,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.000e-02,1.680e-01,3.360e-01,3.360e-01
+SDP_EI,NES,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,5.175e-02,1.739e-01,3.465e-01,3.465e-01
 SDP_EI,NES,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,2.081e-01,3.071e-01,5.050e-01,9.010e-01,9.010e-01
 SDP_EI,NES,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,NES,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_EI,NES,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.192e-01,5.000e-01,9.820e-01,9.820e-01
-SDP_EI,NES,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.743e-02,2.689e-01,9.526e-01,9.526e-01
-SDP_EI,NES,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.743e-02,2.689e-01,9.526e-01,9.526e-01
-SDP_EI,NES,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.743e-02,2.689e-01,9.526e-01,9.526e-01
-SDP_EI,NES,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.192e-01,5.000e-01,9.820e-01,9.820e-01
-SDP_EI,NES,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.473e-03,1.799e-02,5.000e-01,5.000e-01
-SDP_EI,NES,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.693e-03,4.743e-02,7.311e-01,7.311e-01
-SDP_EI,NES,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-03,1.799e-02,5.000e-01,5.000e-01
-SDP_EI,NES,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-03,1.799e-02,5.000e-01,5.000e-01
-SDP_EI,NES,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-03,1.799e-02,5.000e-01,5.000e-01
-SDP_EI,NES,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.693e-03,4.743e-02,7.311e-01,7.311e-01
+SDP_EI,NES,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.138e-01,2.182e-01,3.215e-01,3.215e-01
+SDP_EI,NES,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.528e-02,1.174e-01,3.118e-01,3.118e-01
+SDP_EI,NES,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.528e-02,1.174e-01,3.118e-01,3.118e-01
+SDP_EI,NES,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.528e-02,1.174e-01,3.118e-01,3.118e-01
+SDP_EI,NES,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.138e-01,2.182e-01,3.215e-01,3.215e-01
+SDP_EI,NES,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.698e-03,1.454e-02,3.637e-02,3.637e-02
+SDP_EI,NES,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,9.129e-03,3.833e-02,8.376e-02,8.376e-02
+SDP_EI,NES,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.373e-03,1.454e-02,5.729e-02,5.729e-02
+SDP_EI,NES,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.373e-03,1.454e-02,5.729e-02,5.729e-02
+SDP_EI,NES,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.373e-03,1.454e-02,5.729e-02,5.729e-02
+SDP_EI,NES,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,9.129e-03,3.833e-02,8.376e-02,8.376e-02
 SDP_EI,NES,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0.000e+00,8.315e-07,4.540e-05,1.192e-01,1.192e-01
 SDP_EI,NES,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,NES,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
@@ -2492,63 +2492,63 @@ SDP_EI,NES,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_roa
 SDP_EI,NES,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,NES,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,NES,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_EI,NES,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,3.476e-03,2.970e-02,8.215e-02,1.870e-01,1.870e-01
-SDP_EI,NES,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SDP_EI,NES,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SDP_EI,NES,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SDP_EI,NES,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SDP_EI,NES,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SDP_EI,OAS,,,,,Cycle,trn_pass,S3S,linear,1.256e-02,2.493e-02,3.323e-02,8.309e-02,8.309e-02
-SDP_EI,OAS,,,,,Domestic Aviation,trn_pass,S3S,linear,2.574e-02,2.661e-02,3.726e-02,7.983e-02,7.983e-02
-SDP_EI,OAS,,,,,Domestic Ship,trn_freight,S3S,linear,3.645e-02,3.645e-02,2.804e-02,3.645e-02,3.645e-02
-SDP_EI,OAS,,,,,Freight Rail,trn_freight,S3S,linear,4.649e-02,4.649e-02,3.576e-02,4.649e-02,4.649e-02
-SDP_EI,OAS,,,,,HSR,trn_pass,S3S,linear,9.660e-04,2.997e-03,2.997e-03,3.995e-03,3.995e-03
+SDP_EI,NES,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,3.476e-03,2.970e-02,6.085e-02,7.482e-02,7.482e-02
+SDP_EI,NES,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.289e-02,8.772e-02,1.289e-01,1.289e-01
+SDP_EI,NES,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.289e-02,8.772e-02,1.289e-01,1.289e-01
+SDP_EI,NES,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.289e-02,8.772e-02,1.289e-01,1.289e-01
+SDP_EI,NES,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.289e-02,8.772e-02,1.289e-01,1.289e-01
+SDP_EI,NES,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.289e-02,8.772e-02,1.289e-01,1.289e-01
+SDP_EI,OAS,,,,,Cycle,trn_pass,S3S,linear,1.256e-02,3.616e-02,4.821e-02,1.205e-01,1.205e-01
+SDP_EI,OAS,,,,,Domestic Aviation,trn_pass,S3S,linear,2.456e-02,3.684e-02,5.158e-02,1.326e-01,1.326e-01
+SDP_EI,OAS,,,,,Domestic Ship,trn_freight,S3S,linear,3.712e-02,3.375e-02,2.856e-02,2.700e-02,2.700e-02
+SDP_EI,OAS,,,,,Freight Rail,trn_freight,S3S,linear,4.736e-02,4.305e-02,3.643e-02,3.444e-02,3.444e-02
+SDP_EI,OAS,,,,,HSR,trn_pass,S3S,linear,9.660e-04,4.347e-03,4.347e-03,5.796e-03,5.796e-03
 SDP_EI,OAS,,,,,International Aviation,trn_aviation_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,OAS,,,,,International Ship,trn_shipping_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_EI,OAS,,,,,Passenger Rail,trn_pass,S3S,linear,7.701e-04,7.963e-04,1.194e-03,1.593e-03,1.593e-03
-SDP_EI,OAS,,,,,Walk,trn_pass,S3S,linear,1.000e+00,6.893e-01,6.893e-01,6.893e-01,6.893e-01
+SDP_EI,OAS,,,,,Passenger Rail,trn_pass,S3S,linear,7.701e-04,1.155e-03,1.733e-03,2.310e-03,2.310e-03
+SDP_EI,OAS,,,,,Walk,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,OAS,,,,,trn_freight_road,trn_freight,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_EI,OAS,,,,,trn_pass_road,trn_pass,S3S,linear,8.721e-01,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_EI,OAS,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,2.403e-01,1.402e-01,5.510e-02,5.510e-02,5.510e-02
+SDP_EI,OAS,,,,,trn_pass_road,trn_pass,S3S,linear,4.452e-01,5.697e-01,5.697e-01,7.121e-01,7.121e-01
+SDP_EI,OAS,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,4.352e-01,2.571e-01,1.122e-01,9.620e-02,9.620e-02
 SDP_EI,OAS,,,,trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_EI,OAS,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,2.534e-02,2.233e-02,1.631e-02,4.276e-03,4.276e-03
+SDP_EI,OAS,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,3.520e-01,1.718e-01,1.631e-01,9.503e-02,9.503e-02
 SDP_EI,OAS,,,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_EI,OAS,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,6.745e-03,6.745e-03,6.745e-03,6.745e-03,6.745e-03
+SDP_EI,OAS,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,2.698e-03,2.811e-03,4.216e-03,5.621e-03,5.621e-03
 SDP_EI,OAS,,Large Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,3.018e-01,3.018e-01,3.018e-01,3.018e-01,3.018e-01
 SDP_EI,OAS,,Large Car and SUV,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,6.459e-04,6.459e-04,6.459e-04,6.459e-04,6.459e-04
 SDP_EI,OAS,,Light Truck and SUV,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,OAS,,Midsize Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,2.500e-04,2.500e-04,2.500e-04,2.500e-04,2.500e-04
-SDP_EI,OAS,,Mini Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,6.938e-05,6.938e-05,6.938e-05,6.938e-05,6.938e-05
+SDP_EI,OAS,,Mini Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,2.775e-05,2.891e-05,4.336e-05,5.782e-05,5.782e-05
 SDP_EI,OAS,,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,7.762e-03,7.762e-03,7.762e-03,7.762e-03,7.762e-03
 SDP_EI,OAS,,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,OAS,,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,6.391e-03,6.391e-03,6.391e-03,6.391e-03,6.391e-03
-SDP_EI,OAS,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,8.508e-03,8.508e-03,8.508e-03,8.508e-03,8.508e-03
+SDP_EI,OAS,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,3.403e-03,3.545e-03,5.318e-03,7.090e-03,7.090e-03
 SDP_EI,OAS,,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,3.765e-01,3.765e-01,3.765e-01,3.765e-01,3.765e-01
 SDP_EI,OAS,,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,4.784e-01,4.784e-01,4.784e-01,4.784e-01,4.784e-01
 SDP_EI,OAS,,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.365e-03,1.365e-03,1.365e-03,1.365e-03,1.365e-03
 SDP_EI,OAS,,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,7.361e-04,7.361e-04,7.361e-04,7.361e-04,7.361e-04
 SDP_EI,OAS,,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,OAS,,Van,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.027e-05,1.027e-05,1.027e-05,1.027e-05,1.027e-05
-SDP_EI,OAS,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_EI,OAS,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1.452e-05,1.452e-05,1.452e-05,1.452e-05,1.452e-05
-SDP_EI,OAS,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_EI,OAS,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.423e-01,6.724e-01,1.000e+00,1.000e+00
+SDP_EI,OAS,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.400e-02,1.680e-01,2.940e-01,2.940e-01
+SDP_EI,OAS,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.400e-02,1.680e-01,2.940e-01,2.940e-01
+SDP_EI,OAS,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.400e-02,1.680e-01,2.940e-01,2.940e-01
+SDP_EI,OAS,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.411e-01,6.670e-01,1.000e+00,1.000e+00
 SDP_EI,OAS,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1.733e-01,2.767e-01,4.833e-01,8.967e-01,8.967e-01
 SDP_EI,OAS,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,OAS,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,3.530e-01,4.338e-01,5.956e-01,9.191e-01,9.191e-01
-SDP_EI,OAS,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.973e-02,6.250e-02,7.856e-02,7.856e-02
-SDP_EI,OAS,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.581e-02,3.362e-02,7.621e-02,7.621e-02
-SDP_EI,OAS,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.581e-02,3.362e-02,7.621e-02,7.621e-02
-SDP_EI,OAS,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.581e-02,3.362e-02,7.621e-02,7.621e-02
-SDP_EI,OAS,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.973e-02,6.250e-02,7.856e-02,7.856e-02
-SDP_EI,OAS,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.473e-03,1.799e-02,6.561e-02,6.561e-02
-SDP_EI,OAS,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.115e-02,1.186e-02,2.924e-02,2.924e-02
-SDP_EI,OAS,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.121e-03,4.497e-03,2.000e-02,2.000e-02
-SDP_EI,OAS,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.121e-03,4.497e-03,2.000e-02,2.000e-02
-SDP_EI,OAS,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.121e-03,4.497e-03,2.000e-02,2.000e-02
-SDP_EI,OAS,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.115e-02,1.186e-02,2.924e-02,2.924e-02
+SDP_EI,OAS,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.469e-02,5.456e-02,7.144e-02,7.144e-02
+SDP_EI,OAS,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.380e-02,2.935e-02,6.930e-02,6.930e-02
+SDP_EI,OAS,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.380e-02,2.935e-02,6.930e-02,6.930e-02
+SDP_EI,OAS,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.380e-02,2.935e-02,6.930e-02,6.930e-02
+SDP_EI,OAS,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.469e-02,5.456e-02,7.144e-02,7.144e-02
+SDP_EI,OAS,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.453e-03,1.784e-02,7.290e-02,7.290e-02
+SDP_EI,OAS,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.217e-02,1.294e-02,2.127e-02,2.127e-02
+SDP_EI,OAS,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.497e-03,4.907e-03,1.455e-02,1.455e-02
+SDP_EI,OAS,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.497e-03,4.907e-03,1.455e-02,1.455e-02
+SDP_EI,OAS,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.497e-03,4.907e-03,1.455e-02,1.455e-02
+SDP_EI,OAS,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.217e-02,1.294e-02,2.127e-02,2.127e-02
 SDP_EI,OAS,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0.000e+00,8.315e-07,4.540e-05,1.192e-01,1.192e-01
-SDP_EI,OAS,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,6.561e-01,6.561e-01
+SDP_EI,OAS,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,6.681e-01,6.681e-01
 SDP_EI,OAS,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,OAS,Liquids,Domestic Ship_tmp_vehicletype,Domestic Ship_tmp_subsector_L1,Domestic Ship_tmp_subsector_L2,Domestic Ship,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,OAS,Liquids,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
@@ -2563,58 +2563,58 @@ SDP_EI,OAS,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_roa
 SDP_EI,OAS,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,OAS,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,OAS,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_EI,OAS,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.967e-01,2.178e-01,2.601e-01,2.261e-01,2.261e-01
-SDP_EI,OAS,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,4.535e-04,8.919e-03,3.968e-02,7.383e-02,7.383e-02
-SDP_EI,OAS,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,8.772e-03,3.947e-02,7.368e-02,7.368e-02
-SDP_EI,OAS,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.395e-01,5.404e-02,1.037e-01,1.192e-01,1.192e-01
-SDP_EI,OAS,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,2.466e-01,8.882e-02,1.531e-01,1.542e-01,1.542e-01
-SDP_EI,OAS,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,8.772e-03,3.947e-02,7.368e-02,7.368e-02
-SDP_EI,REF,,,,,Cycle,trn_pass,S3S,linear,4.737e-03,4.737e-03,2.369e-02,7.824e-02,7.824e-02
-SDP_EI,REF,,,,,Domestic Aviation,trn_pass,S3S,linear,1.287e-02,1.232e-02,1.540e-02,1.454e-02,1.454e-02
-SDP_EI,REF,,,,,Domestic Ship,trn_freight,S3S,linear,7.096e-03,7.096e-03,7.096e-03,7.096e-03,7.096e-03
-SDP_EI,REF,,,,,Freight Rail,trn_freight,S3S,linear,1.272e-01,1.272e-01,1.272e-01,1.272e-01,1.272e-01
-SDP_EI,REF,,,,,HSR,trn_pass,S3S,linear,0.000e+00,8.000e-04,8.000e-04,7.550e-04,7.550e-04
+SDP_EI,OAS,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.967e-01,1.980e-01,2.365e-01,2.303e-01,2.303e-01
+SDP_EI,OAS,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,4.535e-04,8.919e-03,3.968e-02,6.153e-02,6.153e-02
+SDP_EI,OAS,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,8.772e-03,3.947e-02,6.140e-02,6.140e-02
+SDP_EI,OAS,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.395e-01,5.404e-02,1.037e-01,9.933e-02,9.933e-02
+SDP_EI,OAS,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,2.466e-01,8.882e-02,1.531e-01,1.285e-01,1.285e-01
+SDP_EI,OAS,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,8.772e-03,3.947e-02,6.140e-02,6.140e-02
+SDP_EI,REF,,,,,Cycle,trn_pass,S3S,linear,1.379e-02,1.206e-02,6.031e-02,7.824e-02,7.824e-02
+SDP_EI,REF,,,,,Domestic Aviation,trn_pass,S3S,linear,3.574e-02,2.995e-02,3.743e-02,1.387e-02,1.387e-02
+SDP_EI,REF,,,,,Domestic Ship,trn_freight,S3S,linear,7.227e-03,7.227e-03,7.227e-03,7.227e-03,7.227e-03
+SDP_EI,REF,,,,,Freight Rail,trn_freight,S3S,linear,1.296e-01,1.296e-01,1.296e-01,1.296e-01,1.296e-01
+SDP_EI,REF,,,,,HSR,trn_pass,S3S,linear,0.000e+00,2.037e-03,2.037e-03,7.550e-04,7.550e-04
 SDP_EI,REF,,,,,International Aviation,trn_aviation_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,REF,,,,,International Ship,trn_shipping_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_EI,REF,,,,,Passenger Rail,trn_pass,S3S,linear,2.366e-03,4.731e-03,5.914e-03,1.116e-02,1.116e-02
-SDP_EI,REF,,,,,Walk,trn_pass,S3S,linear,3.179e-01,3.179e-01,3.179e-01,1.000e+00,1.000e+00
+SDP_EI,REF,,,,,Passenger Rail,trn_pass,S3S,linear,6.884e-03,1.205e-02,1.506e-02,1.116e-02,1.116e-02
+SDP_EI,REF,,,,,Walk,trn_pass,S3S,linear,9.251e-01,8.095e-01,8.095e-01,1.000e+00,1.000e+00
 SDP_EI,REF,,,,,trn_freight_road,trn_freight,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_EI,REF,,,,,trn_pass_road,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,9.437e-01,9.437e-01
-SDP_EI,REF,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,1.186e-01,9.148e-02,7.623e-02,6.099e-02,6.099e-02
+SDP_EI,REF,,,,,trn_pass_road,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,4.633e-01,4.633e-01
+SDP_EI,REF,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,2.684e-01,1.864e-01,1.553e-01,1.242e-01,1.242e-01
 SDP_EI,REF,,,,trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,REF,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,3.698e-01,3.698e-01,3.698e-01,3.698e-01,3.698e-01
 SDP_EI,REF,,,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_EI,REF,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,2.227e-01,2.227e-01,2.227e-01,2.227e-01,2.227e-01
+SDP_EI,REF,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,4.455e-01,4.176e-01,4.176e-01,3.818e-01,3.818e-01
 SDP_EI,REF,,Large Car and SUV,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,REF,,Midsize Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.842e-01,1.842e-01,1.842e-01,1.842e-01,1.842e-01
-SDP_EI,REF,,Mini Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,7.127e-05,7.127e-05,7.127e-05,7.127e-05,7.127e-05
+SDP_EI,REF,,Mini Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.425e-04,1.336e-04,1.336e-04,1.222e-04,1.222e-04
 SDP_EI,REF,,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,3.376e-03,3.376e-03,3.376e-03,3.376e-03,3.376e-03
 SDP_EI,REF,,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,REF,,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,4.141e-01,4.141e-01,4.141e-01,4.141e-01,4.141e-01
-SDP_EI,REF,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.254e-02,1.254e-02,1.254e-02,1.254e-02,1.254e-02
+SDP_EI,REF,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,2.508e-02,2.351e-02,2.351e-02,2.150e-02,2.150e-02
 SDP_EI,REF,,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,REF,,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,5.081e-03,5.081e-03,5.081e-03,5.081e-03,5.081e-03
 SDP_EI,REF,,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,5.837e-01,5.837e-01,5.837e-01,5.837e-01,5.837e-01
 SDP_EI,REF,,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.888e-01,1.888e-01,1.888e-01,1.888e-01,1.888e-01
 SDP_EI,REF,,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.676e-02,1.676e-02,1.676e-02,1.676e-02,1.676e-02
-SDP_EI,REF,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_EI,REF,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,6.589e-03,6.589e-03,6.589e-03,6.589e-03,6.589e-03
-SDP_EI,REF,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_EI,REF,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.743e-02,3.227e-01,9.526e-01,9.526e-01
+SDP_EI,REF,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.000e-02,1.680e-01,3.360e-01,3.360e-01
+SDP_EI,REF,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.000e-02,1.680e-01,3.360e-01,3.360e-01
+SDP_EI,REF,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.000e-02,1.680e-01,3.360e-01,3.360e-01
+SDP_EI,REF,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,7.245e-02,3.202e-01,7.425e-01,7.425e-01
 SDP_EI,REF,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,REF,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,REF,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_EI,REF,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.192e-01,3.000e-01,3.928e-01,3.928e-01
-SDP_EI,REF,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.743e-02,1.614e-01,3.810e-01,3.810e-01
-SDP_EI,REF,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.743e-02,1.614e-01,3.810e-01,3.810e-01
-SDP_EI,REF,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.743e-02,1.614e-01,3.810e-01,3.810e-01
-SDP_EI,REF,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.192e-01,3.000e-01,3.928e-01,3.928e-01
-SDP_EI,REF,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.473e-03,3.597e-02,1.000e-01,1.000e-01
-SDP_EI,REF,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.024e-02,4.743e-02,7.311e-02,7.311e-02
-SDP_EI,REF,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.225e-02,1.799e-02,5.000e-02,5.000e-02
-SDP_EI,REF,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.225e-02,1.799e-02,5.000e-02,5.000e-02
-SDP_EI,REF,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.225e-02,1.799e-02,5.000e-02,5.000e-02
-SDP_EI,REF,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.024e-02,4.743e-02,7.311e-02,7.311e-02
+SDP_EI,REF,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.183e-01,2.678e-01,3.957e-01,3.957e-01
+SDP_EI,REF,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.705e-02,1.441e-01,3.838e-01,3.838e-01
+SDP_EI,REF,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.705e-02,1.441e-01,3.838e-01,3.838e-01
+SDP_EI,REF,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.705e-02,1.441e-01,3.838e-01,3.838e-01
+SDP_EI,REF,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.183e-01,2.678e-01,3.957e-01,3.957e-01
+SDP_EI,REF,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.698e-03,3.569e-02,6.236e-02,6.236e-02
+SDP_EI,REF,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.975e-02,4.705e-02,5.523e-02,5.523e-02
+SDP_EI,REF,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.208e-02,1.784e-02,3.777e-02,3.777e-02
+SDP_EI,REF,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.208e-02,1.784e-02,3.777e-02,3.777e-02
+SDP_EI,REF,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.208e-02,1.784e-02,3.777e-02,3.777e-02
+SDP_EI,REF,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.975e-02,4.705e-02,5.523e-02,5.523e-02
 SDP_EI,REF,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0.000e+00,8.315e-07,4.540e-05,1.192e-01,1.192e-01
 SDP_EI,REF,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,REF,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
@@ -2631,26 +2631,26 @@ SDP_EI,REF,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_roa
 SDP_EI,REF,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,REF,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,REF,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_EI,REF,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.400e-02,3.994e-02,7.347e-02,1.369e-01,1.369e-01
-SDP_EI,REF,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,4.158e-02,6.680e-02,1.172e-01,1.745e-01,1.745e-01
-SDP_EI,REF,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.474e-01,1.474e-01
-SDP_EI,REF,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,6.311e-02,8.776e-02,1.371e-01,1.886e-01,1.886e-01
-SDP_EI,REF,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,3.048e-02,5.599e-02,1.070e-01,1.673e-01,1.673e-01
-SDP_EI,REF,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.474e-01,1.474e-01
-SDP_EI,SSA,,,,,Cycle,trn_pass,S3S,linear,1.388e-02,1.795e-02,2.915e-02,3.279e-02,3.279e-02
-SDP_EI,SSA,,,,,Domestic Aviation,trn_pass,S3S,linear,9.013e-03,5.100e-02,4.140e-02,6.209e-03,6.209e-03
-SDP_EI,SSA,,,,,Domestic Ship,trn_freight,S3S,linear,1.467e-03,1.467e-03,1.467e-03,1.467e-03,1.467e-03
-SDP_EI,SSA,,,,,Freight Rail,trn_freight,S3S,linear,1.634e-02,1.634e-02,1.634e-02,1.634e-02,1.634e-02
-SDP_EI,SSA,,,,,HSR,trn_pass,S3S,linear,1.475e-05,2.003e-05,6.504e-02,9.756e-03,9.756e-03
+SDP_EI,REF,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.400e-02,3.195e-02,6.011e-02,7.825e-02,7.825e-02
+SDP_EI,REF,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,3.465e-02,6.073e-02,9.593e-02,1.342e-01,1.342e-01
+SDP_EI,REF,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.392e-02,6.459e-02,1.134e-01,1.134e-01
+SDP_EI,REF,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,5.259e-02,7.979e-02,1.122e-01,1.450e-01,1.450e-01
+SDP_EI,REF,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,2.540e-02,5.090e-02,8.756e-02,1.287e-01,1.287e-01
+SDP_EI,REF,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.392e-02,6.459e-02,1.134e-01,1.134e-01
+SDP_EI,SSA,,,,,Cycle,trn_pass,S3S,linear,1.388e-02,1.987e-02,2.915e-02,3.279e-02,3.279e-02
+SDP_EI,SSA,,,,,Domestic Aviation,trn_pass,S3S,linear,8.602e-03,5.387e-02,3.951e-02,5.926e-03,5.926e-03
+SDP_EI,SSA,,,,,Domestic Ship,trn_freight,S3S,linear,1.495e-03,1.495e-03,1.495e-03,1.495e-03,1.495e-03
+SDP_EI,SSA,,,,,Freight Rail,trn_freight,S3S,linear,1.665e-02,1.665e-02,1.665e-02,1.498e-02,1.498e-02
+SDP_EI,SSA,,,,,HSR,trn_pass,S3S,linear,1.475e-05,2.217e-05,6.504e-02,9.756e-03,9.756e-03
 SDP_EI,SSA,,,,,International Aviation,trn_aviation_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,SSA,,,,,International Ship,trn_shipping_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_EI,SSA,,,,,Passenger Rail,trn_pass,S3S,linear,6.024e-04,1.559e-03,2.530e-03,5.693e-04,5.693e-04
-SDP_EI,SSA,,,,,Walk,trn_pass,S3S,linear,1.000e+00,9.034e-01,1.000e+00,1.000e+00,1.000e+00
+SDP_EI,SSA,,,,,Passenger Rail,trn_pass,S3S,linear,6.024e-04,1.725e-03,2.530e-03,5.693e-04,5.693e-04
+SDP_EI,SSA,,,,,Walk,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,SSA,,,,,trn_freight_road,trn_freight,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_EI,SSA,,,,,trn_pass_road,trn_pass,S3S,linear,8.902e-01,1.000e+00,9.741e-01,9.741e-02,9.741e-02
-SDP_EI,SSA,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,2.477e-01,1.270e-01,7.328e-02,9.526e-02,9.526e-02
+SDP_EI,SSA,,,,,trn_pass_road,trn_pass,S3S,linear,2.622e-01,3.260e-01,2.869e-01,4.781e-02,4.781e-02
+SDP_EI,SSA,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,7.568e-01,3.234e-01,1.493e-01,9.703e-02,9.703e-02
 SDP_EI,SSA,,,,trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_EI,SSA,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,3.928e-02,3.928e-02,3.928e-02,3.928e-02,3.928e-02
+SDP_EI,SSA,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,2.619e-02,2.619e-02,2.619e-02,3.928e-02,3.928e-02
 SDP_EI,SSA,,,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,SSA,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,SSA,,Large Car and SUV,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,3.022e-03,3.022e-03,3.022e-03,3.022e-03,3.022e-03
@@ -2665,24 +2665,24 @@ SDP_EI,SSA,,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_s
 SDP_EI,SSA,,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,4.207e-06,4.207e-06,4.207e-06,4.207e-06,4.207e-06
 SDP_EI,SSA,,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,SSA,,Van,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,7.570e-05,7.570e-05,7.570e-05,7.570e-05,7.570e-05
-SDP_EI,SSA,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_EI,SSA,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_EI,SSA,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_EI,SSA,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.743e-02,4.034e-01,9.526e-01,9.526e-01
+SDP_EI,SSA,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.000e-01,2.160e-01,3.360e-01,3.360e-01
+SDP_EI,SSA,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.000e-01,2.160e-01,3.360e-01,3.360e-01
+SDP_EI,SSA,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.000e-01,2.160e-01,3.360e-01,3.360e-01
+SDP_EI,SSA,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,6.210e-02,3.962e-01,8.470e-01,8.470e-01
 SDP_EI,SSA,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,SSA,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,SSA,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_EI,SSA,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.384e-02,1.000e-01,1.511e-01,1.511e-01
-SDP_EI,SSA,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,9.485e-03,5.379e-02,1.465e-01,1.465e-01
-SDP_EI,SSA,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,9.485e-03,5.379e-02,1.465e-01,1.465e-01
-SDP_EI,SSA,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,9.485e-03,5.379e-02,1.465e-01,1.465e-01
-SDP_EI,SSA,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.384e-02,1.000e-01,1.511e-01,1.511e-01
-SDP_EI,SSA,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.473e-03,1.799e-02,7.500e-02,7.500e-02
-SDP_EI,SSA,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.693e-03,4.743e-02,2.812e-02,2.812e-02
-SDP_EI,SSA,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-03,1.799e-02,1.923e-02,1.923e-02
-SDP_EI,SSA,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-03,1.799e-02,1.923e-02,1.923e-02
-SDP_EI,SSA,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-03,1.799e-02,1.923e-02,1.923e-02
-SDP_EI,SSA,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.693e-03,4.743e-02,2.812e-02,2.812e-02
+SDP_EI,SSA,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.602e-02,1.007e-01,1.511e-01,1.511e-01
+SDP_EI,SSA,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.035e-02,5.418e-02,1.466e-01,1.466e-01
+SDP_EI,SSA,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.035e-02,5.418e-02,1.466e-01,1.466e-01
+SDP_EI,SSA,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.035e-02,5.418e-02,1.466e-01,1.466e-01
+SDP_EI,SSA,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.602e-02,1.007e-01,1.511e-01,1.511e-01
+SDP_EI,SSA,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.698e-03,1.963e-02,4.850e-02,4.850e-02
+SDP_EI,SSA,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,7.303e-03,1.194e-02,2.045e-02,2.045e-02
+SDP_EI,SSA,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.698e-03,4.529e-03,1.399e-02,1.399e-02
+SDP_EI,SSA,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.698e-03,4.529e-03,1.399e-02,1.399e-02
+SDP_EI,SSA,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.698e-03,4.529e-03,1.399e-02,1.399e-02
+SDP_EI,SSA,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,7.303e-03,1.194e-02,2.045e-02,2.045e-02
 SDP_EI,SSA,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0.000e+00,8.315e-07,4.540e-05,1.192e-01,1.192e-01
 SDP_EI,SSA,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,SSA,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
@@ -2699,59 +2699,59 @@ SDP_EI,SSA,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_roa
 SDP_EI,SSA,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,SSA,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,SSA,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_EI,SSA,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,3.981e-04,2.670e-02,5.552e-02,9.227e-02,9.227e-02
-SDP_EI,SSA,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,7.085e-02,7.085e-02
-SDP_EI,SSA,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,7.085e-02,7.085e-02
-SDP_EI,SSA,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,7.085e-02,7.085e-02
-SDP_EI,SSA,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,7.085e-02,7.085e-02
-SDP_EI,SSA,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,7.085e-02,7.085e-02
+SDP_EI,SSA,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,3.981e-04,2.670e-02,4.997e-02,6.835e-02,6.835e-02
+SDP_EI,SSA,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,4.251e-02,5.904e-02,5.904e-02
+SDP_EI,SSA,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,4.251e-02,5.904e-02,5.904e-02
+SDP_EI,SSA,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,4.251e-02,5.904e-02,5.904e-02
+SDP_EI,SSA,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,4.251e-02,5.904e-02,5.904e-02
+SDP_EI,SSA,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,4.251e-02,5.904e-02,5.904e-02
 SDP_EI,UKI,,,,,Cycle,trn_pass,S3S,linear,2.500e-02,1.092e-02,3.277e-02,6.553e-02,6.553e-02
-SDP_EI,UKI,,,,,Domestic Aviation,trn_pass,S3S,linear,6.250e-05,9.365e-06,9.365e-06,9.365e-06,9.365e-06
-SDP_EI,UKI,,,,,Domestic Ship,trn_freight,S3S,linear,8.512e-03,8.512e-03,8.512e-03,8.512e-03,8.512e-03
-SDP_EI,UKI,,,,,Freight Rail,trn_freight,S3S,linear,6.067e-03,6.067e-03,6.067e-03,6.067e-03,6.067e-03
+SDP_EI,UKI,,,,,Domestic Aviation,trn_pass,S3S,linear,5.965e-05,8.938e-06,8.938e-06,8.938e-06,8.938e-06
+SDP_EI,UKI,,,,,Domestic Ship,trn_freight,S3S,linear,8.670e-03,8.670e-03,8.670e-03,8.670e-03,8.670e-03
+SDP_EI,UKI,,,,,Freight Rail,trn_freight,S3S,linear,6.180e-03,6.180e-03,6.180e-03,6.180e-03,6.180e-03
 SDP_EI,UKI,,,,,HSR,trn_pass,S3S,linear,1.250e-04,1.334e-04,1.779e-04,2.224e-04,2.224e-04
 SDP_EI,UKI,,,,,International Aviation,trn_aviation_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,UKI,,,,,International Ship,trn_shipping_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,UKI,,,,,Passenger Rail,trn_pass,S3S,linear,3.125e-03,2.502e-03,1.876e-03,1.876e-03,1.876e-03
 SDP_EI,UKI,,,,,Walk,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,UKI,,,,,trn_freight_road,trn_freight,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_EI,UKI,,,,,trn_pass_road,trn_pass,S3S,linear,7.500e-02,5.325e-02,3.408e-02,3.408e-02,3.408e-02
-SDP_EI,UKI,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,2.500e-01,2.010e-01,1.843e-01,1.675e-01,1.675e-01
+SDP_EI,UKI,,,,,trn_pass_road,trn_pass,S3S,linear,7.363e-02,5.228e-02,3.346e-02,3.346e-02,3.346e-02
+SDP_EI,UKI,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,2.546e-01,2.048e-01,1.877e-01,1.706e-01,1.706e-01
 SDP_EI,UKI,,,,trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,UKI,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,3.935e-02,3.935e-02,3.935e-02,3.935e-02,3.935e-02
 SDP_EI,UKI,,,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_EI,UKI,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,4.864e-01,4.864e-01,4.864e-01,4.864e-01,4.864e-01
+SDP_EI,UKI,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,5.404e-01,5.404e-01,4.864e-01,4.864e-01,4.864e-01
 SDP_EI,UKI,,Large Car and SUV,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,UKI,,Midsize Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,2.616e-01,2.616e-01,2.616e-01,2.616e-01,2.616e-01
-SDP_EI,UKI,,Mini Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,4.751e-07,4.751e-07,4.751e-07,4.751e-07,4.751e-07
+SDP_EI,UKI,,Mini Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,5.279e-07,5.279e-07,4.751e-07,4.751e-07,4.751e-07
 SDP_EI,UKI,,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,2.088e-02,2.088e-02,2.088e-02,2.088e-02,2.088e-02
 SDP_EI,UKI,,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,3.798e-03,3.798e-03,3.798e-03,3.798e-03,3.798e-03
 SDP_EI,UKI,,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_EI,UKI,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,5.119e-01,5.119e-01,5.119e-01,5.119e-01,5.119e-01
+SDP_EI,UKI,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,5.688e-01,5.688e-01,5.119e-01,5.119e-01,5.119e-01
 SDP_EI,UKI,,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,UKI,,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,4.528e-02,4.528e-02,4.528e-02,4.528e-02,4.528e-02
 SDP_EI,UKI,,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,9.437e-02,9.437e-02,9.437e-02,9.437e-02,9.437e-02
 SDP_EI,UKI,,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,5.696e-01,5.696e-01,5.696e-01,5.696e-01,5.696e-01
 SDP_EI,UKI,,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,7.765e-01,7.765e-01,7.765e-01,7.765e-01,7.765e-01
 SDP_EI,UKI,,Van,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,2.681e-03,2.681e-03,2.681e-03,2.681e-03,2.681e-03
-SDP_EI,UKI,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_EI,UKI,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_EI,UKI,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_EI,UKI,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.186e-01,3.227e-01,8.573e-01,8.573e-01
+SDP_EI,UKI,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,5.000e-02,2.000e-01,3.700e-01,3.700e-01
+SDP_EI,UKI,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,5.000e-02,2.000e-01,3.700e-01,3.700e-01
+SDP_EI,UKI,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,5.000e-02,2.000e-01,3.700e-01,3.700e-01
+SDP_EI,UKI,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,2.500e-02,1.168e-01,3.434e-01,7.434e-01,7.434e-01
 SDP_EI,UKI,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,8.260e-01,8.478e-01,8.913e-01,9.783e-01,9.783e-01
 SDP_EI,UKI,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,UKI,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_EI,UKI,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.384e-01,5.500e-01,8.838e-01,8.838e-01
-SDP_EI,UKI,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,9.485e-02,2.958e-01,8.573e-01,8.573e-01
-SDP_EI,UKI,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,9.485e-02,2.958e-01,8.573e-01,8.573e-01
-SDP_EI,UKI,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,9.485e-02,2.958e-01,8.573e-01,8.573e-01
-SDP_EI,UKI,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.384e-01,5.500e-01,8.838e-01,8.838e-01
-SDP_EI,UKI,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.236e-02,1.799e-02,1.000e-01,1.000e-01
-SDP_EI,UKI,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.693e-02,1.897e-01,1.462e-01,1.462e-01
-SDP_EI,UKI,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-02,7.194e-02,1.000e-01,1.000e-01
-SDP_EI,UKI,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-02,7.194e-02,1.000e-01,1.000e-01
-SDP_EI,UKI,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-02,7.194e-02,1.000e-01,1.000e-01
-SDP_EI,UKI,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.693e-02,1.897e-01,1.462e-01,1.462e-01
+SDP_EI,UKI,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.819e-01,5.853e-01,8.360e-01,8.360e-01
+SDP_EI,UKI,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.122e-01,3.148e-01,8.110e-01,8.110e-01
+SDP_EI,UKI,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.122e-01,3.148e-01,8.110e-01,8.110e-01
+SDP_EI,UKI,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.122e-01,3.148e-01,8.110e-01,8.110e-01
+SDP_EI,UKI,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.819e-01,5.853e-01,8.360e-01,8.360e-01
+SDP_EI,UKI,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,2.500e-05,1.218e-02,2.127e-02,7.883e-02,7.883e-02
+SDP_EI,UKI,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,7.914e-02,2.243e-01,1.729e-01,1.729e-01
+SDP_EI,UKI,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.924e-02,8.507e-02,1.182e-01,1.182e-01
+SDP_EI,UKI,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.924e-02,8.507e-02,1.182e-01,1.182e-01
+SDP_EI,UKI,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.924e-02,8.507e-02,1.182e-01,1.182e-01
+SDP_EI,UKI,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,7.914e-02,2.243e-01,1.729e-01,1.729e-01
 SDP_EI,UKI,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0.000e+00,8.315e-07,4.540e-05,1.192e-01,1.192e-01
 SDP_EI,UKI,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,UKI,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
@@ -2768,24 +2768,24 @@ SDP_EI,UKI,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_roa
 SDP_EI,UKI,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,UKI,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,UKI,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_EI,UKI,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,3.616e-04,2.667e-02,7.928e-02,1.845e-01,1.845e-01
+SDP_EI,UKI,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,9.040e-04,2.222e-02,7.928e-02,1.230e-01,1.230e-01
 SDP_EI,UKI,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
 SDP_EI,UKI,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
 SDP_EI,UKI,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
 SDP_EI,UKI,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
 SDP_EI,UKI,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
 SDP_EI,USA,,,,,Cycle,trn_pass,S3S,linear,8.197e-03,8.197e-03,8.197e-03,4.098e-02,4.098e-02
-SDP_EI,USA,,,,,Domestic Aviation,trn_pass,S3S,linear,1.057e-03,1.600e-03,1.800e-03,1.100e-03,1.100e-03
-SDP_EI,USA,,,,,Domestic Ship,trn_freight,S3S,linear,3.208e-03,3.208e-03,3.208e-03,3.208e-03,3.208e-03
-SDP_EI,USA,,,,,Freight Rail,trn_freight,S3S,linear,3.364e-02,3.364e-02,3.364e-02,3.364e-02,3.364e-02
+SDP_EI,USA,,,,,Domestic Aviation,trn_pass,S3S,linear,1.009e-03,1.527e-03,1.718e-03,1.050e-03,1.050e-03
+SDP_EI,USA,,,,,Domestic Ship,trn_freight,S3S,linear,3.267e-03,3.267e-03,3.267e-03,3.267e-03,3.267e-03
+SDP_EI,USA,,,,,Freight Rail,trn_freight,S3S,linear,3.427e-02,3.427e-02,3.427e-02,3.427e-02,3.427e-02
 SDP_EI,USA,,,,,HSR,trn_pass,S3S,linear,4.530e-06,4.530e-06,4.530e-06,2.265e-04,2.265e-04
 SDP_EI,USA,,,,,International Aviation,trn_aviation_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,USA,,,,,International Ship,trn_shipping_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,USA,,,,,Passenger Rail,trn_pass,S3S,linear,1.933e-03,1.933e-03,1.933e-03,9.665e-04,9.665e-04
 SDP_EI,USA,,,,,Walk,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,USA,,,,,trn_freight_road,trn_freight,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_EI,USA,,,,,trn_pass_road,trn_pass,S3S,linear,1.329e-01,1.329e-01,1.276e-01,6.647e-02,6.647e-02
-SDP_EI,USA,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,8.561e-02,1.070e-01,1.070e-01,1.213e-01,1.213e-01
+SDP_EI,USA,,,,,trn_pass_road,trn_pass,S3S,linear,1.305e-01,1.305e-01,1.253e-01,6.526e-02,6.526e-02
+SDP_EI,USA,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,8.720e-02,1.090e-01,1.090e-01,1.235e-01,1.235e-01
 SDP_EI,USA,,,,trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,USA,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,3.805e-02,3.805e-02,3.805e-02,3.805e-02,3.805e-02
 SDP_EI,USA,,,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
@@ -2798,29 +2798,29 @@ SDP_EI,USA,,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pas
 SDP_EI,USA,,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,USA,,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,7.057e-01,7.057e-01,7.057e-01,7.057e-01,7.057e-01
 SDP_EI,USA,,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_EI,USA,,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_EI,USA,,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
+SDP_EI,USA,,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,9.000e-01,1.000e+00,1.000e+00,1.000e+00,1.000e+00
+SDP_EI,USA,,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,9.000e-01,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,USA,,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,6.263e-01,6.263e-01,6.263e-01,6.263e-01,6.263e-01
-SDP_EI,USA,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_EI,USA,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_EI,USA,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_EI,USA,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.423e-01,5.379e-01,1.000e+00,1.000e+00
+SDP_EI,USA,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.400e-02,2.160e-01,3.780e-01,3.780e-01
+SDP_EI,USA,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.400e-02,2.160e-01,3.780e-01,3.780e-01
+SDP_EI,USA,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.400e-02,2.160e-01,3.780e-01,3.780e-01
+SDP_EI,USA,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.122e-01,5.382e-01,1.000e+00,1.000e+00
 SDP_EI,USA,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,0.000e+00,1.250e-01,3.750e-01,8.750e-01,8.750e-01
 SDP_EI,USA,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,USA,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_EI,USA,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.980e-02,2.500e-01,7.856e-01,7.856e-01
-SDP_EI,USA,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.186e-02,1.345e-01,7.621e-01,7.621e-01
-SDP_EI,USA,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,3.000e-02,2.500e-01,5.000e-01,8.000e-01,8.000e-01
-SDP_EI,USA,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,3.000e-02,2.500e-01,5.000e-01,8.000e-01,8.000e-01
-SDP_EI,USA,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.980e-02,2.500e-01,7.856e-01,7.856e-01
-SDP_EI,USA,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.473e-02,1.799e-02,6.999e-02,6.999e-02
-SDP_EI,USA,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.339e-03,1.423e-02,1.462e-01,1.462e-01
-SDP_EI,USA,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.945e-04,5.396e-03,1.000e-01,1.000e-01
-SDP_EI,USA,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,5.000e-02,2.000e-01,3.000e-01,2.000e-01,2.000e-01
-SDP_EI,USA,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,5.000e-02,2.000e-01,3.000e-01,2.000e-01,2.000e-01
-SDP_EI,USA,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.339e-03,1.423e-02,1.462e-01,1.462e-01
+SDP_EI,USA,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.626e-02,2.323e-01,6.967e-01,6.967e-01
+SDP_EI,USA,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.470e-03,1.249e-01,6.758e-01,6.758e-01
+SDP_EI,USA,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,3.547e-02,1.364e-01,4.645e-01,7.095e-01,7.095e-01
+SDP_EI,USA,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,3.547e-02,1.364e-01,4.645e-01,7.095e-01,7.095e-01
+SDP_EI,USA,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.626e-02,2.323e-01,6.967e-01,6.967e-01
+SDP_EI,USA,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.436e-02,1.636e-02,7.776e-02,7.776e-02
+SDP_EI,USA,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.218e-03,1.202e-02,1.008e-01,1.008e-01
+SDP_EI,USA,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.498e-04,4.557e-03,6.897e-02,6.897e-02
+SDP_EI,USA,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,5.912e-02,1.819e-01,2.534e-01,1.379e-01,1.379e-01
+SDP_EI,USA,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,5.912e-02,1.819e-01,2.534e-01,1.379e-01,1.379e-01
+SDP_EI,USA,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.218e-03,1.202e-02,1.008e-01,1.008e-01
 SDP_EI,USA,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0.000e+00,8.315e-07,4.540e-05,1.192e-01,1.192e-01
-SDP_EI,USA,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,6.999e-01,6.999e-01
+SDP_EI,USA,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,7.892e-01,7.892e-01
 SDP_EI,USA,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,USA,Liquids,Domestic Ship_tmp_vehicletype,Domestic Ship_tmp_subsector_L1,Domestic Ship_tmp_subsector_L2,Domestic Ship,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,USA,Liquids,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
@@ -2835,12 +2835,12 @@ SDP_EI,USA,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_roa
 SDP_EI,USA,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,USA,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_EI,USA,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_EI,USA,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,8.478e-02,1.089e-01,1.570e-01,1.773e-01,1.773e-01
-SDP_EI,USA,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.263e-03,3.158e-02,7.368e-02,7.368e-02
-SDP_EI,USA,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.263e-03,3.158e-02,7.368e-02,7.368e-02
-SDP_EI,USA,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e-01,2.000e-01,4.000e-01,4.000e-01,4.000e-01
-SDP_EI,USA,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e-01,2.000e-01,4.000e-01,4.000e-01,4.000e-01
-SDP_EI,USA,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.263e-03,3.158e-02,7.368e-02,7.368e-02
+SDP_EI,USA,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,8.478e-02,9.072e-02,1.208e-01,1.666e-01,1.666e-01
+SDP_EI,USA,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.049e-03,2.256e-02,6.140e-02,6.140e-02
+SDP_EI,USA,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.049e-03,2.256e-02,6.140e-02,6.140e-02
+SDP_EI,USA,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,5.000e-03,1.538e-01,2.857e-01,3.333e-01,3.333e-01
+SDP_EI,USA,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,5.000e-03,1.538e-01,2.857e-01,3.333e-01,3.333e-01
+SDP_EI,USA,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.049e-03,2.256e-02,6.140e-02,6.140e-02
 SDP_MC,CAZ,,,,,Cycle,trn_pass,S3S,linear,1.911e-02,3.822e-02,3.822e-02,7.645e-02,7.645e-02
 SDP_MC,CAZ,,,,,Domestic Aviation,trn_pass,S3S,linear,1.500e-03,1.600e-03,1.900e-03,2.000e-03,2.000e-03
 SDP_MC,CAZ,,,,,Domestic Ship,trn_freight,S3S,linear,1.554e-02,1.554e-02,1.554e-02,1.554e-02,1.554e-02

--- a/inst/extdata/sw_trends.csv
+++ b/inst/extdata/sw_trends.csv
@@ -4263,17 +4263,17 @@ SDP_MC,USA,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp
 SDP_MC,USA,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,5.000e-03,1.538e-01,2.857e-01,3.333e-01,3.333e-01
 SDP_MC,USA,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.049e-03,2.256e-02,6.140e-02,6.140e-02
 SDP_RC,CAZ,,,,,Cycle,trn_pass,S3S,linear,1.911e-02,3.822e-02,3.822e-02,7.645e-02,7.645e-02
-SDP_RC,CAZ,,,,,Domestic Aviation,trn_pass,S3S,linear,1.500e-03,1.600e-03,1.900e-03,2.000e-03,2.000e-03
-SDP_RC,CAZ,,,,,Domestic Ship,trn_freight,S3S,linear,1.554e-02,1.554e-02,1.554e-02,1.554e-02,1.554e-02
-SDP_RC,CAZ,,,,,Freight Rail,trn_freight,S3S,linear,1.051e-01,1.051e-01,1.051e-01,1.051e-01,1.051e-01
+SDP_RC,CAZ,,,,,Domestic Aviation,trn_pass,S3S,linear,1.432e-03,1.527e-03,1.813e-03,1.909e-03,1.909e-03
+SDP_RC,CAZ,,,,,Domestic Ship,trn_freight,S3S,linear,1.583e-02,1.583e-02,1.583e-02,1.583e-02,1.583e-02
+SDP_RC,CAZ,,,,,Freight Rail,trn_freight,S3S,linear,1.070e-01,1.070e-01,1.070e-01,9.633e-02,9.633e-02
 SDP_RC,CAZ,,,,,HSR,trn_pass,S3S,linear,8.792e-08,8.792e-05,2.638e-04,2.638e-04,2.638e-04
 SDP_RC,CAZ,,,,,International Aviation,trn_aviation_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,CAZ,,,,,International Ship,trn_shipping_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,CAZ,,,,,Passenger Rail,trn_pass,S3S,linear,8.785e-04,8.785e-04,8.785e-04,8.785e-04,8.785e-04
 SDP_RC,CAZ,,,,,Walk,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,CAZ,,,,,trn_freight_road,trn_freight,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_RC,CAZ,,,,,trn_pass_road,trn_pass,S3S,linear,1.537e-01,1.537e-01,1.537e-01,1.537e-01,1.537e-01
-SDP_RC,CAZ,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,8.691e-02,8.691e-02,1.086e-01,1.376e-01,1.376e-01
+SDP_RC,CAZ,,,,,trn_pass_road,trn_pass,S3S,linear,1.509e-01,1.509e-01,1.509e-01,1.509e-01,1.509e-01
+SDP_RC,CAZ,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,8.852e-02,8.852e-02,1.107e-01,1.402e-01,1.402e-01
 SDP_RC,CAZ,,,,trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,CAZ,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.939e-02,1.939e-02,1.939e-02,1.939e-02,1.939e-02
 SDP_RC,CAZ,,,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
@@ -4293,26 +4293,26 @@ SDP_RC,CAZ,,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_s
 SDP_RC,CAZ,,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,3.497e-05,3.497e-05,3.497e-05,3.497e-05,3.497e-05
 SDP_RC,CAZ,,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,6.282e-01,6.282e-01,6.282e-01,6.282e-01,6.282e-01
 SDP_RC,CAZ,,Van,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,2.082e-01,2.082e-01,2.082e-01,2.082e-01,2.082e-01
-SDP_RC,CAZ,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_RC,CAZ,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_RC,CAZ,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_RC,CAZ,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,9.485e-02,4.572e-01,1.000e+00,1.000e+00
+SDP_RC,CAZ,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.400e-02,1.920e-01,3.360e-01,3.360e-01
+SDP_RC,CAZ,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.400e-02,1.920e-01,3.360e-01,3.360e-01
+SDP_RC,CAZ,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.400e-02,1.920e-01,3.360e-01,3.360e-01
+SDP_RC,CAZ,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.122e-01,4.423e-01,9.735e-01,9.735e-01
 SDP_RC,CAZ,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,9.074e-02,2.044e-01,4.317e-01,8.863e-01,8.863e-01
 SDP_RC,CAZ,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,CAZ,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_RC,CAZ,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.192e-01,3.500e-01,4.910e-01,4.910e-01
-SDP_RC,CAZ,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.743e-02,1.883e-01,4.763e-01,4.763e-01
-SDP_RC,CAZ,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.743e-02,1.883e-01,4.763e-01,4.763e-01
-SDP_RC,CAZ,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.743e-02,1.883e-01,4.763e-01,4.763e-01
-SDP_RC,CAZ,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.192e-01,3.500e-01,4.910e-01,4.910e-01
-SDP_RC,CAZ,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.236e-02,1.799e-02,9.544e-02,9.544e-02
-SDP_RC,CAZ,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.346e-02,4.743e-02,1.462e-01,1.462e-01
-SDP_RC,CAZ,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.236e-02,1.799e-02,1.000e-01,1.000e-01
-SDP_RC,CAZ,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.236e-02,1.799e-02,1.000e-01,1.000e-01
-SDP_RC,CAZ,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.236e-02,1.799e-02,1.000e-01,1.000e-01
-SDP_RC,CAZ,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.346e-02,4.743e-02,1.462e-01,1.462e-01
+SDP_RC,CAZ,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.409e-01,3.311e-01,4.354e-01,4.354e-01
+SDP_RC,CAZ,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.608e-02,1.781e-01,4.224e-01,4.224e-01
+SDP_RC,CAZ,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.608e-02,1.781e-01,4.224e-01,4.224e-01
+SDP_RC,CAZ,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.608e-02,1.781e-01,4.224e-01,4.224e-01
+SDP_RC,CAZ,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.409e-01,3.311e-01,4.354e-01,4.354e-01
+SDP_RC,CAZ,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.462e-02,1.933e-02,7.601e-02,7.601e-02
+SDP_RC,CAZ,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.957e-02,5.608e-02,1.153e-01,1.153e-01
+SDP_RC,CAZ,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.462e-02,2.127e-02,7.883e-02,7.883e-02
+SDP_RC,CAZ,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.462e-02,2.127e-02,7.883e-02,7.883e-02
+SDP_RC,CAZ,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.462e-02,2.127e-02,7.883e-02,7.883e-02
+SDP_RC,CAZ,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.957e-02,5.608e-02,1.153e-01,1.153e-01
 SDP_RC,CAZ,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0.000e+00,8.315e-07,4.540e-05,1.192e-01,1.192e-01
-SDP_RC,CAZ,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,9.544e-01,9.544e-01
+SDP_RC,CAZ,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,CAZ,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,CAZ,Liquids,Domestic Ship_tmp_vehicletype,Domestic Ship_tmp_subsector_L1,Domestic Ship_tmp_subsector_L2,Domestic Ship,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,CAZ,Liquids,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
@@ -4327,124 +4327,124 @@ SDP_RC,CAZ,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_roa
 SDP_RC,CAZ,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,CAZ,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,CAZ,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_RC,CAZ,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,3.104e-02,5.654e-02,1.075e-01,2.000e-01,2.000e-01
-SDP_RC,CAZ,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SDP_RC,CAZ,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SDP_RC,CAZ,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SDP_RC,CAZ,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SDP_RC,CAZ,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SDP_RC,CHA,,,,,Cycle,trn_pass,S3S,linear,8.298e-02,4.412e-02,3.782e-02,4.848e-02,4.848e-02
-SDP_RC,CHA,,,,,Domestic Aviation,trn_pass,S3S,linear,1.104e-01,2.842e-02,1.829e-02,3.517e-03,3.517e-03
-SDP_RC,CHA,,,,,Domestic Ship,trn_freight,S3S,linear,2.849e-02,8.548e-02,8.548e-02,8.548e-02,8.548e-02
-SDP_RC,CHA,,,,,Freight Rail,trn_freight,S3S,linear,6.920e-02,2.076e-01,2.076e-01,2.076e-01,2.076e-01
-SDP_RC,CHA,,,,,HSR,trn_pass,S3S,linear,2.108e-01,8.143e-02,1.916e-02,3.695e-03,3.695e-03
+SDP_RC,CAZ,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,3.104e-02,5.654e-02,9.776e-02,1.497e-01,1.497e-01
+SDP_RC,CAZ,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.535e-01,1.535e-01
+SDP_RC,CAZ,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.535e-01,1.535e-01
+SDP_RC,CAZ,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.535e-01,1.535e-01
+SDP_RC,CAZ,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.535e-01,1.535e-01
+SDP_RC,CAZ,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.535e-01,1.535e-01
+SDP_RC,CHA,,,,,Cycle,trn_pass,S3S,linear,9.454e-02,4.412e-02,3.782e-02,4.848e-02,4.848e-02
+SDP_RC,CHA,,,,,Domestic Aviation,trn_pass,S3S,linear,1.200e-01,2.712e-02,1.745e-02,3.357e-03,3.357e-03
+SDP_RC,CHA,,,,,Domestic Ship,trn_freight,S3S,linear,1.847e-02,1.922e-02,2.232e-02,2.232e-02,2.232e-02
+SDP_RC,CHA,,,,,Freight Rail,trn_freight,S3S,linear,3.204e-02,3.570e-02,3.795e-02,3.795e-02,3.795e-02
+SDP_RC,CHA,,,,,HSR,trn_pass,S3S,linear,2.402e-01,8.143e-02,1.916e-02,3.695e-03,3.695e-03
 SDP_RC,CHA,,,,,International Aviation,trn_aviation_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,CHA,,,,,International Ship,trn_shipping_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_RC,CHA,,,,,Passenger Rail,trn_pass,S3S,linear,5.461e-03,3.111e-03,1.867e-03,9.572e-04,9.572e-04
-SDP_RC,CHA,,,,,Walk,trn_pass,S3S,linear,8.777e-01,1.000e+00,1.000e+00,1.000e+00,1.000e+00
+SDP_RC,CHA,,,,,Passenger Rail,trn_pass,S3S,linear,6.222e-03,3.111e-03,1.867e-03,9.572e-04,9.572e-04
+SDP_RC,CHA,,,,,Walk,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,CHA,,,,,trn_freight_road,trn_freight,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_RC,CHA,,,,,trn_pass_road,trn_pass,S3S,linear,1.000e+00,4.557e-01,2.279e-01,5.843e-02,5.843e-02
-SDP_RC,CHA,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,3.816e-01,1.915e-01,1.705e-01,1.895e-01,1.895e-01
+SDP_RC,CHA,,,,,trn_pass_road,trn_pass,S3S,linear,6.711e-01,2.684e-01,1.342e-01,4.015e-02,4.015e-02
+SDP_RC,CHA,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,6.609e-01,2.927e-01,2.084e-01,9.649e-02,9.649e-02
 SDP_RC,CHA,,,,trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_RC,CHA,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.081e-02,9.523e-03,6.956e-03,1.824e-03,1.824e-03
+SDP_RC,CHA,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,2.702e-01,2.116e-01,1.391e-01,1.459e-01,1.459e-01
 SDP_RC,CHA,,,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_RC,CHA,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,3.616e-01,3.616e-01,3.616e-01,3.616e-01,3.616e-01
+SDP_RC,CHA,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,8.035e-01,7.232e-01,6.574e-01,5.563e-01,5.563e-01
 SDP_RC,CHA,,Large Car and SUV,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_RC,CHA,,Mini Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,8.023e-03,8.023e-03,8.023e-03,8.023e-03,8.023e-03
+SDP_RC,CHA,,Mini Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.783e-02,1.605e-02,1.459e-02,1.234e-02,1.234e-02
 SDP_RC,CHA,,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,4.044e-02,4.044e-02,4.044e-02,4.044e-02,4.044e-02
 SDP_RC,CHA,,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,CHA,,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_RC,CHA,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,3.898e-02,3.898e-02,3.898e-02,3.898e-02,3.898e-02
+SDP_RC,CHA,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,8.662e-02,7.795e-02,7.087e-02,5.996e-02,5.996e-02
 SDP_RC,CHA,,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,CHA,,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,2.234e-01,2.234e-01,2.234e-01,2.234e-01,2.234e-01
-SDP_RC,CHA,,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,4.469e-01,3.352e-01,3.352e-01,3.352e-01,3.352e-01
-SDP_RC,CHA,,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,4.469e-01,3.352e-01,3.352e-01,3.352e-01,3.352e-01
+SDP_RC,CHA,,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,4.022e-01,3.352e-01,3.016e-01,3.352e-01,3.352e-01
+SDP_RC,CHA,,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,4.022e-01,3.352e-01,3.016e-01,3.352e-01,3.352e-01
 SDP_RC,CHA,,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.657e-01,1.657e-01,1.657e-01,1.657e-01,1.657e-01
-SDP_RC,CHA,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_RC,CHA,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,8.402e-02,8.402e-02,8.402e-02,8.402e-02,8.402e-02
-SDP_RC,CHA,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_RC,CHA,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,3.320e-01,1.000e+00,1.000e+00,1.000e+00
+SDP_RC,CHA,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,6.000e-01,1.000e+00,1.000e+00,1.000e+00
+SDP_RC,CHA,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,6.000e-02,6.000e-01,1.000e+00,1.000e+00,1.000e+00
+SDP_RC,CHA,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,6.000e-01,1.000e+00,1.000e+00,1.000e+00
+SDP_RC,CHA,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,3.019e-01,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,CHA,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,4.553e-01,5.234e-01,6.595e-01,9.319e-01,9.319e-01
 SDP_RC,CHA,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,CHA,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,4.158e-01,4.888e-01,6.349e-01,9.270e-01,9.270e-01
-SDP_RC,CHA,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.768e-02,4.500e-01,9.820e-01,9.820e-01
-SDP_RC,CHA,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.897e-02,2.420e-01,9.526e-01,9.526e-01
-SDP_RC,CHA,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e-01,4.000e-01,9.000e-01,1.000e+00,1.000e+00
-SDP_RC,CHA,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e-01,4.000e-01,9.000e-01,1.000e+00,1.000e+00
-SDP_RC,CHA,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.768e-02,4.500e-01,9.820e-01,9.820e-01
-SDP_RC,CHA,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.225e-02,6.688e-02,6.999e-02,6.999e-02
-SDP_RC,CHA,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.339e-03,2.846e-02,1.462e-01,1.462e-01
-SDP_RC,CHA,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.945e-04,1.079e-02,1.000e-01,1.000e-01
-SDP_RC,CHA,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e-02,2.000e-01,6.000e-01,2.000e-01,2.000e-01
-SDP_RC,CHA,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e-02,2.000e-01,6.000e-01,2.000e-01,2.000e-01
-SDP_RC,CHA,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.339e-03,2.846e-02,1.462e-01,1.462e-01
+SDP_RC,CHA,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.002e-02,3.725e-01,8.768e-01,8.768e-01
+SDP_RC,CHA,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.592e-02,2.004e-01,8.505e-01,8.505e-01
+SDP_RC,CHA,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,9.920e-02,3.358e-01,7.450e-01,8.928e-01,8.928e-01
+SDP_RC,CHA,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,9.920e-02,3.358e-01,7.450e-01,8.928e-01,8.928e-01
+SDP_RC,CHA,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.002e-02,3.725e-01,8.768e-01,8.768e-01
+SDP_RC,CHA,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.024e-02,9.554e-02,6.999e-02,6.999e-02
+SDP_RC,CHA,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.124e-03,1.713e-02,1.450e-01,1.450e-01
+SDP_RC,CHA,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.151e-04,6.497e-03,9.920e-02,9.920e-02
+SDP_RC,CHA,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,9.920e-03,1.679e-01,3.612e-01,1.984e-01,1.984e-01
+SDP_RC,CHA,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,9.920e-03,1.679e-01,3.612e-01,1.984e-01,1.984e-01
+SDP_RC,CHA,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.124e-03,1.713e-02,1.450e-01,1.450e-01
 SDP_RC,CHA,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0.000e+00,8.315e-07,4.540e-05,1.192e-01,1.192e-01
-SDP_RC,CHA,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,7.437e-01,3.499e-01,3.499e-01
+SDP_RC,CHA,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,9.736e-01,3.527e-01,3.527e-01
 SDP_RC,CHA,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,CHA,Liquids,Domestic Ship_tmp_vehicletype,Domestic Ship_tmp_subsector_L1,Domestic Ship_tmp_subsector_L2,Domestic Ship,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,CHA,Liquids,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,CHA,Liquids,International Aviation_tmp_vehicletype,International Aviation_tmp_subsector_L1,International Aviation_tmp_subsector_L2,International Aviation,trn_aviation_intl,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,CHA,Liquids,International Ship_tmp_vehicletype,International Ship_tmp_subsector_L1,International Ship_tmp_subsector_L2,International Ship,trn_shipping_intl,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_RC,CHA,Liquids,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_RC,CHA,Liquids,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_RC,CHA,Liquids,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
+SDP_RC,CHA,Liquids,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,8.333e-01,6.803e-01,6.803e-01
+SDP_RC,CHA,Liquids,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,8.333e-01,6.803e-01,6.803e-01
+SDP_RC,CHA,Liquids,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,8.333e-01,6.803e-01,6.803e-01
 SDP_RC,CHA,Liquids,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,CHA,Liquids,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,CHA,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,CHA,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,CHA,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,CHA,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_RC,CHA,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.421e-01,1.594e-01,9.020e-02,1.152e-01,1.152e-01
-SDP_RC,CHA,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.878e-05,1.319e-02,5.530e-02,9.213e-02,9.213e-02
-SDP_RC,CHA,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,7.854e-04,1.443e-02,5.695e-02,9.317e-02,9.317e-02
-SDP_RC,CHA,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,3.000e-01,5.000e-01,7.000e-01,5.000e-01,5.000e-01
-SDP_RC,CHA,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,3.000e-01,5.000e-01,7.000e-01,5.000e-01,5.000e-01
-SDP_RC,CHA,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,3.309e-04,1.369e-02,5.597e-02,9.256e-02,9.256e-02
+SDP_RC,CHA,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.421e-01,1.329e-01,1.181e-01,1.055e-01,1.055e-01
+SDP_RC,CHA,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.707e-05,1.014e-02,3.814e-02,8.376e-02,8.376e-02
+SDP_RC,CHA,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,7.140e-04,1.110e-02,3.928e-02,8.470e-02,8.470e-02
+SDP_RC,CHA,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,2.727e-01,3.846e-01,4.828e-01,4.545e-01,4.545e-01
+SDP_RC,CHA,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,2.727e-01,3.846e-01,4.828e-01,4.545e-01,4.545e-01
+SDP_RC,CHA,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,3.008e-04,1.053e-02,3.860e-02,8.414e-02,8.414e-02
 SDP_RC,DEU,,,,,Cycle,trn_pass,S3S,linear,2.500e-02,2.500e-02,2.500e-02,1.875e-01,1.875e-01
-SDP_RC,DEU,,,,,Domestic Aviation,trn_pass,S3S,linear,6.250e-05,6.250e-05,6.250e-05,6.250e-05,6.250e-05
-SDP_RC,DEU,,,,,Domestic Ship,trn_freight,S3S,linear,2.088e-03,2.088e-03,2.088e-03,2.088e-03,2.088e-03
-SDP_RC,DEU,,,,,Freight Rail,trn_freight,S3S,linear,2.749e-02,2.749e-02,2.749e-02,2.749e-02,2.749e-02
+SDP_RC,DEU,,,,,Domestic Aviation,trn_pass,S3S,linear,5.965e-05,5.965e-05,5.965e-05,5.965e-05,5.965e-05
+SDP_RC,DEU,,,,,Domestic Ship,trn_freight,S3S,linear,2.127e-03,2.127e-03,2.127e-03,2.127e-03,2.127e-03
+SDP_RC,DEU,,,,,Freight Rail,trn_freight,S3S,linear,2.800e-02,2.800e-02,2.800e-02,2.800e-02,2.800e-02
 SDP_RC,DEU,,,,,HSR,trn_pass,S3S,linear,1.250e-04,2.500e-04,6.250e-04,6.250e-04,6.250e-04
 SDP_RC,DEU,,,,,International Aviation,trn_aviation_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,DEU,,,,,International Ship,trn_shipping_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,DEU,,,,,Passenger Rail,trn_pass,S3S,linear,2.500e-03,3.750e-03,3.750e-03,3.750e-03,3.750e-03
 SDP_RC,DEU,,,,,Walk,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,DEU,,,,,trn_freight_road,trn_freight,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_RC,DEU,,,,,trn_pass_road,trn_pass,S3S,linear,7.500e-02,7.500e-02,7.500e-02,7.500e-02,7.500e-02
-SDP_RC,DEU,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,8.000e-02,8.000e-02,8.000e-02,1.500e-01,1.500e-01
+SDP_RC,DEU,,,,,trn_pass_road,trn_pass,S3S,linear,7.363e-02,7.363e-02,7.363e-02,7.363e-02,7.363e-02
+SDP_RC,DEU,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,8.149e-02,8.149e-02,8.149e-02,1.528e-01,1.528e-01
 SDP_RC,DEU,,,,trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,DEU,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,3.054e-02,3.054e-02,3.054e-02,3.054e-02,3.054e-02
 SDP_RC,DEU,,,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_RC,DEU,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,4.724e-01,4.724e-01,4.724e-01,4.724e-01,4.724e-01
+SDP_RC,DEU,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,5.249e-01,5.249e-01,4.724e-01,4.724e-01,4.724e-01
 SDP_RC,DEU,,Large Car and SUV,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,DEU,,Midsize Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,2.716e-01,2.716e-01,2.716e-01,2.716e-01,2.716e-01
 SDP_RC,DEU,,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,2.183e-01,2.183e-01,2.183e-01,2.183e-01,2.183e-01
 SDP_RC,DEU,,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,6.630e-03,6.630e-03,6.630e-03,6.630e-03,6.630e-03
 SDP_RC,DEU,,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_RC,DEU,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,4.803e-01,4.803e-01,4.803e-01,4.803e-01,4.803e-01
+SDP_RC,DEU,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,5.337e-01,5.337e-01,4.803e-01,4.803e-01,4.803e-01
 SDP_RC,DEU,,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,4.427e-01,4.427e-01,4.427e-01,4.427e-01,4.427e-01
 SDP_RC,DEU,,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,8.345e-02,8.345e-02,8.345e-02,8.345e-02,8.345e-02
 SDP_RC,DEU,,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,2.127e-01,2.127e-01,2.127e-01,2.127e-01,2.127e-01
 SDP_RC,DEU,,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,4.934e-01,4.934e-01,4.934e-01,4.934e-01,4.934e-01
 SDP_RC,DEU,,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_RC,DEU,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_RC,DEU,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_RC,DEU,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_RC,DEU,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.423e-01,4.034e-01,8.573e-01,8.573e-01
+SDP_RC,DEU,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.000e-02,2.500e-01,4.500e-01,4.500e-01
+SDP_RC,DEU,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.000e-02,2.500e-01,4.500e-01,4.500e-01
+SDP_RC,DEU,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.000e-02,2.500e-01,4.500e-01,4.500e-01
+SDP_RC,DEU,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.294e-01,3.669e-01,7.798e-01,7.798e-01
 SDP_RC,DEU,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,DEU,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,DEU,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_RC,DEU,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.980e-01,6.750e-01,9.820e-01,9.820e-01
-SDP_RC,DEU,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.186e-01,3.631e-01,9.526e-01,9.526e-01
-SDP_RC,DEU,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.186e-01,3.631e-01,9.526e-01,9.526e-01
-SDP_RC,DEU,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.186e-01,3.631e-01,9.526e-01,9.526e-01
-SDP_RC,DEU,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.980e-01,6.750e-01,9.820e-01,9.820e-01
-SDP_RC,DEU,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.473e-03,1.799e-02,5.000e-02,5.000e-02
-SDP_RC,DEU,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,8.031e-02,3.320e-01,2.193e-01,2.193e-01
-SDP_RC,DEU,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.967e-02,1.259e-01,1.500e-01,1.500e-01
-SDP_RC,DEU,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.967e-02,1.259e-01,1.500e-01,1.500e-01
-SDP_RC,DEU,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.967e-02,1.259e-01,1.500e-01,1.500e-01
-SDP_RC,DEU,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,8.031e-02,3.320e-01,2.193e-01,2.193e-01
+SDP_RC,DEU,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.524e-01,6.784e-01,8.709e-01,8.709e-01
+SDP_RC,DEU,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.402e-01,3.649e-01,8.448e-01,8.448e-01
+SDP_RC,DEU,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.402e-01,3.649e-01,8.448e-01,8.448e-01
+SDP_RC,DEU,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.402e-01,3.649e-01,8.448e-01,8.448e-01
+SDP_RC,DEU,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.524e-01,6.784e-01,8.709e-01,8.709e-01
+SDP_RC,DEU,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.249e-03,1.636e-02,4.548e-02,4.548e-02
+SDP_RC,DEU,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,9.497e-02,3.925e-01,1.837e-01,1.837e-01
+SDP_RC,DEU,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.508e-02,1.489e-01,1.257e-01,1.257e-01
+SDP_RC,DEU,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.508e-02,1.489e-01,1.257e-01,1.257e-01
+SDP_RC,DEU,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.508e-02,1.489e-01,1.257e-01,1.257e-01
+SDP_RC,DEU,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,9.497e-02,3.925e-01,1.837e-01,1.837e-01
 SDP_RC,DEU,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0.000e+00,8.315e-07,4.540e-05,1.192e-01,1.192e-01
 SDP_RC,DEU,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,DEU,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
@@ -4461,59 +4461,59 @@ SDP_RC,DEU,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_roa
 SDP_RC,DEU,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,DEU,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,DEU,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_RC,DEU,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,3.948e-02,6.475e-02,1.153e-01,1.731e-01,1.731e-01
-SDP_RC,DEU,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,2.615e-02,4.142e-02,1.030e-01,2.055e-01,2.055e-01
-SDP_RC,DEU,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.105e-02,7.895e-02,1.842e-01,1.842e-01
-SDP_RC,DEU,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.105e-02,7.895e-02,1.842e-01,1.842e-01
-SDP_RC,DEU,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.105e-02,7.895e-02,1.842e-01,1.842e-01
-SDP_RC,DEU,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.105e-02,7.895e-02,1.842e-01,1.842e-01
+SDP_RC,DEU,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,3.948e-02,4.981e-02,8.870e-02,1.332e-01,1.332e-01
+SDP_RC,DEU,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,2.615e-02,4.142e-02,1.030e-01,1.713e-01,1.713e-01
+SDP_RC,DEU,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.105e-02,7.895e-02,1.535e-01,1.535e-01
+SDP_RC,DEU,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.105e-02,7.895e-02,1.535e-01,1.535e-01
+SDP_RC,DEU,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.105e-02,7.895e-02,1.535e-01,1.535e-01
+SDP_RC,DEU,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.105e-02,7.895e-02,1.535e-01,1.535e-01
 SDP_RC,ECE,,,,,Cycle,trn_pass,S3S,linear,1.942e-02,1.942e-02,9.709e-02,1.092e-01,1.092e-01
-SDP_RC,ECE,,,,,Domestic Aviation,trn_pass,S3S,linear,7.313e-05,7.313e-05,7.313e-05,2.057e-05,2.057e-05
-SDP_RC,ECE,,,,,Domestic Ship,trn_freight,S3S,linear,3.893e-04,3.893e-04,3.893e-04,3.893e-04,3.893e-04
-SDP_RC,ECE,,,,,Freight Rail,trn_freight,S3S,linear,5.909e-02,5.909e-02,5.909e-02,5.909e-02,5.909e-02
+SDP_RC,ECE,,,,,Domestic Aviation,trn_pass,S3S,linear,6.979e-05,6.979e-05,6.979e-05,1.963e-05,1.963e-05
+SDP_RC,ECE,,,,,Domestic Ship,trn_freight,S3S,linear,3.966e-04,3.966e-04,3.966e-04,3.966e-04,3.966e-04
+SDP_RC,ECE,,,,,Freight Rail,trn_freight,S3S,linear,6.019e-02,6.019e-02,5.417e-02,5.417e-02,5.417e-02
 SDP_RC,ECE,,,,,HSR,trn_pass,S3S,linear,1.139e-04,1.708e-04,4.555e-04,3.202e-04,3.202e-04
 SDP_RC,ECE,,,,,International Aviation,trn_aviation_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,ECE,,,,,International Ship,trn_shipping_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,ECE,,,,,Passenger Rail,trn_pass,S3S,linear,6.799e-03,6.799e-03,9.065e-03,3.824e-03,3.824e-03
 SDP_RC,ECE,,,,,Walk,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,ECE,,,,,trn_freight_road,trn_freight,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_RC,ECE,,,,,trn_pass_road,trn_pass,S3S,linear,8.972e-01,8.972e-01,7.177e-01,1.615e-01,1.615e-01
-SDP_RC,ECE,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,1.664e-01,1.664e-01,1.109e-01,1.109e-01,1.109e-01
+SDP_RC,ECE,,,,,trn_pass_road,trn_pass,S3S,linear,6.166e-01,6.166e-01,4.933e-01,1.268e-01,1.268e-01
+SDP_RC,ECE,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,2.712e-01,2.543e-01,1.469e-01,1.130e-01,1.130e-01
 SDP_RC,ECE,,,,trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,ECE,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,6.159e-03,6.159e-03,6.159e-03,6.159e-03,6.159e-03
 SDP_RC,ECE,,,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_RC,ECE,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,3.451e-01,3.451e-01,3.451e-01,3.451e-01,3.451e-01
+SDP_RC,ECE,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,4.706e-01,4.706e-01,4.601e-01,4.314e-01,4.314e-01
 SDP_RC,ECE,,Large Car and SUV,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,7.825e-01,7.825e-01,7.825e-01,7.825e-01,7.825e-01
 SDP_RC,ECE,,Midsize Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,ECE,,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,5.321e-02,5.321e-02,5.321e-02,5.321e-02,5.321e-02
 SDP_RC,ECE,,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,4.728e-04,4.728e-04,4.728e-04,4.728e-04,4.728e-04
 SDP_RC,ECE,,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_RC,ECE,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,4.683e-01,4.683e-01,4.683e-01,4.683e-01,4.683e-01
+SDP_RC,ECE,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,6.386e-01,6.386e-01,6.244e-01,5.854e-01,5.854e-01
 SDP_RC,ECE,,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,6.161e-01,6.161e-01,6.161e-01,6.161e-01,6.161e-01
 SDP_RC,ECE,,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.384e-01,1.384e-01,1.384e-01,1.384e-01,1.384e-01
 SDP_RC,ECE,,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.370e-01,1.370e-01,1.370e-01,1.370e-01,1.370e-01
 SDP_RC,ECE,,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.691e-01,1.691e-01,1.691e-01,1.691e-01,1.691e-01
 SDP_RC,ECE,,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_RC,ECE,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_RC,ECE,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_RC,ECE,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_RC,ECE,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.423e-01,5.379e-01,1.000e+00,1.000e+00
+SDP_RC,ECE,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.000e-02,1.900e-01,4.300e-01,4.300e-01
+SDP_RC,ECE,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.000e-02,1.900e-01,4.300e-01,4.300e-01
+SDP_RC,ECE,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.000e-02,1.900e-01,4.300e-01,4.300e-01
+SDP_RC,ECE,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.553e-01,5.283e-01,1.000e+00,1.000e+00
 SDP_RC,ECE,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,ECE,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,ECE,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_RC,ECE,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.960e-02,1.500e-01,2.946e-01,2.946e-01
-SDP_RC,ECE,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.371e-02,8.068e-02,2.858e-01,2.858e-01
-SDP_RC,ECE,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.371e-02,8.068e-02,2.858e-01,2.858e-01
-SDP_RC,ECE,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.371e-02,8.068e-02,2.858e-01,2.858e-01
-SDP_RC,ECE,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.960e-02,1.500e-01,2.946e-01,2.946e-01
-SDP_RC,ECE,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.236e-02,1.799e-02,8.748e-02,8.748e-02
-SDP_RC,ECE,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.339e-02,4.743e-02,1.462e-01,1.462e-01
-SDP_RC,ECE,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.945e-03,1.799e-02,1.000e-01,1.000e-01
-SDP_RC,ECE,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.945e-03,1.799e-02,1.000e-01,1.000e-01
-SDP_RC,ECE,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.945e-03,1.799e-02,1.000e-01,1.000e-01
-SDP_RC,ECE,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.339e-02,4.743e-02,1.462e-01,1.462e-01
+SDP_RC,ECE,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.504e-02,1.455e-01,2.786e-01,2.786e-01
+SDP_RC,ECE,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.588e-02,7.826e-02,2.703e-01,2.703e-01
+SDP_RC,ECE,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.588e-02,7.826e-02,2.703e-01,2.703e-01
+SDP_RC,ECE,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.588e-02,7.826e-02,2.703e-01,2.703e-01
+SDP_RC,ECE,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.504e-02,1.455e-01,2.786e-01,2.786e-01
+SDP_RC,ECE,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.349e-02,1.963e-02,8.748e-02,8.748e-02
+SDP_RC,ECE,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.461e-02,5.750e-02,6.382e-02,6.382e-02
+SDP_RC,ECE,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.396e-03,2.181e-02,4.365e-02,4.365e-02
+SDP_RC,ECE,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.396e-03,2.181e-02,4.365e-02,4.365e-02
+SDP_RC,ECE,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.396e-03,2.181e-02,4.365e-02,4.365e-02
+SDP_RC,ECE,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.461e-02,5.750e-02,6.382e-02,6.382e-02
 SDP_RC,ECE,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0.000e+00,8.315e-07,4.540e-05,1.192e-01,1.192e-01
-SDP_RC,ECE,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,8.748e-01,8.748e-01
+SDP_RC,ECE,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,8.017e-01,8.017e-01
 SDP_RC,ECE,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,ECE,Liquids,Domestic Ship_tmp_vehicletype,Domestic Ship_tmp_subsector_L1,Domestic Ship_tmp_subsector_L2,Domestic Ship,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,ECE,Liquids,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,5.870e-01,5.870e-01,5.870e-01,5.870e-01,5.870e-01
@@ -4528,57 +4528,57 @@ SDP_RC,ECE,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_roa
 SDP_RC,ECE,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,ECE,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,ECE,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_RC,ECE,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_RC,ECE,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_RC,ECE,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_RC,ECE,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
+SDP_RC,ECE,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e-02,2.000e-02,7.000e-02,9.000e-02,9.000e-02
+SDP_RC,ECE,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.000e-02,1.111e-01,1.867e-01,1.867e-01
+SDP_RC,ECE,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.000e-02,1.111e-01,1.867e-01,1.867e-01
+SDP_RC,ECE,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.000e-02,1.111e-01,1.867e-01,1.867e-01
 SDP_RC,ECE,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_RC,ECE,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_RC,ECS,,,,,Cycle,trn_pass,S3S,linear,7.196e-03,2.159e-02,8.635e-02,8.738e-02,8.738e-02
-SDP_RC,ECS,,,,,Domestic Aviation,trn_pass,S3S,linear,2.566e-03,2.566e-03,2.566e-03,3.895e-04,3.895e-04
-SDP_RC,ECS,,,,,Domestic Ship,trn_freight,S3S,linear,3.878e-03,3.878e-03,3.878e-03,3.878e-03,3.878e-03
-SDP_RC,ECS,,,,,Freight Rail,trn_freight,S3S,linear,5.867e-02,5.867e-02,5.867e-02,5.867e-02,5.867e-02
-SDP_RC,ECS,,,,,HSR,trn_pass,S3S,linear,1.956e-04,1.956e-04,5.216e-04,4.000e-04,4.000e-04
+SDP_RC,ECE,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.000e-02,1.111e-01,1.867e-01,1.867e-01
+SDP_RC,ECS,,,,,Cycle,trn_pass,S3S,linear,1.092e-02,3.277e-02,1.311e-01,8.738e-02,8.738e-02
+SDP_RC,ECS,,,,,Domestic Aviation,trn_pass,S3S,linear,3.717e-03,3.717e-03,3.717e-03,3.717e-04,3.717e-04
+SDP_RC,ECS,,,,,Domestic Ship,trn_freight,S3S,linear,3.950e-03,3.950e-03,3.591e-03,3.950e-03,3.950e-03
+SDP_RC,ECS,,,,,Freight Rail,trn_freight,S3S,linear,5.976e-02,5.976e-02,5.433e-02,5.379e-02,5.379e-02
+SDP_RC,ECS,,,,,HSR,trn_pass,S3S,linear,2.969e-04,2.969e-04,7.917e-04,4.000e-04,4.000e-04
 SDP_RC,ECS,,,,,International Aviation,trn_aviation_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,ECS,,,,,International Ship,trn_shipping_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_RC,ECS,,,,,Passenger Rail,trn_pass,S3S,linear,5.215e-03,6.953e-03,8.691e-03,2.638e-03,2.638e-03
-SDP_RC,ECS,,,,,Walk,trn_pass,S3S,linear,6.588e-01,6.588e-01,6.588e-01,1.000e+00,1.000e+00
+SDP_RC,ECS,,,,,Passenger Rail,trn_pass,S3S,linear,7.915e-03,1.055e-02,1.319e-02,2.638e-03,2.638e-03
+SDP_RC,ECS,,,,,Walk,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,ECS,,,,,trn_freight_road,trn_freight,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_RC,ECS,,,,,trn_pass_road,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.518e-01,1.518e-01
-SDP_RC,ECS,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,1.140e-01,1.140e-01,7.980e-02,6.840e-02,6.840e-02
+SDP_RC,ECS,,,,,trn_pass_road,trn_pass,S3S,linear,7.451e-01,7.451e-01,7.451e-01,8.941e-02,8.941e-02
+SDP_RC,ECS,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,2.090e-01,1.742e-01,1.219e-01,1.045e-01,1.045e-01
 SDP_RC,ECS,,,,trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,ECS,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,2.175e-03,2.175e-03,2.175e-03,2.175e-03,2.175e-03
 SDP_RC,ECS,,,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_RC,ECS,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,3.336e-01,3.336e-01,3.336e-01,3.336e-01,3.336e-01
+SDP_RC,ECS,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,5.004e-01,5.004e-01,5.004e-01,4.549e-01,4.549e-01
 SDP_RC,ECS,,Large Car and SUV,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,ECS,,Midsize Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,9.609e-01,9.609e-01,9.609e-01,9.609e-01,9.609e-01
 SDP_RC,ECS,,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.125e-01,1.125e-01,1.125e-01,1.125e-01,1.125e-01
 SDP_RC,ECS,,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,3.579e-02,3.579e-02,3.579e-02,3.579e-02,3.579e-02
 SDP_RC,ECS,,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_RC,ECS,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,6.520e-01,6.520e-01,6.520e-01,6.520e-01,6.520e-01
+SDP_RC,ECS,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,9.780e-01,9.780e-01,9.780e-01,8.891e-01,8.891e-01
 SDP_RC,ECS,,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,ECS,,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,2.555e-01,2.555e-01,2.555e-01,2.555e-01,2.555e-01
 SDP_RC,ECS,,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,3.104e-01,3.104e-01,3.104e-01,3.104e-01,3.104e-01
 SDP_RC,ECS,,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.282e-01,1.282e-01,1.282e-01,1.282e-01,1.282e-01
 SDP_RC,ECS,,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,4.409e-01,4.409e-01,4.409e-01,4.409e-01,4.409e-01
-SDP_RC,ECS,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_RC,ECS,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_RC,ECS,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_RC,ECS,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.743e-02,3.496e-01,8.573e-01,8.573e-01
+SDP_RC,ECS,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,3.200e-02,1.920e-01,4.200e-01,4.200e-01
+SDP_RC,ECS,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,3.200e-02,1.920e-01,4.200e-01,4.200e-01
+SDP_RC,ECS,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,3.200e-02,1.920e-01,4.200e-01,4.200e-01
+SDP_RC,ECS,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,9.315e-02,3.815e-01,8.420e-01,8.420e-01
 SDP_RC,ECS,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,ECS,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,ECS,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_RC,ECS,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.192e-01,2.500e-01,2.946e-01,2.946e-01
-SDP_RC,ECS,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.743e-02,1.345e-01,2.858e-01,2.858e-01
-SDP_RC,ECS,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.743e-02,1.345e-01,2.858e-01,2.858e-01
-SDP_RC,ECS,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.743e-02,1.345e-01,2.858e-01,2.858e-01
-SDP_RC,ECS,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.192e-01,2.500e-01,2.946e-01,2.946e-01
-SDP_RC,ECS,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.473e-03,5.396e-02,1.000e-01,1.000e-01
-SDP_RC,ECS,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.339e-02,4.743e-02,7.311e-02,7.311e-02
-SDP_RC,ECS,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.945e-03,1.799e-02,5.000e-02,5.000e-02
-SDP_RC,ECS,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.945e-03,1.799e-02,5.000e-02,5.000e-02
-SDP_RC,ECS,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.945e-03,1.799e-02,5.000e-02,5.000e-02
-SDP_RC,ECS,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.339e-02,4.743e-02,7.311e-02,7.311e-02
+SDP_RC,ECS,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.041e-01,2.182e-01,2.893e-01,2.893e-01
+SDP_RC,ECS,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.140e-02,1.174e-01,2.807e-01,2.807e-01
+SDP_RC,ECS,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.140e-02,1.174e-01,2.807e-01,2.807e-01
+SDP_RC,ECS,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.140e-02,1.174e-01,2.807e-01,2.807e-01
+SDP_RC,ECS,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.041e-01,2.182e-01,2.893e-01,2.893e-01
+SDP_RC,ECS,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.698e-03,7.360e-02,1.091e-01,1.091e-01
+SDP_RC,ECS,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.461e-02,6.900e-02,7.977e-02,7.977e-02
+SDP_RC,ECS,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.396e-03,2.617e-02,5.456e-02,5.456e-02
+SDP_RC,ECS,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.396e-03,2.617e-02,5.456e-02,5.456e-02
+SDP_RC,ECS,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.396e-03,2.617e-02,5.456e-02,5.456e-02
+SDP_RC,ECS,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.461e-02,6.900e-02,7.977e-02,7.977e-02
 SDP_RC,ECS,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0.000e+00,8.315e-07,4.540e-05,1.192e-01,1.192e-01
 SDP_RC,ECS,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,ECS,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
@@ -4595,61 +4595,61 @@ SDP_RC,ECS,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_roa
 SDP_RC,ECS,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,ECS,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,ECS,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_RC,ECS,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_RC,ECS,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_RC,ECS,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_RC,ECS,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_RC,ECS,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_RC,ECS,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
+SDP_RC,ECS,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e-02,2.000e-02,6.250e-02,1.000e-01,1.000e-01
+SDP_RC,ECS,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e-05,1.300e-02,6.667e-02,1.400e-01,1.400e-01
+SDP_RC,ECS,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e-05,1.300e-02,6.667e-02,1.400e-01,1.400e-01
+SDP_RC,ECS,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e-05,1.300e-02,6.667e-02,1.400e-01,1.400e-01
+SDP_RC,ECS,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e-05,1.300e-02,6.667e-02,1.400e-01,1.400e-01
+SDP_RC,ECS,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e-05,1.300e-02,6.667e-02,1.400e-01,1.400e-01
 SDP_RC,ENC,,,,,Cycle,trn_pass,S3S,linear,2.500e-02,2.500e-02,5.556e-02,1.000e-01,1.000e-01
-SDP_RC,ENC,,,,,Domestic Aviation,trn_pass,S3S,linear,6.250e-05,6.250e-05,5.556e-05,2.500e-05,2.500e-05
-SDP_RC,ENC,,,,,Domestic Ship,trn_freight,S3S,linear,1.223e-02,1.223e-02,1.223e-02,1.223e-02,1.223e-02
-SDP_RC,ENC,,,,,Freight Rail,trn_freight,S3S,linear,2.875e-02,2.875e-02,2.875e-02,2.875e-02,2.875e-02
+SDP_RC,ENC,,,,,Domestic Aviation,trn_pass,S3S,linear,5.965e-05,5.965e-05,5.302e-05,2.386e-05,2.386e-05
+SDP_RC,ENC,,,,,Domestic Ship,trn_freight,S3S,linear,1.246e-02,1.246e-02,1.246e-02,1.246e-02,1.246e-02
+SDP_RC,ENC,,,,,Freight Rail,trn_freight,S3S,linear,2.928e-02,2.928e-02,2.928e-02,2.928e-02,2.928e-02
 SDP_RC,ENC,,,,,HSR,trn_pass,S3S,linear,1.250e-04,2.500e-04,2.222e-04,2.000e-04,2.000e-04
 SDP_RC,ENC,,,,,International Aviation,trn_aviation_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,ENC,,,,,International Ship,trn_shipping_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,ENC,,,,,Passenger Rail,trn_pass,S3S,linear,3.125e-03,3.125e-03,3.333e-03,2.000e-03,2.000e-03
 SDP_RC,ENC,,,,,Walk,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,ENC,,,,,trn_freight_road,trn_freight,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_RC,ENC,,,,,trn_pass_road,trn_pass,S3S,linear,7.500e-02,7.500e-02,6.667e-02,3.000e-02,3.000e-02
-SDP_RC,ENC,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,2.000e-01,1.500e-01,1.500e-01,1.500e-01,1.500e-01
+SDP_RC,ENC,,,,,trn_pass_road,trn_pass,S3S,linear,7.363e-02,7.363e-02,6.545e-02,2.945e-02,2.945e-02
+SDP_RC,ENC,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,2.037e-01,1.528e-01,1.528e-01,1.528e-01,1.528e-01
 SDP_RC,ENC,,,,trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,ENC,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,3.014e-02,3.014e-02,3.014e-02,3.014e-02,3.014e-02
 SDP_RC,ENC,,,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_RC,ENC,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,3.559e-01,3.559e-01,3.559e-01,3.559e-01,3.559e-01
+SDP_RC,ENC,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,3.955e-01,3.955e-01,3.955e-01,3.559e-01,3.559e-01
 SDP_RC,ENC,,Large Car and SUV,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,ENC,,Midsize Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.960e-01,1.960e-01,1.960e-01,1.960e-01,1.960e-01
-SDP_RC,ENC,,Mini Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,2.357e-07,2.357e-07,2.357e-07,2.357e-07,2.357e-07
+SDP_RC,ENC,,Mini Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,2.619e-07,2.619e-07,2.619e-07,2.357e-07,2.357e-07
 SDP_RC,ENC,,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.576e-01,1.576e-01,1.576e-01,1.576e-01,1.576e-01
 SDP_RC,ENC,,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,3.751e-02,3.751e-02,3.751e-02,3.751e-02,3.751e-02
 SDP_RC,ENC,,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_RC,ENC,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.963e-01,1.963e-01,1.963e-01,1.963e-01,1.963e-01
+SDP_RC,ENC,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,2.181e-01,2.181e-01,2.181e-01,1.963e-01,1.963e-01
 SDP_RC,ENC,,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,ENC,,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.002e-01,1.002e-01,1.002e-01,1.002e-01,1.002e-01
 SDP_RC,ENC,,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,3.593e-01,3.593e-01,3.593e-01,3.593e-01,3.593e-01
 SDP_RC,ENC,,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,4.374e-01,4.374e-01,4.374e-01,4.374e-01,4.374e-01
 SDP_RC,ENC,,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,4.946e-01,4.946e-01,4.946e-01,4.946e-01,4.946e-01
 SDP_RC,ENC,,Van,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.049e-03,1.049e-03,1.049e-03,1.049e-03,1.049e-03
-SDP_RC,ENC,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_RC,ENC,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_RC,ENC,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_RC,ENC,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.371e-01,6.724e-01,1.000e+00,1.000e+00
+SDP_RC,ENC,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,5.000e-02,2.300e-01,5.000e-01,5.000e-01
+SDP_RC,ENC,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,5.000e-02,2.300e-01,5.000e-01,5.000e-01
+SDP_RC,ENC,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,5.000e-02,2.300e-01,5.000e-01,5.000e-01
+SDP_RC,ENC,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.157e-01,7.227e-01,1.000e+00,1.000e+00
 SDP_RC,ENC,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,ENC,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,ENC,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_RC,ENC,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.622e-01,6.000e-01,9.820e-01,9.820e-01
-SDP_RC,ENC,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.043e-01,3.227e-01,9.526e-01,9.526e-01
-SDP_RC,ENC,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.043e-01,3.227e-01,9.526e-01,9.526e-01
-SDP_RC,ENC,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.043e-01,3.227e-01,9.526e-01,9.526e-01
-SDP_RC,ENC,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.622e-01,6.000e-01,9.820e-01,9.820e-01
-SDP_RC,ENC,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.236e-02,5.396e-02,1.312e-01,1.312e-01
-SDP_RC,ENC,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.693e-02,2.371e-01,1.462e-01,1.462e-01
-SDP_RC,ENC,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-02,8.993e-02,1.000e-01,1.000e-01
-SDP_RC,ENC,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-02,8.993e-02,1.000e-01,1.000e-01
-SDP_RC,ENC,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-02,8.993e-02,1.000e-01,1.000e-01
-SDP_RC,ENC,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.693e-02,2.371e-01,1.462e-01,1.462e-01
+SDP_RC,ENC,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.101e-01,6.386e-01,9.289e-01,9.289e-01
+SDP_RC,ENC,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.234e-01,3.434e-01,9.011e-01,9.011e-01
+SDP_RC,ENC,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.234e-01,3.434e-01,9.011e-01,9.011e-01
+SDP_RC,ENC,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.234e-01,3.434e-01,9.011e-01,9.011e-01
+SDP_RC,ENC,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.101e-01,6.386e-01,9.289e-01,9.289e-01
+SDP_RC,ENC,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.124e-02,5.800e-02,1.021e-01,1.021e-01
+SDP_RC,ENC,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,7.914e-02,2.804e-01,1.729e-01,1.729e-01
+SDP_RC,ENC,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.924e-02,1.063e-01,1.183e-01,1.183e-01
+SDP_RC,ENC,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.924e-02,1.063e-01,1.183e-01,1.183e-01
+SDP_RC,ENC,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.924e-02,1.063e-01,1.183e-01,1.183e-01
+SDP_RC,ENC,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,7.914e-02,2.804e-01,1.729e-01,1.729e-01
 SDP_RC,ENC,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0.000e+00,8.315e-07,4.540e-05,1.192e-01,1.192e-01
-SDP_RC,ENC,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,5.249e-01,5.249e-01
+SDP_RC,ENC,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,5.426e-01,5.426e-01
 SDP_RC,ENC,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,ENC,Liquids,Domestic Ship_tmp_vehicletype,Domestic Ship_tmp_subsector_L1,Domestic Ship_tmp_subsector_L2,Domestic Ship,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,ENC,Liquids,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1.341e-01,1.341e-01,1.341e-01,1.341e-01,1.341e-01
@@ -4664,30 +4664,30 @@ SDP_RC,ENC,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_roa
 SDP_RC,ENC,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,ENC,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,ENC,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_RC,ENC,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,2.533e-02,5.098e-02,1.023e-01,1.075e-01,1.075e-01
+SDP_RC,ENC,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,2.533e-02,3.921e-02,9.298e-02,1.011e-01,1.011e-01
 SDP_RC,ENC,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
 SDP_RC,ENC,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
 SDP_RC,ENC,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
 SDP_RC,ENC,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
 SDP_RC,ENC,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
 SDP_RC,ESC,,,,,Cycle,trn_pass,S3S,linear,1.942e-02,2.184e-02,4.369e-02,1.638e-01,1.638e-01
-SDP_RC,ESC,,,,,Domestic Aviation,trn_pass,S3S,linear,1.347e-04,3.789e-05,3.789e-05,7.579e-05,7.579e-05
-SDP_RC,ESC,,,,,Domestic Ship,trn_freight,S3S,linear,1.187e-02,1.187e-02,1.187e-02,1.187e-02,1.187e-02
-SDP_RC,ESC,,,,,Freight Rail,trn_freight,S3S,linear,4.020e-03,4.020e-03,4.020e-03,4.020e-03,4.020e-03
+SDP_RC,ESC,,,,,Domestic Aviation,trn_pass,S3S,linear,1.286e-04,3.616e-05,3.616e-05,7.233e-05,7.233e-05
+SDP_RC,ESC,,,,,Domestic Ship,trn_freight,S3S,linear,1.209e-02,1.209e-02,1.209e-02,1.209e-02,1.209e-02
+SDP_RC,ESC,,,,,Freight Rail,trn_freight,S3S,linear,4.094e-03,4.094e-03,4.094e-03,4.094e-03,4.094e-03
 SDP_RC,ESC,,,,,HSR,trn_pass,S3S,linear,6.613e-04,1.860e-04,6.200e-04,6.200e-04,6.200e-04
 SDP_RC,ESC,,,,,International Aviation,trn_aviation_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,ESC,,,,,International Ship,trn_shipping_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,ESC,,,,,Passenger Rail,trn_pass,S3S,linear,3.195e-03,2.696e-03,2.696e-03,4.044e-03,4.044e-03
 SDP_RC,ESC,,,,,Walk,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,ESC,,,,,trn_freight_road,trn_freight,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_RC,ESC,,,,,trn_pass_road,trn_pass,S3S,linear,1.832e-01,1.030e-01,8.242e-02,6.594e-02,6.594e-02
-SDP_RC,ESC,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,6.591e-02,6.591e-02,6.591e-02,9.887e-02,9.887e-02
+SDP_RC,ESC,,,,,trn_pass_road,trn_pass,S3S,linear,1.798e-01,1.011e-01,8.092e-02,6.473e-02,6.473e-02
+SDP_RC,ESC,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,6.714e-02,6.714e-02,6.714e-02,1.007e-01,1.007e-01
 SDP_RC,ESC,,,,trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_RC,ESC,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.687e-01,1.687e-01,1.687e-01,1.687e-01,1.687e-01
+SDP_RC,ESC,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.205e-01,1.125e-01,1.125e-01,1.125e-01,1.125e-01
 SDP_RC,ESC,,,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,ESC,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,3.942e-01,3.942e-01,3.942e-01,3.942e-01,3.942e-01
-SDP_RC,ESC,,Large Car and SUV,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,8.712e-01,8.712e-01,8.712e-01,8.712e-01,8.712e-01
-SDP_RC,ESC,,Midsize Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,2.323e-01,2.323e-01,2.323e-01,2.323e-01,2.323e-01
+SDP_RC,ESC,,Large Car and SUV,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,8.712e-01,7.840e-01,8.712e-01,8.712e-01,8.712e-01
+SDP_RC,ESC,,Midsize Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,2.323e-01,2.091e-01,2.323e-01,2.323e-01,2.323e-01
 SDP_RC,ESC,,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.009e-01,1.009e-01,1.009e-01,1.009e-01,1.009e-01
 SDP_RC,ESC,,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,6.375e-02,6.375e-02,6.375e-02,6.375e-02,6.375e-02
 SDP_RC,ESC,,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
@@ -4697,24 +4697,24 @@ SDP_RC,ESC,,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_s
 SDP_RC,ESC,,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,2.234e-01,2.234e-01,2.234e-01,2.234e-01,2.234e-01
 SDP_RC,ESC,,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,2.172e-01,2.172e-01,2.172e-01,2.172e-01,2.172e-01
 SDP_RC,ESC,,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_RC,ESC,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_RC,ESC,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_RC,ESC,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_RC,ESC,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.423e-01,4.034e-01,9.526e-01,9.526e-01
+SDP_RC,ESC,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.000e-02,2.200e-01,4.200e-01,4.200e-01
+SDP_RC,ESC,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.000e-02,2.200e-01,4.200e-01,4.200e-01
+SDP_RC,ESC,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.000e-02,2.200e-01,4.200e-01,4.200e-01
+SDP_RC,ESC,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.359e-01,3.816e-01,8.448e-01,8.448e-01
 SDP_RC,ESC,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,ESC,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,ESC,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_RC,ESC,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.384e-01,5.000e-01,9.820e-01,9.820e-01
-SDP_RC,ESC,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,9.485e-02,2.689e-01,9.526e-01,9.526e-01
-SDP_RC,ESC,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,9.485e-02,2.689e-01,9.526e-01,9.526e-01
-SDP_RC,ESC,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,9.485e-02,2.689e-01,9.526e-01,9.526e-01
-SDP_RC,ESC,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.384e-01,5.000e-01,9.820e-01,9.820e-01
-SDP_RC,ESC,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.236e-02,5.396e-02,1.000e-01,1.000e-01
-SDP_RC,ESC,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.693e-02,4.743e-02,1.462e-01,1.462e-01
-SDP_RC,ESC,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-02,1.799e-02,1.000e-01,1.000e-01
-SDP_RC,ESC,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-02,1.799e-02,1.000e-01,1.000e-01
-SDP_RC,ESC,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-02,1.799e-02,1.000e-01,1.000e-01
-SDP_RC,ESC,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.693e-02,4.743e-02,1.462e-01,1.462e-01
+SDP_RC,ESC,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.819e-01,5.321e-01,7.741e-01,7.741e-01
+SDP_RC,ESC,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.122e-01,2.862e-01,7.509e-01,7.509e-01
+SDP_RC,ESC,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.122e-01,2.862e-01,7.509e-01,7.509e-01
+SDP_RC,ESC,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.122e-01,2.862e-01,7.509e-01,7.509e-01
+SDP_RC,ESC,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.819e-01,5.321e-01,7.741e-01,7.741e-01
+SDP_RC,ESC,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.124e-02,6.380e-02,7.883e-02,7.883e-02
+SDP_RC,ESC,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,7.914e-02,5.608e-02,1.441e-01,1.441e-01
+SDP_RC,ESC,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.924e-02,2.127e-02,9.854e-02,9.854e-02
+SDP_RC,ESC,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.924e-02,2.127e-02,9.854e-02,9.854e-02
+SDP_RC,ESC,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.924e-02,2.127e-02,9.854e-02,9.854e-02
+SDP_RC,ESC,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,7.914e-02,5.608e-02,1.441e-01,1.441e-01
 SDP_RC,ESC,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0.000e+00,8.315e-07,4.540e-05,1.192e-01,1.192e-01
 SDP_RC,ESC,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,ESC,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
@@ -4731,57 +4731,57 @@ SDP_RC,ESC,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_roa
 SDP_RC,ESC,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,ESC,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,ESC,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_RC,ESC,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,2.742e-02,5.301e-02,1.042e-01,2.066e-01,2.066e-01
-SDP_RC,ESC,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SDP_RC,ESC,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SDP_RC,ESC,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SDP_RC,ESC,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SDP_RC,ESC,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
+SDP_RC,ESC,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,2.742e-02,4.078e-02,1.042e-01,1.721e-01,1.721e-01
+SDP_RC,ESC,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.535e-01,1.535e-01
+SDP_RC,ESC,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.535e-01,1.535e-01
+SDP_RC,ESC,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.535e-01,1.535e-01
+SDP_RC,ESC,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.535e-01,1.535e-01
+SDP_RC,ESC,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.535e-01,1.535e-01
 SDP_RC,ESW,,,,,Cycle,trn_pass,S3S,linear,1.942e-02,3.884e-02,5.825e-02,1.019e-01,1.019e-01
-SDP_RC,ESW,,,,,Domestic Aviation,trn_pass,S3S,linear,7.179e-04,7.179e-04,5.744e-04,1.346e-04,1.346e-04
-SDP_RC,ESW,,,,,Domestic Ship,trn_freight,S3S,linear,6.018e-03,6.018e-03,6.018e-03,6.018e-03,6.018e-03
-SDP_RC,ESW,,,,,Freight Rail,trn_freight,S3S,linear,1.394e-02,1.394e-02,1.394e-02,1.394e-02,1.394e-02
+SDP_RC,ESW,,,,,Domestic Aviation,trn_pass,S3S,linear,6.852e-04,6.852e-04,5.482e-04,1.285e-04,1.285e-04
+SDP_RC,ESW,,,,,Domestic Ship,trn_freight,S3S,linear,6.130e-03,6.130e-03,6.130e-03,6.130e-03,6.130e-03
+SDP_RC,ESW,,,,,Freight Rail,trn_freight,S3S,linear,1.420e-02,1.420e-02,1.420e-02,1.420e-02,1.420e-02
 SDP_RC,ESW,,,,,HSR,trn_pass,S3S,linear,9.579e-04,9.579e-04,9.579e-04,3.592e-04,3.592e-04
 SDP_RC,ESW,,,,,International Aviation,trn_aviation_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,ESW,,,,,International Ship,trn_shipping_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,ESW,,,,,Passenger Rail,trn_pass,S3S,linear,3.621e-03,3.621e-03,5.432e-03,2.037e-03,2.037e-03
 SDP_RC,ESW,,,,,Walk,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,ESW,,,,,trn_freight_road,trn_freight,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_RC,ESW,,,,,trn_pass_road,trn_pass,S3S,linear,1.411e-01,1.129e-01,1.129e-01,3.175e-02,3.175e-02
-SDP_RC,ESW,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,5.667e-02,5.667e-02,7.083e-02,1.063e-01,1.063e-01
+SDP_RC,ESW,,,,,trn_pass_road,trn_pass,S3S,linear,1.385e-01,1.108e-01,1.108e-01,3.117e-02,3.117e-02
+SDP_RC,ESW,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,5.772e-02,5.772e-02,7.215e-02,1.082e-01,1.082e-01
 SDP_RC,ESW,,,,trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_RC,ESW,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,8.570e-02,8.570e-02,8.570e-02,8.570e-02,8.570e-02
+SDP_RC,ESW,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,7.141e-02,7.141e-02,7.141e-02,6.592e-02,6.592e-02
 SDP_RC,ESW,,,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_RC,ESW,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,5.153e-01,5.153e-01,5.153e-01,5.153e-01,5.153e-01
+SDP_RC,ESW,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,5.725e-01,5.725e-01,5.725e-01,5.725e-01,5.725e-01
 SDP_RC,ESW,,Large Car and SUV,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,ESW,,Midsize Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,2.963e-01,2.963e-01,2.963e-01,2.963e-01,2.963e-01
 SDP_RC,ESW,,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,9.741e-02,9.741e-02,9.741e-02,9.741e-02,9.741e-02
 SDP_RC,ESW,,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.669e-01,1.669e-01,1.669e-01,1.669e-01,1.669e-01
 SDP_RC,ESW,,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_RC,ESW,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,4.003e-01,4.003e-01,4.003e-01,4.003e-01,4.003e-01
+SDP_RC,ESW,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,4.448e-01,4.448e-01,4.448e-01,4.448e-01,4.448e-01
 SDP_RC,ESW,,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,2.850e-01,2.850e-01,2.850e-01,2.850e-01,2.850e-01
 SDP_RC,ESW,,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,6.043e-02,6.043e-02,6.043e-02,6.043e-02,6.043e-02
 SDP_RC,ESW,,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,8.424e-02,8.424e-02,8.424e-02,8.424e-02,8.424e-02
 SDP_RC,ESW,,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,4.041e-01,4.041e-01,4.041e-01,4.041e-01,4.041e-01
 SDP_RC,ESW,,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_RC,ESW,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_RC,ESW,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_RC,ESW,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_RC,ESW,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.186e-01,2.689e-01,6.668e-01,6.668e-01
+SDP_RC,ESW,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.800e-02,2.160e-01,4.200e-01,4.200e-01
+SDP_RC,ESW,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.800e-02,2.160e-01,4.200e-01,4.200e-01
+SDP_RC,ESW,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.800e-02,2.160e-01,4.200e-01,4.200e-01
+SDP_RC,ESW,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.078e-02,1.164e-01,2.935e-01,6.237e-01,6.237e-01
 SDP_RC,ESW,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,7.295e-01,7.633e-01,8.309e-01,9.662e-01,9.662e-01
 SDP_RC,ESW,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,ESW,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_RC,ESW,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.576e-01,7.000e-01,9.820e-01,9.820e-01
-SDP_RC,ESW,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.423e-01,3.765e-01,9.526e-01,9.526e-01
-SDP_RC,ESW,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.423e-01,3.765e-01,9.526e-01,9.526e-01
-SDP_RC,ESW,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.423e-01,3.765e-01,9.526e-01,9.526e-01
-SDP_RC,ESW,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.576e-01,7.000e-01,9.820e-01,9.820e-01
-SDP_RC,ESW,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.473e-03,1.799e-02,7.500e-02,7.500e-02
-SDP_RC,ESW,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.693e-02,2.371e-01,1.462e-01,1.462e-01
-SDP_RC,ESW,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-02,8.993e-02,1.000e-01,1.000e-01
-SDP_RC,ESW,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-02,8.993e-02,1.000e-01,1.000e-01
-SDP_RC,ESW,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-02,8.993e-02,1.000e-01,1.000e-01
-SDP_RC,ESW,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.693e-02,2.371e-01,1.462e-01,1.462e-01
+SDP_RC,ESW,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.902e-01,6.875e-01,1.000e+00,1.000e+00
+SDP_RC,ESW,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.553e-01,3.698e-01,1.000e+00,1.000e+00
+SDP_RC,ESW,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.553e-01,3.698e-01,1.000e+00,1.000e+00
+SDP_RC,ESW,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.553e-01,3.698e-01,1.000e+00,1.000e+00
+SDP_RC,ESW,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.902e-01,6.875e-01,1.000e+00,1.000e+00
+SDP_RC,ESW,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,2.248e-03,2.698e-03,1.963e-02,5.846e-02,5.846e-02
+SDP_RC,ESW,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,7.303e-02,2.588e-01,1.489e-01,1.489e-01
+SDP_RC,ESW,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.698e-02,9.813e-02,1.050e-01,1.050e-01
+SDP_RC,ESW,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.698e-02,9.813e-02,1.050e-01,1.050e-01
+SDP_RC,ESW,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.698e-02,9.813e-02,1.050e-01,1.050e-01
+SDP_RC,ESW,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,7.303e-02,2.588e-01,1.489e-01,1.489e-01
 SDP_RC,ESW,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0.000e+00,8.315e-07,4.540e-05,1.192e-01,1.192e-01
 SDP_RC,ESW,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,ESW,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
@@ -4793,39 +4793,39 @@ SDP_RC,ESW,Liquids,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,tr
 SDP_RC,ESW,Liquids,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,ESW,Liquids,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,ESW,Liquids,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,5.162e-01,5.162e-01,5.162e-01,5.162e-01,5.162e-01
-SDP_RC,ESW,Liquids,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_RC,ESW,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_RC,ESW,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_RC,ESW,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_RC,ESW,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_RC,ESW,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SDP_RC,ESW,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SDP_RC,ESW,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SDP_RC,ESW,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SDP_RC,ESW,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SDP_RC,ESW,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
+SDP_RC,ESW,Liquids,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,9.332e-01,9.332e-01
+SDP_RC,ESW,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,9.620e-01,9.620e-01
+SDP_RC,ESW,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,9.620e-01,9.620e-01
+SDP_RC,ESW,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,9.620e-01,9.620e-01
+SDP_RC,ESW,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,9.332e-01,9.332e-01
+SDP_RC,ESW,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.754e-02,2.632e-02,7.895e-02,1.316e-01,1.316e-01
+SDP_RC,ESW,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.719e-01,1.719e-01
+SDP_RC,ESW,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.772e-01,1.772e-01
+SDP_RC,ESW,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.772e-01,1.772e-01
+SDP_RC,ESW,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.772e-01,1.772e-01
+SDP_RC,ESW,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.719e-01,1.719e-01
 SDP_RC,EWN,,,,,Cycle,trn_pass,S3S,linear,1.000e-02,1.000e-02,5.000e-02,1.000e-01,1.000e-01
-SDP_RC,EWN,,,,,Domestic Aviation,trn_pass,S3S,linear,5.000e-05,5.000e-05,5.000e-05,5.000e-06,5.000e-06
-SDP_RC,EWN,,,,,Domestic Ship,trn_freight,S3S,linear,6.147e-03,6.830e-03,6.147e-03,6.147e-03,6.147e-03
-SDP_RC,EWN,,,,,Freight Rail,trn_freight,S3S,linear,1.246e-02,1.385e-02,1.246e-02,1.246e-02,1.246e-02
+SDP_RC,EWN,,,,,Domestic Aviation,trn_pass,S3S,linear,4.772e-05,4.772e-05,4.772e-05,4.772e-06,4.772e-06
+SDP_RC,EWN,,,,,Domestic Ship,trn_freight,S3S,linear,6.261e-03,6.957e-03,6.261e-03,6.261e-03,6.261e-03
+SDP_RC,EWN,,,,,Freight Rail,trn_freight,S3S,linear,1.270e-02,1.411e-02,1.270e-02,1.270e-02,1.270e-02
 SDP_RC,EWN,,,,,HSR,trn_pass,S3S,linear,1.000e-04,1.000e-04,4.000e-04,2.000e-04,2.000e-04
 SDP_RC,EWN,,,,,International Aviation,trn_aviation_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,EWN,,,,,International Ship,trn_shipping_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,EWN,,,,,Passenger Rail,trn_pass,S3S,linear,2.000e-03,3.000e-03,3.000e-03,2.000e-03,2.000e-03
 SDP_RC,EWN,,,,,Walk,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,EWN,,,,,trn_freight_road,trn_freight,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_RC,EWN,,,,,trn_pass_road,trn_pass,S3S,linear,6.000e-02,6.000e-02,6.000e-02,3.000e-02,3.000e-02
-SDP_RC,EWN,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,1.000e-01,1.000e-01,1.000e-01,1.500e-01,1.500e-01
+SDP_RC,EWN,,,,,trn_pass_road,trn_pass,S3S,linear,5.891e-02,5.891e-02,5.891e-02,2.945e-02,2.945e-02
+SDP_RC,EWN,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,1.019e-01,1.019e-01,1.019e-01,1.528e-01,1.528e-01
 SDP_RC,EWN,,,,trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,EWN,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,4.166e-02,4.166e-02,4.166e-02,4.166e-02,4.166e-02
 SDP_RC,EWN,,,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_RC,EWN,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,3.886e-01,3.886e-01,3.886e-01,3.886e-01,3.886e-01
+SDP_RC,EWN,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,4.317e-01,4.317e-01,3.886e-01,3.886e-01,3.886e-01
 SDP_RC,EWN,,Large Car and SUV,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,EWN,,Midsize Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,2.283e-01,2.283e-01,2.283e-01,2.283e-01,2.283e-01
 SDP_RC,EWN,,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.183e-01,1.183e-01,1.183e-01,1.183e-01,1.183e-01
 SDP_RC,EWN,,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,4.339e-02,4.339e-02,4.339e-02,4.339e-02,4.339e-02
 SDP_RC,EWN,,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_RC,EWN,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,4.377e-01,4.377e-01,4.377e-01,4.377e-01,4.377e-01
+SDP_RC,EWN,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,4.864e-01,4.864e-01,4.377e-01,4.377e-01,4.377e-01
 SDP_RC,EWN,,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,EWN,,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.164e-01,1.164e-01,1.164e-01,1.164e-01,1.164e-01
 SDP_RC,EWN,,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,5.225e-01,5.225e-01,5.225e-01,5.225e-01,5.225e-01
@@ -4834,21 +4834,21 @@ SDP_RC,EWN,,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_
 SDP_RC,EWN,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1.000e-03,6.000e-02,2.450e-01,4.500e-01,4.500e-01
 SDP_RC,EWN,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1.000e-03,6.000e-02,2.450e-01,4.500e-01,4.500e-01
 SDP_RC,EWN,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1.000e-03,6.000e-02,2.450e-01,4.500e-01,4.500e-01
-SDP_RC,EWN,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.958e-02,2.323e-01,4.763e-01,4.763e-01
+SDP_RC,EWN,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,8.794e-02,2.197e-01,5.006e-01,5.006e-01
 SDP_RC,EWN,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,EWN,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,EWN,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_RC,EWN,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.550e-01,6.500e-01,8.729e-01,8.729e-01
-SDP_RC,EWN,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.165e-02,3.496e-01,8.467e-01,8.467e-01
-SDP_RC,EWN,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.165e-02,3.496e-01,8.467e-01,8.467e-01
-SDP_RC,EWN,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.165e-02,3.496e-01,8.467e-01,8.467e-01
-SDP_RC,EWN,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.550e-01,6.500e-01,8.729e-01,8.729e-01
-SDP_RC,EWN,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.573e-03,6.540e-03,1.667e-02,1.667e-02
-SDP_RC,EWN,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,9.370e-03,4.743e-02,4.061e-02,4.061e-02
-SDP_RC,EWN,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.462e-03,1.799e-02,2.778e-02,2.778e-02
-SDP_RC,EWN,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.462e-03,1.799e-02,2.778e-02,2.778e-02
-SDP_RC,EWN,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.462e-03,1.799e-02,2.778e-02,2.778e-02
-SDP_RC,EWN,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,9.370e-03,4.743e-02,4.061e-02,4.061e-02
+SDP_RC,EWN,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.436e-01,6.405e-01,9.031e-01,9.031e-01
+SDP_RC,EWN,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.367e-01,3.445e-01,8.760e-01,8.760e-01
+SDP_RC,EWN,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.367e-01,3.445e-01,8.760e-01,8.760e-01
+SDP_RC,EWN,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.367e-01,3.445e-01,8.760e-01,8.760e-01
+SDP_RC,EWN,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.436e-01,6.405e-01,9.031e-01,9.031e-01
+SDP_RC,EWN,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.861e-03,7.734e-03,2.190e-02,2.190e-02
+SDP_RC,EWN,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.385e-02,1.059e-01,6.003e-02,6.003e-02
+SDP_RC,EWN,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.116e-03,4.017e-02,4.106e-02,4.106e-02
+SDP_RC,EWN,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.116e-03,4.017e-02,4.106e-02,4.106e-02
+SDP_RC,EWN,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.116e-03,4.017e-02,4.106e-02,4.106e-02
+SDP_RC,EWN,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.385e-02,1.059e-01,6.003e-02,6.003e-02
 SDP_RC,EWN,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0.000e+00,8.315e-07,4.540e-05,1.192e-01,1.192e-01
 SDP_RC,EWN,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,EWN,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
@@ -4865,26 +4865,26 @@ SDP_RC,EWN,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_roa
 SDP_RC,EWN,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,EWN,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,EWN,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_RC,EWN,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,8.070e-03,3.107e-02,6.282e-02,8.745e-02,8.745e-02
-SDP_RC,EWN,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,8.171e-04,2.711e-02,7.970e-02,1.027e-01,1.027e-01
-SDP_RC,EWN,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.023e-01,1.023e-01
-SDP_RC,EWN,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.023e-01,1.023e-01
-SDP_RC,EWN,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.023e-01,1.023e-01
-SDP_RC,EWN,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.023e-01,1.023e-01
+SDP_RC,EWN,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,8.070e-03,3.107e-02,6.282e-02,9.716e-02,9.716e-02
+SDP_RC,EWN,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,8.171e-04,3.389e-02,8.856e-02,1.284e-01,1.284e-01
+SDP_RC,EWN,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.289e-02,8.772e-02,1.279e-01,1.279e-01
+SDP_RC,EWN,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.289e-02,8.772e-02,1.279e-01,1.279e-01
+SDP_RC,EWN,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.289e-02,8.772e-02,1.279e-01,1.279e-01
+SDP_RC,EWN,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.289e-02,8.772e-02,1.279e-01,1.279e-01
 SDP_RC,FRA,,,,,Cycle,trn_pass,S3S,linear,1.942e-02,2.184e-02,3.641e-02,1.019e-01,1.019e-01
-SDP_RC,FRA,,,,,Domestic Aviation,trn_pass,S3S,linear,1.225e-04,6.891e-05,4.594e-05,2.297e-05,2.297e-05
-SDP_RC,FRA,,,,,Domestic Ship,trn_freight,S3S,linear,3.357e-03,3.357e-03,3.357e-03,3.357e-03,3.357e-03
-SDP_RC,FRA,,,,,Freight Rail,trn_freight,S3S,linear,1.766e-02,1.766e-02,1.766e-02,1.766e-02,1.766e-02
+SDP_RC,FRA,,,,,Domestic Aviation,trn_pass,S3S,linear,1.169e-04,6.577e-05,4.385e-05,2.192e-05,2.192e-05
+SDP_RC,FRA,,,,,Domestic Ship,trn_freight,S3S,linear,3.419e-03,3.419e-03,3.419e-03,3.419e-03,3.419e-03
+SDP_RC,FRA,,,,,Freight Rail,trn_freight,S3S,linear,1.799e-02,1.799e-02,1.799e-02,1.799e-02,1.799e-02
 SDP_RC,FRA,,,,,HSR,trn_pass,S3S,linear,3.359e-04,2.267e-04,2.015e-04,2.015e-04,2.015e-04
 SDP_RC,FRA,,,,,International Aviation,trn_aviation_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,FRA,,,,,International Ship,trn_shipping_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,FRA,,,,,Passenger Rail,trn_pass,S3S,linear,3.972e-03,2.979e-03,1.986e-03,1.986e-03,1.986e-03
 SDP_RC,FRA,,,,,Walk,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,FRA,,,,,trn_freight_road,trn_freight,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_RC,FRA,,,,,trn_pass_road,trn_pass,S3S,linear,9.224e-02,5.188e-02,3.459e-02,2.767e-02,2.767e-02
-SDP_RC,FRA,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,7.788e-02,8.566e-02,9.345e-02,1.402e-01,1.402e-01
+SDP_RC,FRA,,,,,trn_pass_road,trn_pass,S3S,linear,9.055e-02,5.094e-02,3.396e-02,2.717e-02,2.717e-02
+SDP_RC,FRA,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,7.932e-02,8.726e-02,9.519e-02,1.428e-01,1.428e-01
 SDP_RC,FRA,,,,trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_RC,FRA,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,9.470e-02,9.470e-02,9.470e-02,9.470e-02,9.470e-02
+SDP_RC,FRA,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,7.285e-02,7.285e-02,7.285e-02,6.764e-02,6.764e-02
 SDP_RC,FRA,,,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,FRA,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,6.352e-01,6.352e-01,6.352e-01,6.352e-01,6.352e-01
 SDP_RC,FRA,,Large Car and SUV,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
@@ -4898,26 +4898,26 @@ SDP_RC,FRA,,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_s
 SDP_RC,FRA,,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.602e-01,1.602e-01,1.602e-01,1.602e-01,1.602e-01
 SDP_RC,FRA,,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,4.011e-01,4.011e-01,4.011e-01,4.011e-01,4.011e-01
 SDP_RC,FRA,,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,3.755e-01,3.755e-01,3.755e-01,3.755e-01,3.755e-01
-SDP_RC,FRA,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_RC,FRA,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_RC,FRA,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_RC,FRA,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.423e-01,4.303e-01,1.000e+00,1.000e+00
+SDP_RC,FRA,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.000e-02,2.400e-01,4.200e-01,4.200e-01
+SDP_RC,FRA,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.000e-02,2.400e-01,4.200e-01,4.200e-01
+SDP_RC,FRA,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.000e-02,2.400e-01,4.200e-01,4.200e-01
+SDP_RC,FRA,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.402e-02,1.682e-01,4.579e-01,9.531e-01,9.531e-01
 SDP_RC,FRA,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,FRA,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,FRA,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_RC,FRA,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.980e-01,7.500e-01,9.820e-01,9.820e-01
-SDP_RC,FRA,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.186e-01,4.034e-01,9.526e-01,9.526e-01
-SDP_RC,FRA,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.186e-01,4.034e-01,9.526e-01,9.526e-01
-SDP_RC,FRA,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.186e-01,4.034e-01,9.526e-01,9.526e-01
-SDP_RC,FRA,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.980e-01,7.500e-01,9.820e-01,9.820e-01
-SDP_RC,FRA,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.236e-02,1.799e-02,9.544e-02,9.544e-02
-SDP_RC,FRA,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.693e-02,4.743e-02,1.462e-01,1.462e-01
-SDP_RC,FRA,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-02,1.799e-02,1.000e-01,1.000e-01
-SDP_RC,FRA,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-02,1.799e-02,1.000e-01,1.000e-01
-SDP_RC,FRA,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-02,1.799e-02,1.000e-01,1.000e-01
-SDP_RC,FRA,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.693e-02,4.743e-02,1.462e-01,1.462e-01
+SDP_RC,FRA,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.171e-01,6.651e-01,9.087e-01,9.087e-01
+SDP_RC,FRA,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.262e-01,3.578e-01,8.815e-01,8.815e-01
+SDP_RC,FRA,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.262e-01,3.578e-01,8.815e-01,8.815e-01
+SDP_RC,FRA,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.262e-01,3.578e-01,8.815e-01,8.815e-01
+SDP_RC,FRA,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.171e-01,6.651e-01,9.087e-01,9.087e-01
+SDP_RC,FRA,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.218e-02,1.462e-02,2.127e-02,8.186e-02,8.186e-02
+SDP_RC,FRA,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,7.914e-02,2.337e-01,1.503e-01,1.503e-01
+SDP_RC,FRA,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.924e-02,8.861e-02,1.028e-01,1.028e-01
+SDP_RC,FRA,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.924e-02,8.861e-02,1.028e-01,1.028e-01
+SDP_RC,FRA,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.924e-02,8.861e-02,1.028e-01,1.028e-01
+SDP_RC,FRA,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,7.914e-02,2.337e-01,1.503e-01,1.503e-01
 SDP_RC,FRA,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0.000e+00,8.315e-07,4.540e-05,1.192e-01,1.192e-01
-SDP_RC,FRA,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,9.544e-01,9.544e-01
+SDP_RC,FRA,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,FRA,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,FRA,Liquids,Domestic Ship_tmp_vehicletype,Domestic Ship_tmp_subsector_L1,Domestic Ship_tmp_subsector_L2,Domestic Ship,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,FRA,Liquids,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1.608e-01,1.608e-01,1.608e-01,1.608e-01,1.608e-01
@@ -4932,26 +4932,26 @@ SDP_RC,FRA,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_roa
 SDP_RC,FRA,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,FRA,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,FRA,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_RC,FRA,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.758e-01,1.758e-01
-SDP_RC,FRA,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SDP_RC,FRA,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SDP_RC,FRA,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SDP_RC,FRA,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SDP_RC,FRA,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SDP_RC,IND,,,,,Cycle,trn_pass,S3S,linear,2.632e-03,4.364e-03,9.091e-03,1.000e-01,1.000e-01
-SDP_RC,IND,,,,,Domestic Aviation,trn_pass,S3S,linear,9.589e-02,1.091e-01,1.000e-01,2.000e-01,2.000e-01
-SDP_RC,IND,,,,,Domestic Ship,trn_freight,S3S,linear,1.180e-03,1.180e-03,1.073e-03,9.075e-04,9.075e-04
-SDP_RC,IND,,,,,Freight Rail,trn_freight,S3S,linear,1.889e-01,1.889e-01,1.717e-01,1.453e-01,1.453e-01
-SDP_RC,IND,,,,,HSR,trn_pass,S3S,linear,0.000e+00,4.364e-05,1.000e-04,3.000e-04,3.000e-04
+SDP_RC,FRA,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.535e-02,2.632e-02,7.895e-02,1.417e-01,1.417e-01
+SDP_RC,FRA,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,6.579e-02,1.602e-01,1.602e-01
+SDP_RC,FRA,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,6.579e-02,1.602e-01,1.602e-01
+SDP_RC,FRA,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,6.579e-02,1.602e-01,1.602e-01
+SDP_RC,FRA,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,6.579e-02,1.602e-01,1.602e-01
+SDP_RC,FRA,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,6.579e-02,1.602e-01,1.602e-01
+SDP_RC,IND,,,,,Cycle,trn_pass,S3S,linear,1.915e-02,3.175e-02,4.630e-02,1.000e-01,1.000e-01
+SDP_RC,IND,,,,,Domestic Aviation,trn_pass,S3S,linear,6.659e-01,7.575e-01,4.861e-01,1.909e-01,1.909e-01
+SDP_RC,IND,,,,,Domestic Ship,trn_freight,S3S,linear,1.202e-03,1.202e-03,1.092e-03,9.244e-04,9.244e-04
+SDP_RC,IND,,,,,Freight Rail,trn_freight,S3S,linear,1.924e-01,1.924e-01,1.574e-01,1.332e-01,1.332e-01
+SDP_RC,IND,,,,,HSR,trn_pass,S3S,linear,0.000e+00,3.175e-04,5.093e-04,3.000e-04,3.000e-04
 SDP_RC,IND,,,,,International Aviation,trn_aviation_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,IND,,,,,International Ship,trn_shipping_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_RC,IND,,,,,Passenger Rail,trn_pass,S3S,linear,6.842e-04,8.000e-04,1.091e-03,4.000e-03,4.000e-03
-SDP_RC,IND,,,,,Walk,trn_pass,S3S,linear,1.316e-01,9.455e-02,1.818e-01,1.000e+00,1.000e+00
+SDP_RC,IND,,,,,Passenger Rail,trn_pass,S3S,linear,4.978e-03,5.820e-03,5.556e-03,4.000e-03,4.000e-03
+SDP_RC,IND,,,,,Walk,trn_pass,S3S,linear,9.573e-01,6.879e-01,9.260e-01,1.000e+00,1.000e+00
 SDP_RC,IND,,,,,trn_freight_road,trn_freight,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_RC,IND,,,,,trn_pass_road,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_RC,IND,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,1.188e-01,7.143e-02,3.231e-02,3.231e-02,3.231e-02
-SDP_RC,IND,,,,trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_RC,IND,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,3.027e-03,2.668e-03,1.949e-03,5.108e-04,5.108e-04
+SDP_RC,IND,,,,,trn_pass_road,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,2.945e-01,2.945e-01
+SDP_RC,IND,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,1.000e+00,3.638e-01,1.645e-01,9.872e-02,9.872e-02
+SDP_RC,IND,,,,trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,9.180e-01,1.000e+00,1.000e+00,1.000e+00,1.000e+00
+SDP_RC,IND,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.816e-02,1.867e-02,2.923e-02,5.108e-02,5.108e-02
 SDP_RC,IND,,,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,IND,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,IND,,Mini Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,6.374e-03,6.374e-03,6.374e-03,6.374e-03,6.374e-03
@@ -4962,24 +4962,24 @@ SDP_RC,IND,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,
 SDP_RC,IND,,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.853e-01,1.853e-01,1.853e-01,1.853e-01,1.853e-01
 SDP_RC,IND,,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.987e-01,1.987e-01,1.987e-01,1.987e-01,1.987e-01
 SDP_RC,IND,,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_RC,IND,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_RC,IND,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_RC,IND,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_RC,IND,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.743e-02,2.689e-01,7.621e-01,7.621e-01
+SDP_RC,IND,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.000e-01,3.600e-01,3.780e-01,3.780e-01
+SDP_RC,IND,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.000e-01,3.600e-01,3.780e-01,3.780e-01
+SDP_RC,IND,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.000e-01,3.600e-01,3.780e-01,3.780e-01
+SDP_RC,IND,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,5.175e-02,2.935e-01,6.653e-01,6.653e-01
 SDP_RC,IND,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,IND,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,IND,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,8.340e-01,8.547e-01,8.962e-01,9.792e-01,9.792e-01
-SDP_RC,IND,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.576e-02,1.000e-01,9.820e-02,9.820e-02
-SDP_RC,IND,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.423e-02,5.379e-02,9.526e-02,9.526e-02
-SDP_RC,IND,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,3.000e-01,2.000e-01,1.000e-01,1.000e-01
-SDP_RC,IND,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,3.000e-01,2.000e-01,1.000e-01,1.000e-01
-SDP_RC,IND,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.576e-02,1.000e-01,9.820e-02,9.820e-02
-SDP_RC,IND,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.473e-03,1.799e-02,5.000e-02,5.000e-02
-SDP_RC,IND,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.693e-03,9.485e-03,1.462e-02,1.462e-02
-SDP_RC,IND,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-03,3.597e-03,1.000e-02,1.000e-02
-SDP_RC,IND,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,2.000e-01,2.000e-02,2.000e-02
-SDP_RC,IND,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,2.000e-01,2.000e-02,2.000e-02
-SDP_RC,IND,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.693e-03,9.485e-03,1.462e-02,1.462e-02
+SDP_RC,IND,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.787e-02,6.365e-02,6.430e-02,6.430e-02
+SDP_RC,IND,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.109e-02,3.424e-02,6.237e-02,6.237e-02
+SDP_RC,IND,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,2.338e-01,1.273e-01,6.547e-02,6.547e-02
+SDP_RC,IND,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,2.338e-01,1.273e-01,6.547e-02,6.547e-02
+SDP_RC,IND,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.787e-02,6.365e-02,6.430e-02,6.430e-02
+SDP_RC,IND,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.698e-03,1.963e-02,5.456e-02,5.456e-02
+SDP_RC,IND,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.217e-03,8.625e-03,1.595e-03,1.595e-03
+SDP_RC,IND,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.927e-03,3.271e-03,1.091e-03,1.091e-03
+SDP_RC,IND,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,7.794e-01,1.819e-01,2.182e-03,2.182e-03
+SDP_RC,IND,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,7.794e-01,1.819e-01,2.182e-03,2.182e-03
+SDP_RC,IND,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.217e-03,8.625e-03,1.595e-03,1.595e-03
 SDP_RC,IND,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0.000e+00,8.315e-07,4.540e-05,1.192e-01,1.192e-01
 SDP_RC,IND,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,IND,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
@@ -4993,27 +4993,27 @@ SDP_RC,IND,Liquids,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,tr
 SDP_RC,IND,Liquids,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,IND,Liquids,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,IND,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_RC,IND,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_RC,IND,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
+SDP_RC,IND,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,9.164e-01,1.000e+00,1.000e+00,1.000e+00,1.000e+00
+SDP_RC,IND,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,9.164e-01,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,IND,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,IND,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,2.408e-01,2.086e-01,2.105e-01,1.903e-01,1.903e-01
-SDP_RC,IND,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,8.768e-02,1.117e-01,7.985e-02,2.557e-02,2.557e-02
-SDP_RC,IND,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,3.947e-02,1.842e-02,1.842e-02
-SDP_RC,IND,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,5.000e-01,1.000e-01,1.000e-01
-SDP_RC,IND,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,5.000e-01,1.000e-01,1.000e-01
-SDP_RC,IND,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,3.947e-02,1.842e-02,1.842e-02
+SDP_RC,IND,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,8.768e-02,7.978e-02,6.655e-02,2.557e-02,2.557e-02
+SDP_RC,IND,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.880e-02,3.289e-02,1.842e-02,1.842e-02
+SDP_RC,IND,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,9.164e-01,7.143e-01,4.167e-01,1.000e-01,1.000e-01
+SDP_RC,IND,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,9.164e-01,7.143e-01,4.167e-01,1.000e-01,1.000e-01
+SDP_RC,IND,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.880e-02,3.289e-02,1.842e-02,1.842e-02
 SDP_RC,JPN,,,,,Cycle,trn_pass,S3S,linear,1.743e-02,1.743e-02,3.486e-02,1.961e-02,1.961e-02
-SDP_RC,JPN,,,,,Domestic Aviation,trn_pass,S3S,linear,1.811e-04,2.174e-04,3.261e-04,9.170e-05,9.170e-05
-SDP_RC,JPN,,,,,Domestic Ship,trn_freight,S3S,linear,1.146e-02,1.146e-02,1.146e-02,1.146e-02,1.146e-02
-SDP_RC,JPN,,,,,Freight Rail,trn_freight,S3S,linear,2.781e-03,2.781e-03,2.781e-03,2.781e-03,2.781e-03
+SDP_RC,JPN,,,,,Domestic Aviation,trn_pass,S3S,linear,1.729e-04,2.075e-04,3.112e-04,8.752e-05,8.752e-05
+SDP_RC,JPN,,,,,Domestic Ship,trn_freight,S3S,linear,1.167e-02,1.111e-02,1.167e-02,1.167e-02,1.167e-02
+SDP_RC,JPN,,,,,Freight Rail,trn_freight,S3S,linear,2.833e-03,2.698e-03,2.833e-03,2.833e-03,2.833e-03
 SDP_RC,JPN,,,,,HSR,trn_pass,S3S,linear,4.081e-04,4.081e-04,4.591e-04,1.291e-04,1.291e-04
 SDP_RC,JPN,,,,,International Aviation,trn_aviation_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,JPN,,,,,International Ship,trn_shipping_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,JPN,,,,,Passenger Rail,trn_pass,S3S,linear,6.084e-03,6.084e-03,7.000e-03,2.281e-03,2.281e-03
 SDP_RC,JPN,,,,,Walk,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,JPN,,,,,trn_freight_road,trn_freight,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_RC,JPN,,,,,trn_pass_road,trn_pass,S3S,linear,7.245e-02,7.770e-02,7.770e-02,2.185e-02,2.185e-02
-SDP_RC,JPN,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,5.971e-02,5.971e-02,5.971e-02,5.971e-02,5.971e-02
+SDP_RC,JPN,,,,,trn_pass_road,trn_pass,S3S,linear,7.113e-02,7.629e-02,7.629e-02,2.146e-02,2.146e-02
+SDP_RC,JPN,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,6.081e-02,6.081e-02,6.081e-02,6.081e-02,6.081e-02
 SDP_RC,JPN,,,,trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,JPN,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,5.491e-02,5.491e-02,5.491e-02,5.491e-02,5.491e-02
 SDP_RC,JPN,,,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
@@ -5026,24 +5026,24 @@ SDP_RC,JPN,,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_
 SDP_RC,JPN,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.286e-01,1.286e-01,1.286e-01,1.286e-01,1.286e-01
 SDP_RC,JPN,,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,JPN,,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,5.896e-01,5.896e-01,5.896e-01,5.896e-01,5.896e-01
-SDP_RC,JPN,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_RC,JPN,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_RC,JPN,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_RC,JPN,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.091e-01,1.793e-01,3.810e-01,3.810e-01
+SDP_RC,JPN,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.600e-01,5.280e-01,1.000e+00,1.000e+00
+SDP_RC,JPN,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.600e-01,5.280e-01,1.000e+00,1.000e+00
+SDP_RC,JPN,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.600e-01,5.280e-01,1.000e+00,1.000e+00
+SDP_RC,JPN,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,9.673e-02,1.794e-01,3.754e-01,3.754e-01
 SDP_RC,JPN,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,JPN,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,JPN,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_RC,JPN,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.252e-01,3.529e-01,8.183e-01,8.183e-01
-SDP_RC,JPN,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,6.364e-02,1.333e-01,8.333e-01,8.333e-01
-SDP_RC,JPN,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,6.364e-02,1.333e-01,8.333e-01,8.333e-01
-SDP_RC,JPN,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,6.364e-02,1.333e-01,8.333e-01,8.333e-01
-SDP_RC,JPN,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.252e-01,3.529e-01,8.183e-01,8.183e-01
-SDP_RC,JPN,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,6.182e-02,1.319e-01,1.000e-01,1.000e-01
-SDP_RC,JPN,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.104e-01,2.511e-01,3.046e-01,3.046e-01
-SDP_RC,JPN,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,4.167e-01,4.167e-01
-SDP_RC,JPN,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,4.167e-01,4.167e-01
-SDP_RC,JPN,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,4.167e-01,4.167e-01
-SDP_RC,JPN,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.104e-01,2.511e-01,3.046e-01,3.046e-01
+SDP_RC,JPN,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.332e-01,3.414e-01,8.870e-01,8.870e-01
+SDP_RC,JPN,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,5.727e-02,1.200e-01,9.032e-01,9.032e-01
+SDP_RC,JPN,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,5.727e-02,1.200e-01,9.032e-01,9.032e-01
+SDP_RC,JPN,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,5.727e-02,1.200e-01,9.032e-01,9.032e-01
+SDP_RC,JPN,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.332e-01,3.414e-01,8.870e-01,8.870e-01
+SDP_RC,JPN,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,6.091e-02,1.200e-01,9.854e-02,9.854e-02
+SDP_RC,JPN,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.306e-01,2.699e-01,2.701e-01,2.701e-01
+SDP_RC,JPN,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,3.695e-01,3.695e-01
+SDP_RC,JPN,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,3.695e-01,3.695e-01
+SDP_RC,JPN,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,3.695e-01,3.695e-01
+SDP_RC,JPN,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.306e-01,2.699e-01,2.701e-01,2.701e-01
 SDP_RC,JPN,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0.000e+00,8.315e-07,4.540e-05,1.192e-01,1.192e-01
 SDP_RC,JPN,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,JPN,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
@@ -5051,41 +5051,41 @@ SDP_RC,JPN,Liquids,Domestic Ship_tmp_vehicletype,Domestic Ship_tmp_subsector_L1,
 SDP_RC,JPN,Liquids,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,8.837e-01,8.837e-01,8.837e-01,8.837e-01,8.837e-01
 SDP_RC,JPN,Liquids,International Aviation_tmp_vehicletype,International Aviation_tmp_subsector_L1,International Aviation_tmp_subsector_L2,International Aviation,trn_aviation_intl,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,JPN,Liquids,International Ship_tmp_vehicletype,International Ship_tmp_subsector_L1,International Ship_tmp_subsector_L2,International Ship,trn_shipping_intl,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_RC,JPN,Liquids,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_RC,JPN,Liquids,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_RC,JPN,Liquids,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
+SDP_RC,JPN,Liquids,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,9.921e-01,9.921e-01
+SDP_RC,JPN,Liquids,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,9.921e-01,9.921e-01
+SDP_RC,JPN,Liquids,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,9.921e-01,9.921e-01
 SDP_RC,JPN,Liquids,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,3.433e-02,3.433e-02,3.433e-02,3.433e-02,3.433e-02
 SDP_RC,JPN,Liquids,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_RC,JPN,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,6.061e-02,1.889e-01,1.000e+00,1.000e+00
-SDP_RC,JPN,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,6.061e-02,1.889e-01,1.000e+00,1.000e+00
-SDP_RC,JPN,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,6.061e-02,1.889e-01,1.000e+00,1.000e+00
+SDP_RC,JPN,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,8.457e-01,5.126e-02,1.757e-01,1.000e+00,1.000e+00
+SDP_RC,JPN,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,8.457e-01,5.126e-02,1.757e-01,1.000e+00,1.000e+00
+SDP_RC,JPN,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,8.457e-01,5.126e-02,1.757e-01,1.000e+00,1.000e+00
 SDP_RC,JPN,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_RC,JPN,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,7.895e-03,1.579e-02,2.303e-02,2.303e-02
-SDP_RC,JPN,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.316e-02,4.644e-02,4.605e-02,4.605e-02
-SDP_RC,JPN,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,3.030e-02,1.111e-01,2.500e-01,2.500e-01
-SDP_RC,JPN,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,3.030e-02,1.111e-01,2.500e-01,2.500e-01
-SDP_RC,JPN,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,3.030e-02,1.111e-01,2.500e-01,2.500e-01
-SDP_RC,JPN,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.316e-02,4.644e-02,4.605e-02,4.605e-02
-SDP_RC,LAM,,,,,Cycle,trn_pass,S3S,linear,9.812e-03,1.852e-02,4.629e-02,2.315e-01,2.315e-01
-SDP_RC,LAM,,,,,Domestic Aviation,trn_pass,S3S,linear,8.407e-03,1.058e-02,2.644e-02,1.983e-02,1.983e-02
-SDP_RC,LAM,,,,,Domestic Ship,trn_freight,S3S,linear,9.523e-03,9.523e-03,8.658e-03,7.936e-03,7.936e-03
-SDP_RC,LAM,,,,,Freight Rail,trn_freight,S3S,linear,4.694e-02,4.694e-02,4.268e-02,3.912e-02,3.912e-02
-SDP_RC,LAM,,,,,HSR,trn_pass,S3S,linear,4.709e-03,2.465e-01,2.465e-01,2.465e-01,2.465e-01
+SDP_RC,JPN,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,6.579e-03,1.215e-02,1.919e-02,1.919e-02
+SDP_RC,JPN,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.316e-02,4.222e-02,3.838e-02,3.838e-02
+SDP_RC,JPN,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,8.457e-01,2.563e-02,9.397e-02,2.083e-01,2.083e-01
+SDP_RC,JPN,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,8.457e-01,2.563e-02,9.397e-02,2.083e-01,2.083e-01
+SDP_RC,JPN,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,8.457e-01,2.563e-02,9.397e-02,2.083e-01,2.083e-01
+SDP_RC,JPN,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.316e-02,4.222e-02,3.838e-02,3.838e-02
+SDP_RC,LAM,,,,,Cycle,trn_pass,S3S,linear,1.091e-02,2.182e-02,5.455e-02,2.728e-01,2.728e-01
+SDP_RC,LAM,,,,,Domestic Aviation,trn_pass,S3S,linear,8.921e-03,1.190e-02,2.974e-02,2.230e-02,2.230e-02
+SDP_RC,LAM,,,,,Domestic Ship,trn_freight,S3S,linear,9.700e-03,9.700e-03,8.908e-03,6.736e-03,6.736e-03
+SDP_RC,LAM,,,,,Freight Rail,trn_freight,S3S,linear,4.782e-02,4.782e-02,4.391e-02,3.985e-02,3.985e-02
+SDP_RC,LAM,,,,,HSR,trn_pass,S3S,linear,5.236e-03,2.905e-01,2.905e-01,2.905e-01,2.905e-01
 SDP_RC,LAM,,,,,International Aviation,trn_aviation_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,LAM,,,,,International Ship,trn_shipping_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_RC,LAM,,,,,Passenger Rail,trn_pass,S3S,linear,1.348e-01,1.272e-01,1.272e-01,8.482e-02,8.482e-02
-SDP_RC,LAM,,,,,Walk,trn_pass,S3S,linear,8.993e-01,8.486e-01,8.486e-01,8.486e-01,8.486e-01
+SDP_RC,LAM,,,,,Passenger Rail,trn_pass,S3S,linear,1.499e-01,1.499e-01,1.499e-01,9.996e-02,9.996e-02
+SDP_RC,LAM,,,,,Walk,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,LAM,,,,,trn_freight_road,trn_freight,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_RC,LAM,,,,,trn_pass_road,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_RC,LAM,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,1.732e-01,1.083e-01,8.662e-02,8.662e-02,8.662e-02
+SDP_RC,LAM,,,,,trn_pass_road,trn_pass,S3S,linear,6.550e-01,6.942e-01,6.942e-01,8.099e-01,8.099e-01
+SDP_RC,LAM,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,2.647e-01,1.654e-01,1.323e-01,1.323e-01,1.323e-01
 SDP_RC,LAM,,,,trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,LAM,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.377e-01,1.377e-01,1.377e-01,1.377e-01,1.377e-01
 SDP_RC,LAM,,,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,LAM,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_RC,LAM,,Large Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,5.465e-02,5.465e-02,5.465e-02,5.465e-02,5.465e-02
-SDP_RC,LAM,,Large Car and SUV,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,6.039e-01,6.039e-01,6.039e-01,6.039e-01,6.039e-01
-SDP_RC,LAM,,Light Truck and SUV,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,2.182e-01,2.182e-01,2.182e-01,2.182e-01,2.182e-01
-SDP_RC,LAM,,Midsize Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,7.979e-02,7.979e-02,7.979e-02,7.979e-02,7.979e-02
+SDP_RC,LAM,,Large Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,3.279e-02,3.935e-02,4.099e-02,4.372e-02,4.372e-02
+SDP_RC,LAM,,Large Car and SUV,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,3.624e-01,4.348e-01,4.529e-01,4.831e-01,4.831e-01
+SDP_RC,LAM,,Light Truck and SUV,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.309e-01,1.571e-01,1.636e-01,1.745e-01,1.745e-01
+SDP_RC,LAM,,Midsize Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,4.788e-02,5.745e-02,5.984e-02,6.383e-02,6.383e-02
 SDP_RC,LAM,,Mini Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.226e-02,1.226e-02,1.226e-02,1.226e-02,1.226e-02
 SDP_RC,LAM,,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,4.580e-04,4.580e-04,4.580e-04,4.580e-04,4.580e-04
 SDP_RC,LAM,,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
@@ -5096,27 +5096,27 @@ SDP_RC,LAM,,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_s
 SDP_RC,LAM,,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,LAM,,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,5.079e-04,5.079e-04,5.079e-04,5.079e-04,5.079e-04
 SDP_RC,LAM,,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.892e-01,1.892e-01,1.892e-01,1.892e-01,1.892e-01
-SDP_RC,LAM,,Van,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,2.455e-03,2.455e-03,2.455e-03,2.455e-03,2.455e-03
-SDP_RC,LAM,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_RC,LAM,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_RC,LAM,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_RC,LAM,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.186e-01,5.379e-01,1.000e+00,1.000e+00
+SDP_RC,LAM,,Van,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.473e-03,1.768e-03,1.842e-03,1.964e-03,1.964e-03
+SDP_RC,LAM,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,5.600e-02,2.160e-01,5.040e-01,5.040e-01
+SDP_RC,LAM,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,5.600e-02,2.160e-01,5.040e-01,5.040e-01
+SDP_RC,LAM,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,5.600e-02,2.160e-01,5.040e-01,5.040e-01
+SDP_RC,LAM,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.294e-01,5.869e-01,1.000e+00,1.000e+00
 SDP_RC,LAM,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,6.810e-02,1.846e-01,4.176e-01,8.835e-01,8.835e-01
 SDP_RC,LAM,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,LAM,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_RC,LAM,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,7.947e-02,2.000e-01,2.400e-01,2.400e-01
-SDP_RC,LAM,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.162e-02,1.076e-01,2.329e-01,2.329e-01
-SDP_RC,LAM,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.162e-02,1.076e-01,2.329e-01,2.329e-01
-SDP_RC,LAM,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.162e-02,1.076e-01,2.329e-01,2.329e-01
-SDP_RC,LAM,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,7.947e-02,2.000e-01,2.400e-01,2.400e-01
-SDP_RC,LAM,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.473e-03,1.799e-02,6.561e-02,6.561e-02
-SDP_RC,LAM,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,8.924e-03,5.691e-02,8.123e-02,8.123e-02
-SDP_RC,LAM,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.297e-03,2.158e-02,5.556e-02,5.556e-02
-SDP_RC,LAM,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.297e-03,2.158e-02,5.556e-02,5.556e-02
-SDP_RC,LAM,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.297e-03,2.158e-02,5.556e-02,5.556e-02
-SDP_RC,LAM,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,8.924e-03,5.691e-02,8.123e-02,8.123e-02
+SDP_RC,LAM,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.041e-01,1.964e-01,2.357e-01,2.357e-01
+SDP_RC,LAM,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.140e-02,1.057e-01,2.287e-01,2.287e-01
+SDP_RC,LAM,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.140e-02,1.057e-01,2.287e-01,2.287e-01
+SDP_RC,LAM,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.140e-02,1.057e-01,2.287e-01,2.287e-01
+SDP_RC,LAM,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.041e-01,1.964e-01,2.357e-01,2.357e-01
+SDP_RC,LAM,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.698e-03,1.963e-02,6.561e-02,6.561e-02
+SDP_RC,LAM,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,9.738e-03,6.210e-02,8.864e-02,8.864e-02
+SDP_RC,LAM,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.598e-03,2.355e-02,6.062e-02,6.062e-02
+SDP_RC,LAM,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.598e-03,2.355e-02,6.062e-02,6.062e-02
+SDP_RC,LAM,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.598e-03,2.355e-02,6.062e-02,6.062e-02
+SDP_RC,LAM,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,9.738e-03,6.210e-02,8.864e-02,8.864e-02
 SDP_RC,LAM,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0.000e+00,8.315e-07,4.540e-05,1.192e-01,1.192e-01
-SDP_RC,LAM,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,7.217e-01,7.217e-01
+SDP_RC,LAM,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,7.275e-01,7.275e-01
 SDP_RC,LAM,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,LAM,Liquids,Domestic Ship_tmp_vehicletype,Domestic Ship_tmp_subsector_L1,Domestic Ship_tmp_subsector_L2,Domestic Ship,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,LAM,Liquids,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
@@ -5131,55 +5131,55 @@ SDP_RC,LAM,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_roa
 SDP_RC,LAM,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,LAM,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,LAM,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_RC,LAM,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,2.689e-02,4.725e-02,1.037e-01,1.353e-01,1.353e-01
+SDP_RC,LAM,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,2.689e-02,4.725e-02,1.037e-01,1.240e-01,1.240e-01
 SDP_RC,LAM,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.754e-02,3.158e-02,6.140e-02,6.140e-02
 SDP_RC,LAM,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.754e-02,3.158e-02,6.140e-02,6.140e-02
 SDP_RC,LAM,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.754e-02,3.158e-02,6.140e-02,6.140e-02
 SDP_RC,LAM,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.754e-02,3.158e-02,6.140e-02,6.140e-02
 SDP_RC,LAM,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.754e-02,3.158e-02,6.140e-02,6.140e-02
 SDP_RC,MEA,,,,,Cycle,trn_pass,S3S,linear,1.660e-02,1.660e-02,1.660e-02,4.149e-02,4.149e-02
-SDP_RC,MEA,,,,,Domestic Aviation,trn_pass,S3S,linear,8.929e-03,5.953e-03,1.786e-02,2.381e-02,2.381e-02
-SDP_RC,MEA,,,,,Domestic Ship,trn_freight,S3S,linear,2.022e-03,2.022e-03,2.022e-03,2.022e-03,2.022e-03
-SDP_RC,MEA,,,,,Freight Rail,trn_freight,S3S,linear,3.143e-03,3.143e-03,3.143e-03,3.143e-03,3.143e-03
+SDP_RC,MEA,,,,,Domestic Aviation,trn_pass,S3S,linear,8.522e-03,5.681e-03,1.704e-02,2.500e-02,2.500e-02
+SDP_RC,MEA,,,,,Domestic Ship,trn_freight,S3S,linear,2.060e-03,2.060e-03,2.060e-03,2.060e-03,2.060e-03
+SDP_RC,MEA,,,,,Freight Rail,trn_freight,S3S,linear,3.202e-03,3.202e-03,3.202e-03,3.202e-03,3.202e-03
 SDP_RC,MEA,,,,,HSR,trn_pass,S3S,linear,0.000e+00,1.667e-02,1.667e-02,1.667e-02,1.667e-02
 SDP_RC,MEA,,,,,International Aviation,trn_aviation_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,MEA,,,,,International Ship,trn_shipping_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,MEA,,,,,Passenger Rail,trn_pass,S3S,linear,5.567e-04,1.113e-03,1.113e-03,1.856e-03,1.856e-03
 SDP_RC,MEA,,,,,Walk,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,MEA,,,,,trn_freight_road,trn_freight,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_RC,MEA,,,,,trn_pass_road,trn_pass,S3S,linear,6.395e-01,7.197e-01,7.197e-01,7.197e-01,7.197e-01
-SDP_RC,MEA,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,2.627e-01,1.226e-01,6.131e-02,4.905e-02,4.905e-02
+SDP_RC,MEA,,,,,trn_pass_road,trn_pass,S3S,linear,3.767e-01,4.239e-01,3.815e-01,3.815e-01,3.815e-01
+SDP_RC,MEA,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,2.676e-01,1.873e-01,9.367e-02,7.493e-02,7.493e-02
 SDP_RC,MEA,,,,trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_RC,MEA,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,7.508e-03,7.508e-03,7.508e-03,7.508e-03,7.508e-03
+SDP_RC,MEA,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.502e-02,1.502e-02,1.502e-02,1.502e-02,1.502e-02
 SDP_RC,MEA,,,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_RC,MEA,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,4.732e-01,4.732e-01,4.732e-01,4.732e-01,4.732e-01
+SDP_RC,MEA,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,5.257e-01,4.732e-01,4.337e-01,3.943e-01,3.943e-01
 SDP_RC,MEA,,Large Car and SUV,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_RC,MEA,,Mini Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,3.955e-02,3.955e-02,3.955e-02,3.955e-02,3.955e-02
+SDP_RC,MEA,,Mini Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,4.395e-02,3.955e-02,3.626e-02,3.296e-02,3.296e-02
 SDP_RC,MEA,,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,MEA,,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,MEA,,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_RC,MEA,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.864e-01,1.864e-01,1.864e-01,1.864e-01,1.864e-01
+SDP_RC,MEA,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,2.071e-01,1.864e-01,1.709e-01,1.553e-01,1.553e-01
 SDP_RC,MEA,,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.304e-01,1.304e-01,1.304e-01,1.304e-01,1.304e-01
 SDP_RC,MEA,,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,2.013e-01,2.013e-01,2.013e-01,2.013e-01,2.013e-01
 SDP_RC,MEA,,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_RC,MEA,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_RC,MEA,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_RC,MEA,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_RC,MEA,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.743e-02,2.958e-01,6.549e-01,6.549e-01
+SDP_RC,MEA,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.200e-01,2.160e-01,2.100e-01,2.100e-01
+SDP_RC,MEA,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.200e-01,2.160e-01,2.100e-01,2.100e-01
+SDP_RC,MEA,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.200e-01,2.160e-01,2.100e-01,2.100e-01
+SDP_RC,MEA,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,5.175e-02,2.935e-01,6.497e-01,6.497e-01
 SDP_RC,MEA,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,4.021e-01,4.768e-01,6.263e-01,9.253e-01,9.253e-01
 SDP_RC,MEA,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,MEA,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_RC,MEA,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.960e-02,1.000e-01,1.403e-01,1.403e-01
-SDP_RC,MEA,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.371e-02,5.379e-02,1.361e-01,1.361e-01
-SDP_RC,MEA,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.429e-01,2.000e-01,1.429e-01,1.429e-01
-SDP_RC,MEA,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.429e-01,2.000e-01,1.429e-01,1.429e-01
-SDP_RC,MEA,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.960e-02,1.000e-01,1.403e-01,1.403e-01
-SDP_RC,MEA,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.473e-03,1.799e-02,6.250e-02,6.250e-02
-SDP_RC,MEA,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.346e-03,9.485e-03,4.177e-02,4.177e-02
-SDP_RC,MEA,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.236e-03,3.597e-03,2.857e-02,2.857e-02
-SDP_RC,MEA,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.429e-01,2.000e-01,5.714e-02,5.714e-02
-SDP_RC,MEA,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.429e-01,2.000e-01,5.714e-02,5.714e-02
-SDP_RC,MEA,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.346e-03,9.485e-03,4.177e-02,4.177e-02
+SDP_RC,MEA,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.504e-02,1.091e-01,1.392e-01,1.392e-01
+SDP_RC,MEA,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.588e-02,5.869e-02,1.350e-01,1.350e-01
+SDP_RC,MEA,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.559e-01,2.182e-01,1.417e-01,1.417e-01
+SDP_RC,MEA,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.559e-01,2.182e-01,1.417e-01,1.417e-01
+SDP_RC,MEA,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.504e-02,1.091e-01,1.392e-01,1.392e-01
+SDP_RC,MEA,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.698e-03,1.784e-02,5.580e-02,5.580e-02
+SDP_RC,MEA,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.652e-03,1.035e-02,4.144e-04,4.144e-04
+SDP_RC,MEA,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.349e-03,3.925e-03,2.834e-04,2.834e-04
+SDP_RC,MEA,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.559e-01,2.182e-01,5.669e-04,5.669e-04
+SDP_RC,MEA,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.559e-01,2.182e-01,5.669e-04,5.669e-04
+SDP_RC,MEA,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.652e-03,1.035e-02,4.144e-04,4.144e-04
 SDP_RC,MEA,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0.000e+00,8.315e-07,4.540e-05,1.192e-01,1.192e-01
 SDP_RC,MEA,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,MEA,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
@@ -5193,27 +5193,27 @@ SDP_RC,MEA,Liquids,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,tr
 SDP_RC,MEA,Liquids,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,7.852e-02,7.852e-02,7.852e-02,7.852e-02,7.852e-02
 SDP_RC,MEA,Liquids,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,MEA,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_RC,MEA,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,2.857e-01,1.000e+00,1.000e+00,1.000e+00
-SDP_RC,MEA,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,2.857e-01,1.000e+00,1.000e+00,1.000e+00
+SDP_RC,MEA,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,9.164e-01,2.857e-01,1.000e+00,1.000e+00,1.000e+00
+SDP_RC,MEA,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,9.164e-01,2.857e-01,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,MEA,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_RC,MEA,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.342e-02,3.938e-02,9.130e-02,1.220e-01,1.220e-01
-SDP_RC,MEA,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,9.283e-04,9.527e-02,4.788e-02,5.285e-02,5.285e-02
-SDP_RC,MEA,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,9.211e-02,4.737e-02,5.263e-02,5.263e-02
-SDP_RC,MEA,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,6.000e-01,2.857e-01,2.857e-01
-SDP_RC,MEA,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,6.000e-01,2.857e-01,2.857e-01
-SDP_RC,MEA,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,9.211e-02,4.737e-02,5.263e-02,5.263e-02
+SDP_RC,MEA,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.342e-02,3.938e-02,8.300e-02,1.109e-01,1.109e-01
+SDP_RC,MEA,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,9.283e-04,9.527e-02,4.788e-02,4.804e-02,4.804e-02
+SDP_RC,MEA,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,9.211e-02,4.737e-02,4.785e-02,4.785e-02
+SDP_RC,MEA,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,9.164e-01,1.000e+00,6.000e-01,2.597e-01,2.597e-01
+SDP_RC,MEA,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,9.164e-01,1.000e+00,6.000e-01,2.597e-01,2.597e-01
+SDP_RC,MEA,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,9.211e-02,4.737e-02,4.785e-02,4.785e-02
 SDP_RC,NEN,,,,,Cycle,trn_pass,S3S,linear,3.033e-03,3.024e-03,2.621e-03,1.820e-02,1.820e-02
-SDP_RC,NEN,,,,,Domestic Aviation,trn_pass,S3S,linear,7.555e-06,7.895e-06,2.566e-06,1.497e-06,1.497e-06
-SDP_RC,NEN,,,,,Domestic Ship,trn_freight,S3S,linear,3.117e-02,3.117e-02,3.117e-02,3.117e-02,3.117e-02
-SDP_RC,NEN,,,,,Freight Rail,trn_freight,S3S,linear,1.890e-02,1.890e-02,1.890e-02,1.890e-02,1.890e-02
+SDP_RC,NEN,,,,,Domestic Aviation,trn_pass,S3S,linear,7.210e-06,7.535e-06,2.449e-06,1.428e-06,1.428e-06
+SDP_RC,NEN,,,,,Domestic Ship,trn_freight,S3S,linear,3.175e-02,3.175e-02,3.175e-02,3.175e-02,3.175e-02
+SDP_RC,NEN,,,,,Freight Rail,trn_freight,S3S,linear,1.925e-02,1.925e-02,1.925e-02,1.925e-02,1.925e-02
 SDP_RC,NEN,,,,,HSR,trn_pass,S3S,linear,2.000e-05,4.532e-05,7.364e-06,5.523e-06,5.523e-06
 SDP_RC,NEN,,,,,International Aviation,trn_aviation_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,NEN,,,,,International Ship,trn_shipping_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,NEN,,,,,Passenger Rail,trn_pass,S3S,linear,3.000e-06,2.967e-06,6.751e-07,3.215e-07,3.215e-07
 SDP_RC,NEN,,,,,Walk,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,NEN,,,,,trn_freight_road,trn_freight,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_RC,NEN,,,,,trn_pass_road,trn_pass,S3S,linear,5.052e-02,6.996e-02,2.842e-02,2.368e-02,2.368e-02
-SDP_RC,NEN,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,1.263e-02,7.897e-03,3.948e-03,1.974e-03,1.974e-03
+SDP_RC,NEN,,,,,trn_pass_road,trn_pass,S3S,linear,4.960e-02,6.868e-02,2.790e-02,2.325e-02,2.325e-02
+SDP_RC,NEN,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,1.287e-02,8.044e-03,4.022e-03,2.011e-03,2.011e-03
 SDP_RC,NEN,,,,trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,NEN,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,3.994e-02,3.994e-02,3.994e-02,3.994e-02,3.994e-02
 SDP_RC,NEN,,,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
@@ -5231,24 +5231,24 @@ SDP_RC,NEN,,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_s
 SDP_RC,NEN,,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,6.397e-02,6.397e-02,6.397e-02,6.397e-02,6.397e-02
 SDP_RC,NEN,,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,3.433e-01,3.433e-01,3.433e-01,3.433e-01,3.433e-01
 SDP_RC,NEN,,Van,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,7.350e-03,7.350e-03,7.350e-03,7.350e-03,7.350e-03
-SDP_RC,NEN,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_RC,NEN,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_RC,NEN,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_RC,NEN,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.743e-02,2.689e-01,9.526e-01,9.526e-01
+SDP_RC,NEN,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.000e-02,1.680e-01,2.940e-01,2.940e-01
+SDP_RC,NEN,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.000e-02,1.680e-01,2.940e-01,2.940e-01
+SDP_RC,NEN,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.000e-02,1.680e-01,2.940e-01,2.940e-01
+SDP_RC,NEN,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,5.608e-02,1.402e-01,4.134e-01,9.856e-01,9.856e-01
 SDP_RC,NEN,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,NEN,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,NEN,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_RC,NEN,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.192e-01,5.000e-01,9.820e-01,9.820e-01
-SDP_RC,NEN,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.743e-02,2.689e-01,9.526e-01,9.526e-01
-SDP_RC,NEN,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.743e-02,2.689e-01,9.526e-01,9.526e-01
-SDP_RC,NEN,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.743e-02,2.689e-01,9.526e-01,9.526e-01
-SDP_RC,NEN,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.192e-01,5.000e-01,9.820e-01,9.820e-01
-SDP_RC,NEN,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.473e-03,1.799e-02,5.000e-01,5.000e-01
-SDP_RC,NEN,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.693e-03,4.743e-02,7.311e-01,7.311e-01
-SDP_RC,NEN,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-03,1.799e-02,5.000e-01,5.000e-01
-SDP_RC,NEN,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-03,1.799e-02,5.000e-01,5.000e-01
-SDP_RC,NEN,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-03,1.799e-02,5.000e-01,5.000e-01
-SDP_RC,NEN,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.693e-03,4.743e-02,7.311e-01,7.311e-01
+SDP_RC,NEN,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.537e-01,5.912e-01,8.932e-01,8.932e-01
+SDP_RC,NEN,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.009e-01,3.180e-01,8.664e-01,8.664e-01
+SDP_RC,NEN,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.009e-01,3.180e-01,8.664e-01,8.664e-01
+SDP_RC,NEN,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.009e-01,3.180e-01,8.664e-01,8.664e-01
+SDP_RC,NEN,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.537e-01,5.912e-01,8.932e-01,8.932e-01
+SDP_RC,NEN,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.924e-03,2.127e-02,5.543e-02,5.543e-02
+SDP_RC,NEN,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,7.914e-03,1.682e-01,9.974e-02,9.974e-02
+SDP_RC,NEN,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.924e-03,6.380e-02,6.822e-02,6.822e-02
+SDP_RC,NEN,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.924e-03,6.380e-02,6.822e-02,6.822e-02
+SDP_RC,NEN,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.924e-03,6.380e-02,6.822e-02,6.822e-02
+SDP_RC,NEN,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,7.914e-03,1.682e-01,9.974e-02,9.974e-02
 SDP_RC,NEN,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0.000e+00,8.315e-07,4.540e-05,1.192e-01,1.192e-01
 SDP_RC,NEN,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,NEN,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
@@ -5265,59 +5265,59 @@ SDP_RC,NEN,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_roa
 SDP_RC,NEN,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,NEN,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,NEN,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_RC,NEN,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,2.147e-02,4.722e-02,9.872e-02,2.017e-01,2.017e-01
-SDP_RC,NEN,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,6.427e-03,3.257e-02,8.487e-02,1.895e-01,1.895e-01
-SDP_RC,NEN,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SDP_RC,NEN,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SDP_RC,NEN,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SDP_RC,NEN,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
+SDP_RC,NEN,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,2.362e-02,3.778e-02,9.872e-02,1.261e-01,1.261e-01
+SDP_RC,NEN,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,6.427e-03,3.257e-02,8.487e-02,1.457e-01,1.457e-01
+SDP_RC,NEN,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.417e-01,1.417e-01
+SDP_RC,NEN,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.417e-01,1.417e-01
+SDP_RC,NEN,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.417e-01,1.417e-01
+SDP_RC,NEN,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.417e-01,1.417e-01
 SDP_RC,NES,,,,,Cycle,trn_pass,S3S,linear,8.738e-03,7.802e-03,9.929e-03,1.365e-02,1.365e-02
-SDP_RC,NES,,,,,Domestic Aviation,trn_pass,S3S,linear,4.947e-03,3.534e-03,1.499e-03,4.123e-04,4.123e-04
-SDP_RC,NES,,,,,Domestic Ship,trn_freight,S3S,linear,1.442e-02,1.442e-02,1.442e-02,1.442e-02,1.442e-02
-SDP_RC,NES,,,,,Freight Rail,trn_freight,S3S,linear,1.666e-02,1.666e-02,1.666e-02,1.666e-02,1.666e-02
+SDP_RC,NES,,,,,Domestic Aviation,trn_pass,S3S,linear,4.721e-03,3.372e-03,1.431e-03,3.935e-04,3.935e-04
+SDP_RC,NES,,,,,Domestic Ship,trn_freight,S3S,linear,1.468e-02,1.468e-02,1.468e-02,1.322e-02,1.322e-02
+SDP_RC,NES,,,,,Freight Rail,trn_freight,S3S,linear,1.697e-02,1.697e-02,1.697e-02,1.697e-02,1.697e-02
 SDP_RC,NES,,,,,HSR,trn_pass,S3S,linear,5.085e-04,3.632e-04,2.311e-04,1.271e-04,1.271e-04
 SDP_RC,NES,,,,,International Aviation,trn_aviation_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,NES,,,,,International Ship,trn_shipping_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,NES,,,,,Passenger Rail,trn_pass,S3S,linear,1.607e-03,1.148e-03,7.303e-04,4.017e-04,4.017e-04
 SDP_RC,NES,,,,,Walk,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,NES,,,,,trn_freight_road,trn_freight,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_RC,NES,,,,,trn_pass_road,trn_pass,S3S,linear,9.258e-01,7.176e-01,4.566e-01,2.512e-01,2.512e-01
-SDP_RC,NES,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,5.499e-02,2.199e-02,1.100e-02,1.100e-02,1.100e-02
+SDP_RC,NES,,,,,trn_pass_road,trn_pass,S3S,linear,2.727e-01,2.818e-01,2.242e-01,1.233e-01,1.233e-01
+SDP_RC,NES,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,8.401e-02,3.734e-02,2.240e-02,2.240e-02,2.240e-02
 SDP_RC,NES,,,,trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,NES,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,4.923e-03,4.923e-03,4.923e-03,4.923e-03,4.923e-03
 SDP_RC,NES,,,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_RC,NES,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,4.608e-01,4.608e-01,4.608e-01,4.608e-01,4.608e-01
+SDP_RC,NES,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,5.760e-01,5.760e-01,6.144e-01,6.144e-01,6.144e-01
 SDP_RC,NES,,Large Car and SUV,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,NES,,Midsize Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,2.352e-01,2.352e-01,2.352e-01,2.352e-01,2.352e-01
-SDP_RC,NES,,Mini Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.509e-03,1.509e-03,1.509e-03,1.509e-03,1.509e-03
+SDP_RC,NES,,Mini Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.886e-03,1.886e-03,2.012e-03,2.012e-03,2.012e-03
 SDP_RC,NES,,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.148e-02,1.148e-02,1.148e-02,1.148e-02,1.148e-02
 SDP_RC,NES,,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.337e-01,1.337e-01,1.337e-01,1.337e-01,1.337e-01
 SDP_RC,NES,,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_RC,NES,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,7.460e-02,7.460e-02,7.460e-02,7.460e-02,7.460e-02
+SDP_RC,NES,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,9.325e-02,9.325e-02,9.946e-02,9.946e-02,9.946e-02
 SDP_RC,NES,,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,NES,,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,6.299e-02,6.299e-02,6.299e-02,6.299e-02,6.299e-02
 SDP_RC,NES,,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,3.651e-01,3.651e-01,3.651e-01,3.651e-01,3.651e-01
 SDP_RC,NES,,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,5.704e-01,5.704e-01,5.704e-01,5.704e-01,5.704e-01
 SDP_RC,NES,,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,4.799e-01,4.799e-01,4.799e-01,4.799e-01,4.799e-01
 SDP_RC,NES,,Van,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,2.880e-03,2.880e-03,2.880e-03,2.880e-03,2.880e-03
-SDP_RC,NES,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_RC,NES,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_RC,NES,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_RC,NES,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.743e-02,2.689e-01,9.526e-01,9.526e-01
+SDP_RC,NES,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.000e-02,1.680e-01,3.360e-01,3.360e-01
+SDP_RC,NES,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.000e-02,1.680e-01,3.360e-01,3.360e-01
+SDP_RC,NES,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.000e-02,1.680e-01,3.360e-01,3.360e-01
+SDP_RC,NES,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,5.175e-02,1.739e-01,3.465e-01,3.465e-01
 SDP_RC,NES,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,2.081e-01,3.071e-01,5.050e-01,9.010e-01,9.010e-01
 SDP_RC,NES,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,NES,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_RC,NES,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.192e-01,5.000e-01,9.820e-01,9.820e-01
-SDP_RC,NES,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.743e-02,2.689e-01,9.526e-01,9.526e-01
-SDP_RC,NES,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.743e-02,2.689e-01,9.526e-01,9.526e-01
-SDP_RC,NES,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.743e-02,2.689e-01,9.526e-01,9.526e-01
-SDP_RC,NES,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.192e-01,5.000e-01,9.820e-01,9.820e-01
-SDP_RC,NES,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.473e-03,1.799e-02,5.000e-01,5.000e-01
-SDP_RC,NES,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.693e-03,4.743e-02,7.311e-01,7.311e-01
-SDP_RC,NES,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-03,1.799e-02,5.000e-01,5.000e-01
-SDP_RC,NES,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-03,1.799e-02,5.000e-01,5.000e-01
-SDP_RC,NES,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-03,1.799e-02,5.000e-01,5.000e-01
-SDP_RC,NES,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.693e-03,4.743e-02,7.311e-01,7.311e-01
+SDP_RC,NES,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.138e-01,2.182e-01,3.215e-01,3.215e-01
+SDP_RC,NES,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.528e-02,1.174e-01,3.118e-01,3.118e-01
+SDP_RC,NES,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.528e-02,1.174e-01,3.118e-01,3.118e-01
+SDP_RC,NES,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.528e-02,1.174e-01,3.118e-01,3.118e-01
+SDP_RC,NES,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.138e-01,2.182e-01,3.215e-01,3.215e-01
+SDP_RC,NES,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.698e-03,1.454e-02,3.637e-02,3.637e-02
+SDP_RC,NES,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,9.129e-03,3.833e-02,8.376e-02,8.376e-02
+SDP_RC,NES,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.373e-03,1.454e-02,5.729e-02,5.729e-02
+SDP_RC,NES,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.373e-03,1.454e-02,5.729e-02,5.729e-02
+SDP_RC,NES,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.373e-03,1.454e-02,5.729e-02,5.729e-02
+SDP_RC,NES,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,9.129e-03,3.833e-02,8.376e-02,8.376e-02
 SDP_RC,NES,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0.000e+00,8.315e-07,4.540e-05,1.192e-01,1.192e-01
 SDP_RC,NES,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,NES,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
@@ -5334,63 +5334,63 @@ SDP_RC,NES,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_roa
 SDP_RC,NES,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,NES,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,NES,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_RC,NES,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,3.476e-03,2.970e-02,8.215e-02,1.870e-01,1.870e-01
-SDP_RC,NES,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SDP_RC,NES,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SDP_RC,NES,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SDP_RC,NES,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SDP_RC,NES,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SDP_RC,OAS,,,,,Cycle,trn_pass,S3S,linear,1.256e-02,2.493e-02,3.323e-02,8.309e-02,8.309e-02
-SDP_RC,OAS,,,,,Domestic Aviation,trn_pass,S3S,linear,2.574e-02,2.661e-02,3.726e-02,7.983e-02,7.983e-02
-SDP_RC,OAS,,,,,Domestic Ship,trn_freight,S3S,linear,3.645e-02,3.645e-02,2.804e-02,3.645e-02,3.645e-02
-SDP_RC,OAS,,,,,Freight Rail,trn_freight,S3S,linear,4.649e-02,4.649e-02,3.576e-02,4.649e-02,4.649e-02
-SDP_RC,OAS,,,,,HSR,trn_pass,S3S,linear,9.660e-04,2.997e-03,2.997e-03,3.995e-03,3.995e-03
+SDP_RC,NES,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,3.476e-03,2.970e-02,6.085e-02,7.482e-02,7.482e-02
+SDP_RC,NES,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.289e-02,8.772e-02,1.289e-01,1.289e-01
+SDP_RC,NES,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.289e-02,8.772e-02,1.289e-01,1.289e-01
+SDP_RC,NES,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.289e-02,8.772e-02,1.289e-01,1.289e-01
+SDP_RC,NES,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.289e-02,8.772e-02,1.289e-01,1.289e-01
+SDP_RC,NES,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.289e-02,8.772e-02,1.289e-01,1.289e-01
+SDP_RC,OAS,,,,,Cycle,trn_pass,S3S,linear,1.256e-02,3.616e-02,4.821e-02,1.205e-01,1.205e-01
+SDP_RC,OAS,,,,,Domestic Aviation,trn_pass,S3S,linear,2.456e-02,3.684e-02,5.158e-02,1.326e-01,1.326e-01
+SDP_RC,OAS,,,,,Domestic Ship,trn_freight,S3S,linear,3.712e-02,3.375e-02,2.856e-02,2.700e-02,2.700e-02
+SDP_RC,OAS,,,,,Freight Rail,trn_freight,S3S,linear,4.736e-02,4.305e-02,3.643e-02,3.444e-02,3.444e-02
+SDP_RC,OAS,,,,,HSR,trn_pass,S3S,linear,9.660e-04,4.347e-03,4.347e-03,5.796e-03,5.796e-03
 SDP_RC,OAS,,,,,International Aviation,trn_aviation_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,OAS,,,,,International Ship,trn_shipping_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_RC,OAS,,,,,Passenger Rail,trn_pass,S3S,linear,7.701e-04,7.963e-04,1.194e-03,1.593e-03,1.593e-03
-SDP_RC,OAS,,,,,Walk,trn_pass,S3S,linear,1.000e+00,6.893e-01,6.893e-01,6.893e-01,6.893e-01
+SDP_RC,OAS,,,,,Passenger Rail,trn_pass,S3S,linear,7.701e-04,1.155e-03,1.733e-03,2.310e-03,2.310e-03
+SDP_RC,OAS,,,,,Walk,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,OAS,,,,,trn_freight_road,trn_freight,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_RC,OAS,,,,,trn_pass_road,trn_pass,S3S,linear,8.721e-01,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_RC,OAS,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,2.403e-01,1.402e-01,5.510e-02,5.510e-02,5.510e-02
+SDP_RC,OAS,,,,,trn_pass_road,trn_pass,S3S,linear,4.452e-01,5.697e-01,5.697e-01,7.121e-01,7.121e-01
+SDP_RC,OAS,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,4.352e-01,2.571e-01,1.122e-01,9.620e-02,9.620e-02
 SDP_RC,OAS,,,,trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_RC,OAS,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,2.534e-02,2.233e-02,1.631e-02,4.276e-03,4.276e-03
+SDP_RC,OAS,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,3.520e-01,1.718e-01,1.631e-01,9.503e-02,9.503e-02
 SDP_RC,OAS,,,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_RC,OAS,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,6.745e-03,6.745e-03,6.745e-03,6.745e-03,6.745e-03
+SDP_RC,OAS,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,2.698e-03,2.811e-03,4.216e-03,5.621e-03,5.621e-03
 SDP_RC,OAS,,Large Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,3.018e-01,3.018e-01,3.018e-01,3.018e-01,3.018e-01
 SDP_RC,OAS,,Large Car and SUV,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,6.459e-04,6.459e-04,6.459e-04,6.459e-04,6.459e-04
 SDP_RC,OAS,,Light Truck and SUV,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,OAS,,Midsize Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,2.500e-04,2.500e-04,2.500e-04,2.500e-04,2.500e-04
-SDP_RC,OAS,,Mini Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,6.938e-05,6.938e-05,6.938e-05,6.938e-05,6.938e-05
+SDP_RC,OAS,,Mini Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,2.775e-05,2.891e-05,4.336e-05,5.782e-05,5.782e-05
 SDP_RC,OAS,,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,7.762e-03,7.762e-03,7.762e-03,7.762e-03,7.762e-03
 SDP_RC,OAS,,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,OAS,,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,6.391e-03,6.391e-03,6.391e-03,6.391e-03,6.391e-03
-SDP_RC,OAS,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,8.508e-03,8.508e-03,8.508e-03,8.508e-03,8.508e-03
+SDP_RC,OAS,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,3.403e-03,3.545e-03,5.318e-03,7.090e-03,7.090e-03
 SDP_RC,OAS,,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,3.765e-01,3.765e-01,3.765e-01,3.765e-01,3.765e-01
 SDP_RC,OAS,,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,4.784e-01,4.784e-01,4.784e-01,4.784e-01,4.784e-01
 SDP_RC,OAS,,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.365e-03,1.365e-03,1.365e-03,1.365e-03,1.365e-03
 SDP_RC,OAS,,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,7.361e-04,7.361e-04,7.361e-04,7.361e-04,7.361e-04
 SDP_RC,OAS,,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,OAS,,Van,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.027e-05,1.027e-05,1.027e-05,1.027e-05,1.027e-05
-SDP_RC,OAS,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_RC,OAS,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1.452e-05,1.452e-05,1.452e-05,1.452e-05,1.452e-05
-SDP_RC,OAS,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_RC,OAS,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.423e-01,6.724e-01,1.000e+00,1.000e+00
+SDP_RC,OAS,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.400e-02,1.680e-01,2.940e-01,2.940e-01
+SDP_RC,OAS,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.400e-02,1.680e-01,2.940e-01,2.940e-01
+SDP_RC,OAS,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.400e-02,1.680e-01,2.940e-01,2.940e-01
+SDP_RC,OAS,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.411e-01,6.670e-01,1.000e+00,1.000e+00
 SDP_RC,OAS,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1.733e-01,2.767e-01,4.833e-01,8.967e-01,8.967e-01
 SDP_RC,OAS,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,OAS,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,3.530e-01,4.338e-01,5.956e-01,9.191e-01,9.191e-01
-SDP_RC,OAS,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.973e-02,6.250e-02,7.856e-02,7.856e-02
-SDP_RC,OAS,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.581e-02,3.362e-02,7.621e-02,7.621e-02
-SDP_RC,OAS,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.581e-02,3.362e-02,7.621e-02,7.621e-02
-SDP_RC,OAS,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.581e-02,3.362e-02,7.621e-02,7.621e-02
-SDP_RC,OAS,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.973e-02,6.250e-02,7.856e-02,7.856e-02
-SDP_RC,OAS,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.473e-03,1.799e-02,6.561e-02,6.561e-02
-SDP_RC,OAS,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.115e-02,1.186e-02,2.924e-02,2.924e-02
-SDP_RC,OAS,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.121e-03,4.497e-03,2.000e-02,2.000e-02
-SDP_RC,OAS,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.121e-03,4.497e-03,2.000e-02,2.000e-02
-SDP_RC,OAS,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.121e-03,4.497e-03,2.000e-02,2.000e-02
-SDP_RC,OAS,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.115e-02,1.186e-02,2.924e-02,2.924e-02
+SDP_RC,OAS,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.469e-02,5.456e-02,7.144e-02,7.144e-02
+SDP_RC,OAS,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.380e-02,2.935e-02,6.930e-02,6.930e-02
+SDP_RC,OAS,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.380e-02,2.935e-02,6.930e-02,6.930e-02
+SDP_RC,OAS,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.380e-02,2.935e-02,6.930e-02,6.930e-02
+SDP_RC,OAS,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.469e-02,5.456e-02,7.144e-02,7.144e-02
+SDP_RC,OAS,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.453e-03,1.784e-02,7.290e-02,7.290e-02
+SDP_RC,OAS,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.217e-02,1.294e-02,2.127e-02,2.127e-02
+SDP_RC,OAS,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.497e-03,4.907e-03,1.455e-02,1.455e-02
+SDP_RC,OAS,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.497e-03,4.907e-03,1.455e-02,1.455e-02
+SDP_RC,OAS,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.497e-03,4.907e-03,1.455e-02,1.455e-02
+SDP_RC,OAS,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.217e-02,1.294e-02,2.127e-02,2.127e-02
 SDP_RC,OAS,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0.000e+00,8.315e-07,4.540e-05,1.192e-01,1.192e-01
-SDP_RC,OAS,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,6.561e-01,6.561e-01
+SDP_RC,OAS,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,6.681e-01,6.681e-01
 SDP_RC,OAS,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,OAS,Liquids,Domestic Ship_tmp_vehicletype,Domestic Ship_tmp_subsector_L1,Domestic Ship_tmp_subsector_L2,Domestic Ship,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,OAS,Liquids,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
@@ -5405,58 +5405,58 @@ SDP_RC,OAS,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_roa
 SDP_RC,OAS,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,OAS,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,OAS,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_RC,OAS,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.967e-01,2.178e-01,2.601e-01,2.261e-01,2.261e-01
-SDP_RC,OAS,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,4.535e-04,8.919e-03,3.968e-02,7.383e-02,7.383e-02
-SDP_RC,OAS,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,8.772e-03,3.947e-02,7.368e-02,7.368e-02
-SDP_RC,OAS,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.395e-01,5.404e-02,1.037e-01,1.192e-01,1.192e-01
-SDP_RC,OAS,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,2.466e-01,8.882e-02,1.531e-01,1.542e-01,1.542e-01
-SDP_RC,OAS,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,8.772e-03,3.947e-02,7.368e-02,7.368e-02
-SDP_RC,REF,,,,,Cycle,trn_pass,S3S,linear,4.737e-03,4.737e-03,2.369e-02,7.824e-02,7.824e-02
-SDP_RC,REF,,,,,Domestic Aviation,trn_pass,S3S,linear,1.287e-02,1.232e-02,1.540e-02,1.454e-02,1.454e-02
-SDP_RC,REF,,,,,Domestic Ship,trn_freight,S3S,linear,7.096e-03,7.096e-03,7.096e-03,7.096e-03,7.096e-03
-SDP_RC,REF,,,,,Freight Rail,trn_freight,S3S,linear,1.272e-01,1.272e-01,1.272e-01,1.272e-01,1.272e-01
-SDP_RC,REF,,,,,HSR,trn_pass,S3S,linear,0.000e+00,8.000e-04,8.000e-04,7.550e-04,7.550e-04
+SDP_RC,OAS,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.967e-01,1.980e-01,2.365e-01,2.303e-01,2.303e-01
+SDP_RC,OAS,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,4.535e-04,8.919e-03,3.968e-02,6.153e-02,6.153e-02
+SDP_RC,OAS,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,8.772e-03,3.947e-02,6.140e-02,6.140e-02
+SDP_RC,OAS,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.395e-01,5.404e-02,1.037e-01,9.933e-02,9.933e-02
+SDP_RC,OAS,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,2.466e-01,8.882e-02,1.531e-01,1.285e-01,1.285e-01
+SDP_RC,OAS,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,8.772e-03,3.947e-02,6.140e-02,6.140e-02
+SDP_RC,REF,,,,,Cycle,trn_pass,S3S,linear,1.379e-02,1.206e-02,6.031e-02,7.824e-02,7.824e-02
+SDP_RC,REF,,,,,Domestic Aviation,trn_pass,S3S,linear,3.574e-02,2.995e-02,3.743e-02,1.387e-02,1.387e-02
+SDP_RC,REF,,,,,Domestic Ship,trn_freight,S3S,linear,7.227e-03,7.227e-03,7.227e-03,7.227e-03,7.227e-03
+SDP_RC,REF,,,,,Freight Rail,trn_freight,S3S,linear,1.296e-01,1.296e-01,1.296e-01,1.296e-01,1.296e-01
+SDP_RC,REF,,,,,HSR,trn_pass,S3S,linear,0.000e+00,2.037e-03,2.037e-03,7.550e-04,7.550e-04
 SDP_RC,REF,,,,,International Aviation,trn_aviation_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,REF,,,,,International Ship,trn_shipping_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_RC,REF,,,,,Passenger Rail,trn_pass,S3S,linear,2.366e-03,4.731e-03,5.914e-03,1.116e-02,1.116e-02
-SDP_RC,REF,,,,,Walk,trn_pass,S3S,linear,3.179e-01,3.179e-01,3.179e-01,1.000e+00,1.000e+00
+SDP_RC,REF,,,,,Passenger Rail,trn_pass,S3S,linear,6.884e-03,1.205e-02,1.506e-02,1.116e-02,1.116e-02
+SDP_RC,REF,,,,,Walk,trn_pass,S3S,linear,9.251e-01,8.095e-01,8.095e-01,1.000e+00,1.000e+00
 SDP_RC,REF,,,,,trn_freight_road,trn_freight,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_RC,REF,,,,,trn_pass_road,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,9.437e-01,9.437e-01
-SDP_RC,REF,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,1.186e-01,9.148e-02,7.623e-02,6.099e-02,6.099e-02
+SDP_RC,REF,,,,,trn_pass_road,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,4.633e-01,4.633e-01
+SDP_RC,REF,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,2.684e-01,1.864e-01,1.553e-01,1.242e-01,1.242e-01
 SDP_RC,REF,,,,trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,REF,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,3.698e-01,3.698e-01,3.698e-01,3.698e-01,3.698e-01
 SDP_RC,REF,,,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_RC,REF,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,2.227e-01,2.227e-01,2.227e-01,2.227e-01,2.227e-01
+SDP_RC,REF,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,4.455e-01,4.176e-01,4.176e-01,3.818e-01,3.818e-01
 SDP_RC,REF,,Large Car and SUV,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,REF,,Midsize Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.842e-01,1.842e-01,1.842e-01,1.842e-01,1.842e-01
-SDP_RC,REF,,Mini Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,7.127e-05,7.127e-05,7.127e-05,7.127e-05,7.127e-05
+SDP_RC,REF,,Mini Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.425e-04,1.336e-04,1.336e-04,1.222e-04,1.222e-04
 SDP_RC,REF,,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,3.376e-03,3.376e-03,3.376e-03,3.376e-03,3.376e-03
 SDP_RC,REF,,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,REF,,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,4.141e-01,4.141e-01,4.141e-01,4.141e-01,4.141e-01
-SDP_RC,REF,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.254e-02,1.254e-02,1.254e-02,1.254e-02,1.254e-02
+SDP_RC,REF,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,2.508e-02,2.351e-02,2.351e-02,2.150e-02,2.150e-02
 SDP_RC,REF,,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,REF,,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,5.081e-03,5.081e-03,5.081e-03,5.081e-03,5.081e-03
 SDP_RC,REF,,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,5.837e-01,5.837e-01,5.837e-01,5.837e-01,5.837e-01
 SDP_RC,REF,,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.888e-01,1.888e-01,1.888e-01,1.888e-01,1.888e-01
 SDP_RC,REF,,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.676e-02,1.676e-02,1.676e-02,1.676e-02,1.676e-02
-SDP_RC,REF,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_RC,REF,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,6.589e-03,6.589e-03,6.589e-03,6.589e-03,6.589e-03
-SDP_RC,REF,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_RC,REF,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.743e-02,3.227e-01,9.526e-01,9.526e-01
+SDP_RC,REF,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.000e-02,1.680e-01,3.360e-01,3.360e-01
+SDP_RC,REF,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.000e-02,1.680e-01,3.360e-01,3.360e-01
+SDP_RC,REF,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.000e-02,1.680e-01,3.360e-01,3.360e-01
+SDP_RC,REF,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,7.245e-02,3.202e-01,7.425e-01,7.425e-01
 SDP_RC,REF,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,REF,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,REF,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_RC,REF,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.192e-01,3.000e-01,3.928e-01,3.928e-01
-SDP_RC,REF,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.743e-02,1.614e-01,3.810e-01,3.810e-01
-SDP_RC,REF,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.743e-02,1.614e-01,3.810e-01,3.810e-01
-SDP_RC,REF,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.743e-02,1.614e-01,3.810e-01,3.810e-01
-SDP_RC,REF,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.192e-01,3.000e-01,3.928e-01,3.928e-01
-SDP_RC,REF,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.473e-03,3.597e-02,1.000e-01,1.000e-01
-SDP_RC,REF,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.024e-02,4.743e-02,7.311e-02,7.311e-02
-SDP_RC,REF,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.225e-02,1.799e-02,5.000e-02,5.000e-02
-SDP_RC,REF,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.225e-02,1.799e-02,5.000e-02,5.000e-02
-SDP_RC,REF,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.225e-02,1.799e-02,5.000e-02,5.000e-02
-SDP_RC,REF,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.024e-02,4.743e-02,7.311e-02,7.311e-02
+SDP_RC,REF,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.183e-01,2.678e-01,3.957e-01,3.957e-01
+SDP_RC,REF,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.705e-02,1.441e-01,3.838e-01,3.838e-01
+SDP_RC,REF,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.705e-02,1.441e-01,3.838e-01,3.838e-01
+SDP_RC,REF,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.705e-02,1.441e-01,3.838e-01,3.838e-01
+SDP_RC,REF,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.183e-01,2.678e-01,3.957e-01,3.957e-01
+SDP_RC,REF,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.698e-03,3.569e-02,6.236e-02,6.236e-02
+SDP_RC,REF,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.975e-02,4.705e-02,5.523e-02,5.523e-02
+SDP_RC,REF,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.208e-02,1.784e-02,3.777e-02,3.777e-02
+SDP_RC,REF,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.208e-02,1.784e-02,3.777e-02,3.777e-02
+SDP_RC,REF,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.208e-02,1.784e-02,3.777e-02,3.777e-02
+SDP_RC,REF,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.975e-02,4.705e-02,5.523e-02,5.523e-02
 SDP_RC,REF,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0.000e+00,8.315e-07,4.540e-05,1.192e-01,1.192e-01
 SDP_RC,REF,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,REF,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
@@ -5473,26 +5473,26 @@ SDP_RC,REF,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_roa
 SDP_RC,REF,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,REF,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,REF,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_RC,REF,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.400e-02,3.994e-02,7.347e-02,1.369e-01,1.369e-01
-SDP_RC,REF,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,4.158e-02,6.680e-02,1.172e-01,1.745e-01,1.745e-01
-SDP_RC,REF,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.474e-01,1.474e-01
-SDP_RC,REF,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,6.311e-02,8.776e-02,1.371e-01,1.886e-01,1.886e-01
-SDP_RC,REF,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,3.048e-02,5.599e-02,1.070e-01,1.673e-01,1.673e-01
-SDP_RC,REF,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.474e-01,1.474e-01
-SDP_RC,SSA,,,,,Cycle,trn_pass,S3S,linear,1.388e-02,1.795e-02,2.915e-02,3.279e-02,3.279e-02
-SDP_RC,SSA,,,,,Domestic Aviation,trn_pass,S3S,linear,9.013e-03,5.100e-02,4.140e-02,6.209e-03,6.209e-03
-SDP_RC,SSA,,,,,Domestic Ship,trn_freight,S3S,linear,1.467e-03,1.467e-03,1.467e-03,1.467e-03,1.467e-03
-SDP_RC,SSA,,,,,Freight Rail,trn_freight,S3S,linear,1.634e-02,1.634e-02,1.634e-02,1.634e-02,1.634e-02
-SDP_RC,SSA,,,,,HSR,trn_pass,S3S,linear,1.475e-05,2.003e-05,6.504e-02,9.756e-03,9.756e-03
+SDP_RC,REF,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.400e-02,3.195e-02,6.011e-02,7.825e-02,7.825e-02
+SDP_RC,REF,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,3.465e-02,6.073e-02,9.593e-02,1.342e-01,1.342e-01
+SDP_RC,REF,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.392e-02,6.459e-02,1.134e-01,1.134e-01
+SDP_RC,REF,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,5.259e-02,7.979e-02,1.122e-01,1.450e-01,1.450e-01
+SDP_RC,REF,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,2.540e-02,5.090e-02,8.756e-02,1.287e-01,1.287e-01
+SDP_RC,REF,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.392e-02,6.459e-02,1.134e-01,1.134e-01
+SDP_RC,SSA,,,,,Cycle,trn_pass,S3S,linear,1.388e-02,1.987e-02,2.915e-02,3.279e-02,3.279e-02
+SDP_RC,SSA,,,,,Domestic Aviation,trn_pass,S3S,linear,8.602e-03,5.387e-02,3.951e-02,5.926e-03,5.926e-03
+SDP_RC,SSA,,,,,Domestic Ship,trn_freight,S3S,linear,1.495e-03,1.495e-03,1.495e-03,1.495e-03,1.495e-03
+SDP_RC,SSA,,,,,Freight Rail,trn_freight,S3S,linear,1.665e-02,1.665e-02,1.665e-02,1.498e-02,1.498e-02
+SDP_RC,SSA,,,,,HSR,trn_pass,S3S,linear,1.475e-05,2.217e-05,6.504e-02,9.756e-03,9.756e-03
 SDP_RC,SSA,,,,,International Aviation,trn_aviation_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,SSA,,,,,International Ship,trn_shipping_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_RC,SSA,,,,,Passenger Rail,trn_pass,S3S,linear,6.024e-04,1.559e-03,2.530e-03,5.693e-04,5.693e-04
-SDP_RC,SSA,,,,,Walk,trn_pass,S3S,linear,1.000e+00,9.034e-01,1.000e+00,1.000e+00,1.000e+00
+SDP_RC,SSA,,,,,Passenger Rail,trn_pass,S3S,linear,6.024e-04,1.725e-03,2.530e-03,5.693e-04,5.693e-04
+SDP_RC,SSA,,,,,Walk,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,SSA,,,,,trn_freight_road,trn_freight,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_RC,SSA,,,,,trn_pass_road,trn_pass,S3S,linear,8.902e-01,1.000e+00,9.741e-01,9.741e-02,9.741e-02
-SDP_RC,SSA,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,2.477e-01,1.270e-01,7.328e-02,9.526e-02,9.526e-02
+SDP_RC,SSA,,,,,trn_pass_road,trn_pass,S3S,linear,2.622e-01,3.260e-01,2.869e-01,4.781e-02,4.781e-02
+SDP_RC,SSA,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,7.568e-01,3.234e-01,1.493e-01,9.703e-02,9.703e-02
 SDP_RC,SSA,,,,trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_RC,SSA,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,3.928e-02,3.928e-02,3.928e-02,3.928e-02,3.928e-02
+SDP_RC,SSA,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,2.619e-02,2.619e-02,2.619e-02,3.928e-02,3.928e-02
 SDP_RC,SSA,,,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,SSA,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,SSA,,Large Car and SUV,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,3.022e-03,3.022e-03,3.022e-03,3.022e-03,3.022e-03
@@ -5507,24 +5507,24 @@ SDP_RC,SSA,,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_s
 SDP_RC,SSA,,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,4.207e-06,4.207e-06,4.207e-06,4.207e-06,4.207e-06
 SDP_RC,SSA,,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,SSA,,Van,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,7.570e-05,7.570e-05,7.570e-05,7.570e-05,7.570e-05
-SDP_RC,SSA,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_RC,SSA,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_RC,SSA,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_RC,SSA,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.743e-02,4.034e-01,9.526e-01,9.526e-01
+SDP_RC,SSA,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.000e-01,2.160e-01,3.360e-01,3.360e-01
+SDP_RC,SSA,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.000e-01,2.160e-01,3.360e-01,3.360e-01
+SDP_RC,SSA,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.000e-01,2.160e-01,3.360e-01,3.360e-01
+SDP_RC,SSA,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,6.210e-02,3.962e-01,8.470e-01,8.470e-01
 SDP_RC,SSA,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,SSA,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,SSA,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_RC,SSA,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.384e-02,1.000e-01,1.511e-01,1.511e-01
-SDP_RC,SSA,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,9.485e-03,5.379e-02,1.465e-01,1.465e-01
-SDP_RC,SSA,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,9.485e-03,5.379e-02,1.465e-01,1.465e-01
-SDP_RC,SSA,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,9.485e-03,5.379e-02,1.465e-01,1.465e-01
-SDP_RC,SSA,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.384e-02,1.000e-01,1.511e-01,1.511e-01
-SDP_RC,SSA,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.473e-03,1.799e-02,7.500e-02,7.500e-02
-SDP_RC,SSA,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.693e-03,4.743e-02,2.812e-02,2.812e-02
-SDP_RC,SSA,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-03,1.799e-02,1.923e-02,1.923e-02
-SDP_RC,SSA,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-03,1.799e-02,1.923e-02,1.923e-02
-SDP_RC,SSA,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-03,1.799e-02,1.923e-02,1.923e-02
-SDP_RC,SSA,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.693e-03,4.743e-02,2.812e-02,2.812e-02
+SDP_RC,SSA,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.602e-02,1.007e-01,1.511e-01,1.511e-01
+SDP_RC,SSA,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.035e-02,5.418e-02,1.466e-01,1.466e-01
+SDP_RC,SSA,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.035e-02,5.418e-02,1.466e-01,1.466e-01
+SDP_RC,SSA,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.035e-02,5.418e-02,1.466e-01,1.466e-01
+SDP_RC,SSA,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.602e-02,1.007e-01,1.511e-01,1.511e-01
+SDP_RC,SSA,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.698e-03,1.963e-02,4.850e-02,4.850e-02
+SDP_RC,SSA,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,7.303e-03,1.194e-02,2.045e-02,2.045e-02
+SDP_RC,SSA,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.698e-03,4.529e-03,1.399e-02,1.399e-02
+SDP_RC,SSA,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.698e-03,4.529e-03,1.399e-02,1.399e-02
+SDP_RC,SSA,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.698e-03,4.529e-03,1.399e-02,1.399e-02
+SDP_RC,SSA,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,7.303e-03,1.194e-02,2.045e-02,2.045e-02
 SDP_RC,SSA,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0.000e+00,8.315e-07,4.540e-05,1.192e-01,1.192e-01
 SDP_RC,SSA,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,SSA,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
@@ -5541,59 +5541,59 @@ SDP_RC,SSA,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_roa
 SDP_RC,SSA,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,SSA,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,SSA,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_RC,SSA,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,3.981e-04,2.670e-02,5.552e-02,9.227e-02,9.227e-02
-SDP_RC,SSA,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,7.085e-02,7.085e-02
-SDP_RC,SSA,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,7.085e-02,7.085e-02
-SDP_RC,SSA,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,7.085e-02,7.085e-02
-SDP_RC,SSA,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,7.085e-02,7.085e-02
-SDP_RC,SSA,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,7.085e-02,7.085e-02
+SDP_RC,SSA,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,3.981e-04,2.670e-02,4.997e-02,6.835e-02,6.835e-02
+SDP_RC,SSA,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,4.251e-02,5.904e-02,5.904e-02
+SDP_RC,SSA,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,4.251e-02,5.904e-02,5.904e-02
+SDP_RC,SSA,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,4.251e-02,5.904e-02,5.904e-02
+SDP_RC,SSA,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,4.251e-02,5.904e-02,5.904e-02
+SDP_RC,SSA,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,4.251e-02,5.904e-02,5.904e-02
 SDP_RC,UKI,,,,,Cycle,trn_pass,S3S,linear,2.500e-02,1.092e-02,3.277e-02,6.553e-02,6.553e-02
-SDP_RC,UKI,,,,,Domestic Aviation,trn_pass,S3S,linear,6.250e-05,9.365e-06,9.365e-06,9.365e-06,9.365e-06
-SDP_RC,UKI,,,,,Domestic Ship,trn_freight,S3S,linear,8.512e-03,8.512e-03,8.512e-03,8.512e-03,8.512e-03
-SDP_RC,UKI,,,,,Freight Rail,trn_freight,S3S,linear,6.067e-03,6.067e-03,6.067e-03,6.067e-03,6.067e-03
+SDP_RC,UKI,,,,,Domestic Aviation,trn_pass,S3S,linear,5.965e-05,8.938e-06,8.938e-06,8.938e-06,8.938e-06
+SDP_RC,UKI,,,,,Domestic Ship,trn_freight,S3S,linear,8.670e-03,8.670e-03,8.670e-03,8.670e-03,8.670e-03
+SDP_RC,UKI,,,,,Freight Rail,trn_freight,S3S,linear,6.180e-03,6.180e-03,6.180e-03,6.180e-03,6.180e-03
 SDP_RC,UKI,,,,,HSR,trn_pass,S3S,linear,1.250e-04,1.334e-04,1.779e-04,2.224e-04,2.224e-04
 SDP_RC,UKI,,,,,International Aviation,trn_aviation_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,UKI,,,,,International Ship,trn_shipping_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,UKI,,,,,Passenger Rail,trn_pass,S3S,linear,3.125e-03,2.502e-03,1.876e-03,1.876e-03,1.876e-03
 SDP_RC,UKI,,,,,Walk,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,UKI,,,,,trn_freight_road,trn_freight,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_RC,UKI,,,,,trn_pass_road,trn_pass,S3S,linear,7.500e-02,5.325e-02,3.408e-02,3.408e-02,3.408e-02
-SDP_RC,UKI,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,2.500e-01,2.010e-01,1.843e-01,1.675e-01,1.675e-01
+SDP_RC,UKI,,,,,trn_pass_road,trn_pass,S3S,linear,7.363e-02,5.228e-02,3.346e-02,3.346e-02,3.346e-02
+SDP_RC,UKI,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,2.546e-01,2.048e-01,1.877e-01,1.706e-01,1.706e-01
 SDP_RC,UKI,,,,trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,UKI,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,3.935e-02,3.935e-02,3.935e-02,3.935e-02,3.935e-02
 SDP_RC,UKI,,,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_RC,UKI,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,4.864e-01,4.864e-01,4.864e-01,4.864e-01,4.864e-01
+SDP_RC,UKI,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,5.404e-01,5.404e-01,4.864e-01,4.864e-01,4.864e-01
 SDP_RC,UKI,,Large Car and SUV,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,UKI,,Midsize Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,2.616e-01,2.616e-01,2.616e-01,2.616e-01,2.616e-01
-SDP_RC,UKI,,Mini Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,4.751e-07,4.751e-07,4.751e-07,4.751e-07,4.751e-07
+SDP_RC,UKI,,Mini Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,5.279e-07,5.279e-07,4.751e-07,4.751e-07,4.751e-07
 SDP_RC,UKI,,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,2.088e-02,2.088e-02,2.088e-02,2.088e-02,2.088e-02
 SDP_RC,UKI,,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,3.798e-03,3.798e-03,3.798e-03,3.798e-03,3.798e-03
 SDP_RC,UKI,,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_RC,UKI,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,5.119e-01,5.119e-01,5.119e-01,5.119e-01,5.119e-01
+SDP_RC,UKI,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,5.688e-01,5.688e-01,5.119e-01,5.119e-01,5.119e-01
 SDP_RC,UKI,,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,UKI,,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,4.528e-02,4.528e-02,4.528e-02,4.528e-02,4.528e-02
 SDP_RC,UKI,,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,9.437e-02,9.437e-02,9.437e-02,9.437e-02,9.437e-02
 SDP_RC,UKI,,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,5.696e-01,5.696e-01,5.696e-01,5.696e-01,5.696e-01
 SDP_RC,UKI,,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,7.765e-01,7.765e-01,7.765e-01,7.765e-01,7.765e-01
 SDP_RC,UKI,,Van,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,2.681e-03,2.681e-03,2.681e-03,2.681e-03,2.681e-03
-SDP_RC,UKI,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_RC,UKI,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_RC,UKI,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_RC,UKI,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.186e-01,3.227e-01,8.573e-01,8.573e-01
+SDP_RC,UKI,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,5.000e-02,2.000e-01,3.700e-01,3.700e-01
+SDP_RC,UKI,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,5.000e-02,2.000e-01,3.700e-01,3.700e-01
+SDP_RC,UKI,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,5.000e-02,2.000e-01,3.700e-01,3.700e-01
+SDP_RC,UKI,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,2.500e-02,1.168e-01,3.434e-01,7.434e-01,7.434e-01
 SDP_RC,UKI,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,8.260e-01,8.478e-01,8.913e-01,9.783e-01,9.783e-01
 SDP_RC,UKI,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,UKI,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_RC,UKI,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.384e-01,5.500e-01,8.838e-01,8.838e-01
-SDP_RC,UKI,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,9.485e-02,2.958e-01,8.573e-01,8.573e-01
-SDP_RC,UKI,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,9.485e-02,2.958e-01,8.573e-01,8.573e-01
-SDP_RC,UKI,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,9.485e-02,2.958e-01,8.573e-01,8.573e-01
-SDP_RC,UKI,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.384e-01,5.500e-01,8.838e-01,8.838e-01
-SDP_RC,UKI,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.236e-02,1.799e-02,1.000e-01,1.000e-01
-SDP_RC,UKI,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.693e-02,1.897e-01,1.462e-01,1.462e-01
-SDP_RC,UKI,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-02,7.194e-02,1.000e-01,1.000e-01
-SDP_RC,UKI,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-02,7.194e-02,1.000e-01,1.000e-01
-SDP_RC,UKI,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-02,7.194e-02,1.000e-01,1.000e-01
-SDP_RC,UKI,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.693e-02,1.897e-01,1.462e-01,1.462e-01
+SDP_RC,UKI,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.819e-01,5.853e-01,8.360e-01,8.360e-01
+SDP_RC,UKI,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.122e-01,3.148e-01,8.110e-01,8.110e-01
+SDP_RC,UKI,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.122e-01,3.148e-01,8.110e-01,8.110e-01
+SDP_RC,UKI,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.122e-01,3.148e-01,8.110e-01,8.110e-01
+SDP_RC,UKI,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.819e-01,5.853e-01,8.360e-01,8.360e-01
+SDP_RC,UKI,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,2.500e-05,1.218e-02,2.127e-02,7.883e-02,7.883e-02
+SDP_RC,UKI,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,7.914e-02,2.243e-01,1.729e-01,1.729e-01
+SDP_RC,UKI,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.924e-02,8.507e-02,1.182e-01,1.182e-01
+SDP_RC,UKI,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.924e-02,8.507e-02,1.182e-01,1.182e-01
+SDP_RC,UKI,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.924e-02,8.507e-02,1.182e-01,1.182e-01
+SDP_RC,UKI,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,7.914e-02,2.243e-01,1.729e-01,1.729e-01
 SDP_RC,UKI,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0.000e+00,8.315e-07,4.540e-05,1.192e-01,1.192e-01
 SDP_RC,UKI,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,UKI,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
@@ -5610,24 +5610,24 @@ SDP_RC,UKI,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_roa
 SDP_RC,UKI,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,UKI,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,UKI,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_RC,UKI,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,3.616e-04,2.667e-02,7.928e-02,1.845e-01,1.845e-01
+SDP_RC,UKI,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,9.040e-04,2.222e-02,7.928e-02,1.230e-01,1.230e-01
 SDP_RC,UKI,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
 SDP_RC,UKI,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
 SDP_RC,UKI,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
 SDP_RC,UKI,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
 SDP_RC,UKI,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
 SDP_RC,USA,,,,,Cycle,trn_pass,S3S,linear,8.197e-03,8.197e-03,8.197e-03,4.098e-02,4.098e-02
-SDP_RC,USA,,,,,Domestic Aviation,trn_pass,S3S,linear,1.057e-03,1.600e-03,1.800e-03,1.100e-03,1.100e-03
-SDP_RC,USA,,,,,Domestic Ship,trn_freight,S3S,linear,3.208e-03,3.208e-03,3.208e-03,3.208e-03,3.208e-03
-SDP_RC,USA,,,,,Freight Rail,trn_freight,S3S,linear,3.364e-02,3.364e-02,3.364e-02,3.364e-02,3.364e-02
+SDP_RC,USA,,,,,Domestic Aviation,trn_pass,S3S,linear,1.009e-03,1.527e-03,1.718e-03,1.050e-03,1.050e-03
+SDP_RC,USA,,,,,Domestic Ship,trn_freight,S3S,linear,3.267e-03,3.267e-03,3.267e-03,3.267e-03,3.267e-03
+SDP_RC,USA,,,,,Freight Rail,trn_freight,S3S,linear,3.427e-02,3.427e-02,3.427e-02,3.427e-02,3.427e-02
 SDP_RC,USA,,,,,HSR,trn_pass,S3S,linear,4.530e-06,4.530e-06,4.530e-06,2.265e-04,2.265e-04
 SDP_RC,USA,,,,,International Aviation,trn_aviation_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,USA,,,,,International Ship,trn_shipping_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,USA,,,,,Passenger Rail,trn_pass,S3S,linear,1.933e-03,1.933e-03,1.933e-03,9.665e-04,9.665e-04
 SDP_RC,USA,,,,,Walk,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,USA,,,,,trn_freight_road,trn_freight,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_RC,USA,,,,,trn_pass_road,trn_pass,S3S,linear,1.329e-01,1.329e-01,1.276e-01,6.647e-02,6.647e-02
-SDP_RC,USA,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,8.561e-02,1.070e-01,1.070e-01,1.213e-01,1.213e-01
+SDP_RC,USA,,,,,trn_pass_road,trn_pass,S3S,linear,1.305e-01,1.305e-01,1.253e-01,6.526e-02,6.526e-02
+SDP_RC,USA,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,8.720e-02,1.090e-01,1.090e-01,1.235e-01,1.235e-01
 SDP_RC,USA,,,,trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,USA,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,3.805e-02,3.805e-02,3.805e-02,3.805e-02,3.805e-02
 SDP_RC,USA,,,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
@@ -5640,29 +5640,29 @@ SDP_RC,USA,,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pas
 SDP_RC,USA,,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,USA,,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,7.057e-01,7.057e-01,7.057e-01,7.057e-01,7.057e-01
 SDP_RC,USA,,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_RC,USA,,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_RC,USA,,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
+SDP_RC,USA,,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,9.000e-01,1.000e+00,1.000e+00,1.000e+00,1.000e+00
+SDP_RC,USA,,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,9.000e-01,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,USA,,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,6.263e-01,6.263e-01,6.263e-01,6.263e-01,6.263e-01
-SDP_RC,USA,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_RC,USA,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_RC,USA,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP_RC,USA,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.423e-01,5.379e-01,1.000e+00,1.000e+00
+SDP_RC,USA,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.400e-02,2.160e-01,3.780e-01,3.780e-01
+SDP_RC,USA,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.400e-02,2.160e-01,3.780e-01,3.780e-01
+SDP_RC,USA,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.400e-02,2.160e-01,3.780e-01,3.780e-01
+SDP_RC,USA,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.122e-01,5.382e-01,1.000e+00,1.000e+00
 SDP_RC,USA,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,0.000e+00,1.250e-01,3.750e-01,8.750e-01,8.750e-01
 SDP_RC,USA,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,USA,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_RC,USA,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.980e-02,2.500e-01,7.856e-01,7.856e-01
-SDP_RC,USA,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.186e-02,1.345e-01,7.621e-01,7.621e-01
-SDP_RC,USA,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,3.000e-02,2.500e-01,5.000e-01,8.000e-01,8.000e-01
-SDP_RC,USA,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,3.000e-02,2.500e-01,5.000e-01,8.000e-01,8.000e-01
-SDP_RC,USA,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.980e-02,2.500e-01,7.856e-01,7.856e-01
-SDP_RC,USA,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.473e-02,1.799e-02,6.999e-02,6.999e-02
-SDP_RC,USA,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.339e-03,1.423e-02,1.462e-01,1.462e-01
-SDP_RC,USA,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.945e-04,5.396e-03,1.000e-01,1.000e-01
-SDP_RC,USA,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,5.000e-02,2.000e-01,3.000e-01,2.000e-01,2.000e-01
-SDP_RC,USA,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,5.000e-02,2.000e-01,3.000e-01,2.000e-01,2.000e-01
-SDP_RC,USA,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.339e-03,1.423e-02,1.462e-01,1.462e-01
+SDP_RC,USA,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.626e-02,2.323e-01,6.967e-01,6.967e-01
+SDP_RC,USA,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.470e-03,1.249e-01,6.758e-01,6.758e-01
+SDP_RC,USA,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,3.547e-02,1.364e-01,4.645e-01,7.095e-01,7.095e-01
+SDP_RC,USA,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,3.547e-02,1.364e-01,4.645e-01,7.095e-01,7.095e-01
+SDP_RC,USA,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.626e-02,2.323e-01,6.967e-01,6.967e-01
+SDP_RC,USA,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.436e-02,1.636e-02,7.776e-02,7.776e-02
+SDP_RC,USA,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.218e-03,1.202e-02,1.008e-01,1.008e-01
+SDP_RC,USA,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.498e-04,4.557e-03,6.897e-02,6.897e-02
+SDP_RC,USA,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,5.912e-02,1.819e-01,2.534e-01,1.379e-01,1.379e-01
+SDP_RC,USA,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,5.912e-02,1.819e-01,2.534e-01,1.379e-01,1.379e-01
+SDP_RC,USA,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.218e-03,1.202e-02,1.008e-01,1.008e-01
 SDP_RC,USA,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0.000e+00,8.315e-07,4.540e-05,1.192e-01,1.192e-01
-SDP_RC,USA,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,6.999e-01,6.999e-01
+SDP_RC,USA,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,7.892e-01,7.892e-01
 SDP_RC,USA,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,USA,Liquids,Domestic Ship_tmp_vehicletype,Domestic Ship_tmp_subsector_L1,Domestic Ship_tmp_subsector_L2,Domestic Ship,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,USA,Liquids,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
@@ -5677,12 +5677,12 @@ SDP_RC,USA,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_roa
 SDP_RC,USA,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,USA,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP_RC,USA,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP_RC,USA,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,8.478e-02,1.089e-01,1.570e-01,1.773e-01,1.773e-01
-SDP_RC,USA,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.263e-03,3.158e-02,7.368e-02,7.368e-02
-SDP_RC,USA,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.263e-03,3.158e-02,7.368e-02,7.368e-02
-SDP_RC,USA,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e-01,2.000e-01,4.000e-01,4.000e-01,4.000e-01
-SDP_RC,USA,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e-01,2.000e-01,4.000e-01,4.000e-01,4.000e-01
-SDP_RC,USA,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.263e-03,3.158e-02,7.368e-02,7.368e-02
+SDP_RC,USA,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,8.478e-02,9.072e-02,1.208e-01,1.666e-01,1.666e-01
+SDP_RC,USA,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.049e-03,2.256e-02,6.140e-02,6.140e-02
+SDP_RC,USA,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.049e-03,2.256e-02,6.140e-02,6.140e-02
+SDP_RC,USA,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,5.000e-03,1.538e-01,2.857e-01,3.333e-01,3.333e-01
+SDP_RC,USA,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,5.000e-03,1.538e-01,2.857e-01,3.333e-01,3.333e-01
+SDP_RC,USA,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.049e-03,2.256e-02,6.140e-02,6.140e-02
 SSP1,CAZ,,,,,Cycle,trn_pass,S3S,linear,1.911e-02,3.822e-02,3.822e-02,7.645e-02,7.645e-02
 SSP1,CAZ,,,,,Domestic Aviation,trn_pass,S3S,linear,1.500e-03,1.600e-03,1.900e-03,2.000e-03,2.000e-03
 SSP1,CAZ,,,,,Domestic Ship,trn_freight,S3S,linear,1.554e-02,1.554e-02,1.554e-02,1.554e-02,1.554e-02

--- a/inst/extdata/sw_trends.csv
+++ b/inst/extdata/sw_trends.csv
@@ -1,16 +1,16 @@
 SSP_scenario,region,technology,vehicle_type,subsector_L1,subsector_L2,subsector_L3,sector,level,approx,2020,2030,2050,2100,2150
 SDP,CAZ,,,,,Cycle,trn_pass,S3S,linear,1.911e-02,3.822e-02,3.822e-02,7.645e-02,7.645e-02
-SDP,CAZ,,,,,Domestic Aviation,trn_pass,S3S,linear,1.500e-03,1.600e-03,1.900e-03,2.000e-03,2.000e-03
-SDP,CAZ,,,,,Domestic Ship,trn_freight,S3S,linear,1.554e-02,1.554e-02,1.554e-02,1.554e-02,1.554e-02
-SDP,CAZ,,,,,Freight Rail,trn_freight,S3S,linear,1.051e-01,1.051e-01,1.051e-01,1.051e-01,1.051e-01
+SDP,CAZ,,,,,Domestic Aviation,trn_pass,S3S,linear,1.432e-03,1.527e-03,1.813e-03,1.909e-03,1.909e-03
+SDP,CAZ,,,,,Domestic Ship,trn_freight,S3S,linear,1.583e-02,1.583e-02,1.583e-02,1.583e-02,1.583e-02
+SDP,CAZ,,,,,Freight Rail,trn_freight,S3S,linear,1.070e-01,1.070e-01,1.070e-01,9.633e-02,9.633e-02
 SDP,CAZ,,,,,HSR,trn_pass,S3S,linear,8.792e-08,8.792e-05,2.638e-04,2.638e-04,2.638e-04
 SDP,CAZ,,,,,International Aviation,trn_aviation_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,CAZ,,,,,International Ship,trn_shipping_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,CAZ,,,,,Passenger Rail,trn_pass,S3S,linear,8.785e-04,8.785e-04,8.785e-04,8.785e-04,8.785e-04
 SDP,CAZ,,,,,Walk,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,CAZ,,,,,trn_freight_road,trn_freight,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP,CAZ,,,,,trn_pass_road,trn_pass,S3S,linear,1.537e-01,1.537e-01,1.537e-01,1.537e-01,1.537e-01
-SDP,CAZ,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,8.691e-02,8.691e-02,1.086e-01,1.376e-01,1.376e-01
+SDP,CAZ,,,,,trn_pass_road,trn_pass,S3S,linear,1.509e-01,1.509e-01,1.509e-01,1.509e-01,1.509e-01
+SDP,CAZ,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,8.852e-02,8.852e-02,1.107e-01,1.402e-01,1.402e-01
 SDP,CAZ,,,,trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,CAZ,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.939e-02,1.939e-02,1.939e-02,1.939e-02,1.939e-02
 SDP,CAZ,,,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
@@ -30,26 +30,26 @@ SDP,CAZ,,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subs
 SDP,CAZ,,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,3.497e-05,3.497e-05,3.497e-05,3.497e-05,3.497e-05
 SDP,CAZ,,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,6.282e-01,6.282e-01,6.282e-01,6.282e-01,6.282e-01
 SDP,CAZ,,Van,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,2.082e-01,2.082e-01,2.082e-01,2.082e-01,2.082e-01
-SDP,CAZ,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP,CAZ,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP,CAZ,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP,CAZ,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,9.485e-02,4.572e-01,1.000e+00,1.000e+00
+SDP,CAZ,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.400e-02,1.920e-01,3.360e-01,3.360e-01
+SDP,CAZ,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.400e-02,1.920e-01,3.360e-01,3.360e-01
+SDP,CAZ,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.400e-02,1.920e-01,3.360e-01,3.360e-01
+SDP,CAZ,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.122e-01,4.423e-01,9.735e-01,9.735e-01
 SDP,CAZ,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,9.074e-02,2.044e-01,4.317e-01,8.863e-01,8.863e-01
 SDP,CAZ,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,CAZ,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP,CAZ,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.192e-01,3.500e-01,4.910e-01,4.910e-01
-SDP,CAZ,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.743e-02,1.883e-01,4.763e-01,4.763e-01
-SDP,CAZ,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.743e-02,1.883e-01,4.763e-01,4.763e-01
-SDP,CAZ,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.743e-02,1.883e-01,4.763e-01,4.763e-01
-SDP,CAZ,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.192e-01,3.500e-01,4.910e-01,4.910e-01
-SDP,CAZ,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.236e-02,1.799e-02,9.544e-02,9.544e-02
-SDP,CAZ,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.346e-02,4.743e-02,1.462e-01,1.462e-01
-SDP,CAZ,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.236e-02,1.799e-02,1.000e-01,1.000e-01
-SDP,CAZ,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.236e-02,1.799e-02,1.000e-01,1.000e-01
-SDP,CAZ,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.236e-02,1.799e-02,1.000e-01,1.000e-01
-SDP,CAZ,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.346e-02,4.743e-02,1.462e-01,1.462e-01
+SDP,CAZ,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.409e-01,3.311e-01,4.354e-01,4.354e-01
+SDP,CAZ,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.608e-02,1.781e-01,4.224e-01,4.224e-01
+SDP,CAZ,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.608e-02,1.781e-01,4.224e-01,4.224e-01
+SDP,CAZ,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.608e-02,1.781e-01,4.224e-01,4.224e-01
+SDP,CAZ,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.409e-01,3.311e-01,4.354e-01,4.354e-01
+SDP,CAZ,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.462e-02,1.933e-02,7.601e-02,7.601e-02
+SDP,CAZ,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.957e-02,5.608e-02,1.153e-01,1.153e-01
+SDP,CAZ,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.462e-02,2.127e-02,7.883e-02,7.883e-02
+SDP,CAZ,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.462e-02,2.127e-02,7.883e-02,7.883e-02
+SDP,CAZ,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.462e-02,2.127e-02,7.883e-02,7.883e-02
+SDP,CAZ,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.957e-02,5.608e-02,1.153e-01,1.153e-01
 SDP,CAZ,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0.000e+00,8.315e-07,4.540e-05,1.192e-01,1.192e-01
-SDP,CAZ,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,9.544e-01,9.544e-01
+SDP,CAZ,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,CAZ,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,CAZ,Liquids,Domestic Ship_tmp_vehicletype,Domestic Ship_tmp_subsector_L1,Domestic Ship_tmp_subsector_L2,Domestic Ship,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,CAZ,Liquids,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
@@ -64,124 +64,124 @@ SDP,CAZ,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_t
 SDP,CAZ,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,CAZ,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,CAZ,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP,CAZ,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,3.104e-02,5.654e-02,1.075e-01,2.000e-01,2.000e-01
-SDP,CAZ,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SDP,CAZ,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SDP,CAZ,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SDP,CAZ,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SDP,CAZ,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SDP,CHA,,,,,Cycle,trn_pass,S3S,linear,8.298e-02,4.412e-02,3.782e-02,4.848e-02,4.848e-02
-SDP,CHA,,,,,Domestic Aviation,trn_pass,S3S,linear,1.104e-01,2.842e-02,1.829e-02,3.517e-03,3.517e-03
-SDP,CHA,,,,,Domestic Ship,trn_freight,S3S,linear,2.849e-02,8.548e-02,8.548e-02,8.548e-02,8.548e-02
-SDP,CHA,,,,,Freight Rail,trn_freight,S3S,linear,6.920e-02,2.076e-01,2.076e-01,2.076e-01,2.076e-01
-SDP,CHA,,,,,HSR,trn_pass,S3S,linear,2.108e-01,8.143e-02,1.916e-02,3.695e-03,3.695e-03
+SDP,CAZ,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,3.104e-02,5.654e-02,9.776e-02,1.497e-01,1.497e-01
+SDP,CAZ,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.535e-01,1.535e-01
+SDP,CAZ,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.535e-01,1.535e-01
+SDP,CAZ,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.535e-01,1.535e-01
+SDP,CAZ,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.535e-01,1.535e-01
+SDP,CAZ,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.535e-01,1.535e-01
+SDP,CHA,,,,,Cycle,trn_pass,S3S,linear,9.454e-02,4.412e-02,3.782e-02,4.848e-02,4.848e-02
+SDP,CHA,,,,,Domestic Aviation,trn_pass,S3S,linear,1.200e-01,2.712e-02,1.745e-02,3.357e-03,3.357e-03
+SDP,CHA,,,,,Domestic Ship,trn_freight,S3S,linear,1.847e-02,1.922e-02,2.232e-02,2.232e-02,2.232e-02
+SDP,CHA,,,,,Freight Rail,trn_freight,S3S,linear,3.204e-02,3.570e-02,3.795e-02,3.795e-02,3.795e-02
+SDP,CHA,,,,,HSR,trn_pass,S3S,linear,2.402e-01,8.143e-02,1.916e-02,3.695e-03,3.695e-03
 SDP,CHA,,,,,International Aviation,trn_aviation_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,CHA,,,,,International Ship,trn_shipping_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP,CHA,,,,,Passenger Rail,trn_pass,S3S,linear,5.461e-03,3.111e-03,1.867e-03,9.572e-04,9.572e-04
-SDP,CHA,,,,,Walk,trn_pass,S3S,linear,8.777e-01,1.000e+00,1.000e+00,1.000e+00,1.000e+00
+SDP,CHA,,,,,Passenger Rail,trn_pass,S3S,linear,6.222e-03,3.111e-03,1.867e-03,9.572e-04,9.572e-04
+SDP,CHA,,,,,Walk,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,CHA,,,,,trn_freight_road,trn_freight,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP,CHA,,,,,trn_pass_road,trn_pass,S3S,linear,1.000e+00,4.557e-01,2.279e-01,5.843e-02,5.843e-02
-SDP,CHA,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,3.816e-01,1.915e-01,1.705e-01,1.895e-01,1.895e-01
+SDP,CHA,,,,,trn_pass_road,trn_pass,S3S,linear,6.711e-01,2.684e-01,1.342e-01,4.015e-02,4.015e-02
+SDP,CHA,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,6.609e-01,2.927e-01,2.084e-01,9.649e-02,9.649e-02
 SDP,CHA,,,,trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP,CHA,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.081e-02,9.523e-03,6.956e-03,1.824e-03,1.824e-03
+SDP,CHA,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,2.702e-01,2.116e-01,1.391e-01,1.459e-01,1.459e-01
 SDP,CHA,,,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP,CHA,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,3.616e-01,3.616e-01,3.616e-01,3.616e-01,3.616e-01
+SDP,CHA,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,8.035e-01,7.232e-01,6.574e-01,5.563e-01,5.563e-01
 SDP,CHA,,Large Car and SUV,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP,CHA,,Mini Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,8.023e-03,8.023e-03,8.023e-03,8.023e-03,8.023e-03
+SDP,CHA,,Mini Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.783e-02,1.605e-02,1.459e-02,1.234e-02,1.234e-02
 SDP,CHA,,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,4.044e-02,4.044e-02,4.044e-02,4.044e-02,4.044e-02
 SDP,CHA,,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,CHA,,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP,CHA,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,3.898e-02,3.898e-02,3.898e-02,3.898e-02,3.898e-02
+SDP,CHA,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,8.662e-02,7.795e-02,7.087e-02,5.996e-02,5.996e-02
 SDP,CHA,,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,CHA,,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,2.234e-01,2.234e-01,2.234e-01,2.234e-01,2.234e-01
-SDP,CHA,,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,4.469e-01,3.352e-01,3.352e-01,3.352e-01,3.352e-01
-SDP,CHA,,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,4.469e-01,3.352e-01,3.352e-01,3.352e-01,3.352e-01
+SDP,CHA,,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,4.022e-01,3.352e-01,3.016e-01,3.352e-01,3.352e-01
+SDP,CHA,,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,4.022e-01,3.352e-01,3.016e-01,3.352e-01,3.352e-01
 SDP,CHA,,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.657e-01,1.657e-01,1.657e-01,1.657e-01,1.657e-01
-SDP,CHA,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP,CHA,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,8.402e-02,8.402e-02,8.402e-02,8.402e-02,8.402e-02
-SDP,CHA,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP,CHA,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,3.320e-01,1.000e+00,1.000e+00,1.000e+00
+SDP,CHA,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,6.000e-01,1.000e+00,1.000e+00,1.000e+00
+SDP,CHA,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,6.000e-02,6.000e-01,1.000e+00,1.000e+00,1.000e+00
+SDP,CHA,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,6.000e-01,1.000e+00,1.000e+00,1.000e+00
+SDP,CHA,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,3.019e-01,1.000e+00,1.000e+00,1.000e+00
 SDP,CHA,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,4.553e-01,5.234e-01,6.595e-01,9.319e-01,9.319e-01
 SDP,CHA,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,CHA,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,4.158e-01,4.888e-01,6.349e-01,9.270e-01,9.270e-01
-SDP,CHA,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.768e-02,4.500e-01,9.820e-01,9.820e-01
-SDP,CHA,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.897e-02,2.420e-01,9.526e-01,9.526e-01
-SDP,CHA,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e-01,4.000e-01,9.000e-01,1.000e+00,1.000e+00
-SDP,CHA,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e-01,4.000e-01,9.000e-01,1.000e+00,1.000e+00
-SDP,CHA,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.768e-02,4.500e-01,9.820e-01,9.820e-01
-SDP,CHA,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.225e-02,6.688e-02,6.999e-02,6.999e-02
-SDP,CHA,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.339e-03,2.846e-02,1.462e-01,1.462e-01
-SDP,CHA,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.945e-04,1.079e-02,1.000e-01,1.000e-01
-SDP,CHA,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e-02,2.000e-01,6.000e-01,2.000e-01,2.000e-01
-SDP,CHA,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e-02,2.000e-01,6.000e-01,2.000e-01,2.000e-01
-SDP,CHA,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.339e-03,2.846e-02,1.462e-01,1.462e-01
+SDP,CHA,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.002e-02,3.725e-01,8.768e-01,8.768e-01
+SDP,CHA,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.592e-02,2.004e-01,8.505e-01,8.505e-01
+SDP,CHA,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,9.920e-02,3.358e-01,7.450e-01,8.928e-01,8.928e-01
+SDP,CHA,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,9.920e-02,3.358e-01,7.450e-01,8.928e-01,8.928e-01
+SDP,CHA,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.002e-02,3.725e-01,8.768e-01,8.768e-01
+SDP,CHA,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.024e-02,9.554e-02,6.999e-02,6.999e-02
+SDP,CHA,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.124e-03,1.713e-02,1.450e-01,1.450e-01
+SDP,CHA,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.151e-04,6.497e-03,9.920e-02,9.920e-02
+SDP,CHA,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,9.920e-03,1.679e-01,3.612e-01,1.984e-01,1.984e-01
+SDP,CHA,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,9.920e-03,1.679e-01,3.612e-01,1.984e-01,1.984e-01
+SDP,CHA,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.124e-03,1.713e-02,1.450e-01,1.450e-01
 SDP,CHA,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0.000e+00,8.315e-07,4.540e-05,1.192e-01,1.192e-01
-SDP,CHA,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,7.437e-01,3.499e-01,3.499e-01
+SDP,CHA,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,9.736e-01,3.527e-01,3.527e-01
 SDP,CHA,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,CHA,Liquids,Domestic Ship_tmp_vehicletype,Domestic Ship_tmp_subsector_L1,Domestic Ship_tmp_subsector_L2,Domestic Ship,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,CHA,Liquids,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,CHA,Liquids,International Aviation_tmp_vehicletype,International Aviation_tmp_subsector_L1,International Aviation_tmp_subsector_L2,International Aviation,trn_aviation_intl,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,CHA,Liquids,International Ship_tmp_vehicletype,International Ship_tmp_subsector_L1,International Ship_tmp_subsector_L2,International Ship,trn_shipping_intl,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP,CHA,Liquids,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP,CHA,Liquids,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP,CHA,Liquids,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
+SDP,CHA,Liquids,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,8.333e-01,6.803e-01,6.803e-01
+SDP,CHA,Liquids,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,8.333e-01,6.803e-01,6.803e-01
+SDP,CHA,Liquids,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,8.333e-01,6.803e-01,6.803e-01
 SDP,CHA,Liquids,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,CHA,Liquids,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,CHA,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,CHA,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,CHA,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,CHA,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP,CHA,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.421e-01,1.594e-01,9.020e-02,1.152e-01,1.152e-01
-SDP,CHA,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.878e-05,1.319e-02,5.530e-02,9.213e-02,9.213e-02
-SDP,CHA,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,7.854e-04,1.443e-02,5.695e-02,9.317e-02,9.317e-02
-SDP,CHA,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,3.000e-01,5.000e-01,7.000e-01,5.000e-01,5.000e-01
-SDP,CHA,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,3.000e-01,5.000e-01,7.000e-01,5.000e-01,5.000e-01
-SDP,CHA,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,3.309e-04,1.369e-02,5.597e-02,9.256e-02,9.256e-02
+SDP,CHA,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.421e-01,1.329e-01,1.181e-01,1.055e-01,1.055e-01
+SDP,CHA,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.707e-05,1.014e-02,3.814e-02,8.376e-02,8.376e-02
+SDP,CHA,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,7.140e-04,1.110e-02,3.928e-02,8.470e-02,8.470e-02
+SDP,CHA,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,2.727e-01,3.846e-01,4.828e-01,4.545e-01,4.545e-01
+SDP,CHA,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,2.727e-01,3.846e-01,4.828e-01,4.545e-01,4.545e-01
+SDP,CHA,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,3.008e-04,1.053e-02,3.860e-02,8.414e-02,8.414e-02
 SDP,DEU,,,,,Cycle,trn_pass,S3S,linear,2.500e-02,2.500e-02,2.500e-02,1.875e-01,1.875e-01
-SDP,DEU,,,,,Domestic Aviation,trn_pass,S3S,linear,6.250e-05,6.250e-05,6.250e-05,6.250e-05,6.250e-05
-SDP,DEU,,,,,Domestic Ship,trn_freight,S3S,linear,2.088e-03,2.088e-03,2.088e-03,2.088e-03,2.088e-03
-SDP,DEU,,,,,Freight Rail,trn_freight,S3S,linear,2.749e-02,2.749e-02,2.749e-02,2.749e-02,2.749e-02
+SDP,DEU,,,,,Domestic Aviation,trn_pass,S3S,linear,5.965e-05,5.965e-05,5.965e-05,5.965e-05,5.965e-05
+SDP,DEU,,,,,Domestic Ship,trn_freight,S3S,linear,2.127e-03,2.127e-03,2.127e-03,2.127e-03,2.127e-03
+SDP,DEU,,,,,Freight Rail,trn_freight,S3S,linear,2.800e-02,2.800e-02,2.800e-02,2.800e-02,2.800e-02
 SDP,DEU,,,,,HSR,trn_pass,S3S,linear,1.250e-04,2.500e-04,6.250e-04,6.250e-04,6.250e-04
 SDP,DEU,,,,,International Aviation,trn_aviation_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,DEU,,,,,International Ship,trn_shipping_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,DEU,,,,,Passenger Rail,trn_pass,S3S,linear,2.500e-03,3.750e-03,3.750e-03,3.750e-03,3.750e-03
 SDP,DEU,,,,,Walk,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,DEU,,,,,trn_freight_road,trn_freight,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP,DEU,,,,,trn_pass_road,trn_pass,S3S,linear,7.500e-02,7.500e-02,7.500e-02,7.500e-02,7.500e-02
-SDP,DEU,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,8.000e-02,8.000e-02,8.000e-02,1.500e-01,1.500e-01
+SDP,DEU,,,,,trn_pass_road,trn_pass,S3S,linear,7.363e-02,7.363e-02,7.363e-02,7.363e-02,7.363e-02
+SDP,DEU,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,8.149e-02,8.149e-02,8.149e-02,1.528e-01,1.528e-01
 SDP,DEU,,,,trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,DEU,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,3.054e-02,3.054e-02,3.054e-02,3.054e-02,3.054e-02
 SDP,DEU,,,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP,DEU,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,4.724e-01,4.724e-01,4.724e-01,4.724e-01,4.724e-01
+SDP,DEU,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,5.249e-01,5.249e-01,4.724e-01,4.724e-01,4.724e-01
 SDP,DEU,,Large Car and SUV,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,DEU,,Midsize Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,2.716e-01,2.716e-01,2.716e-01,2.716e-01,2.716e-01
 SDP,DEU,,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,2.183e-01,2.183e-01,2.183e-01,2.183e-01,2.183e-01
 SDP,DEU,,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,6.630e-03,6.630e-03,6.630e-03,6.630e-03,6.630e-03
 SDP,DEU,,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP,DEU,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,4.803e-01,4.803e-01,4.803e-01,4.803e-01,4.803e-01
+SDP,DEU,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,5.337e-01,5.337e-01,4.803e-01,4.803e-01,4.803e-01
 SDP,DEU,,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,4.427e-01,4.427e-01,4.427e-01,4.427e-01,4.427e-01
 SDP,DEU,,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,8.345e-02,8.345e-02,8.345e-02,8.345e-02,8.345e-02
 SDP,DEU,,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,2.127e-01,2.127e-01,2.127e-01,2.127e-01,2.127e-01
 SDP,DEU,,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,4.934e-01,4.934e-01,4.934e-01,4.934e-01,4.934e-01
 SDP,DEU,,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP,DEU,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP,DEU,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP,DEU,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP,DEU,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.423e-01,4.034e-01,8.573e-01,8.573e-01
+SDP,DEU,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.000e-02,2.500e-01,4.500e-01,4.500e-01
+SDP,DEU,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.000e-02,2.500e-01,4.500e-01,4.500e-01
+SDP,DEU,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.000e-02,2.500e-01,4.500e-01,4.500e-01
+SDP,DEU,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.294e-01,3.669e-01,7.798e-01,7.798e-01
 SDP,DEU,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,DEU,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,DEU,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP,DEU,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.980e-01,6.750e-01,9.820e-01,9.820e-01
-SDP,DEU,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.186e-01,3.631e-01,9.526e-01,9.526e-01
-SDP,DEU,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.186e-01,3.631e-01,9.526e-01,9.526e-01
-SDP,DEU,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.186e-01,3.631e-01,9.526e-01,9.526e-01
-SDP,DEU,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.980e-01,6.750e-01,9.820e-01,9.820e-01
-SDP,DEU,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.473e-03,1.799e-02,5.000e-02,5.000e-02
-SDP,DEU,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,8.031e-02,3.320e-01,2.193e-01,2.193e-01
-SDP,DEU,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.967e-02,1.259e-01,1.500e-01,1.500e-01
-SDP,DEU,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.967e-02,1.259e-01,1.500e-01,1.500e-01
-SDP,DEU,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.967e-02,1.259e-01,1.500e-01,1.500e-01
-SDP,DEU,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,8.031e-02,3.320e-01,2.193e-01,2.193e-01
+SDP,DEU,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.524e-01,6.784e-01,8.709e-01,8.709e-01
+SDP,DEU,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.402e-01,3.649e-01,8.448e-01,8.448e-01
+SDP,DEU,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.402e-01,3.649e-01,8.448e-01,8.448e-01
+SDP,DEU,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.402e-01,3.649e-01,8.448e-01,8.448e-01
+SDP,DEU,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.524e-01,6.784e-01,8.709e-01,8.709e-01
+SDP,DEU,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.249e-03,1.636e-02,4.548e-02,4.548e-02
+SDP,DEU,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,9.497e-02,3.925e-01,1.837e-01,1.837e-01
+SDP,DEU,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.508e-02,1.489e-01,1.257e-01,1.257e-01
+SDP,DEU,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.508e-02,1.489e-01,1.257e-01,1.257e-01
+SDP,DEU,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.508e-02,1.489e-01,1.257e-01,1.257e-01
+SDP,DEU,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,9.497e-02,3.925e-01,1.837e-01,1.837e-01
 SDP,DEU,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0.000e+00,8.315e-07,4.540e-05,1.192e-01,1.192e-01
 SDP,DEU,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,DEU,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
@@ -198,59 +198,59 @@ SDP,DEU,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_t
 SDP,DEU,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,DEU,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,DEU,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP,DEU,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,3.948e-02,6.475e-02,1.153e-01,1.731e-01,1.731e-01
-SDP,DEU,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,2.615e-02,4.142e-02,1.030e-01,2.055e-01,2.055e-01
-SDP,DEU,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.105e-02,7.895e-02,1.842e-01,1.842e-01
-SDP,DEU,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.105e-02,7.895e-02,1.842e-01,1.842e-01
-SDP,DEU,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.105e-02,7.895e-02,1.842e-01,1.842e-01
-SDP,DEU,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.105e-02,7.895e-02,1.842e-01,1.842e-01
+SDP,DEU,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,3.948e-02,4.981e-02,8.870e-02,1.332e-01,1.332e-01
+SDP,DEU,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,2.615e-02,4.142e-02,1.030e-01,1.713e-01,1.713e-01
+SDP,DEU,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.105e-02,7.895e-02,1.535e-01,1.535e-01
+SDP,DEU,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.105e-02,7.895e-02,1.535e-01,1.535e-01
+SDP,DEU,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.105e-02,7.895e-02,1.535e-01,1.535e-01
+SDP,DEU,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.105e-02,7.895e-02,1.535e-01,1.535e-01
 SDP,ECE,,,,,Cycle,trn_pass,S3S,linear,1.942e-02,1.942e-02,9.709e-02,1.092e-01,1.092e-01
-SDP,ECE,,,,,Domestic Aviation,trn_pass,S3S,linear,7.313e-05,7.313e-05,7.313e-05,2.057e-05,2.057e-05
-SDP,ECE,,,,,Domestic Ship,trn_freight,S3S,linear,3.893e-04,3.893e-04,3.893e-04,3.893e-04,3.893e-04
-SDP,ECE,,,,,Freight Rail,trn_freight,S3S,linear,5.909e-02,5.909e-02,5.909e-02,5.909e-02,5.909e-02
+SDP,ECE,,,,,Domestic Aviation,trn_pass,S3S,linear,6.979e-05,6.979e-05,6.979e-05,1.963e-05,1.963e-05
+SDP,ECE,,,,,Domestic Ship,trn_freight,S3S,linear,3.966e-04,3.966e-04,3.966e-04,3.966e-04,3.966e-04
+SDP,ECE,,,,,Freight Rail,trn_freight,S3S,linear,6.019e-02,6.019e-02,5.417e-02,5.417e-02,5.417e-02
 SDP,ECE,,,,,HSR,trn_pass,S3S,linear,1.139e-04,1.708e-04,4.555e-04,3.202e-04,3.202e-04
 SDP,ECE,,,,,International Aviation,trn_aviation_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,ECE,,,,,International Ship,trn_shipping_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,ECE,,,,,Passenger Rail,trn_pass,S3S,linear,6.799e-03,6.799e-03,9.065e-03,3.824e-03,3.824e-03
 SDP,ECE,,,,,Walk,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,ECE,,,,,trn_freight_road,trn_freight,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP,ECE,,,,,trn_pass_road,trn_pass,S3S,linear,8.972e-01,8.972e-01,7.177e-01,1.615e-01,1.615e-01
-SDP,ECE,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,1.664e-01,1.664e-01,1.109e-01,1.109e-01,1.109e-01
+SDP,ECE,,,,,trn_pass_road,trn_pass,S3S,linear,6.166e-01,6.166e-01,4.933e-01,1.268e-01,1.268e-01
+SDP,ECE,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,2.712e-01,2.543e-01,1.469e-01,1.130e-01,1.130e-01
 SDP,ECE,,,,trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,ECE,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,6.159e-03,6.159e-03,6.159e-03,6.159e-03,6.159e-03
 SDP,ECE,,,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP,ECE,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,3.451e-01,3.451e-01,3.451e-01,3.451e-01,3.451e-01
+SDP,ECE,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,4.706e-01,4.706e-01,4.601e-01,4.314e-01,4.314e-01
 SDP,ECE,,Large Car and SUV,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,7.825e-01,7.825e-01,7.825e-01,7.825e-01,7.825e-01
 SDP,ECE,,Midsize Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,ECE,,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,5.321e-02,5.321e-02,5.321e-02,5.321e-02,5.321e-02
 SDP,ECE,,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,4.728e-04,4.728e-04,4.728e-04,4.728e-04,4.728e-04
 SDP,ECE,,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP,ECE,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,4.683e-01,4.683e-01,4.683e-01,4.683e-01,4.683e-01
+SDP,ECE,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,6.386e-01,6.386e-01,6.244e-01,5.854e-01,5.854e-01
 SDP,ECE,,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,6.161e-01,6.161e-01,6.161e-01,6.161e-01,6.161e-01
 SDP,ECE,,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.384e-01,1.384e-01,1.384e-01,1.384e-01,1.384e-01
 SDP,ECE,,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.370e-01,1.370e-01,1.370e-01,1.370e-01,1.370e-01
 SDP,ECE,,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.691e-01,1.691e-01,1.691e-01,1.691e-01,1.691e-01
 SDP,ECE,,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP,ECE,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP,ECE,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP,ECE,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP,ECE,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.423e-01,5.379e-01,1.000e+00,1.000e+00
+SDP,ECE,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.000e-02,1.900e-01,4.300e-01,4.300e-01
+SDP,ECE,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.000e-02,1.900e-01,4.300e-01,4.300e-01
+SDP,ECE,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.000e-02,1.900e-01,4.300e-01,4.300e-01
+SDP,ECE,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.553e-01,5.283e-01,1.000e+00,1.000e+00
 SDP,ECE,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,ECE,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,ECE,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP,ECE,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.960e-02,1.500e-01,2.946e-01,2.946e-01
-SDP,ECE,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.371e-02,8.068e-02,2.858e-01,2.858e-01
-SDP,ECE,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.371e-02,8.068e-02,2.858e-01,2.858e-01
-SDP,ECE,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.371e-02,8.068e-02,2.858e-01,2.858e-01
-SDP,ECE,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.960e-02,1.500e-01,2.946e-01,2.946e-01
-SDP,ECE,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.236e-02,1.799e-02,8.748e-02,8.748e-02
-SDP,ECE,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.339e-02,4.743e-02,1.462e-01,1.462e-01
-SDP,ECE,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.945e-03,1.799e-02,1.000e-01,1.000e-01
-SDP,ECE,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.945e-03,1.799e-02,1.000e-01,1.000e-01
-SDP,ECE,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.945e-03,1.799e-02,1.000e-01,1.000e-01
-SDP,ECE,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.339e-02,4.743e-02,1.462e-01,1.462e-01
+SDP,ECE,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.504e-02,1.455e-01,2.786e-01,2.786e-01
+SDP,ECE,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.588e-02,7.826e-02,2.703e-01,2.703e-01
+SDP,ECE,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.588e-02,7.826e-02,2.703e-01,2.703e-01
+SDP,ECE,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.588e-02,7.826e-02,2.703e-01,2.703e-01
+SDP,ECE,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.504e-02,1.455e-01,2.786e-01,2.786e-01
+SDP,ECE,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.349e-02,1.963e-02,8.748e-02,8.748e-02
+SDP,ECE,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.461e-02,5.750e-02,6.382e-02,6.382e-02
+SDP,ECE,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.396e-03,2.181e-02,4.365e-02,4.365e-02
+SDP,ECE,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.396e-03,2.181e-02,4.365e-02,4.365e-02
+SDP,ECE,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.396e-03,2.181e-02,4.365e-02,4.365e-02
+SDP,ECE,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.461e-02,5.750e-02,6.382e-02,6.382e-02
 SDP,ECE,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0.000e+00,8.315e-07,4.540e-05,1.192e-01,1.192e-01
-SDP,ECE,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,8.748e-01,8.748e-01
+SDP,ECE,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,8.017e-01,8.017e-01
 SDP,ECE,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,ECE,Liquids,Domestic Ship_tmp_vehicletype,Domestic Ship_tmp_subsector_L1,Domestic Ship_tmp_subsector_L2,Domestic Ship,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,ECE,Liquids,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,5.870e-01,5.870e-01,5.870e-01,5.870e-01,5.870e-01
@@ -265,57 +265,57 @@ SDP,ECE,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_t
 SDP,ECE,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,ECE,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,ECE,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP,ECE,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP,ECE,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP,ECE,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP,ECE,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
+SDP,ECE,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e-02,2.000e-02,7.000e-02,9.000e-02,9.000e-02
+SDP,ECE,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.000e-02,1.111e-01,1.867e-01,1.867e-01
+SDP,ECE,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.000e-02,1.111e-01,1.867e-01,1.867e-01
+SDP,ECE,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.000e-02,1.111e-01,1.867e-01,1.867e-01
 SDP,ECE,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP,ECE,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP,ECS,,,,,Cycle,trn_pass,S3S,linear,7.196e-03,2.159e-02,8.635e-02,8.738e-02,8.738e-02
-SDP,ECS,,,,,Domestic Aviation,trn_pass,S3S,linear,2.566e-03,2.566e-03,2.566e-03,3.895e-04,3.895e-04
-SDP,ECS,,,,,Domestic Ship,trn_freight,S3S,linear,3.878e-03,3.878e-03,3.878e-03,3.878e-03,3.878e-03
-SDP,ECS,,,,,Freight Rail,trn_freight,S3S,linear,5.867e-02,5.867e-02,5.867e-02,5.867e-02,5.867e-02
-SDP,ECS,,,,,HSR,trn_pass,S3S,linear,1.956e-04,1.956e-04,5.216e-04,4.000e-04,4.000e-04
+SDP,ECE,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.000e-02,1.111e-01,1.867e-01,1.867e-01
+SDP,ECS,,,,,Cycle,trn_pass,S3S,linear,1.092e-02,3.277e-02,1.311e-01,8.738e-02,8.738e-02
+SDP,ECS,,,,,Domestic Aviation,trn_pass,S3S,linear,3.717e-03,3.717e-03,3.717e-03,3.717e-04,3.717e-04
+SDP,ECS,,,,,Domestic Ship,trn_freight,S3S,linear,3.950e-03,3.950e-03,3.591e-03,3.950e-03,3.950e-03
+SDP,ECS,,,,,Freight Rail,trn_freight,S3S,linear,5.976e-02,5.976e-02,5.433e-02,5.379e-02,5.379e-02
+SDP,ECS,,,,,HSR,trn_pass,S3S,linear,2.969e-04,2.969e-04,7.917e-04,4.000e-04,4.000e-04
 SDP,ECS,,,,,International Aviation,trn_aviation_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,ECS,,,,,International Ship,trn_shipping_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP,ECS,,,,,Passenger Rail,trn_pass,S3S,linear,5.215e-03,6.953e-03,8.691e-03,2.638e-03,2.638e-03
-SDP,ECS,,,,,Walk,trn_pass,S3S,linear,6.588e-01,6.588e-01,6.588e-01,1.000e+00,1.000e+00
+SDP,ECS,,,,,Passenger Rail,trn_pass,S3S,linear,7.915e-03,1.055e-02,1.319e-02,2.638e-03,2.638e-03
+SDP,ECS,,,,,Walk,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,ECS,,,,,trn_freight_road,trn_freight,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP,ECS,,,,,trn_pass_road,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.518e-01,1.518e-01
-SDP,ECS,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,1.140e-01,1.140e-01,7.980e-02,6.840e-02,6.840e-02
+SDP,ECS,,,,,trn_pass_road,trn_pass,S3S,linear,7.451e-01,7.451e-01,7.451e-01,8.941e-02,8.941e-02
+SDP,ECS,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,2.090e-01,1.742e-01,1.219e-01,1.045e-01,1.045e-01
 SDP,ECS,,,,trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,ECS,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,2.175e-03,2.175e-03,2.175e-03,2.175e-03,2.175e-03
 SDP,ECS,,,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP,ECS,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,3.336e-01,3.336e-01,3.336e-01,3.336e-01,3.336e-01
+SDP,ECS,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,5.004e-01,5.004e-01,5.004e-01,4.549e-01,4.549e-01
 SDP,ECS,,Large Car and SUV,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,ECS,,Midsize Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,9.609e-01,9.609e-01,9.609e-01,9.609e-01,9.609e-01
 SDP,ECS,,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.125e-01,1.125e-01,1.125e-01,1.125e-01,1.125e-01
 SDP,ECS,,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,3.579e-02,3.579e-02,3.579e-02,3.579e-02,3.579e-02
 SDP,ECS,,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP,ECS,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,6.520e-01,6.520e-01,6.520e-01,6.520e-01,6.520e-01
+SDP,ECS,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,9.780e-01,9.780e-01,9.780e-01,8.891e-01,8.891e-01
 SDP,ECS,,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,ECS,,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,2.555e-01,2.555e-01,2.555e-01,2.555e-01,2.555e-01
 SDP,ECS,,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,3.104e-01,3.104e-01,3.104e-01,3.104e-01,3.104e-01
 SDP,ECS,,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.282e-01,1.282e-01,1.282e-01,1.282e-01,1.282e-01
 SDP,ECS,,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,4.409e-01,4.409e-01,4.409e-01,4.409e-01,4.409e-01
-SDP,ECS,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP,ECS,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP,ECS,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP,ECS,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.743e-02,3.496e-01,8.573e-01,8.573e-01
+SDP,ECS,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,3.200e-02,1.920e-01,4.200e-01,4.200e-01
+SDP,ECS,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,3.200e-02,1.920e-01,4.200e-01,4.200e-01
+SDP,ECS,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,3.200e-02,1.920e-01,4.200e-01,4.200e-01
+SDP,ECS,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,9.315e-02,3.815e-01,8.420e-01,8.420e-01
 SDP,ECS,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,ECS,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,ECS,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP,ECS,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.192e-01,2.500e-01,2.946e-01,2.946e-01
-SDP,ECS,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.743e-02,1.345e-01,2.858e-01,2.858e-01
-SDP,ECS,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.743e-02,1.345e-01,2.858e-01,2.858e-01
-SDP,ECS,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.743e-02,1.345e-01,2.858e-01,2.858e-01
-SDP,ECS,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.192e-01,2.500e-01,2.946e-01,2.946e-01
-SDP,ECS,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.473e-03,5.396e-02,1.000e-01,1.000e-01
-SDP,ECS,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.339e-02,4.743e-02,7.311e-02,7.311e-02
-SDP,ECS,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.945e-03,1.799e-02,5.000e-02,5.000e-02
-SDP,ECS,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.945e-03,1.799e-02,5.000e-02,5.000e-02
-SDP,ECS,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.945e-03,1.799e-02,5.000e-02,5.000e-02
-SDP,ECS,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.339e-02,4.743e-02,7.311e-02,7.311e-02
+SDP,ECS,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.041e-01,2.182e-01,2.893e-01,2.893e-01
+SDP,ECS,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.140e-02,1.174e-01,2.807e-01,2.807e-01
+SDP,ECS,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.140e-02,1.174e-01,2.807e-01,2.807e-01
+SDP,ECS,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.140e-02,1.174e-01,2.807e-01,2.807e-01
+SDP,ECS,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.041e-01,2.182e-01,2.893e-01,2.893e-01
+SDP,ECS,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.698e-03,7.360e-02,1.091e-01,1.091e-01
+SDP,ECS,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.461e-02,6.900e-02,7.977e-02,7.977e-02
+SDP,ECS,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.396e-03,2.617e-02,5.456e-02,5.456e-02
+SDP,ECS,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.396e-03,2.617e-02,5.456e-02,5.456e-02
+SDP,ECS,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.396e-03,2.617e-02,5.456e-02,5.456e-02
+SDP,ECS,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.461e-02,6.900e-02,7.977e-02,7.977e-02
 SDP,ECS,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0.000e+00,8.315e-07,4.540e-05,1.192e-01,1.192e-01
 SDP,ECS,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,ECS,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
@@ -332,61 +332,61 @@ SDP,ECS,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_t
 SDP,ECS,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,ECS,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,ECS,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP,ECS,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP,ECS,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP,ECS,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP,ECS,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP,ECS,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP,ECS,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
+SDP,ECS,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e-02,2.000e-02,6.250e-02,1.000e-01,1.000e-01
+SDP,ECS,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e-05,1.300e-02,6.667e-02,1.400e-01,1.400e-01
+SDP,ECS,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e-05,1.300e-02,6.667e-02,1.400e-01,1.400e-01
+SDP,ECS,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e-05,1.300e-02,6.667e-02,1.400e-01,1.400e-01
+SDP,ECS,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e-05,1.300e-02,6.667e-02,1.400e-01,1.400e-01
+SDP,ECS,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e-05,1.300e-02,6.667e-02,1.400e-01,1.400e-01
 SDP,ENC,,,,,Cycle,trn_pass,S3S,linear,2.500e-02,2.500e-02,5.556e-02,1.000e-01,1.000e-01
-SDP,ENC,,,,,Domestic Aviation,trn_pass,S3S,linear,6.250e-05,6.250e-05,5.556e-05,2.500e-05,2.500e-05
-SDP,ENC,,,,,Domestic Ship,trn_freight,S3S,linear,1.223e-02,1.223e-02,1.223e-02,1.223e-02,1.223e-02
-SDP,ENC,,,,,Freight Rail,trn_freight,S3S,linear,2.875e-02,2.875e-02,2.875e-02,2.875e-02,2.875e-02
+SDP,ENC,,,,,Domestic Aviation,trn_pass,S3S,linear,5.965e-05,5.965e-05,5.302e-05,2.386e-05,2.386e-05
+SDP,ENC,,,,,Domestic Ship,trn_freight,S3S,linear,1.246e-02,1.246e-02,1.246e-02,1.246e-02,1.246e-02
+SDP,ENC,,,,,Freight Rail,trn_freight,S3S,linear,2.928e-02,2.928e-02,2.928e-02,2.928e-02,2.928e-02
 SDP,ENC,,,,,HSR,trn_pass,S3S,linear,1.250e-04,2.500e-04,2.222e-04,2.000e-04,2.000e-04
 SDP,ENC,,,,,International Aviation,trn_aviation_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,ENC,,,,,International Ship,trn_shipping_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,ENC,,,,,Passenger Rail,trn_pass,S3S,linear,3.125e-03,3.125e-03,3.333e-03,2.000e-03,2.000e-03
 SDP,ENC,,,,,Walk,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,ENC,,,,,trn_freight_road,trn_freight,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP,ENC,,,,,trn_pass_road,trn_pass,S3S,linear,7.500e-02,7.500e-02,6.667e-02,3.000e-02,3.000e-02
-SDP,ENC,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,2.000e-01,1.500e-01,1.500e-01,1.500e-01,1.500e-01
+SDP,ENC,,,,,trn_pass_road,trn_pass,S3S,linear,7.363e-02,7.363e-02,6.545e-02,2.945e-02,2.945e-02
+SDP,ENC,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,2.037e-01,1.528e-01,1.528e-01,1.528e-01,1.528e-01
 SDP,ENC,,,,trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,ENC,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,3.014e-02,3.014e-02,3.014e-02,3.014e-02,3.014e-02
 SDP,ENC,,,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP,ENC,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,3.559e-01,3.559e-01,3.559e-01,3.559e-01,3.559e-01
+SDP,ENC,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,3.955e-01,3.955e-01,3.955e-01,3.559e-01,3.559e-01
 SDP,ENC,,Large Car and SUV,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,ENC,,Midsize Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.960e-01,1.960e-01,1.960e-01,1.960e-01,1.960e-01
-SDP,ENC,,Mini Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,2.357e-07,2.357e-07,2.357e-07,2.357e-07,2.357e-07
+SDP,ENC,,Mini Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,2.619e-07,2.619e-07,2.619e-07,2.357e-07,2.357e-07
 SDP,ENC,,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.576e-01,1.576e-01,1.576e-01,1.576e-01,1.576e-01
 SDP,ENC,,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,3.751e-02,3.751e-02,3.751e-02,3.751e-02,3.751e-02
 SDP,ENC,,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP,ENC,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.963e-01,1.963e-01,1.963e-01,1.963e-01,1.963e-01
+SDP,ENC,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,2.181e-01,2.181e-01,2.181e-01,1.963e-01,1.963e-01
 SDP,ENC,,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,ENC,,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.002e-01,1.002e-01,1.002e-01,1.002e-01,1.002e-01
 SDP,ENC,,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,3.593e-01,3.593e-01,3.593e-01,3.593e-01,3.593e-01
 SDP,ENC,,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,4.374e-01,4.374e-01,4.374e-01,4.374e-01,4.374e-01
 SDP,ENC,,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,4.946e-01,4.946e-01,4.946e-01,4.946e-01,4.946e-01
 SDP,ENC,,Van,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.049e-03,1.049e-03,1.049e-03,1.049e-03,1.049e-03
-SDP,ENC,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP,ENC,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP,ENC,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP,ENC,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.371e-01,6.724e-01,1.000e+00,1.000e+00
+SDP,ENC,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,5.000e-02,2.300e-01,5.000e-01,5.000e-01
+SDP,ENC,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,5.000e-02,2.300e-01,5.000e-01,5.000e-01
+SDP,ENC,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,5.000e-02,2.300e-01,5.000e-01,5.000e-01
+SDP,ENC,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.157e-01,7.227e-01,1.000e+00,1.000e+00
 SDP,ENC,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,ENC,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,ENC,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP,ENC,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.622e-01,6.000e-01,9.820e-01,9.820e-01
-SDP,ENC,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.043e-01,3.227e-01,9.526e-01,9.526e-01
-SDP,ENC,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.043e-01,3.227e-01,9.526e-01,9.526e-01
-SDP,ENC,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.043e-01,3.227e-01,9.526e-01,9.526e-01
-SDP,ENC,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.622e-01,6.000e-01,9.820e-01,9.820e-01
-SDP,ENC,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.236e-02,5.396e-02,1.312e-01,1.312e-01
-SDP,ENC,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.693e-02,2.371e-01,1.462e-01,1.462e-01
-SDP,ENC,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-02,8.993e-02,1.000e-01,1.000e-01
-SDP,ENC,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-02,8.993e-02,1.000e-01,1.000e-01
-SDP,ENC,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-02,8.993e-02,1.000e-01,1.000e-01
-SDP,ENC,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.693e-02,2.371e-01,1.462e-01,1.462e-01
+SDP,ENC,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.101e-01,6.386e-01,9.289e-01,9.289e-01
+SDP,ENC,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.234e-01,3.434e-01,9.011e-01,9.011e-01
+SDP,ENC,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.234e-01,3.434e-01,9.011e-01,9.011e-01
+SDP,ENC,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.234e-01,3.434e-01,9.011e-01,9.011e-01
+SDP,ENC,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.101e-01,6.386e-01,9.289e-01,9.289e-01
+SDP,ENC,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.124e-02,5.800e-02,1.021e-01,1.021e-01
+SDP,ENC,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,7.914e-02,2.804e-01,1.729e-01,1.729e-01
+SDP,ENC,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.924e-02,1.063e-01,1.183e-01,1.183e-01
+SDP,ENC,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.924e-02,1.063e-01,1.183e-01,1.183e-01
+SDP,ENC,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.924e-02,1.063e-01,1.183e-01,1.183e-01
+SDP,ENC,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,7.914e-02,2.804e-01,1.729e-01,1.729e-01
 SDP,ENC,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0.000e+00,8.315e-07,4.540e-05,1.192e-01,1.192e-01
-SDP,ENC,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,5.249e-01,5.249e-01
+SDP,ENC,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,5.426e-01,5.426e-01
 SDP,ENC,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,ENC,Liquids,Domestic Ship_tmp_vehicletype,Domestic Ship_tmp_subsector_L1,Domestic Ship_tmp_subsector_L2,Domestic Ship,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,ENC,Liquids,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1.341e-01,1.341e-01,1.341e-01,1.341e-01,1.341e-01
@@ -401,30 +401,30 @@ SDP,ENC,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_t
 SDP,ENC,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,ENC,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,ENC,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP,ENC,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,2.533e-02,5.098e-02,1.023e-01,1.075e-01,1.075e-01
+SDP,ENC,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,2.533e-02,3.921e-02,9.298e-02,1.011e-01,1.011e-01
 SDP,ENC,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
 SDP,ENC,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
 SDP,ENC,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
 SDP,ENC,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
 SDP,ENC,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
 SDP,ESC,,,,,Cycle,trn_pass,S3S,linear,1.942e-02,2.184e-02,4.369e-02,1.638e-01,1.638e-01
-SDP,ESC,,,,,Domestic Aviation,trn_pass,S3S,linear,1.347e-04,3.789e-05,3.789e-05,7.579e-05,7.579e-05
-SDP,ESC,,,,,Domestic Ship,trn_freight,S3S,linear,1.187e-02,1.187e-02,1.187e-02,1.187e-02,1.187e-02
-SDP,ESC,,,,,Freight Rail,trn_freight,S3S,linear,4.020e-03,4.020e-03,4.020e-03,4.020e-03,4.020e-03
+SDP,ESC,,,,,Domestic Aviation,trn_pass,S3S,linear,1.286e-04,3.616e-05,3.616e-05,7.233e-05,7.233e-05
+SDP,ESC,,,,,Domestic Ship,trn_freight,S3S,linear,1.209e-02,1.209e-02,1.209e-02,1.209e-02,1.209e-02
+SDP,ESC,,,,,Freight Rail,trn_freight,S3S,linear,4.094e-03,4.094e-03,4.094e-03,4.094e-03,4.094e-03
 SDP,ESC,,,,,HSR,trn_pass,S3S,linear,6.613e-04,1.860e-04,6.200e-04,6.200e-04,6.200e-04
 SDP,ESC,,,,,International Aviation,trn_aviation_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,ESC,,,,,International Ship,trn_shipping_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,ESC,,,,,Passenger Rail,trn_pass,S3S,linear,3.195e-03,2.696e-03,2.696e-03,4.044e-03,4.044e-03
 SDP,ESC,,,,,Walk,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,ESC,,,,,trn_freight_road,trn_freight,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP,ESC,,,,,trn_pass_road,trn_pass,S3S,linear,1.832e-01,1.030e-01,8.242e-02,6.594e-02,6.594e-02
-SDP,ESC,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,6.591e-02,6.591e-02,6.591e-02,9.887e-02,9.887e-02
+SDP,ESC,,,,,trn_pass_road,trn_pass,S3S,linear,1.798e-01,1.011e-01,8.092e-02,6.473e-02,6.473e-02
+SDP,ESC,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,6.714e-02,6.714e-02,6.714e-02,1.007e-01,1.007e-01
 SDP,ESC,,,,trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP,ESC,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.687e-01,1.687e-01,1.687e-01,1.687e-01,1.687e-01
+SDP,ESC,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.205e-01,1.125e-01,1.125e-01,1.125e-01,1.125e-01
 SDP,ESC,,,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,ESC,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,3.942e-01,3.942e-01,3.942e-01,3.942e-01,3.942e-01
-SDP,ESC,,Large Car and SUV,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,8.712e-01,8.712e-01,8.712e-01,8.712e-01,8.712e-01
-SDP,ESC,,Midsize Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,2.323e-01,2.323e-01,2.323e-01,2.323e-01,2.323e-01
+SDP,ESC,,Large Car and SUV,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,8.712e-01,7.840e-01,8.712e-01,8.712e-01,8.712e-01
+SDP,ESC,,Midsize Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,2.323e-01,2.091e-01,2.323e-01,2.323e-01,2.323e-01
 SDP,ESC,,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.009e-01,1.009e-01,1.009e-01,1.009e-01,1.009e-01
 SDP,ESC,,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,6.375e-02,6.375e-02,6.375e-02,6.375e-02,6.375e-02
 SDP,ESC,,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
@@ -434,24 +434,24 @@ SDP,ESC,,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subs
 SDP,ESC,,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,2.234e-01,2.234e-01,2.234e-01,2.234e-01,2.234e-01
 SDP,ESC,,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,2.172e-01,2.172e-01,2.172e-01,2.172e-01,2.172e-01
 SDP,ESC,,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP,ESC,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP,ESC,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP,ESC,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP,ESC,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.423e-01,4.034e-01,9.526e-01,9.526e-01
+SDP,ESC,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.000e-02,2.200e-01,4.200e-01,4.200e-01
+SDP,ESC,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.000e-02,2.200e-01,4.200e-01,4.200e-01
+SDP,ESC,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.000e-02,2.200e-01,4.200e-01,4.200e-01
+SDP,ESC,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.359e-01,3.816e-01,8.448e-01,8.448e-01
 SDP,ESC,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,ESC,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,ESC,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP,ESC,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.384e-01,5.000e-01,9.820e-01,9.820e-01
-SDP,ESC,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,9.485e-02,2.689e-01,9.526e-01,9.526e-01
-SDP,ESC,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,9.485e-02,2.689e-01,9.526e-01,9.526e-01
-SDP,ESC,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,9.485e-02,2.689e-01,9.526e-01,9.526e-01
-SDP,ESC,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.384e-01,5.000e-01,9.820e-01,9.820e-01
-SDP,ESC,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.236e-02,5.396e-02,1.000e-01,1.000e-01
-SDP,ESC,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.693e-02,4.743e-02,1.462e-01,1.462e-01
-SDP,ESC,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-02,1.799e-02,1.000e-01,1.000e-01
-SDP,ESC,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-02,1.799e-02,1.000e-01,1.000e-01
-SDP,ESC,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-02,1.799e-02,1.000e-01,1.000e-01
-SDP,ESC,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.693e-02,4.743e-02,1.462e-01,1.462e-01
+SDP,ESC,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.819e-01,5.321e-01,7.741e-01,7.741e-01
+SDP,ESC,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.122e-01,2.862e-01,7.509e-01,7.509e-01
+SDP,ESC,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.122e-01,2.862e-01,7.509e-01,7.509e-01
+SDP,ESC,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.122e-01,2.862e-01,7.509e-01,7.509e-01
+SDP,ESC,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.819e-01,5.321e-01,7.741e-01,7.741e-01
+SDP,ESC,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.124e-02,6.380e-02,7.883e-02,7.883e-02
+SDP,ESC,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,7.914e-02,5.608e-02,1.441e-01,1.441e-01
+SDP,ESC,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.924e-02,2.127e-02,9.854e-02,9.854e-02
+SDP,ESC,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.924e-02,2.127e-02,9.854e-02,9.854e-02
+SDP,ESC,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.924e-02,2.127e-02,9.854e-02,9.854e-02
+SDP,ESC,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,7.914e-02,5.608e-02,1.441e-01,1.441e-01
 SDP,ESC,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0.000e+00,8.315e-07,4.540e-05,1.192e-01,1.192e-01
 SDP,ESC,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,ESC,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
@@ -468,57 +468,57 @@ SDP,ESC,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_t
 SDP,ESC,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,ESC,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,ESC,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP,ESC,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,2.742e-02,5.301e-02,1.042e-01,2.066e-01,2.066e-01
-SDP,ESC,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SDP,ESC,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SDP,ESC,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SDP,ESC,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SDP,ESC,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
+SDP,ESC,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,2.742e-02,4.078e-02,1.042e-01,1.721e-01,1.721e-01
+SDP,ESC,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.535e-01,1.535e-01
+SDP,ESC,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.535e-01,1.535e-01
+SDP,ESC,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.535e-01,1.535e-01
+SDP,ESC,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.535e-01,1.535e-01
+SDP,ESC,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.535e-01,1.535e-01
 SDP,ESW,,,,,Cycle,trn_pass,S3S,linear,1.942e-02,3.884e-02,5.825e-02,1.019e-01,1.019e-01
-SDP,ESW,,,,,Domestic Aviation,trn_pass,S3S,linear,7.179e-04,7.179e-04,5.744e-04,1.346e-04,1.346e-04
-SDP,ESW,,,,,Domestic Ship,trn_freight,S3S,linear,6.018e-03,6.018e-03,6.018e-03,6.018e-03,6.018e-03
-SDP,ESW,,,,,Freight Rail,trn_freight,S3S,linear,1.394e-02,1.394e-02,1.394e-02,1.394e-02,1.394e-02
+SDP,ESW,,,,,Domestic Aviation,trn_pass,S3S,linear,6.852e-04,6.852e-04,5.482e-04,1.285e-04,1.285e-04
+SDP,ESW,,,,,Domestic Ship,trn_freight,S3S,linear,6.130e-03,6.130e-03,6.130e-03,6.130e-03,6.130e-03
+SDP,ESW,,,,,Freight Rail,trn_freight,S3S,linear,1.420e-02,1.420e-02,1.420e-02,1.420e-02,1.420e-02
 SDP,ESW,,,,,HSR,trn_pass,S3S,linear,9.579e-04,9.579e-04,9.579e-04,3.592e-04,3.592e-04
 SDP,ESW,,,,,International Aviation,trn_aviation_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,ESW,,,,,International Ship,trn_shipping_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,ESW,,,,,Passenger Rail,trn_pass,S3S,linear,3.621e-03,3.621e-03,5.432e-03,2.037e-03,2.037e-03
 SDP,ESW,,,,,Walk,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,ESW,,,,,trn_freight_road,trn_freight,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP,ESW,,,,,trn_pass_road,trn_pass,S3S,linear,1.411e-01,1.129e-01,1.129e-01,3.175e-02,3.175e-02
-SDP,ESW,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,5.667e-02,5.667e-02,7.083e-02,1.063e-01,1.063e-01
+SDP,ESW,,,,,trn_pass_road,trn_pass,S3S,linear,1.385e-01,1.108e-01,1.108e-01,3.117e-02,3.117e-02
+SDP,ESW,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,5.772e-02,5.772e-02,7.215e-02,1.082e-01,1.082e-01
 SDP,ESW,,,,trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP,ESW,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,8.570e-02,8.570e-02,8.570e-02,8.570e-02,8.570e-02
+SDP,ESW,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,7.141e-02,7.141e-02,7.141e-02,6.592e-02,6.592e-02
 SDP,ESW,,,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP,ESW,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,5.153e-01,5.153e-01,5.153e-01,5.153e-01,5.153e-01
+SDP,ESW,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,5.725e-01,5.725e-01,5.725e-01,5.725e-01,5.725e-01
 SDP,ESW,,Large Car and SUV,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,ESW,,Midsize Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,2.963e-01,2.963e-01,2.963e-01,2.963e-01,2.963e-01
 SDP,ESW,,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,9.741e-02,9.741e-02,9.741e-02,9.741e-02,9.741e-02
 SDP,ESW,,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.669e-01,1.669e-01,1.669e-01,1.669e-01,1.669e-01
 SDP,ESW,,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP,ESW,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,4.003e-01,4.003e-01,4.003e-01,4.003e-01,4.003e-01
+SDP,ESW,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,4.448e-01,4.448e-01,4.448e-01,4.448e-01,4.448e-01
 SDP,ESW,,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,2.850e-01,2.850e-01,2.850e-01,2.850e-01,2.850e-01
 SDP,ESW,,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,6.043e-02,6.043e-02,6.043e-02,6.043e-02,6.043e-02
 SDP,ESW,,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,8.424e-02,8.424e-02,8.424e-02,8.424e-02,8.424e-02
 SDP,ESW,,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,4.041e-01,4.041e-01,4.041e-01,4.041e-01,4.041e-01
 SDP,ESW,,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP,ESW,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP,ESW,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP,ESW,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP,ESW,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.186e-01,2.689e-01,6.668e-01,6.668e-01
+SDP,ESW,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.800e-02,2.160e-01,4.200e-01,4.200e-01
+SDP,ESW,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.800e-02,2.160e-01,4.200e-01,4.200e-01
+SDP,ESW,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.800e-02,2.160e-01,4.200e-01,4.200e-01
+SDP,ESW,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.078e-02,1.164e-01,2.935e-01,6.237e-01,6.237e-01
 SDP,ESW,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,7.295e-01,7.633e-01,8.309e-01,9.662e-01,9.662e-01
 SDP,ESW,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,ESW,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP,ESW,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.576e-01,7.000e-01,9.820e-01,9.820e-01
-SDP,ESW,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.423e-01,3.765e-01,9.526e-01,9.526e-01
-SDP,ESW,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.423e-01,3.765e-01,9.526e-01,9.526e-01
-SDP,ESW,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.423e-01,3.765e-01,9.526e-01,9.526e-01
-SDP,ESW,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.576e-01,7.000e-01,9.820e-01,9.820e-01
-SDP,ESW,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.473e-03,1.799e-02,7.500e-02,7.500e-02
-SDP,ESW,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.693e-02,2.371e-01,1.462e-01,1.462e-01
-SDP,ESW,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-02,8.993e-02,1.000e-01,1.000e-01
-SDP,ESW,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-02,8.993e-02,1.000e-01,1.000e-01
-SDP,ESW,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-02,8.993e-02,1.000e-01,1.000e-01
-SDP,ESW,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.693e-02,2.371e-01,1.462e-01,1.462e-01
+SDP,ESW,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.902e-01,6.875e-01,1.000e+00,1.000e+00
+SDP,ESW,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.553e-01,3.698e-01,1.000e+00,1.000e+00
+SDP,ESW,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.553e-01,3.698e-01,1.000e+00,1.000e+00
+SDP,ESW,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.553e-01,3.698e-01,1.000e+00,1.000e+00
+SDP,ESW,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.902e-01,6.875e-01,1.000e+00,1.000e+00
+SDP,ESW,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,2.248e-03,2.698e-03,1.963e-02,5.846e-02,5.846e-02
+SDP,ESW,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,7.303e-02,2.588e-01,1.489e-01,1.489e-01
+SDP,ESW,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.698e-02,9.813e-02,1.050e-01,1.050e-01
+SDP,ESW,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.698e-02,9.813e-02,1.050e-01,1.050e-01
+SDP,ESW,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.698e-02,9.813e-02,1.050e-01,1.050e-01
+SDP,ESW,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,7.303e-02,2.588e-01,1.489e-01,1.489e-01
 SDP,ESW,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0.000e+00,8.315e-07,4.540e-05,1.192e-01,1.192e-01
 SDP,ESW,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,ESW,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
@@ -530,39 +530,39 @@ SDP,ESW,Liquids,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_p
 SDP,ESW,Liquids,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,ESW,Liquids,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,ESW,Liquids,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,5.162e-01,5.162e-01,5.162e-01,5.162e-01,5.162e-01
-SDP,ESW,Liquids,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP,ESW,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP,ESW,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP,ESW,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP,ESW,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP,ESW,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SDP,ESW,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SDP,ESW,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SDP,ESW,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SDP,ESW,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SDP,ESW,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
+SDP,ESW,Liquids,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,9.332e-01,9.332e-01
+SDP,ESW,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,9.620e-01,9.620e-01
+SDP,ESW,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,9.620e-01,9.620e-01
+SDP,ESW,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,9.620e-01,9.620e-01
+SDP,ESW,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,9.332e-01,9.332e-01
+SDP,ESW,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.754e-02,2.632e-02,7.895e-02,1.316e-01,1.316e-01
+SDP,ESW,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.719e-01,1.719e-01
+SDP,ESW,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.772e-01,1.772e-01
+SDP,ESW,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.772e-01,1.772e-01
+SDP,ESW,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.772e-01,1.772e-01
+SDP,ESW,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.719e-01,1.719e-01
 SDP,EWN,,,,,Cycle,trn_pass,S3S,linear,1.000e-02,1.000e-02,5.000e-02,1.000e-01,1.000e-01
-SDP,EWN,,,,,Domestic Aviation,trn_pass,S3S,linear,5.000e-05,5.000e-05,5.000e-05,5.000e-06,5.000e-06
-SDP,EWN,,,,,Domestic Ship,trn_freight,S3S,linear,6.147e-03,6.830e-03,6.147e-03,6.147e-03,6.147e-03
-SDP,EWN,,,,,Freight Rail,trn_freight,S3S,linear,1.246e-02,1.385e-02,1.246e-02,1.246e-02,1.246e-02
+SDP,EWN,,,,,Domestic Aviation,trn_pass,S3S,linear,4.772e-05,4.772e-05,4.772e-05,4.772e-06,4.772e-06
+SDP,EWN,,,,,Domestic Ship,trn_freight,S3S,linear,6.261e-03,6.957e-03,6.261e-03,6.261e-03,6.261e-03
+SDP,EWN,,,,,Freight Rail,trn_freight,S3S,linear,1.270e-02,1.411e-02,1.270e-02,1.270e-02,1.270e-02
 SDP,EWN,,,,,HSR,trn_pass,S3S,linear,1.000e-04,1.000e-04,4.000e-04,2.000e-04,2.000e-04
 SDP,EWN,,,,,International Aviation,trn_aviation_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,EWN,,,,,International Ship,trn_shipping_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,EWN,,,,,Passenger Rail,trn_pass,S3S,linear,2.000e-03,3.000e-03,3.000e-03,2.000e-03,2.000e-03
 SDP,EWN,,,,,Walk,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,EWN,,,,,trn_freight_road,trn_freight,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP,EWN,,,,,trn_pass_road,trn_pass,S3S,linear,6.000e-02,6.000e-02,6.000e-02,3.000e-02,3.000e-02
-SDP,EWN,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,1.000e-01,1.000e-01,1.000e-01,1.500e-01,1.500e-01
+SDP,EWN,,,,,trn_pass_road,trn_pass,S3S,linear,5.891e-02,5.891e-02,5.891e-02,2.945e-02,2.945e-02
+SDP,EWN,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,1.019e-01,1.019e-01,1.019e-01,1.528e-01,1.528e-01
 SDP,EWN,,,,trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,EWN,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,4.166e-02,4.166e-02,4.166e-02,4.166e-02,4.166e-02
 SDP,EWN,,,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP,EWN,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,3.886e-01,3.886e-01,3.886e-01,3.886e-01,3.886e-01
+SDP,EWN,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,4.317e-01,4.317e-01,3.886e-01,3.886e-01,3.886e-01
 SDP,EWN,,Large Car and SUV,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,EWN,,Midsize Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,2.283e-01,2.283e-01,2.283e-01,2.283e-01,2.283e-01
 SDP,EWN,,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.183e-01,1.183e-01,1.183e-01,1.183e-01,1.183e-01
 SDP,EWN,,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,4.339e-02,4.339e-02,4.339e-02,4.339e-02,4.339e-02
 SDP,EWN,,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP,EWN,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,4.377e-01,4.377e-01,4.377e-01,4.377e-01,4.377e-01
+SDP,EWN,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,4.864e-01,4.864e-01,4.377e-01,4.377e-01,4.377e-01
 SDP,EWN,,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,EWN,,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.164e-01,1.164e-01,1.164e-01,1.164e-01,1.164e-01
 SDP,EWN,,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,5.225e-01,5.225e-01,5.225e-01,5.225e-01,5.225e-01
@@ -571,21 +571,21 @@ SDP,EWN,,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_sub
 SDP,EWN,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1.000e-03,6.000e-02,2.450e-01,4.500e-01,4.500e-01
 SDP,EWN,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1.000e-03,6.000e-02,2.450e-01,4.500e-01,4.500e-01
 SDP,EWN,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1.000e-03,6.000e-02,2.450e-01,4.500e-01,4.500e-01
-SDP,EWN,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.958e-02,2.323e-01,4.763e-01,4.763e-01
+SDP,EWN,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,8.794e-02,2.197e-01,5.006e-01,5.006e-01
 SDP,EWN,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,EWN,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,EWN,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP,EWN,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.550e-01,6.500e-01,8.729e-01,8.729e-01
-SDP,EWN,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.165e-02,3.496e-01,8.467e-01,8.467e-01
-SDP,EWN,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.165e-02,3.496e-01,8.467e-01,8.467e-01
-SDP,EWN,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.165e-02,3.496e-01,8.467e-01,8.467e-01
-SDP,EWN,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.550e-01,6.500e-01,8.729e-01,8.729e-01
-SDP,EWN,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.573e-03,6.540e-03,1.667e-02,1.667e-02
-SDP,EWN,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,9.370e-03,4.743e-02,4.061e-02,4.061e-02
-SDP,EWN,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.462e-03,1.799e-02,2.778e-02,2.778e-02
-SDP,EWN,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.462e-03,1.799e-02,2.778e-02,2.778e-02
-SDP,EWN,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.462e-03,1.799e-02,2.778e-02,2.778e-02
-SDP,EWN,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,9.370e-03,4.743e-02,4.061e-02,4.061e-02
+SDP,EWN,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.436e-01,6.405e-01,9.031e-01,9.031e-01
+SDP,EWN,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.367e-01,3.445e-01,8.760e-01,8.760e-01
+SDP,EWN,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.367e-01,3.445e-01,8.760e-01,8.760e-01
+SDP,EWN,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.367e-01,3.445e-01,8.760e-01,8.760e-01
+SDP,EWN,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.436e-01,6.405e-01,9.031e-01,9.031e-01
+SDP,EWN,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.861e-03,7.734e-03,2.190e-02,2.190e-02
+SDP,EWN,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.385e-02,1.059e-01,6.003e-02,6.003e-02
+SDP,EWN,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.116e-03,4.017e-02,4.106e-02,4.106e-02
+SDP,EWN,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.116e-03,4.017e-02,4.106e-02,4.106e-02
+SDP,EWN,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.116e-03,4.017e-02,4.106e-02,4.106e-02
+SDP,EWN,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.385e-02,1.059e-01,6.003e-02,6.003e-02
 SDP,EWN,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0.000e+00,8.315e-07,4.540e-05,1.192e-01,1.192e-01
 SDP,EWN,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,EWN,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
@@ -602,26 +602,26 @@ SDP,EWN,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_t
 SDP,EWN,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,EWN,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,EWN,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP,EWN,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,8.070e-03,3.107e-02,6.282e-02,8.745e-02,8.745e-02
-SDP,EWN,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,8.171e-04,2.711e-02,7.970e-02,1.027e-01,1.027e-01
-SDP,EWN,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.023e-01,1.023e-01
-SDP,EWN,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.023e-01,1.023e-01
-SDP,EWN,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.023e-01,1.023e-01
-SDP,EWN,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.023e-01,1.023e-01
+SDP,EWN,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,8.070e-03,3.107e-02,6.282e-02,9.716e-02,9.716e-02
+SDP,EWN,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,8.171e-04,3.389e-02,8.856e-02,1.284e-01,1.284e-01
+SDP,EWN,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.289e-02,8.772e-02,1.279e-01,1.279e-01
+SDP,EWN,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.289e-02,8.772e-02,1.279e-01,1.279e-01
+SDP,EWN,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.289e-02,8.772e-02,1.279e-01,1.279e-01
+SDP,EWN,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.289e-02,8.772e-02,1.279e-01,1.279e-01
 SDP,FRA,,,,,Cycle,trn_pass,S3S,linear,1.942e-02,2.184e-02,3.641e-02,1.019e-01,1.019e-01
-SDP,FRA,,,,,Domestic Aviation,trn_pass,S3S,linear,1.225e-04,6.891e-05,4.594e-05,2.297e-05,2.297e-05
-SDP,FRA,,,,,Domestic Ship,trn_freight,S3S,linear,3.357e-03,3.357e-03,3.357e-03,3.357e-03,3.357e-03
-SDP,FRA,,,,,Freight Rail,trn_freight,S3S,linear,1.766e-02,1.766e-02,1.766e-02,1.766e-02,1.766e-02
+SDP,FRA,,,,,Domestic Aviation,trn_pass,S3S,linear,1.169e-04,6.577e-05,4.385e-05,2.192e-05,2.192e-05
+SDP,FRA,,,,,Domestic Ship,trn_freight,S3S,linear,3.419e-03,3.419e-03,3.419e-03,3.419e-03,3.419e-03
+SDP,FRA,,,,,Freight Rail,trn_freight,S3S,linear,1.799e-02,1.799e-02,1.799e-02,1.799e-02,1.799e-02
 SDP,FRA,,,,,HSR,trn_pass,S3S,linear,3.359e-04,2.267e-04,2.015e-04,2.015e-04,2.015e-04
 SDP,FRA,,,,,International Aviation,trn_aviation_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,FRA,,,,,International Ship,trn_shipping_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,FRA,,,,,Passenger Rail,trn_pass,S3S,linear,3.972e-03,2.979e-03,1.986e-03,1.986e-03,1.986e-03
 SDP,FRA,,,,,Walk,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,FRA,,,,,trn_freight_road,trn_freight,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP,FRA,,,,,trn_pass_road,trn_pass,S3S,linear,9.224e-02,5.188e-02,3.459e-02,2.767e-02,2.767e-02
-SDP,FRA,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,7.788e-02,8.566e-02,9.345e-02,1.402e-01,1.402e-01
+SDP,FRA,,,,,trn_pass_road,trn_pass,S3S,linear,9.055e-02,5.094e-02,3.396e-02,2.717e-02,2.717e-02
+SDP,FRA,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,7.932e-02,8.726e-02,9.519e-02,1.428e-01,1.428e-01
 SDP,FRA,,,,trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP,FRA,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,9.470e-02,9.470e-02,9.470e-02,9.470e-02,9.470e-02
+SDP,FRA,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,7.285e-02,7.285e-02,7.285e-02,6.764e-02,6.764e-02
 SDP,FRA,,,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,FRA,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,6.352e-01,6.352e-01,6.352e-01,6.352e-01,6.352e-01
 SDP,FRA,,Large Car and SUV,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
@@ -635,26 +635,26 @@ SDP,FRA,,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subs
 SDP,FRA,,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.602e-01,1.602e-01,1.602e-01,1.602e-01,1.602e-01
 SDP,FRA,,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,4.011e-01,4.011e-01,4.011e-01,4.011e-01,4.011e-01
 SDP,FRA,,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,3.755e-01,3.755e-01,3.755e-01,3.755e-01,3.755e-01
-SDP,FRA,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP,FRA,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP,FRA,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP,FRA,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.423e-01,4.303e-01,1.000e+00,1.000e+00
+SDP,FRA,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.000e-02,2.400e-01,4.200e-01,4.200e-01
+SDP,FRA,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.000e-02,2.400e-01,4.200e-01,4.200e-01
+SDP,FRA,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.000e-02,2.400e-01,4.200e-01,4.200e-01
+SDP,FRA,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.402e-02,1.682e-01,4.579e-01,9.531e-01,9.531e-01
 SDP,FRA,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,FRA,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,FRA,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP,FRA,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.980e-01,7.500e-01,9.820e-01,9.820e-01
-SDP,FRA,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.186e-01,4.034e-01,9.526e-01,9.526e-01
-SDP,FRA,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.186e-01,4.034e-01,9.526e-01,9.526e-01
-SDP,FRA,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.186e-01,4.034e-01,9.526e-01,9.526e-01
-SDP,FRA,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.980e-01,7.500e-01,9.820e-01,9.820e-01
-SDP,FRA,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.236e-02,1.799e-02,9.544e-02,9.544e-02
-SDP,FRA,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.693e-02,4.743e-02,1.462e-01,1.462e-01
-SDP,FRA,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-02,1.799e-02,1.000e-01,1.000e-01
-SDP,FRA,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-02,1.799e-02,1.000e-01,1.000e-01
-SDP,FRA,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-02,1.799e-02,1.000e-01,1.000e-01
-SDP,FRA,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.693e-02,4.743e-02,1.462e-01,1.462e-01
+SDP,FRA,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.171e-01,6.651e-01,9.087e-01,9.087e-01
+SDP,FRA,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.262e-01,3.578e-01,8.815e-01,8.815e-01
+SDP,FRA,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.262e-01,3.578e-01,8.815e-01,8.815e-01
+SDP,FRA,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.262e-01,3.578e-01,8.815e-01,8.815e-01
+SDP,FRA,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.171e-01,6.651e-01,9.087e-01,9.087e-01
+SDP,FRA,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.218e-02,1.462e-02,2.127e-02,8.186e-02,8.186e-02
+SDP,FRA,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,7.914e-02,2.337e-01,1.503e-01,1.503e-01
+SDP,FRA,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.924e-02,8.861e-02,1.028e-01,1.028e-01
+SDP,FRA,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.924e-02,8.861e-02,1.028e-01,1.028e-01
+SDP,FRA,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.924e-02,8.861e-02,1.028e-01,1.028e-01
+SDP,FRA,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,7.914e-02,2.337e-01,1.503e-01,1.503e-01
 SDP,FRA,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0.000e+00,8.315e-07,4.540e-05,1.192e-01,1.192e-01
-SDP,FRA,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,9.544e-01,9.544e-01
+SDP,FRA,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,FRA,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,FRA,Liquids,Domestic Ship_tmp_vehicletype,Domestic Ship_tmp_subsector_L1,Domestic Ship_tmp_subsector_L2,Domestic Ship,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,FRA,Liquids,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1.608e-01,1.608e-01,1.608e-01,1.608e-01,1.608e-01
@@ -669,26 +669,26 @@ SDP,FRA,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_t
 SDP,FRA,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,FRA,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,FRA,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP,FRA,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.758e-01,1.758e-01
-SDP,FRA,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SDP,FRA,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SDP,FRA,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SDP,FRA,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SDP,FRA,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SDP,IND,,,,,Cycle,trn_pass,S3S,linear,2.632e-03,4.364e-03,9.091e-03,1.000e-01,1.000e-01
-SDP,IND,,,,,Domestic Aviation,trn_pass,S3S,linear,9.589e-02,1.091e-01,1.000e-01,2.000e-01,2.000e-01
-SDP,IND,,,,,Domestic Ship,trn_freight,S3S,linear,1.180e-03,1.180e-03,1.073e-03,9.075e-04,9.075e-04
-SDP,IND,,,,,Freight Rail,trn_freight,S3S,linear,1.889e-01,1.889e-01,1.717e-01,1.453e-01,1.453e-01
-SDP,IND,,,,,HSR,trn_pass,S3S,linear,0.000e+00,4.364e-05,1.000e-04,3.000e-04,3.000e-04
+SDP,FRA,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.535e-02,2.632e-02,7.895e-02,1.417e-01,1.417e-01
+SDP,FRA,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,6.579e-02,1.602e-01,1.602e-01
+SDP,FRA,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,6.579e-02,1.602e-01,1.602e-01
+SDP,FRA,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,6.579e-02,1.602e-01,1.602e-01
+SDP,FRA,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,6.579e-02,1.602e-01,1.602e-01
+SDP,FRA,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,6.579e-02,1.602e-01,1.602e-01
+SDP,IND,,,,,Cycle,trn_pass,S3S,linear,1.915e-02,3.175e-02,4.630e-02,1.000e-01,1.000e-01
+SDP,IND,,,,,Domestic Aviation,trn_pass,S3S,linear,6.659e-01,7.575e-01,4.861e-01,1.909e-01,1.909e-01
+SDP,IND,,,,,Domestic Ship,trn_freight,S3S,linear,1.202e-03,1.202e-03,1.092e-03,9.244e-04,9.244e-04
+SDP,IND,,,,,Freight Rail,trn_freight,S3S,linear,1.924e-01,1.924e-01,1.574e-01,1.332e-01,1.332e-01
+SDP,IND,,,,,HSR,trn_pass,S3S,linear,0.000e+00,3.175e-04,5.093e-04,3.000e-04,3.000e-04
 SDP,IND,,,,,International Aviation,trn_aviation_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,IND,,,,,International Ship,trn_shipping_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP,IND,,,,,Passenger Rail,trn_pass,S3S,linear,6.842e-04,8.000e-04,1.091e-03,4.000e-03,4.000e-03
-SDP,IND,,,,,Walk,trn_pass,S3S,linear,1.316e-01,9.455e-02,1.818e-01,1.000e+00,1.000e+00
+SDP,IND,,,,,Passenger Rail,trn_pass,S3S,linear,4.978e-03,5.820e-03,5.556e-03,4.000e-03,4.000e-03
+SDP,IND,,,,,Walk,trn_pass,S3S,linear,9.573e-01,6.879e-01,9.260e-01,1.000e+00,1.000e+00
 SDP,IND,,,,,trn_freight_road,trn_freight,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP,IND,,,,,trn_pass_road,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP,IND,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,1.188e-01,7.143e-02,3.231e-02,3.231e-02,3.231e-02
-SDP,IND,,,,trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP,IND,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,3.027e-03,2.668e-03,1.949e-03,5.108e-04,5.108e-04
+SDP,IND,,,,,trn_pass_road,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,2.945e-01,2.945e-01
+SDP,IND,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,1.000e+00,3.638e-01,1.645e-01,9.872e-02,9.872e-02
+SDP,IND,,,,trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,9.180e-01,1.000e+00,1.000e+00,1.000e+00,1.000e+00
+SDP,IND,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.816e-02,1.867e-02,2.923e-02,5.108e-02,5.108e-02
 SDP,IND,,,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,IND,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,IND,,Mini Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,6.374e-03,6.374e-03,6.374e-03,6.374e-03,6.374e-03
@@ -699,24 +699,24 @@ SDP,IND,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn
 SDP,IND,,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.853e-01,1.853e-01,1.853e-01,1.853e-01,1.853e-01
 SDP,IND,,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.987e-01,1.987e-01,1.987e-01,1.987e-01,1.987e-01
 SDP,IND,,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP,IND,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP,IND,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP,IND,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP,IND,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.743e-02,2.689e-01,7.621e-01,7.621e-01
+SDP,IND,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.000e-01,3.600e-01,3.780e-01,3.780e-01
+SDP,IND,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.000e-01,3.600e-01,3.780e-01,3.780e-01
+SDP,IND,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.000e-01,3.600e-01,3.780e-01,3.780e-01
+SDP,IND,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,5.175e-02,2.935e-01,6.653e-01,6.653e-01
 SDP,IND,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,IND,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,IND,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,8.340e-01,8.547e-01,8.962e-01,9.792e-01,9.792e-01
-SDP,IND,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.576e-02,1.000e-01,9.820e-02,9.820e-02
-SDP,IND,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.423e-02,5.379e-02,9.526e-02,9.526e-02
-SDP,IND,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,3.000e-01,2.000e-01,1.000e-01,1.000e-01
-SDP,IND,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,3.000e-01,2.000e-01,1.000e-01,1.000e-01
-SDP,IND,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.576e-02,1.000e-01,9.820e-02,9.820e-02
-SDP,IND,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.473e-03,1.799e-02,5.000e-02,5.000e-02
-SDP,IND,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.693e-03,9.485e-03,1.462e-02,1.462e-02
-SDP,IND,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-03,3.597e-03,1.000e-02,1.000e-02
-SDP,IND,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,2.000e-01,2.000e-02,2.000e-02
-SDP,IND,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,2.000e-01,2.000e-02,2.000e-02
-SDP,IND,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.693e-03,9.485e-03,1.462e-02,1.462e-02
+SDP,IND,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.787e-02,6.365e-02,6.430e-02,6.430e-02
+SDP,IND,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.109e-02,3.424e-02,6.237e-02,6.237e-02
+SDP,IND,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,2.338e-01,1.273e-01,6.547e-02,6.547e-02
+SDP,IND,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,2.338e-01,1.273e-01,6.547e-02,6.547e-02
+SDP,IND,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.787e-02,6.365e-02,6.430e-02,6.430e-02
+SDP,IND,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.698e-03,1.963e-02,5.456e-02,5.456e-02
+SDP,IND,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.217e-03,8.625e-03,1.595e-03,1.595e-03
+SDP,IND,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.927e-03,3.271e-03,1.091e-03,1.091e-03
+SDP,IND,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,7.794e-01,1.819e-01,2.182e-03,2.182e-03
+SDP,IND,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,7.794e-01,1.819e-01,2.182e-03,2.182e-03
+SDP,IND,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.217e-03,8.625e-03,1.595e-03,1.595e-03
 SDP,IND,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0.000e+00,8.315e-07,4.540e-05,1.192e-01,1.192e-01
 SDP,IND,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,IND,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
@@ -730,27 +730,27 @@ SDP,IND,Liquids,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_p
 SDP,IND,Liquids,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,IND,Liquids,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,IND,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP,IND,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP,IND,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
+SDP,IND,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,9.164e-01,1.000e+00,1.000e+00,1.000e+00,1.000e+00
+SDP,IND,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,9.164e-01,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,IND,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,IND,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,2.408e-01,2.086e-01,2.105e-01,1.903e-01,1.903e-01
-SDP,IND,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,8.768e-02,1.117e-01,7.985e-02,2.557e-02,2.557e-02
-SDP,IND,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,3.947e-02,1.842e-02,1.842e-02
-SDP,IND,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,5.000e-01,1.000e-01,1.000e-01
-SDP,IND,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,5.000e-01,1.000e-01,1.000e-01
-SDP,IND,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,3.947e-02,1.842e-02,1.842e-02
+SDP,IND,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,8.768e-02,7.978e-02,6.655e-02,2.557e-02,2.557e-02
+SDP,IND,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.880e-02,3.289e-02,1.842e-02,1.842e-02
+SDP,IND,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,9.164e-01,7.143e-01,4.167e-01,1.000e-01,1.000e-01
+SDP,IND,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,9.164e-01,7.143e-01,4.167e-01,1.000e-01,1.000e-01
+SDP,IND,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.880e-02,3.289e-02,1.842e-02,1.842e-02
 SDP,JPN,,,,,Cycle,trn_pass,S3S,linear,1.743e-02,1.743e-02,3.486e-02,1.961e-02,1.961e-02
-SDP,JPN,,,,,Domestic Aviation,trn_pass,S3S,linear,1.811e-04,2.174e-04,3.261e-04,9.170e-05,9.170e-05
-SDP,JPN,,,,,Domestic Ship,trn_freight,S3S,linear,1.146e-02,1.146e-02,1.146e-02,1.146e-02,1.146e-02
-SDP,JPN,,,,,Freight Rail,trn_freight,S3S,linear,2.781e-03,2.781e-03,2.781e-03,2.781e-03,2.781e-03
+SDP,JPN,,,,,Domestic Aviation,trn_pass,S3S,linear,1.729e-04,2.075e-04,3.112e-04,8.752e-05,8.752e-05
+SDP,JPN,,,,,Domestic Ship,trn_freight,S3S,linear,1.167e-02,1.111e-02,1.167e-02,1.167e-02,1.167e-02
+SDP,JPN,,,,,Freight Rail,trn_freight,S3S,linear,2.833e-03,2.698e-03,2.833e-03,2.833e-03,2.833e-03
 SDP,JPN,,,,,HSR,trn_pass,S3S,linear,4.081e-04,4.081e-04,4.591e-04,1.291e-04,1.291e-04
 SDP,JPN,,,,,International Aviation,trn_aviation_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,JPN,,,,,International Ship,trn_shipping_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,JPN,,,,,Passenger Rail,trn_pass,S3S,linear,6.084e-03,6.084e-03,7.000e-03,2.281e-03,2.281e-03
 SDP,JPN,,,,,Walk,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,JPN,,,,,trn_freight_road,trn_freight,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP,JPN,,,,,trn_pass_road,trn_pass,S3S,linear,7.245e-02,7.770e-02,7.770e-02,2.185e-02,2.185e-02
-SDP,JPN,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,5.971e-02,5.971e-02,5.971e-02,5.971e-02,5.971e-02
+SDP,JPN,,,,,trn_pass_road,trn_pass,S3S,linear,7.113e-02,7.629e-02,7.629e-02,2.146e-02,2.146e-02
+SDP,JPN,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,6.081e-02,6.081e-02,6.081e-02,6.081e-02,6.081e-02
 SDP,JPN,,,,trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,JPN,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,5.491e-02,5.491e-02,5.491e-02,5.491e-02,5.491e-02
 SDP,JPN,,,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
@@ -763,24 +763,24 @@ SDP,JPN,,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_roa
 SDP,JPN,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.286e-01,1.286e-01,1.286e-01,1.286e-01,1.286e-01
 SDP,JPN,,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,JPN,,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,5.896e-01,5.896e-01,5.896e-01,5.896e-01,5.896e-01
-SDP,JPN,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP,JPN,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP,JPN,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP,JPN,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.091e-01,1.793e-01,3.810e-01,3.810e-01
+SDP,JPN,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.600e-01,5.280e-01,1.000e+00,1.000e+00
+SDP,JPN,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.600e-01,5.280e-01,1.000e+00,1.000e+00
+SDP,JPN,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.600e-01,5.280e-01,1.000e+00,1.000e+00
+SDP,JPN,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,9.673e-02,1.794e-01,3.754e-01,3.754e-01
 SDP,JPN,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,JPN,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,JPN,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP,JPN,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.252e-01,3.529e-01,8.183e-01,8.183e-01
-SDP,JPN,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,6.364e-02,1.333e-01,8.333e-01,8.333e-01
-SDP,JPN,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,6.364e-02,1.333e-01,8.333e-01,8.333e-01
-SDP,JPN,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,6.364e-02,1.333e-01,8.333e-01,8.333e-01
-SDP,JPN,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.252e-01,3.529e-01,8.183e-01,8.183e-01
-SDP,JPN,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,6.182e-02,1.319e-01,1.000e-01,1.000e-01
-SDP,JPN,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.104e-01,2.511e-01,3.046e-01,3.046e-01
-SDP,JPN,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,4.167e-01,4.167e-01
-SDP,JPN,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,4.167e-01,4.167e-01
-SDP,JPN,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,4.167e-01,4.167e-01
-SDP,JPN,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.104e-01,2.511e-01,3.046e-01,3.046e-01
+SDP,JPN,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.332e-01,3.414e-01,8.870e-01,8.870e-01
+SDP,JPN,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,5.727e-02,1.200e-01,9.032e-01,9.032e-01
+SDP,JPN,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,5.727e-02,1.200e-01,9.032e-01,9.032e-01
+SDP,JPN,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,5.727e-02,1.200e-01,9.032e-01,9.032e-01
+SDP,JPN,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.332e-01,3.414e-01,8.870e-01,8.870e-01
+SDP,JPN,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,6.091e-02,1.200e-01,9.854e-02,9.854e-02
+SDP,JPN,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.306e-01,2.699e-01,2.701e-01,2.701e-01
+SDP,JPN,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,3.695e-01,3.695e-01
+SDP,JPN,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,3.695e-01,3.695e-01
+SDP,JPN,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,3.695e-01,3.695e-01
+SDP,JPN,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.306e-01,2.699e-01,2.701e-01,2.701e-01
 SDP,JPN,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0.000e+00,8.315e-07,4.540e-05,1.192e-01,1.192e-01
 SDP,JPN,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,JPN,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
@@ -788,41 +788,41 @@ SDP,JPN,Liquids,Domestic Ship_tmp_vehicletype,Domestic Ship_tmp_subsector_L1,Dom
 SDP,JPN,Liquids,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,8.837e-01,8.837e-01,8.837e-01,8.837e-01,8.837e-01
 SDP,JPN,Liquids,International Aviation_tmp_vehicletype,International Aviation_tmp_subsector_L1,International Aviation_tmp_subsector_L2,International Aviation,trn_aviation_intl,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,JPN,Liquids,International Ship_tmp_vehicletype,International Ship_tmp_subsector_L1,International Ship_tmp_subsector_L2,International Ship,trn_shipping_intl,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP,JPN,Liquids,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP,JPN,Liquids,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP,JPN,Liquids,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
+SDP,JPN,Liquids,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,9.921e-01,9.921e-01
+SDP,JPN,Liquids,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,9.921e-01,9.921e-01
+SDP,JPN,Liquids,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,9.921e-01,9.921e-01
 SDP,JPN,Liquids,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,3.433e-02,3.433e-02,3.433e-02,3.433e-02,3.433e-02
 SDP,JPN,Liquids,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP,JPN,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,6.061e-02,1.889e-01,1.000e+00,1.000e+00
-SDP,JPN,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,6.061e-02,1.889e-01,1.000e+00,1.000e+00
-SDP,JPN,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,6.061e-02,1.889e-01,1.000e+00,1.000e+00
+SDP,JPN,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,8.457e-01,5.126e-02,1.757e-01,1.000e+00,1.000e+00
+SDP,JPN,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,8.457e-01,5.126e-02,1.757e-01,1.000e+00,1.000e+00
+SDP,JPN,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,8.457e-01,5.126e-02,1.757e-01,1.000e+00,1.000e+00
 SDP,JPN,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP,JPN,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,7.895e-03,1.579e-02,2.303e-02,2.303e-02
-SDP,JPN,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.316e-02,4.644e-02,4.605e-02,4.605e-02
-SDP,JPN,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,3.030e-02,1.111e-01,2.500e-01,2.500e-01
-SDP,JPN,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,3.030e-02,1.111e-01,2.500e-01,2.500e-01
-SDP,JPN,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,3.030e-02,1.111e-01,2.500e-01,2.500e-01
-SDP,JPN,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.316e-02,4.644e-02,4.605e-02,4.605e-02
-SDP,LAM,,,,,Cycle,trn_pass,S3S,linear,9.812e-03,1.852e-02,4.629e-02,2.315e-01,2.315e-01
-SDP,LAM,,,,,Domestic Aviation,trn_pass,S3S,linear,8.407e-03,1.058e-02,2.644e-02,1.983e-02,1.983e-02
-SDP,LAM,,,,,Domestic Ship,trn_freight,S3S,linear,9.523e-03,9.523e-03,8.658e-03,7.936e-03,7.936e-03
-SDP,LAM,,,,,Freight Rail,trn_freight,S3S,linear,4.694e-02,4.694e-02,4.268e-02,3.912e-02,3.912e-02
-SDP,LAM,,,,,HSR,trn_pass,S3S,linear,4.709e-03,2.465e-01,2.465e-01,2.465e-01,2.465e-01
+SDP,JPN,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,6.579e-03,1.215e-02,1.919e-02,1.919e-02
+SDP,JPN,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.316e-02,4.222e-02,3.838e-02,3.838e-02
+SDP,JPN,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,8.457e-01,2.563e-02,9.397e-02,2.083e-01,2.083e-01
+SDP,JPN,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,8.457e-01,2.563e-02,9.397e-02,2.083e-01,2.083e-01
+SDP,JPN,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,8.457e-01,2.563e-02,9.397e-02,2.083e-01,2.083e-01
+SDP,JPN,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.316e-02,4.222e-02,3.838e-02,3.838e-02
+SDP,LAM,,,,,Cycle,trn_pass,S3S,linear,1.091e-02,2.182e-02,5.455e-02,2.728e-01,2.728e-01
+SDP,LAM,,,,,Domestic Aviation,trn_pass,S3S,linear,8.921e-03,1.190e-02,2.974e-02,2.230e-02,2.230e-02
+SDP,LAM,,,,,Domestic Ship,trn_freight,S3S,linear,9.700e-03,9.700e-03,8.908e-03,6.736e-03,6.736e-03
+SDP,LAM,,,,,Freight Rail,trn_freight,S3S,linear,4.782e-02,4.782e-02,4.391e-02,3.985e-02,3.985e-02
+SDP,LAM,,,,,HSR,trn_pass,S3S,linear,5.236e-03,2.905e-01,2.905e-01,2.905e-01,2.905e-01
 SDP,LAM,,,,,International Aviation,trn_aviation_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,LAM,,,,,International Ship,trn_shipping_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP,LAM,,,,,Passenger Rail,trn_pass,S3S,linear,1.348e-01,1.272e-01,1.272e-01,8.482e-02,8.482e-02
-SDP,LAM,,,,,Walk,trn_pass,S3S,linear,8.993e-01,8.486e-01,8.486e-01,8.486e-01,8.486e-01
+SDP,LAM,,,,,Passenger Rail,trn_pass,S3S,linear,1.499e-01,1.499e-01,1.499e-01,9.996e-02,9.996e-02
+SDP,LAM,,,,,Walk,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,LAM,,,,,trn_freight_road,trn_freight,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP,LAM,,,,,trn_pass_road,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP,LAM,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,1.732e-01,1.083e-01,8.662e-02,8.662e-02,8.662e-02
+SDP,LAM,,,,,trn_pass_road,trn_pass,S3S,linear,6.550e-01,6.942e-01,6.942e-01,8.099e-01,8.099e-01
+SDP,LAM,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,2.647e-01,1.654e-01,1.323e-01,1.323e-01,1.323e-01
 SDP,LAM,,,,trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,LAM,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.377e-01,1.377e-01,1.377e-01,1.377e-01,1.377e-01
 SDP,LAM,,,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,LAM,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP,LAM,,Large Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,5.465e-02,5.465e-02,5.465e-02,5.465e-02,5.465e-02
-SDP,LAM,,Large Car and SUV,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,6.039e-01,6.039e-01,6.039e-01,6.039e-01,6.039e-01
-SDP,LAM,,Light Truck and SUV,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,2.182e-01,2.182e-01,2.182e-01,2.182e-01,2.182e-01
-SDP,LAM,,Midsize Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,7.979e-02,7.979e-02,7.979e-02,7.979e-02,7.979e-02
+SDP,LAM,,Large Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,3.279e-02,3.935e-02,4.099e-02,4.372e-02,4.372e-02
+SDP,LAM,,Large Car and SUV,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,3.624e-01,4.348e-01,4.529e-01,4.831e-01,4.831e-01
+SDP,LAM,,Light Truck and SUV,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.309e-01,1.571e-01,1.636e-01,1.745e-01,1.745e-01
+SDP,LAM,,Midsize Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,4.788e-02,5.745e-02,5.984e-02,6.383e-02,6.383e-02
 SDP,LAM,,Mini Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.226e-02,1.226e-02,1.226e-02,1.226e-02,1.226e-02
 SDP,LAM,,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,4.580e-04,4.580e-04,4.580e-04,4.580e-04,4.580e-04
 SDP,LAM,,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
@@ -833,27 +833,27 @@ SDP,LAM,,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subs
 SDP,LAM,,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,LAM,,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,5.079e-04,5.079e-04,5.079e-04,5.079e-04,5.079e-04
 SDP,LAM,,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.892e-01,1.892e-01,1.892e-01,1.892e-01,1.892e-01
-SDP,LAM,,Van,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,2.455e-03,2.455e-03,2.455e-03,2.455e-03,2.455e-03
-SDP,LAM,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP,LAM,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP,LAM,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP,LAM,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.186e-01,5.379e-01,1.000e+00,1.000e+00
+SDP,LAM,,Van,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.473e-03,1.768e-03,1.842e-03,1.964e-03,1.964e-03
+SDP,LAM,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,5.600e-02,2.160e-01,5.040e-01,5.040e-01
+SDP,LAM,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,5.600e-02,2.160e-01,5.040e-01,5.040e-01
+SDP,LAM,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,5.600e-02,2.160e-01,5.040e-01,5.040e-01
+SDP,LAM,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.294e-01,5.869e-01,1.000e+00,1.000e+00
 SDP,LAM,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,6.810e-02,1.846e-01,4.176e-01,8.835e-01,8.835e-01
 SDP,LAM,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,LAM,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP,LAM,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,7.947e-02,2.000e-01,2.400e-01,2.400e-01
-SDP,LAM,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.162e-02,1.076e-01,2.329e-01,2.329e-01
-SDP,LAM,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.162e-02,1.076e-01,2.329e-01,2.329e-01
-SDP,LAM,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.162e-02,1.076e-01,2.329e-01,2.329e-01
-SDP,LAM,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,7.947e-02,2.000e-01,2.400e-01,2.400e-01
-SDP,LAM,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.473e-03,1.799e-02,6.561e-02,6.561e-02
-SDP,LAM,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,8.924e-03,5.691e-02,8.123e-02,8.123e-02
-SDP,LAM,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.297e-03,2.158e-02,5.556e-02,5.556e-02
-SDP,LAM,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.297e-03,2.158e-02,5.556e-02,5.556e-02
-SDP,LAM,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.297e-03,2.158e-02,5.556e-02,5.556e-02
-SDP,LAM,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,8.924e-03,5.691e-02,8.123e-02,8.123e-02
+SDP,LAM,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.041e-01,1.964e-01,2.357e-01,2.357e-01
+SDP,LAM,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.140e-02,1.057e-01,2.287e-01,2.287e-01
+SDP,LAM,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.140e-02,1.057e-01,2.287e-01,2.287e-01
+SDP,LAM,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.140e-02,1.057e-01,2.287e-01,2.287e-01
+SDP,LAM,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.041e-01,1.964e-01,2.357e-01,2.357e-01
+SDP,LAM,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.698e-03,1.963e-02,6.561e-02,6.561e-02
+SDP,LAM,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,9.738e-03,6.210e-02,8.864e-02,8.864e-02
+SDP,LAM,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.598e-03,2.355e-02,6.062e-02,6.062e-02
+SDP,LAM,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.598e-03,2.355e-02,6.062e-02,6.062e-02
+SDP,LAM,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.598e-03,2.355e-02,6.062e-02,6.062e-02
+SDP,LAM,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,9.738e-03,6.210e-02,8.864e-02,8.864e-02
 SDP,LAM,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0.000e+00,8.315e-07,4.540e-05,1.192e-01,1.192e-01
-SDP,LAM,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,7.217e-01,7.217e-01
+SDP,LAM,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,7.275e-01,7.275e-01
 SDP,LAM,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,LAM,Liquids,Domestic Ship_tmp_vehicletype,Domestic Ship_tmp_subsector_L1,Domestic Ship_tmp_subsector_L2,Domestic Ship,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,LAM,Liquids,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
@@ -868,55 +868,55 @@ SDP,LAM,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_t
 SDP,LAM,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,LAM,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,LAM,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP,LAM,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,2.689e-02,4.725e-02,1.037e-01,1.353e-01,1.353e-01
+SDP,LAM,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,2.689e-02,4.725e-02,1.037e-01,1.240e-01,1.240e-01
 SDP,LAM,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.754e-02,3.158e-02,6.140e-02,6.140e-02
 SDP,LAM,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.754e-02,3.158e-02,6.140e-02,6.140e-02
 SDP,LAM,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.754e-02,3.158e-02,6.140e-02,6.140e-02
 SDP,LAM,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.754e-02,3.158e-02,6.140e-02,6.140e-02
 SDP,LAM,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.754e-02,3.158e-02,6.140e-02,6.140e-02
 SDP,MEA,,,,,Cycle,trn_pass,S3S,linear,1.660e-02,1.660e-02,1.660e-02,4.149e-02,4.149e-02
-SDP,MEA,,,,,Domestic Aviation,trn_pass,S3S,linear,8.929e-03,5.953e-03,1.786e-02,2.381e-02,2.381e-02
-SDP,MEA,,,,,Domestic Ship,trn_freight,S3S,linear,2.022e-03,2.022e-03,2.022e-03,2.022e-03,2.022e-03
-SDP,MEA,,,,,Freight Rail,trn_freight,S3S,linear,3.143e-03,3.143e-03,3.143e-03,3.143e-03,3.143e-03
+SDP,MEA,,,,,Domestic Aviation,trn_pass,S3S,linear,8.522e-03,5.681e-03,1.704e-02,2.500e-02,2.500e-02
+SDP,MEA,,,,,Domestic Ship,trn_freight,S3S,linear,2.060e-03,2.060e-03,2.060e-03,2.060e-03,2.060e-03
+SDP,MEA,,,,,Freight Rail,trn_freight,S3S,linear,3.202e-03,3.202e-03,3.202e-03,3.202e-03,3.202e-03
 SDP,MEA,,,,,HSR,trn_pass,S3S,linear,0.000e+00,1.667e-02,1.667e-02,1.667e-02,1.667e-02
 SDP,MEA,,,,,International Aviation,trn_aviation_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,MEA,,,,,International Ship,trn_shipping_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,MEA,,,,,Passenger Rail,trn_pass,S3S,linear,5.567e-04,1.113e-03,1.113e-03,1.856e-03,1.856e-03
 SDP,MEA,,,,,Walk,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,MEA,,,,,trn_freight_road,trn_freight,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP,MEA,,,,,trn_pass_road,trn_pass,S3S,linear,6.395e-01,7.197e-01,7.197e-01,7.197e-01,7.197e-01
-SDP,MEA,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,2.627e-01,1.226e-01,6.131e-02,4.905e-02,4.905e-02
+SDP,MEA,,,,,trn_pass_road,trn_pass,S3S,linear,3.767e-01,4.239e-01,3.815e-01,3.815e-01,3.815e-01
+SDP,MEA,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,2.676e-01,1.873e-01,9.367e-02,7.493e-02,7.493e-02
 SDP,MEA,,,,trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP,MEA,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,7.508e-03,7.508e-03,7.508e-03,7.508e-03,7.508e-03
+SDP,MEA,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.502e-02,1.502e-02,1.502e-02,1.502e-02,1.502e-02
 SDP,MEA,,,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP,MEA,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,4.732e-01,4.732e-01,4.732e-01,4.732e-01,4.732e-01
+SDP,MEA,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,5.257e-01,4.732e-01,4.337e-01,3.943e-01,3.943e-01
 SDP,MEA,,Large Car and SUV,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP,MEA,,Mini Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,3.955e-02,3.955e-02,3.955e-02,3.955e-02,3.955e-02
+SDP,MEA,,Mini Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,4.395e-02,3.955e-02,3.626e-02,3.296e-02,3.296e-02
 SDP,MEA,,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,MEA,,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,MEA,,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP,MEA,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.864e-01,1.864e-01,1.864e-01,1.864e-01,1.864e-01
+SDP,MEA,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,2.071e-01,1.864e-01,1.709e-01,1.553e-01,1.553e-01
 SDP,MEA,,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.304e-01,1.304e-01,1.304e-01,1.304e-01,1.304e-01
 SDP,MEA,,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,2.013e-01,2.013e-01,2.013e-01,2.013e-01,2.013e-01
 SDP,MEA,,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP,MEA,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP,MEA,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP,MEA,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP,MEA,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.743e-02,2.958e-01,6.549e-01,6.549e-01
+SDP,MEA,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.200e-01,2.160e-01,2.100e-01,2.100e-01
+SDP,MEA,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.200e-01,2.160e-01,2.100e-01,2.100e-01
+SDP,MEA,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.200e-01,2.160e-01,2.100e-01,2.100e-01
+SDP,MEA,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,5.175e-02,2.935e-01,6.497e-01,6.497e-01
 SDP,MEA,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,4.021e-01,4.768e-01,6.263e-01,9.253e-01,9.253e-01
 SDP,MEA,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,MEA,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP,MEA,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.960e-02,1.000e-01,1.403e-01,1.403e-01
-SDP,MEA,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.371e-02,5.379e-02,1.361e-01,1.361e-01
-SDP,MEA,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.429e-01,2.000e-01,1.429e-01,1.429e-01
-SDP,MEA,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.429e-01,2.000e-01,1.429e-01,1.429e-01
-SDP,MEA,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.960e-02,1.000e-01,1.403e-01,1.403e-01
-SDP,MEA,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.473e-03,1.799e-02,6.250e-02,6.250e-02
-SDP,MEA,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.346e-03,9.485e-03,4.177e-02,4.177e-02
-SDP,MEA,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.236e-03,3.597e-03,2.857e-02,2.857e-02
-SDP,MEA,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.429e-01,2.000e-01,5.714e-02,5.714e-02
-SDP,MEA,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.429e-01,2.000e-01,5.714e-02,5.714e-02
-SDP,MEA,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.346e-03,9.485e-03,4.177e-02,4.177e-02
+SDP,MEA,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.504e-02,1.091e-01,1.392e-01,1.392e-01
+SDP,MEA,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.588e-02,5.869e-02,1.350e-01,1.350e-01
+SDP,MEA,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.559e-01,2.182e-01,1.417e-01,1.417e-01
+SDP,MEA,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.559e-01,2.182e-01,1.417e-01,1.417e-01
+SDP,MEA,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.504e-02,1.091e-01,1.392e-01,1.392e-01
+SDP,MEA,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.698e-03,1.784e-02,5.580e-02,5.580e-02
+SDP,MEA,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.652e-03,1.035e-02,4.144e-04,4.144e-04
+SDP,MEA,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.349e-03,3.925e-03,2.834e-04,2.834e-04
+SDP,MEA,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.559e-01,2.182e-01,5.669e-04,5.669e-04
+SDP,MEA,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.559e-01,2.182e-01,5.669e-04,5.669e-04
+SDP,MEA,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.652e-03,1.035e-02,4.144e-04,4.144e-04
 SDP,MEA,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0.000e+00,8.315e-07,4.540e-05,1.192e-01,1.192e-01
 SDP,MEA,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,MEA,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
@@ -930,27 +930,27 @@ SDP,MEA,Liquids,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_p
 SDP,MEA,Liquids,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,7.852e-02,7.852e-02,7.852e-02,7.852e-02,7.852e-02
 SDP,MEA,Liquids,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,MEA,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP,MEA,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,2.857e-01,1.000e+00,1.000e+00,1.000e+00
-SDP,MEA,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,2.857e-01,1.000e+00,1.000e+00,1.000e+00
+SDP,MEA,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,9.164e-01,2.857e-01,1.000e+00,1.000e+00,1.000e+00
+SDP,MEA,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,9.164e-01,2.857e-01,1.000e+00,1.000e+00,1.000e+00
 SDP,MEA,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP,MEA,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.342e-02,3.938e-02,9.130e-02,1.220e-01,1.220e-01
-SDP,MEA,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,9.283e-04,9.527e-02,4.788e-02,5.285e-02,5.285e-02
-SDP,MEA,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,9.211e-02,4.737e-02,5.263e-02,5.263e-02
-SDP,MEA,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,6.000e-01,2.857e-01,2.857e-01
-SDP,MEA,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,6.000e-01,2.857e-01,2.857e-01
-SDP,MEA,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,9.211e-02,4.737e-02,5.263e-02,5.263e-02
+SDP,MEA,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.342e-02,3.938e-02,8.300e-02,1.109e-01,1.109e-01
+SDP,MEA,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,9.283e-04,9.527e-02,4.788e-02,4.804e-02,4.804e-02
+SDP,MEA,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,9.211e-02,4.737e-02,4.785e-02,4.785e-02
+SDP,MEA,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,9.164e-01,1.000e+00,6.000e-01,2.597e-01,2.597e-01
+SDP,MEA,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,9.164e-01,1.000e+00,6.000e-01,2.597e-01,2.597e-01
+SDP,MEA,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,9.211e-02,4.737e-02,4.785e-02,4.785e-02
 SDP,NEN,,,,,Cycle,trn_pass,S3S,linear,3.033e-03,3.024e-03,2.621e-03,1.820e-02,1.820e-02
-SDP,NEN,,,,,Domestic Aviation,trn_pass,S3S,linear,7.555e-06,7.895e-06,2.566e-06,1.497e-06,1.497e-06
-SDP,NEN,,,,,Domestic Ship,trn_freight,S3S,linear,3.117e-02,3.117e-02,3.117e-02,3.117e-02,3.117e-02
-SDP,NEN,,,,,Freight Rail,trn_freight,S3S,linear,1.890e-02,1.890e-02,1.890e-02,1.890e-02,1.890e-02
+SDP,NEN,,,,,Domestic Aviation,trn_pass,S3S,linear,7.210e-06,7.535e-06,2.449e-06,1.428e-06,1.428e-06
+SDP,NEN,,,,,Domestic Ship,trn_freight,S3S,linear,3.175e-02,3.175e-02,3.175e-02,3.175e-02,3.175e-02
+SDP,NEN,,,,,Freight Rail,trn_freight,S3S,linear,1.925e-02,1.925e-02,1.925e-02,1.925e-02,1.925e-02
 SDP,NEN,,,,,HSR,trn_pass,S3S,linear,2.000e-05,4.532e-05,7.364e-06,5.523e-06,5.523e-06
 SDP,NEN,,,,,International Aviation,trn_aviation_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,NEN,,,,,International Ship,trn_shipping_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,NEN,,,,,Passenger Rail,trn_pass,S3S,linear,3.000e-06,2.967e-06,6.751e-07,3.215e-07,3.215e-07
 SDP,NEN,,,,,Walk,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,NEN,,,,,trn_freight_road,trn_freight,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP,NEN,,,,,trn_pass_road,trn_pass,S3S,linear,5.052e-02,6.996e-02,2.842e-02,2.368e-02,2.368e-02
-SDP,NEN,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,1.263e-02,7.897e-03,3.948e-03,1.974e-03,1.974e-03
+SDP,NEN,,,,,trn_pass_road,trn_pass,S3S,linear,4.960e-02,6.868e-02,2.790e-02,2.325e-02,2.325e-02
+SDP,NEN,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,1.287e-02,8.044e-03,4.022e-03,2.011e-03,2.011e-03
 SDP,NEN,,,,trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,NEN,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,3.994e-02,3.994e-02,3.994e-02,3.994e-02,3.994e-02
 SDP,NEN,,,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
@@ -968,24 +968,24 @@ SDP,NEN,,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subs
 SDP,NEN,,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,6.397e-02,6.397e-02,6.397e-02,6.397e-02,6.397e-02
 SDP,NEN,,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,3.433e-01,3.433e-01,3.433e-01,3.433e-01,3.433e-01
 SDP,NEN,,Van,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,7.350e-03,7.350e-03,7.350e-03,7.350e-03,7.350e-03
-SDP,NEN,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP,NEN,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP,NEN,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP,NEN,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.743e-02,2.689e-01,9.526e-01,9.526e-01
+SDP,NEN,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.000e-02,1.680e-01,2.940e-01,2.940e-01
+SDP,NEN,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.000e-02,1.680e-01,2.940e-01,2.940e-01
+SDP,NEN,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.000e-02,1.680e-01,2.940e-01,2.940e-01
+SDP,NEN,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,5.608e-02,1.402e-01,4.134e-01,9.856e-01,9.856e-01
 SDP,NEN,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,NEN,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,NEN,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP,NEN,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.192e-01,5.000e-01,9.820e-01,9.820e-01
-SDP,NEN,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.743e-02,2.689e-01,9.526e-01,9.526e-01
-SDP,NEN,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.743e-02,2.689e-01,9.526e-01,9.526e-01
-SDP,NEN,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.743e-02,2.689e-01,9.526e-01,9.526e-01
-SDP,NEN,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.192e-01,5.000e-01,9.820e-01,9.820e-01
-SDP,NEN,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.473e-03,1.799e-02,5.000e-01,5.000e-01
-SDP,NEN,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.693e-03,4.743e-02,7.311e-01,7.311e-01
-SDP,NEN,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-03,1.799e-02,5.000e-01,5.000e-01
-SDP,NEN,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-03,1.799e-02,5.000e-01,5.000e-01
-SDP,NEN,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-03,1.799e-02,5.000e-01,5.000e-01
-SDP,NEN,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.693e-03,4.743e-02,7.311e-01,7.311e-01
+SDP,NEN,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.537e-01,5.912e-01,8.932e-01,8.932e-01
+SDP,NEN,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.009e-01,3.180e-01,8.664e-01,8.664e-01
+SDP,NEN,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.009e-01,3.180e-01,8.664e-01,8.664e-01
+SDP,NEN,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.009e-01,3.180e-01,8.664e-01,8.664e-01
+SDP,NEN,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.537e-01,5.912e-01,8.932e-01,8.932e-01
+SDP,NEN,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.924e-03,2.127e-02,5.543e-02,5.543e-02
+SDP,NEN,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,7.914e-03,1.682e-01,9.974e-02,9.974e-02
+SDP,NEN,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.924e-03,6.380e-02,6.822e-02,6.822e-02
+SDP,NEN,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.924e-03,6.380e-02,6.822e-02,6.822e-02
+SDP,NEN,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.924e-03,6.380e-02,6.822e-02,6.822e-02
+SDP,NEN,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,7.914e-03,1.682e-01,9.974e-02,9.974e-02
 SDP,NEN,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0.000e+00,8.315e-07,4.540e-05,1.192e-01,1.192e-01
 SDP,NEN,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,NEN,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
@@ -1002,59 +1002,59 @@ SDP,NEN,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_t
 SDP,NEN,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,NEN,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,NEN,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP,NEN,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,2.147e-02,4.722e-02,9.872e-02,2.017e-01,2.017e-01
-SDP,NEN,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,6.427e-03,3.257e-02,8.487e-02,1.895e-01,1.895e-01
-SDP,NEN,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SDP,NEN,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SDP,NEN,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SDP,NEN,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
+SDP,NEN,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,2.362e-02,3.778e-02,9.872e-02,1.261e-01,1.261e-01
+SDP,NEN,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,6.427e-03,3.257e-02,8.487e-02,1.457e-01,1.457e-01
+SDP,NEN,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.417e-01,1.417e-01
+SDP,NEN,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.417e-01,1.417e-01
+SDP,NEN,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.417e-01,1.417e-01
+SDP,NEN,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.417e-01,1.417e-01
 SDP,NES,,,,,Cycle,trn_pass,S3S,linear,8.738e-03,7.802e-03,9.929e-03,1.365e-02,1.365e-02
-SDP,NES,,,,,Domestic Aviation,trn_pass,S3S,linear,4.947e-03,3.534e-03,1.499e-03,4.123e-04,4.123e-04
-SDP,NES,,,,,Domestic Ship,trn_freight,S3S,linear,1.442e-02,1.442e-02,1.442e-02,1.442e-02,1.442e-02
-SDP,NES,,,,,Freight Rail,trn_freight,S3S,linear,1.666e-02,1.666e-02,1.666e-02,1.666e-02,1.666e-02
+SDP,NES,,,,,Domestic Aviation,trn_pass,S3S,linear,4.721e-03,3.372e-03,1.431e-03,3.935e-04,3.935e-04
+SDP,NES,,,,,Domestic Ship,trn_freight,S3S,linear,1.468e-02,1.468e-02,1.468e-02,1.322e-02,1.322e-02
+SDP,NES,,,,,Freight Rail,trn_freight,S3S,linear,1.697e-02,1.697e-02,1.697e-02,1.697e-02,1.697e-02
 SDP,NES,,,,,HSR,trn_pass,S3S,linear,5.085e-04,3.632e-04,2.311e-04,1.271e-04,1.271e-04
 SDP,NES,,,,,International Aviation,trn_aviation_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,NES,,,,,International Ship,trn_shipping_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,NES,,,,,Passenger Rail,trn_pass,S3S,linear,1.607e-03,1.148e-03,7.303e-04,4.017e-04,4.017e-04
 SDP,NES,,,,,Walk,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,NES,,,,,trn_freight_road,trn_freight,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP,NES,,,,,trn_pass_road,trn_pass,S3S,linear,9.258e-01,7.176e-01,4.566e-01,2.512e-01,2.512e-01
-SDP,NES,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,5.499e-02,2.199e-02,1.100e-02,1.100e-02,1.100e-02
+SDP,NES,,,,,trn_pass_road,trn_pass,S3S,linear,2.727e-01,2.818e-01,2.242e-01,1.233e-01,1.233e-01
+SDP,NES,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,8.401e-02,3.734e-02,2.240e-02,2.240e-02,2.240e-02
 SDP,NES,,,,trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,NES,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,4.923e-03,4.923e-03,4.923e-03,4.923e-03,4.923e-03
 SDP,NES,,,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP,NES,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,4.608e-01,4.608e-01,4.608e-01,4.608e-01,4.608e-01
+SDP,NES,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,5.760e-01,5.760e-01,6.144e-01,6.144e-01,6.144e-01
 SDP,NES,,Large Car and SUV,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,NES,,Midsize Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,2.352e-01,2.352e-01,2.352e-01,2.352e-01,2.352e-01
-SDP,NES,,Mini Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.509e-03,1.509e-03,1.509e-03,1.509e-03,1.509e-03
+SDP,NES,,Mini Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.886e-03,1.886e-03,2.012e-03,2.012e-03,2.012e-03
 SDP,NES,,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.148e-02,1.148e-02,1.148e-02,1.148e-02,1.148e-02
 SDP,NES,,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.337e-01,1.337e-01,1.337e-01,1.337e-01,1.337e-01
 SDP,NES,,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP,NES,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,7.460e-02,7.460e-02,7.460e-02,7.460e-02,7.460e-02
+SDP,NES,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,9.325e-02,9.325e-02,9.946e-02,9.946e-02,9.946e-02
 SDP,NES,,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,NES,,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,6.299e-02,6.299e-02,6.299e-02,6.299e-02,6.299e-02
 SDP,NES,,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,3.651e-01,3.651e-01,3.651e-01,3.651e-01,3.651e-01
 SDP,NES,,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,5.704e-01,5.704e-01,5.704e-01,5.704e-01,5.704e-01
 SDP,NES,,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,4.799e-01,4.799e-01,4.799e-01,4.799e-01,4.799e-01
 SDP,NES,,Van,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,2.880e-03,2.880e-03,2.880e-03,2.880e-03,2.880e-03
-SDP,NES,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP,NES,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP,NES,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP,NES,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.743e-02,2.689e-01,9.526e-01,9.526e-01
+SDP,NES,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.000e-02,1.680e-01,3.360e-01,3.360e-01
+SDP,NES,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.000e-02,1.680e-01,3.360e-01,3.360e-01
+SDP,NES,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.000e-02,1.680e-01,3.360e-01,3.360e-01
+SDP,NES,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,5.175e-02,1.739e-01,3.465e-01,3.465e-01
 SDP,NES,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,2.081e-01,3.071e-01,5.050e-01,9.010e-01,9.010e-01
 SDP,NES,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,NES,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP,NES,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.192e-01,5.000e-01,9.820e-01,9.820e-01
-SDP,NES,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.743e-02,2.689e-01,9.526e-01,9.526e-01
-SDP,NES,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.743e-02,2.689e-01,9.526e-01,9.526e-01
-SDP,NES,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.743e-02,2.689e-01,9.526e-01,9.526e-01
-SDP,NES,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.192e-01,5.000e-01,9.820e-01,9.820e-01
-SDP,NES,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.473e-03,1.799e-02,5.000e-01,5.000e-01
-SDP,NES,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.693e-03,4.743e-02,7.311e-01,7.311e-01
-SDP,NES,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-03,1.799e-02,5.000e-01,5.000e-01
-SDP,NES,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-03,1.799e-02,5.000e-01,5.000e-01
-SDP,NES,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-03,1.799e-02,5.000e-01,5.000e-01
-SDP,NES,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.693e-03,4.743e-02,7.311e-01,7.311e-01
+SDP,NES,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.138e-01,2.182e-01,3.215e-01,3.215e-01
+SDP,NES,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.528e-02,1.174e-01,3.118e-01,3.118e-01
+SDP,NES,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.528e-02,1.174e-01,3.118e-01,3.118e-01
+SDP,NES,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.528e-02,1.174e-01,3.118e-01,3.118e-01
+SDP,NES,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.138e-01,2.182e-01,3.215e-01,3.215e-01
+SDP,NES,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.698e-03,1.454e-02,3.637e-02,3.637e-02
+SDP,NES,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,9.129e-03,3.833e-02,8.376e-02,8.376e-02
+SDP,NES,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.373e-03,1.454e-02,5.729e-02,5.729e-02
+SDP,NES,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.373e-03,1.454e-02,5.729e-02,5.729e-02
+SDP,NES,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.373e-03,1.454e-02,5.729e-02,5.729e-02
+SDP,NES,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,9.129e-03,3.833e-02,8.376e-02,8.376e-02
 SDP,NES,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0.000e+00,8.315e-07,4.540e-05,1.192e-01,1.192e-01
 SDP,NES,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,NES,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
@@ -1071,63 +1071,63 @@ SDP,NES,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_t
 SDP,NES,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,NES,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,NES,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP,NES,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,3.476e-03,2.970e-02,8.215e-02,1.870e-01,1.870e-01
-SDP,NES,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SDP,NES,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SDP,NES,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SDP,NES,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SDP,NES,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SDP,OAS,,,,,Cycle,trn_pass,S3S,linear,1.256e-02,2.493e-02,3.323e-02,8.309e-02,8.309e-02
-SDP,OAS,,,,,Domestic Aviation,trn_pass,S3S,linear,2.574e-02,2.661e-02,3.726e-02,7.983e-02,7.983e-02
-SDP,OAS,,,,,Domestic Ship,trn_freight,S3S,linear,3.645e-02,3.645e-02,2.804e-02,3.645e-02,3.645e-02
-SDP,OAS,,,,,Freight Rail,trn_freight,S3S,linear,4.649e-02,4.649e-02,3.576e-02,4.649e-02,4.649e-02
-SDP,OAS,,,,,HSR,trn_pass,S3S,linear,9.660e-04,2.997e-03,2.997e-03,3.995e-03,3.995e-03
+SDP,NES,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,3.476e-03,2.970e-02,6.085e-02,7.482e-02,7.482e-02
+SDP,NES,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.289e-02,8.772e-02,1.289e-01,1.289e-01
+SDP,NES,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.289e-02,8.772e-02,1.289e-01,1.289e-01
+SDP,NES,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.289e-02,8.772e-02,1.289e-01,1.289e-01
+SDP,NES,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.289e-02,8.772e-02,1.289e-01,1.289e-01
+SDP,NES,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.289e-02,8.772e-02,1.289e-01,1.289e-01
+SDP,OAS,,,,,Cycle,trn_pass,S3S,linear,1.256e-02,3.616e-02,4.821e-02,1.205e-01,1.205e-01
+SDP,OAS,,,,,Domestic Aviation,trn_pass,S3S,linear,2.456e-02,3.684e-02,5.158e-02,1.326e-01,1.326e-01
+SDP,OAS,,,,,Domestic Ship,trn_freight,S3S,linear,3.712e-02,3.375e-02,2.856e-02,2.700e-02,2.700e-02
+SDP,OAS,,,,,Freight Rail,trn_freight,S3S,linear,4.736e-02,4.305e-02,3.643e-02,3.444e-02,3.444e-02
+SDP,OAS,,,,,HSR,trn_pass,S3S,linear,9.660e-04,4.347e-03,4.347e-03,5.796e-03,5.796e-03
 SDP,OAS,,,,,International Aviation,trn_aviation_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,OAS,,,,,International Ship,trn_shipping_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP,OAS,,,,,Passenger Rail,trn_pass,S3S,linear,7.701e-04,7.963e-04,1.194e-03,1.593e-03,1.593e-03
-SDP,OAS,,,,,Walk,trn_pass,S3S,linear,1.000e+00,6.893e-01,6.893e-01,6.893e-01,6.893e-01
+SDP,OAS,,,,,Passenger Rail,trn_pass,S3S,linear,7.701e-04,1.155e-03,1.733e-03,2.310e-03,2.310e-03
+SDP,OAS,,,,,Walk,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,OAS,,,,,trn_freight_road,trn_freight,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP,OAS,,,,,trn_pass_road,trn_pass,S3S,linear,8.721e-01,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP,OAS,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,2.403e-01,1.402e-01,5.510e-02,5.510e-02,5.510e-02
+SDP,OAS,,,,,trn_pass_road,trn_pass,S3S,linear,4.452e-01,5.697e-01,5.697e-01,7.121e-01,7.121e-01
+SDP,OAS,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,4.352e-01,2.571e-01,1.122e-01,9.620e-02,9.620e-02
 SDP,OAS,,,,trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP,OAS,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,2.534e-02,2.233e-02,1.631e-02,4.276e-03,4.276e-03
+SDP,OAS,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,3.520e-01,1.718e-01,1.631e-01,9.503e-02,9.503e-02
 SDP,OAS,,,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP,OAS,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,6.745e-03,6.745e-03,6.745e-03,6.745e-03,6.745e-03
+SDP,OAS,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,2.698e-03,2.811e-03,4.216e-03,5.621e-03,5.621e-03
 SDP,OAS,,Large Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,3.018e-01,3.018e-01,3.018e-01,3.018e-01,3.018e-01
 SDP,OAS,,Large Car and SUV,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,6.459e-04,6.459e-04,6.459e-04,6.459e-04,6.459e-04
 SDP,OAS,,Light Truck and SUV,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,OAS,,Midsize Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,2.500e-04,2.500e-04,2.500e-04,2.500e-04,2.500e-04
-SDP,OAS,,Mini Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,6.938e-05,6.938e-05,6.938e-05,6.938e-05,6.938e-05
+SDP,OAS,,Mini Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,2.775e-05,2.891e-05,4.336e-05,5.782e-05,5.782e-05
 SDP,OAS,,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,7.762e-03,7.762e-03,7.762e-03,7.762e-03,7.762e-03
 SDP,OAS,,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,OAS,,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,6.391e-03,6.391e-03,6.391e-03,6.391e-03,6.391e-03
-SDP,OAS,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,8.508e-03,8.508e-03,8.508e-03,8.508e-03,8.508e-03
+SDP,OAS,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,3.403e-03,3.545e-03,5.318e-03,7.090e-03,7.090e-03
 SDP,OAS,,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,3.765e-01,3.765e-01,3.765e-01,3.765e-01,3.765e-01
 SDP,OAS,,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,4.784e-01,4.784e-01,4.784e-01,4.784e-01,4.784e-01
 SDP,OAS,,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.365e-03,1.365e-03,1.365e-03,1.365e-03,1.365e-03
 SDP,OAS,,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,7.361e-04,7.361e-04,7.361e-04,7.361e-04,7.361e-04
 SDP,OAS,,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,OAS,,Van,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.027e-05,1.027e-05,1.027e-05,1.027e-05,1.027e-05
-SDP,OAS,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP,OAS,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1.452e-05,1.452e-05,1.452e-05,1.452e-05,1.452e-05
-SDP,OAS,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP,OAS,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.423e-01,6.724e-01,1.000e+00,1.000e+00
+SDP,OAS,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.400e-02,1.680e-01,2.940e-01,2.940e-01
+SDP,OAS,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.400e-02,1.680e-01,2.940e-01,2.940e-01
+SDP,OAS,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.400e-02,1.680e-01,2.940e-01,2.940e-01
+SDP,OAS,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.411e-01,6.670e-01,1.000e+00,1.000e+00
 SDP,OAS,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1.733e-01,2.767e-01,4.833e-01,8.967e-01,8.967e-01
 SDP,OAS,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,OAS,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,3.530e-01,4.338e-01,5.956e-01,9.191e-01,9.191e-01
-SDP,OAS,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.973e-02,6.250e-02,7.856e-02,7.856e-02
-SDP,OAS,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.581e-02,3.362e-02,7.621e-02,7.621e-02
-SDP,OAS,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.581e-02,3.362e-02,7.621e-02,7.621e-02
-SDP,OAS,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.581e-02,3.362e-02,7.621e-02,7.621e-02
-SDP,OAS,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.973e-02,6.250e-02,7.856e-02,7.856e-02
-SDP,OAS,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.473e-03,1.799e-02,6.561e-02,6.561e-02
-SDP,OAS,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.115e-02,1.186e-02,2.924e-02,2.924e-02
-SDP,OAS,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.121e-03,4.497e-03,2.000e-02,2.000e-02
-SDP,OAS,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.121e-03,4.497e-03,2.000e-02,2.000e-02
-SDP,OAS,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.121e-03,4.497e-03,2.000e-02,2.000e-02
-SDP,OAS,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.115e-02,1.186e-02,2.924e-02,2.924e-02
+SDP,OAS,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.469e-02,5.456e-02,7.144e-02,7.144e-02
+SDP,OAS,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.380e-02,2.935e-02,6.930e-02,6.930e-02
+SDP,OAS,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.380e-02,2.935e-02,6.930e-02,6.930e-02
+SDP,OAS,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.380e-02,2.935e-02,6.930e-02,6.930e-02
+SDP,OAS,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.469e-02,5.456e-02,7.144e-02,7.144e-02
+SDP,OAS,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.453e-03,1.784e-02,7.290e-02,7.290e-02
+SDP,OAS,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.217e-02,1.294e-02,2.127e-02,2.127e-02
+SDP,OAS,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.497e-03,4.907e-03,1.455e-02,1.455e-02
+SDP,OAS,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.497e-03,4.907e-03,1.455e-02,1.455e-02
+SDP,OAS,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.497e-03,4.907e-03,1.455e-02,1.455e-02
+SDP,OAS,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.217e-02,1.294e-02,2.127e-02,2.127e-02
 SDP,OAS,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0.000e+00,8.315e-07,4.540e-05,1.192e-01,1.192e-01
-SDP,OAS,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,6.561e-01,6.561e-01
+SDP,OAS,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,6.681e-01,6.681e-01
 SDP,OAS,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,OAS,Liquids,Domestic Ship_tmp_vehicletype,Domestic Ship_tmp_subsector_L1,Domestic Ship_tmp_subsector_L2,Domestic Ship,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,OAS,Liquids,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
@@ -1142,58 +1142,58 @@ SDP,OAS,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_t
 SDP,OAS,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,OAS,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,OAS,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP,OAS,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.967e-01,2.178e-01,2.601e-01,2.261e-01,2.261e-01
-SDP,OAS,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,4.535e-04,8.919e-03,3.968e-02,7.383e-02,7.383e-02
-SDP,OAS,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,8.772e-03,3.947e-02,7.368e-02,7.368e-02
-SDP,OAS,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.395e-01,5.404e-02,1.037e-01,1.192e-01,1.192e-01
-SDP,OAS,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,2.466e-01,8.882e-02,1.531e-01,1.542e-01,1.542e-01
-SDP,OAS,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,8.772e-03,3.947e-02,7.368e-02,7.368e-02
-SDP,REF,,,,,Cycle,trn_pass,S3S,linear,4.737e-03,4.737e-03,2.369e-02,7.824e-02,7.824e-02
-SDP,REF,,,,,Domestic Aviation,trn_pass,S3S,linear,1.287e-02,1.232e-02,1.540e-02,1.454e-02,1.454e-02
-SDP,REF,,,,,Domestic Ship,trn_freight,S3S,linear,7.096e-03,7.096e-03,7.096e-03,7.096e-03,7.096e-03
-SDP,REF,,,,,Freight Rail,trn_freight,S3S,linear,1.272e-01,1.272e-01,1.272e-01,1.272e-01,1.272e-01
-SDP,REF,,,,,HSR,trn_pass,S3S,linear,0.000e+00,8.000e-04,8.000e-04,7.550e-04,7.550e-04
+SDP,OAS,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.967e-01,1.980e-01,2.365e-01,2.303e-01,2.303e-01
+SDP,OAS,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,4.535e-04,8.919e-03,3.968e-02,6.153e-02,6.153e-02
+SDP,OAS,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,8.772e-03,3.947e-02,6.140e-02,6.140e-02
+SDP,OAS,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.395e-01,5.404e-02,1.037e-01,9.933e-02,9.933e-02
+SDP,OAS,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,2.466e-01,8.882e-02,1.531e-01,1.285e-01,1.285e-01
+SDP,OAS,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,8.772e-03,3.947e-02,6.140e-02,6.140e-02
+SDP,REF,,,,,Cycle,trn_pass,S3S,linear,1.379e-02,1.206e-02,6.031e-02,7.824e-02,7.824e-02
+SDP,REF,,,,,Domestic Aviation,trn_pass,S3S,linear,3.574e-02,2.995e-02,3.743e-02,1.387e-02,1.387e-02
+SDP,REF,,,,,Domestic Ship,trn_freight,S3S,linear,7.227e-03,7.227e-03,7.227e-03,7.227e-03,7.227e-03
+SDP,REF,,,,,Freight Rail,trn_freight,S3S,linear,1.296e-01,1.296e-01,1.296e-01,1.296e-01,1.296e-01
+SDP,REF,,,,,HSR,trn_pass,S3S,linear,0.000e+00,2.037e-03,2.037e-03,7.550e-04,7.550e-04
 SDP,REF,,,,,International Aviation,trn_aviation_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,REF,,,,,International Ship,trn_shipping_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP,REF,,,,,Passenger Rail,trn_pass,S3S,linear,2.366e-03,4.731e-03,5.914e-03,1.116e-02,1.116e-02
-SDP,REF,,,,,Walk,trn_pass,S3S,linear,3.179e-01,3.179e-01,3.179e-01,1.000e+00,1.000e+00
+SDP,REF,,,,,Passenger Rail,trn_pass,S3S,linear,6.884e-03,1.205e-02,1.506e-02,1.116e-02,1.116e-02
+SDP,REF,,,,,Walk,trn_pass,S3S,linear,9.251e-01,8.095e-01,8.095e-01,1.000e+00,1.000e+00
 SDP,REF,,,,,trn_freight_road,trn_freight,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP,REF,,,,,trn_pass_road,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,9.437e-01,9.437e-01
-SDP,REF,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,1.186e-01,9.148e-02,7.623e-02,6.099e-02,6.099e-02
+SDP,REF,,,,,trn_pass_road,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,4.633e-01,4.633e-01
+SDP,REF,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,2.684e-01,1.864e-01,1.553e-01,1.242e-01,1.242e-01
 SDP,REF,,,,trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,REF,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,3.698e-01,3.698e-01,3.698e-01,3.698e-01,3.698e-01
 SDP,REF,,,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP,REF,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,2.227e-01,2.227e-01,2.227e-01,2.227e-01,2.227e-01
+SDP,REF,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,4.455e-01,4.176e-01,4.176e-01,3.818e-01,3.818e-01
 SDP,REF,,Large Car and SUV,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,REF,,Midsize Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.842e-01,1.842e-01,1.842e-01,1.842e-01,1.842e-01
-SDP,REF,,Mini Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,7.127e-05,7.127e-05,7.127e-05,7.127e-05,7.127e-05
+SDP,REF,,Mini Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.425e-04,1.336e-04,1.336e-04,1.222e-04,1.222e-04
 SDP,REF,,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,3.376e-03,3.376e-03,3.376e-03,3.376e-03,3.376e-03
 SDP,REF,,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,REF,,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,4.141e-01,4.141e-01,4.141e-01,4.141e-01,4.141e-01
-SDP,REF,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.254e-02,1.254e-02,1.254e-02,1.254e-02,1.254e-02
+SDP,REF,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,2.508e-02,2.351e-02,2.351e-02,2.150e-02,2.150e-02
 SDP,REF,,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,REF,,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,5.081e-03,5.081e-03,5.081e-03,5.081e-03,5.081e-03
 SDP,REF,,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,5.837e-01,5.837e-01,5.837e-01,5.837e-01,5.837e-01
 SDP,REF,,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.888e-01,1.888e-01,1.888e-01,1.888e-01,1.888e-01
 SDP,REF,,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.676e-02,1.676e-02,1.676e-02,1.676e-02,1.676e-02
-SDP,REF,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP,REF,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,6.589e-03,6.589e-03,6.589e-03,6.589e-03,6.589e-03
-SDP,REF,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP,REF,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.743e-02,3.227e-01,9.526e-01,9.526e-01
+SDP,REF,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.000e-02,1.680e-01,3.360e-01,3.360e-01
+SDP,REF,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.000e-02,1.680e-01,3.360e-01,3.360e-01
+SDP,REF,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.000e-02,1.680e-01,3.360e-01,3.360e-01
+SDP,REF,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,7.245e-02,3.202e-01,7.425e-01,7.425e-01
 SDP,REF,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,REF,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,REF,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP,REF,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.192e-01,3.000e-01,3.928e-01,3.928e-01
-SDP,REF,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.743e-02,1.614e-01,3.810e-01,3.810e-01
-SDP,REF,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.743e-02,1.614e-01,3.810e-01,3.810e-01
-SDP,REF,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.743e-02,1.614e-01,3.810e-01,3.810e-01
-SDP,REF,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.192e-01,3.000e-01,3.928e-01,3.928e-01
-SDP,REF,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.473e-03,3.597e-02,1.000e-01,1.000e-01
-SDP,REF,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.024e-02,4.743e-02,7.311e-02,7.311e-02
-SDP,REF,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.225e-02,1.799e-02,5.000e-02,5.000e-02
-SDP,REF,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.225e-02,1.799e-02,5.000e-02,5.000e-02
-SDP,REF,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.225e-02,1.799e-02,5.000e-02,5.000e-02
-SDP,REF,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.024e-02,4.743e-02,7.311e-02,7.311e-02
+SDP,REF,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.183e-01,2.678e-01,3.957e-01,3.957e-01
+SDP,REF,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.705e-02,1.441e-01,3.838e-01,3.838e-01
+SDP,REF,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.705e-02,1.441e-01,3.838e-01,3.838e-01
+SDP,REF,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.705e-02,1.441e-01,3.838e-01,3.838e-01
+SDP,REF,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.183e-01,2.678e-01,3.957e-01,3.957e-01
+SDP,REF,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.698e-03,3.569e-02,6.236e-02,6.236e-02
+SDP,REF,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.975e-02,4.705e-02,5.523e-02,5.523e-02
+SDP,REF,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.208e-02,1.784e-02,3.777e-02,3.777e-02
+SDP,REF,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.208e-02,1.784e-02,3.777e-02,3.777e-02
+SDP,REF,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.208e-02,1.784e-02,3.777e-02,3.777e-02
+SDP,REF,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.975e-02,4.705e-02,5.523e-02,5.523e-02
 SDP,REF,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0.000e+00,8.315e-07,4.540e-05,1.192e-01,1.192e-01
 SDP,REF,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,REF,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
@@ -1210,26 +1210,26 @@ SDP,REF,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_t
 SDP,REF,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,REF,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,REF,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP,REF,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.400e-02,3.994e-02,7.347e-02,1.369e-01,1.369e-01
-SDP,REF,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,4.158e-02,6.680e-02,1.172e-01,1.745e-01,1.745e-01
-SDP,REF,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.474e-01,1.474e-01
-SDP,REF,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,6.311e-02,8.776e-02,1.371e-01,1.886e-01,1.886e-01
-SDP,REF,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,3.048e-02,5.599e-02,1.070e-01,1.673e-01,1.673e-01
-SDP,REF,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.474e-01,1.474e-01
-SDP,SSA,,,,,Cycle,trn_pass,S3S,linear,1.388e-02,1.795e-02,2.915e-02,3.279e-02,3.279e-02
-SDP,SSA,,,,,Domestic Aviation,trn_pass,S3S,linear,9.013e-03,5.100e-02,4.140e-02,6.209e-03,6.209e-03
-SDP,SSA,,,,,Domestic Ship,trn_freight,S3S,linear,1.467e-03,1.467e-03,1.467e-03,1.467e-03,1.467e-03
-SDP,SSA,,,,,Freight Rail,trn_freight,S3S,linear,1.634e-02,1.634e-02,1.634e-02,1.634e-02,1.634e-02
-SDP,SSA,,,,,HSR,trn_pass,S3S,linear,1.475e-05,2.003e-05,6.504e-02,9.756e-03,9.756e-03
+SDP,REF,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.400e-02,3.195e-02,6.011e-02,7.825e-02,7.825e-02
+SDP,REF,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,3.465e-02,6.073e-02,9.593e-02,1.342e-01,1.342e-01
+SDP,REF,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.392e-02,6.459e-02,1.134e-01,1.134e-01
+SDP,REF,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,5.259e-02,7.979e-02,1.122e-01,1.450e-01,1.450e-01
+SDP,REF,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,2.540e-02,5.090e-02,8.756e-02,1.287e-01,1.287e-01
+SDP,REF,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.392e-02,6.459e-02,1.134e-01,1.134e-01
+SDP,SSA,,,,,Cycle,trn_pass,S3S,linear,1.388e-02,1.987e-02,2.915e-02,3.279e-02,3.279e-02
+SDP,SSA,,,,,Domestic Aviation,trn_pass,S3S,linear,8.602e-03,5.387e-02,3.951e-02,5.926e-03,5.926e-03
+SDP,SSA,,,,,Domestic Ship,trn_freight,S3S,linear,1.495e-03,1.495e-03,1.495e-03,1.495e-03,1.495e-03
+SDP,SSA,,,,,Freight Rail,trn_freight,S3S,linear,1.665e-02,1.665e-02,1.665e-02,1.498e-02,1.498e-02
+SDP,SSA,,,,,HSR,trn_pass,S3S,linear,1.475e-05,2.217e-05,6.504e-02,9.756e-03,9.756e-03
 SDP,SSA,,,,,International Aviation,trn_aviation_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,SSA,,,,,International Ship,trn_shipping_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP,SSA,,,,,Passenger Rail,trn_pass,S3S,linear,6.024e-04,1.559e-03,2.530e-03,5.693e-04,5.693e-04
-SDP,SSA,,,,,Walk,trn_pass,S3S,linear,1.000e+00,9.034e-01,1.000e+00,1.000e+00,1.000e+00
+SDP,SSA,,,,,Passenger Rail,trn_pass,S3S,linear,6.024e-04,1.725e-03,2.530e-03,5.693e-04,5.693e-04
+SDP,SSA,,,,,Walk,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,SSA,,,,,trn_freight_road,trn_freight,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP,SSA,,,,,trn_pass_road,trn_pass,S3S,linear,8.902e-01,1.000e+00,9.741e-01,9.741e-02,9.741e-02
-SDP,SSA,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,2.477e-01,1.270e-01,7.328e-02,9.526e-02,9.526e-02
+SDP,SSA,,,,,trn_pass_road,trn_pass,S3S,linear,2.622e-01,3.260e-01,2.869e-01,4.781e-02,4.781e-02
+SDP,SSA,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,7.568e-01,3.234e-01,1.493e-01,9.703e-02,9.703e-02
 SDP,SSA,,,,trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP,SSA,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,3.928e-02,3.928e-02,3.928e-02,3.928e-02,3.928e-02
+SDP,SSA,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,2.619e-02,2.619e-02,2.619e-02,3.928e-02,3.928e-02
 SDP,SSA,,,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,SSA,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,SSA,,Large Car and SUV,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,3.022e-03,3.022e-03,3.022e-03,3.022e-03,3.022e-03
@@ -1244,24 +1244,24 @@ SDP,SSA,,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subs
 SDP,SSA,,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,4.207e-06,4.207e-06,4.207e-06,4.207e-06,4.207e-06
 SDP,SSA,,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,SSA,,Van,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,7.570e-05,7.570e-05,7.570e-05,7.570e-05,7.570e-05
-SDP,SSA,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP,SSA,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP,SSA,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP,SSA,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.743e-02,4.034e-01,9.526e-01,9.526e-01
+SDP,SSA,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.000e-01,2.160e-01,3.360e-01,3.360e-01
+SDP,SSA,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.000e-01,2.160e-01,3.360e-01,3.360e-01
+SDP,SSA,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.000e-01,2.160e-01,3.360e-01,3.360e-01
+SDP,SSA,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,6.210e-02,3.962e-01,8.470e-01,8.470e-01
 SDP,SSA,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,SSA,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,SSA,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP,SSA,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.384e-02,1.000e-01,1.511e-01,1.511e-01
-SDP,SSA,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,9.485e-03,5.379e-02,1.465e-01,1.465e-01
-SDP,SSA,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,9.485e-03,5.379e-02,1.465e-01,1.465e-01
-SDP,SSA,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,9.485e-03,5.379e-02,1.465e-01,1.465e-01
-SDP,SSA,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.384e-02,1.000e-01,1.511e-01,1.511e-01
-SDP,SSA,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.473e-03,1.799e-02,7.500e-02,7.500e-02
-SDP,SSA,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.693e-03,4.743e-02,2.812e-02,2.812e-02
-SDP,SSA,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-03,1.799e-02,1.923e-02,1.923e-02
-SDP,SSA,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-03,1.799e-02,1.923e-02,1.923e-02
-SDP,SSA,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-03,1.799e-02,1.923e-02,1.923e-02
-SDP,SSA,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.693e-03,4.743e-02,2.812e-02,2.812e-02
+SDP,SSA,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.602e-02,1.007e-01,1.511e-01,1.511e-01
+SDP,SSA,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.035e-02,5.418e-02,1.466e-01,1.466e-01
+SDP,SSA,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.035e-02,5.418e-02,1.466e-01,1.466e-01
+SDP,SSA,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.035e-02,5.418e-02,1.466e-01,1.466e-01
+SDP,SSA,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.602e-02,1.007e-01,1.511e-01,1.511e-01
+SDP,SSA,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.698e-03,1.963e-02,4.850e-02,4.850e-02
+SDP,SSA,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,7.303e-03,1.194e-02,2.045e-02,2.045e-02
+SDP,SSA,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.698e-03,4.529e-03,1.399e-02,1.399e-02
+SDP,SSA,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.698e-03,4.529e-03,1.399e-02,1.399e-02
+SDP,SSA,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.698e-03,4.529e-03,1.399e-02,1.399e-02
+SDP,SSA,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,7.303e-03,1.194e-02,2.045e-02,2.045e-02
 SDP,SSA,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0.000e+00,8.315e-07,4.540e-05,1.192e-01,1.192e-01
 SDP,SSA,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,SSA,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
@@ -1278,59 +1278,59 @@ SDP,SSA,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_t
 SDP,SSA,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,SSA,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,SSA,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP,SSA,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,3.981e-04,2.670e-02,5.552e-02,9.227e-02,9.227e-02
-SDP,SSA,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,7.085e-02,7.085e-02
-SDP,SSA,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,7.085e-02,7.085e-02
-SDP,SSA,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,7.085e-02,7.085e-02
-SDP,SSA,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,7.085e-02,7.085e-02
-SDP,SSA,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,7.085e-02,7.085e-02
+SDP,SSA,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,3.981e-04,2.670e-02,4.997e-02,6.835e-02,6.835e-02
+SDP,SSA,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,4.251e-02,5.904e-02,5.904e-02
+SDP,SSA,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,4.251e-02,5.904e-02,5.904e-02
+SDP,SSA,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,4.251e-02,5.904e-02,5.904e-02
+SDP,SSA,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,4.251e-02,5.904e-02,5.904e-02
+SDP,SSA,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,4.251e-02,5.904e-02,5.904e-02
 SDP,UKI,,,,,Cycle,trn_pass,S3S,linear,2.500e-02,1.092e-02,3.277e-02,6.553e-02,6.553e-02
-SDP,UKI,,,,,Domestic Aviation,trn_pass,S3S,linear,6.250e-05,9.365e-06,9.365e-06,9.365e-06,9.365e-06
-SDP,UKI,,,,,Domestic Ship,trn_freight,S3S,linear,8.512e-03,8.512e-03,8.512e-03,8.512e-03,8.512e-03
-SDP,UKI,,,,,Freight Rail,trn_freight,S3S,linear,6.067e-03,6.067e-03,6.067e-03,6.067e-03,6.067e-03
+SDP,UKI,,,,,Domestic Aviation,trn_pass,S3S,linear,5.965e-05,8.938e-06,8.938e-06,8.938e-06,8.938e-06
+SDP,UKI,,,,,Domestic Ship,trn_freight,S3S,linear,8.670e-03,8.670e-03,8.670e-03,8.670e-03,8.670e-03
+SDP,UKI,,,,,Freight Rail,trn_freight,S3S,linear,6.180e-03,6.180e-03,6.180e-03,6.180e-03,6.180e-03
 SDP,UKI,,,,,HSR,trn_pass,S3S,linear,1.250e-04,1.334e-04,1.779e-04,2.224e-04,2.224e-04
 SDP,UKI,,,,,International Aviation,trn_aviation_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,UKI,,,,,International Ship,trn_shipping_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,UKI,,,,,Passenger Rail,trn_pass,S3S,linear,3.125e-03,2.502e-03,1.876e-03,1.876e-03,1.876e-03
 SDP,UKI,,,,,Walk,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,UKI,,,,,trn_freight_road,trn_freight,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP,UKI,,,,,trn_pass_road,trn_pass,S3S,linear,7.500e-02,5.325e-02,3.408e-02,3.408e-02,3.408e-02
-SDP,UKI,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,2.500e-01,2.010e-01,1.843e-01,1.675e-01,1.675e-01
+SDP,UKI,,,,,trn_pass_road,trn_pass,S3S,linear,7.363e-02,5.228e-02,3.346e-02,3.346e-02,3.346e-02
+SDP,UKI,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,2.546e-01,2.048e-01,1.877e-01,1.706e-01,1.706e-01
 SDP,UKI,,,,trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,UKI,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,3.935e-02,3.935e-02,3.935e-02,3.935e-02,3.935e-02
 SDP,UKI,,,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP,UKI,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,4.864e-01,4.864e-01,4.864e-01,4.864e-01,4.864e-01
+SDP,UKI,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,5.404e-01,5.404e-01,4.864e-01,4.864e-01,4.864e-01
 SDP,UKI,,Large Car and SUV,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,UKI,,Midsize Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,2.616e-01,2.616e-01,2.616e-01,2.616e-01,2.616e-01
-SDP,UKI,,Mini Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,4.751e-07,4.751e-07,4.751e-07,4.751e-07,4.751e-07
+SDP,UKI,,Mini Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,5.279e-07,5.279e-07,4.751e-07,4.751e-07,4.751e-07
 SDP,UKI,,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,2.088e-02,2.088e-02,2.088e-02,2.088e-02,2.088e-02
 SDP,UKI,,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,3.798e-03,3.798e-03,3.798e-03,3.798e-03,3.798e-03
 SDP,UKI,,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP,UKI,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,5.119e-01,5.119e-01,5.119e-01,5.119e-01,5.119e-01
+SDP,UKI,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,5.688e-01,5.688e-01,5.119e-01,5.119e-01,5.119e-01
 SDP,UKI,,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,UKI,,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,4.528e-02,4.528e-02,4.528e-02,4.528e-02,4.528e-02
 SDP,UKI,,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,9.437e-02,9.437e-02,9.437e-02,9.437e-02,9.437e-02
 SDP,UKI,,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,5.696e-01,5.696e-01,5.696e-01,5.696e-01,5.696e-01
 SDP,UKI,,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,7.765e-01,7.765e-01,7.765e-01,7.765e-01,7.765e-01
 SDP,UKI,,Van,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,2.681e-03,2.681e-03,2.681e-03,2.681e-03,2.681e-03
-SDP,UKI,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP,UKI,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP,UKI,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP,UKI,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.186e-01,3.227e-01,8.573e-01,8.573e-01
+SDP,UKI,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,5.000e-02,2.000e-01,3.700e-01,3.700e-01
+SDP,UKI,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,5.000e-02,2.000e-01,3.700e-01,3.700e-01
+SDP,UKI,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,5.000e-02,2.000e-01,3.700e-01,3.700e-01
+SDP,UKI,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,2.500e-02,1.168e-01,3.434e-01,7.434e-01,7.434e-01
 SDP,UKI,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,8.260e-01,8.478e-01,8.913e-01,9.783e-01,9.783e-01
 SDP,UKI,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,UKI,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP,UKI,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.384e-01,5.500e-01,8.838e-01,8.838e-01
-SDP,UKI,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,9.485e-02,2.958e-01,8.573e-01,8.573e-01
-SDP,UKI,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,9.485e-02,2.958e-01,8.573e-01,8.573e-01
-SDP,UKI,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,9.485e-02,2.958e-01,8.573e-01,8.573e-01
-SDP,UKI,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.384e-01,5.500e-01,8.838e-01,8.838e-01
-SDP,UKI,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.236e-02,1.799e-02,1.000e-01,1.000e-01
-SDP,UKI,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.693e-02,1.897e-01,1.462e-01,1.462e-01
-SDP,UKI,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-02,7.194e-02,1.000e-01,1.000e-01
-SDP,UKI,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-02,7.194e-02,1.000e-01,1.000e-01
-SDP,UKI,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-02,7.194e-02,1.000e-01,1.000e-01
-SDP,UKI,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.693e-02,1.897e-01,1.462e-01,1.462e-01
+SDP,UKI,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.819e-01,5.853e-01,8.360e-01,8.360e-01
+SDP,UKI,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.122e-01,3.148e-01,8.110e-01,8.110e-01
+SDP,UKI,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.122e-01,3.148e-01,8.110e-01,8.110e-01
+SDP,UKI,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.122e-01,3.148e-01,8.110e-01,8.110e-01
+SDP,UKI,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.819e-01,5.853e-01,8.360e-01,8.360e-01
+SDP,UKI,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,2.500e-05,1.218e-02,2.127e-02,7.883e-02,7.883e-02
+SDP,UKI,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,7.914e-02,2.243e-01,1.729e-01,1.729e-01
+SDP,UKI,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.924e-02,8.507e-02,1.182e-01,1.182e-01
+SDP,UKI,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.924e-02,8.507e-02,1.182e-01,1.182e-01
+SDP,UKI,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.924e-02,8.507e-02,1.182e-01,1.182e-01
+SDP,UKI,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,7.914e-02,2.243e-01,1.729e-01,1.729e-01
 SDP,UKI,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0.000e+00,8.315e-07,4.540e-05,1.192e-01,1.192e-01
 SDP,UKI,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,UKI,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
@@ -1347,24 +1347,24 @@ SDP,UKI,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_t
 SDP,UKI,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,UKI,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,UKI,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP,UKI,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,3.616e-04,2.667e-02,7.928e-02,1.845e-01,1.845e-01
+SDP,UKI,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,9.040e-04,2.222e-02,7.928e-02,1.230e-01,1.230e-01
 SDP,UKI,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
 SDP,UKI,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
 SDP,UKI,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
 SDP,UKI,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
 SDP,UKI,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
 SDP,USA,,,,,Cycle,trn_pass,S3S,linear,8.197e-03,8.197e-03,8.197e-03,4.098e-02,4.098e-02
-SDP,USA,,,,,Domestic Aviation,trn_pass,S3S,linear,1.057e-03,1.600e-03,1.800e-03,1.100e-03,1.100e-03
-SDP,USA,,,,,Domestic Ship,trn_freight,S3S,linear,3.208e-03,3.208e-03,3.208e-03,3.208e-03,3.208e-03
-SDP,USA,,,,,Freight Rail,trn_freight,S3S,linear,3.364e-02,3.364e-02,3.364e-02,3.364e-02,3.364e-02
+SDP,USA,,,,,Domestic Aviation,trn_pass,S3S,linear,1.009e-03,1.527e-03,1.718e-03,1.050e-03,1.050e-03
+SDP,USA,,,,,Domestic Ship,trn_freight,S3S,linear,3.267e-03,3.267e-03,3.267e-03,3.267e-03,3.267e-03
+SDP,USA,,,,,Freight Rail,trn_freight,S3S,linear,3.427e-02,3.427e-02,3.427e-02,3.427e-02,3.427e-02
 SDP,USA,,,,,HSR,trn_pass,S3S,linear,4.530e-06,4.530e-06,4.530e-06,2.265e-04,2.265e-04
 SDP,USA,,,,,International Aviation,trn_aviation_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,USA,,,,,International Ship,trn_shipping_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,USA,,,,,Passenger Rail,trn_pass,S3S,linear,1.933e-03,1.933e-03,1.933e-03,9.665e-04,9.665e-04
 SDP,USA,,,,,Walk,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,USA,,,,,trn_freight_road,trn_freight,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP,USA,,,,,trn_pass_road,trn_pass,S3S,linear,1.329e-01,1.329e-01,1.276e-01,6.647e-02,6.647e-02
-SDP,USA,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,8.561e-02,1.070e-01,1.070e-01,1.213e-01,1.213e-01
+SDP,USA,,,,,trn_pass_road,trn_pass,S3S,linear,1.305e-01,1.305e-01,1.253e-01,6.526e-02,6.526e-02
+SDP,USA,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,8.720e-02,1.090e-01,1.090e-01,1.235e-01,1.235e-01
 SDP,USA,,,,trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,USA,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,3.805e-02,3.805e-02,3.805e-02,3.805e-02,3.805e-02
 SDP,USA,,,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
@@ -1377,29 +1377,29 @@ SDP,USA,,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_r
 SDP,USA,,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,USA,,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,7.057e-01,7.057e-01,7.057e-01,7.057e-01,7.057e-01
 SDP,USA,,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP,USA,,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP,USA,,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
+SDP,USA,,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,9.000e-01,1.000e+00,1.000e+00,1.000e+00,1.000e+00
+SDP,USA,,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,9.000e-01,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,USA,,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,6.263e-01,6.263e-01,6.263e-01,6.263e-01,6.263e-01
-SDP,USA,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP,USA,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP,USA,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SDP,USA,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.423e-01,5.379e-01,1.000e+00,1.000e+00
+SDP,USA,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.400e-02,2.160e-01,3.780e-01,3.780e-01
+SDP,USA,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.400e-02,2.160e-01,3.780e-01,3.780e-01
+SDP,USA,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.400e-02,2.160e-01,3.780e-01,3.780e-01
+SDP,USA,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.122e-01,5.382e-01,1.000e+00,1.000e+00
 SDP,USA,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,0.000e+00,1.250e-01,3.750e-01,8.750e-01,8.750e-01
 SDP,USA,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,USA,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP,USA,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.980e-02,2.500e-01,7.856e-01,7.856e-01
-SDP,USA,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.186e-02,1.345e-01,7.621e-01,7.621e-01
-SDP,USA,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,3.000e-02,2.500e-01,5.000e-01,8.000e-01,8.000e-01
-SDP,USA,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,3.000e-02,2.500e-01,5.000e-01,8.000e-01,8.000e-01
-SDP,USA,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.980e-02,2.500e-01,7.856e-01,7.856e-01
-SDP,USA,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.473e-02,1.799e-02,6.999e-02,6.999e-02
-SDP,USA,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.339e-03,1.423e-02,1.462e-01,1.462e-01
-SDP,USA,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.945e-04,5.396e-03,1.000e-01,1.000e-01
-SDP,USA,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,5.000e-02,2.000e-01,3.000e-01,2.000e-01,2.000e-01
-SDP,USA,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,5.000e-02,2.000e-01,3.000e-01,2.000e-01,2.000e-01
-SDP,USA,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.339e-03,1.423e-02,1.462e-01,1.462e-01
+SDP,USA,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.626e-02,2.323e-01,6.967e-01,6.967e-01
+SDP,USA,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.470e-03,1.249e-01,6.758e-01,6.758e-01
+SDP,USA,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,3.547e-02,1.364e-01,4.645e-01,7.095e-01,7.095e-01
+SDP,USA,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,3.547e-02,1.364e-01,4.645e-01,7.095e-01,7.095e-01
+SDP,USA,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.626e-02,2.323e-01,6.967e-01,6.967e-01
+SDP,USA,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.436e-02,1.636e-02,7.776e-02,7.776e-02
+SDP,USA,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.218e-03,1.202e-02,1.008e-01,1.008e-01
+SDP,USA,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.498e-04,4.557e-03,6.897e-02,6.897e-02
+SDP,USA,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,5.912e-02,1.819e-01,2.534e-01,1.379e-01,1.379e-01
+SDP,USA,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,5.912e-02,1.819e-01,2.534e-01,1.379e-01,1.379e-01
+SDP,USA,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.218e-03,1.202e-02,1.008e-01,1.008e-01
 SDP,USA,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0.000e+00,8.315e-07,4.540e-05,1.192e-01,1.192e-01
-SDP,USA,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,6.999e-01,6.999e-01
+SDP,USA,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,7.892e-01,7.892e-01
 SDP,USA,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,USA,Liquids,Domestic Ship_tmp_vehicletype,Domestic Ship_tmp_subsector_L1,Domestic Ship_tmp_subsector_L2,Domestic Ship,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,USA,Liquids,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
@@ -1414,12 +1414,12 @@ SDP,USA,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_t
 SDP,USA,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,USA,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SDP,USA,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SDP,USA,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,8.478e-02,1.089e-01,1.570e-01,1.773e-01,1.773e-01
-SDP,USA,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.263e-03,3.158e-02,7.368e-02,7.368e-02
-SDP,USA,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.263e-03,3.158e-02,7.368e-02,7.368e-02
-SDP,USA,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e-01,2.000e-01,4.000e-01,4.000e-01,4.000e-01
-SDP,USA,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e-01,2.000e-01,4.000e-01,4.000e-01,4.000e-01
-SDP,USA,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.263e-03,3.158e-02,7.368e-02,7.368e-02
+SDP,USA,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,8.478e-02,9.072e-02,1.208e-01,1.666e-01,1.666e-01
+SDP,USA,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.049e-03,2.256e-02,6.140e-02,6.140e-02
+SDP,USA,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.049e-03,2.256e-02,6.140e-02,6.140e-02
+SDP,USA,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,5.000e-03,1.538e-01,2.857e-01,3.333e-01,3.333e-01
+SDP,USA,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,5.000e-03,1.538e-01,2.857e-01,3.333e-01,3.333e-01
+SDP,USA,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.049e-03,2.256e-02,6.140e-02,6.140e-02
 SDP_EI,CAZ,,,,,Cycle,trn_pass,S3S,linear,1.911e-02,3.822e-02,3.822e-02,7.645e-02,7.645e-02
 SDP_EI,CAZ,,,,,Domestic Aviation,trn_pass,S3S,linear,1.500e-03,1.600e-03,1.900e-03,2.000e-03,2.000e-03
 SDP_EI,CAZ,,,,,Domestic Ship,trn_freight,S3S,linear,1.554e-02,1.554e-02,1.554e-02,1.554e-02,1.554e-02

--- a/inst/extdata/sw_trends.csv
+++ b/inst/extdata/sw_trends.csv
@@ -8526,17 +8526,17 @@ SSP2,USA,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_s
 SSP2,USA,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,5.000e-03,1.538e-01,2.857e-01,3.333e-01,3.333e-01
 SSP2,USA,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.049e-03,2.256e-02,6.140e-02,6.140e-02
 SSP2EU,CAZ,,,,,Cycle,trn_pass,S3S,linear,1.911e-02,3.822e-02,3.822e-02,7.645e-02,7.645e-02
-SSP2EU,CAZ,,,,,Domestic Aviation,trn_pass,S3S,linear,1.500e-03,1.600e-03,1.900e-03,2.000e-03,2.000e-03
-SSP2EU,CAZ,,,,,Domestic Ship,trn_freight,S3S,linear,1.554e-02,1.554e-02,1.554e-02,1.554e-02,1.554e-02
-SSP2EU,CAZ,,,,,Freight Rail,trn_freight,S3S,linear,1.051e-01,1.051e-01,1.051e-01,1.051e-01,1.051e-01
+SSP2EU,CAZ,,,,,Domestic Aviation,trn_pass,S3S,linear,1.432e-03,1.527e-03,1.813e-03,1.909e-03,1.909e-03
+SSP2EU,CAZ,,,,,Domestic Ship,trn_freight,S3S,linear,1.583e-02,1.583e-02,1.583e-02,1.583e-02,1.583e-02
+SSP2EU,CAZ,,,,,Freight Rail,trn_freight,S3S,linear,1.070e-01,1.070e-01,1.070e-01,9.633e-02,9.633e-02
 SSP2EU,CAZ,,,,,HSR,trn_pass,S3S,linear,8.792e-08,8.792e-05,2.638e-04,2.638e-04,2.638e-04
 SSP2EU,CAZ,,,,,International Aviation,trn_aviation_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,CAZ,,,,,International Ship,trn_shipping_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,CAZ,,,,,Passenger Rail,trn_pass,S3S,linear,8.785e-04,8.785e-04,8.785e-04,8.785e-04,8.785e-04
 SSP2EU,CAZ,,,,,Walk,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,CAZ,,,,,trn_freight_road,trn_freight,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP2EU,CAZ,,,,,trn_pass_road,trn_pass,S3S,linear,1.537e-01,1.537e-01,1.537e-01,1.537e-01,1.537e-01
-SSP2EU,CAZ,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,8.691e-02,8.691e-02,1.086e-01,1.376e-01,1.376e-01
+SSP2EU,CAZ,,,,,trn_pass_road,trn_pass,S3S,linear,1.509e-01,1.509e-01,1.509e-01,1.509e-01,1.509e-01
+SSP2EU,CAZ,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,8.852e-02,8.852e-02,1.107e-01,1.402e-01,1.402e-01
 SSP2EU,CAZ,,,,trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,CAZ,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.939e-02,1.939e-02,1.939e-02,1.939e-02,1.939e-02
 SSP2EU,CAZ,,,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
@@ -8556,26 +8556,26 @@ SSP2EU,CAZ,,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_s
 SSP2EU,CAZ,,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,3.497e-05,3.497e-05,3.497e-05,3.497e-05,3.497e-05
 SSP2EU,CAZ,,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,6.282e-01,6.282e-01,6.282e-01,6.282e-01,6.282e-01
 SSP2EU,CAZ,,Van,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,2.082e-01,2.082e-01,2.082e-01,2.082e-01,2.082e-01
-SSP2EU,CAZ,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP2EU,CAZ,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP2EU,CAZ,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP2EU,CAZ,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,9.485e-02,4.572e-01,1.000e+00,1.000e+00
+SSP2EU,CAZ,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.400e-02,1.920e-01,3.360e-01,3.360e-01
+SSP2EU,CAZ,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.400e-02,1.920e-01,3.360e-01,3.360e-01
+SSP2EU,CAZ,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.400e-02,1.920e-01,3.360e-01,3.360e-01
+SSP2EU,CAZ,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.122e-01,4.423e-01,9.735e-01,9.735e-01
 SSP2EU,CAZ,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,9.074e-02,2.044e-01,4.317e-01,8.863e-01,8.863e-01
 SSP2EU,CAZ,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,CAZ,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP2EU,CAZ,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.192e-01,3.500e-01,4.910e-01,4.910e-01
-SSP2EU,CAZ,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.743e-02,1.883e-01,4.763e-01,4.763e-01
-SSP2EU,CAZ,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.743e-02,1.883e-01,4.763e-01,4.763e-01
-SSP2EU,CAZ,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.743e-02,1.883e-01,4.763e-01,4.763e-01
-SSP2EU,CAZ,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.192e-01,3.500e-01,4.910e-01,4.910e-01
-SSP2EU,CAZ,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.236e-02,1.799e-02,9.544e-02,9.544e-02
-SSP2EU,CAZ,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.346e-02,4.743e-02,1.462e-01,1.462e-01
-SSP2EU,CAZ,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.236e-02,1.799e-02,1.000e-01,1.000e-01
-SSP2EU,CAZ,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.236e-02,1.799e-02,1.000e-01,1.000e-01
-SSP2EU,CAZ,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.236e-02,1.799e-02,1.000e-01,1.000e-01
-SSP2EU,CAZ,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.346e-02,4.743e-02,1.462e-01,1.462e-01
+SSP2EU,CAZ,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.409e-01,3.311e-01,4.354e-01,4.354e-01
+SSP2EU,CAZ,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.608e-02,1.781e-01,4.224e-01,4.224e-01
+SSP2EU,CAZ,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.608e-02,1.781e-01,4.224e-01,4.224e-01
+SSP2EU,CAZ,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.608e-02,1.781e-01,4.224e-01,4.224e-01
+SSP2EU,CAZ,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.409e-01,3.311e-01,4.354e-01,4.354e-01
+SSP2EU,CAZ,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.462e-02,1.933e-02,7.601e-02,7.601e-02
+SSP2EU,CAZ,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.957e-02,5.608e-02,1.153e-01,1.153e-01
+SSP2EU,CAZ,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.462e-02,2.127e-02,7.883e-02,7.883e-02
+SSP2EU,CAZ,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.462e-02,2.127e-02,7.883e-02,7.883e-02
+SSP2EU,CAZ,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.462e-02,2.127e-02,7.883e-02,7.883e-02
+SSP2EU,CAZ,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.957e-02,5.608e-02,1.153e-01,1.153e-01
 SSP2EU,CAZ,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0.000e+00,8.315e-07,4.540e-05,1.192e-01,1.192e-01
-SSP2EU,CAZ,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,9.544e-01,9.544e-01
+SSP2EU,CAZ,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,CAZ,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,CAZ,Liquids,Domestic Ship_tmp_vehicletype,Domestic Ship_tmp_subsector_L1,Domestic Ship_tmp_subsector_L2,Domestic Ship,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,CAZ,Liquids,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
@@ -8590,124 +8590,124 @@ SSP2EU,CAZ,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_roa
 SSP2EU,CAZ,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,CAZ,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,CAZ,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP2EU,CAZ,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,3.104e-02,5.654e-02,1.075e-01,2.000e-01,2.000e-01
-SSP2EU,CAZ,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SSP2EU,CAZ,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SSP2EU,CAZ,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SSP2EU,CAZ,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SSP2EU,CAZ,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SSP2EU,CHA,,,,,Cycle,trn_pass,S3S,linear,8.298e-02,4.412e-02,3.782e-02,4.848e-02,4.848e-02
-SSP2EU,CHA,,,,,Domestic Aviation,trn_pass,S3S,linear,1.104e-01,2.842e-02,1.829e-02,3.517e-03,3.517e-03
-SSP2EU,CHA,,,,,Domestic Ship,trn_freight,S3S,linear,2.849e-02,8.548e-02,8.548e-02,8.548e-02,8.548e-02
-SSP2EU,CHA,,,,,Freight Rail,trn_freight,S3S,linear,6.920e-02,2.076e-01,2.076e-01,2.076e-01,2.076e-01
-SSP2EU,CHA,,,,,HSR,trn_pass,S3S,linear,2.108e-01,8.143e-02,1.916e-02,3.695e-03,3.695e-03
+SSP2EU,CAZ,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,3.104e-02,5.654e-02,9.776e-02,1.497e-01,1.497e-01
+SSP2EU,CAZ,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.535e-01,1.535e-01
+SSP2EU,CAZ,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.535e-01,1.535e-01
+SSP2EU,CAZ,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.535e-01,1.535e-01
+SSP2EU,CAZ,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.535e-01,1.535e-01
+SSP2EU,CAZ,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.535e-01,1.535e-01
+SSP2EU,CHA,,,,,Cycle,trn_pass,S3S,linear,9.454e-02,4.412e-02,3.782e-02,4.848e-02,4.848e-02
+SSP2EU,CHA,,,,,Domestic Aviation,trn_pass,S3S,linear,1.200e-01,2.712e-02,1.745e-02,3.357e-03,3.357e-03
+SSP2EU,CHA,,,,,Domestic Ship,trn_freight,S3S,linear,1.847e-02,1.922e-02,2.232e-02,2.232e-02,2.232e-02
+SSP2EU,CHA,,,,,Freight Rail,trn_freight,S3S,linear,3.204e-02,3.570e-02,3.795e-02,3.795e-02,3.795e-02
+SSP2EU,CHA,,,,,HSR,trn_pass,S3S,linear,2.402e-01,8.143e-02,1.916e-02,3.695e-03,3.695e-03
 SSP2EU,CHA,,,,,International Aviation,trn_aviation_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,CHA,,,,,International Ship,trn_shipping_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP2EU,CHA,,,,,Passenger Rail,trn_pass,S3S,linear,5.461e-03,3.111e-03,1.867e-03,9.572e-04,9.572e-04
-SSP2EU,CHA,,,,,Walk,trn_pass,S3S,linear,8.777e-01,1.000e+00,1.000e+00,1.000e+00,1.000e+00
+SSP2EU,CHA,,,,,Passenger Rail,trn_pass,S3S,linear,6.222e-03,3.111e-03,1.867e-03,9.572e-04,9.572e-04
+SSP2EU,CHA,,,,,Walk,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,CHA,,,,,trn_freight_road,trn_freight,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP2EU,CHA,,,,,trn_pass_road,trn_pass,S3S,linear,1.000e+00,4.557e-01,2.279e-01,5.843e-02,5.843e-02
-SSP2EU,CHA,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,3.816e-01,1.915e-01,1.705e-01,1.895e-01,1.895e-01
+SSP2EU,CHA,,,,,trn_pass_road,trn_pass,S3S,linear,6.711e-01,2.684e-01,1.342e-01,4.015e-02,4.015e-02
+SSP2EU,CHA,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,6.609e-01,2.927e-01,2.084e-01,9.649e-02,9.649e-02
 SSP2EU,CHA,,,,trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP2EU,CHA,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.081e-02,9.523e-03,6.956e-03,1.824e-03,1.824e-03
+SSP2EU,CHA,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,2.702e-01,2.116e-01,1.391e-01,1.459e-01,1.459e-01
 SSP2EU,CHA,,,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP2EU,CHA,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,3.616e-01,3.616e-01,3.616e-01,3.616e-01,3.616e-01
+SSP2EU,CHA,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,8.035e-01,7.232e-01,6.574e-01,5.563e-01,5.563e-01
 SSP2EU,CHA,,Large Car and SUV,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP2EU,CHA,,Mini Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,8.023e-03,8.023e-03,8.023e-03,8.023e-03,8.023e-03
+SSP2EU,CHA,,Mini Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.783e-02,1.605e-02,1.459e-02,1.234e-02,1.234e-02
 SSP2EU,CHA,,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,4.044e-02,4.044e-02,4.044e-02,4.044e-02,4.044e-02
 SSP2EU,CHA,,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,CHA,,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP2EU,CHA,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,3.898e-02,3.898e-02,3.898e-02,3.898e-02,3.898e-02
+SSP2EU,CHA,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,8.662e-02,7.795e-02,7.087e-02,5.996e-02,5.996e-02
 SSP2EU,CHA,,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,CHA,,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,2.234e-01,2.234e-01,2.234e-01,2.234e-01,2.234e-01
-SSP2EU,CHA,,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,4.469e-01,3.352e-01,3.352e-01,3.352e-01,3.352e-01
-SSP2EU,CHA,,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,4.469e-01,3.352e-01,3.352e-01,3.352e-01,3.352e-01
+SSP2EU,CHA,,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,4.022e-01,3.352e-01,3.016e-01,3.352e-01,3.352e-01
+SSP2EU,CHA,,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,4.022e-01,3.352e-01,3.016e-01,3.352e-01,3.352e-01
 SSP2EU,CHA,,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.657e-01,1.657e-01,1.657e-01,1.657e-01,1.657e-01
-SSP2EU,CHA,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP2EU,CHA,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,8.402e-02,8.402e-02,8.402e-02,8.402e-02,8.402e-02
-SSP2EU,CHA,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP2EU,CHA,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,3.320e-01,1.000e+00,1.000e+00,1.000e+00
+SSP2EU,CHA,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,6.000e-01,1.000e+00,1.000e+00,1.000e+00
+SSP2EU,CHA,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,6.000e-02,6.000e-01,1.000e+00,1.000e+00,1.000e+00
+SSP2EU,CHA,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,6.000e-01,1.000e+00,1.000e+00,1.000e+00
+SSP2EU,CHA,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,3.019e-01,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,CHA,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,4.553e-01,5.234e-01,6.595e-01,9.319e-01,9.319e-01
 SSP2EU,CHA,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,CHA,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,4.158e-01,4.888e-01,6.349e-01,9.270e-01,9.270e-01
-SSP2EU,CHA,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.768e-02,4.500e-01,9.820e-01,9.820e-01
-SSP2EU,CHA,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.897e-02,2.420e-01,9.526e-01,9.526e-01
-SSP2EU,CHA,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e-01,4.000e-01,9.000e-01,1.000e+00,1.000e+00
-SSP2EU,CHA,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e-01,4.000e-01,9.000e-01,1.000e+00,1.000e+00
-SSP2EU,CHA,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.768e-02,4.500e-01,9.820e-01,9.820e-01
-SSP2EU,CHA,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.225e-02,6.688e-02,6.999e-02,6.999e-02
-SSP2EU,CHA,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.339e-03,2.846e-02,1.462e-01,1.462e-01
-SSP2EU,CHA,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.945e-04,1.079e-02,1.000e-01,1.000e-01
-SSP2EU,CHA,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e-02,2.000e-01,6.000e-01,2.000e-01,2.000e-01
-SSP2EU,CHA,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e-02,2.000e-01,6.000e-01,2.000e-01,2.000e-01
-SSP2EU,CHA,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.339e-03,2.846e-02,1.462e-01,1.462e-01
+SSP2EU,CHA,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.002e-02,3.725e-01,8.768e-01,8.768e-01
+SSP2EU,CHA,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.592e-02,2.004e-01,8.505e-01,8.505e-01
+SSP2EU,CHA,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,9.920e-02,3.358e-01,7.450e-01,8.928e-01,8.928e-01
+SSP2EU,CHA,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,9.920e-02,3.358e-01,7.450e-01,8.928e-01,8.928e-01
+SSP2EU,CHA,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.002e-02,3.725e-01,8.768e-01,8.768e-01
+SSP2EU,CHA,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.024e-02,9.554e-02,6.999e-02,6.999e-02
+SSP2EU,CHA,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.124e-03,1.713e-02,1.450e-01,1.450e-01
+SSP2EU,CHA,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.151e-04,6.497e-03,9.920e-02,9.920e-02
+SSP2EU,CHA,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,9.920e-03,1.679e-01,3.612e-01,1.984e-01,1.984e-01
+SSP2EU,CHA,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,9.920e-03,1.679e-01,3.612e-01,1.984e-01,1.984e-01
+SSP2EU,CHA,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.124e-03,1.713e-02,1.450e-01,1.450e-01
 SSP2EU,CHA,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0.000e+00,8.315e-07,4.540e-05,1.192e-01,1.192e-01
-SSP2EU,CHA,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,7.437e-01,3.499e-01,3.499e-01
+SSP2EU,CHA,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,9.736e-01,3.527e-01,3.527e-01
 SSP2EU,CHA,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,CHA,Liquids,Domestic Ship_tmp_vehicletype,Domestic Ship_tmp_subsector_L1,Domestic Ship_tmp_subsector_L2,Domestic Ship,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,CHA,Liquids,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,CHA,Liquids,International Aviation_tmp_vehicletype,International Aviation_tmp_subsector_L1,International Aviation_tmp_subsector_L2,International Aviation,trn_aviation_intl,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,CHA,Liquids,International Ship_tmp_vehicletype,International Ship_tmp_subsector_L1,International Ship_tmp_subsector_L2,International Ship,trn_shipping_intl,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP2EU,CHA,Liquids,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP2EU,CHA,Liquids,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP2EU,CHA,Liquids,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
+SSP2EU,CHA,Liquids,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,8.333e-01,6.803e-01,6.803e-01
+SSP2EU,CHA,Liquids,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,8.333e-01,6.803e-01,6.803e-01
+SSP2EU,CHA,Liquids,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,8.333e-01,6.803e-01,6.803e-01
 SSP2EU,CHA,Liquids,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,CHA,Liquids,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,CHA,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,CHA,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,CHA,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,CHA,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP2EU,CHA,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.421e-01,1.594e-01,9.020e-02,1.152e-01,1.152e-01
-SSP2EU,CHA,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.878e-05,1.319e-02,5.530e-02,9.213e-02,9.213e-02
-SSP2EU,CHA,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,7.854e-04,1.443e-02,5.695e-02,9.317e-02,9.317e-02
-SSP2EU,CHA,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,3.000e-01,5.000e-01,7.000e-01,5.000e-01,5.000e-01
-SSP2EU,CHA,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,3.000e-01,5.000e-01,7.000e-01,5.000e-01,5.000e-01
-SSP2EU,CHA,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,3.309e-04,1.369e-02,5.597e-02,9.256e-02,9.256e-02
+SSP2EU,CHA,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.421e-01,1.329e-01,1.181e-01,1.055e-01,1.055e-01
+SSP2EU,CHA,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.707e-05,1.014e-02,3.814e-02,8.376e-02,8.376e-02
+SSP2EU,CHA,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,7.140e-04,1.110e-02,3.928e-02,8.470e-02,8.470e-02
+SSP2EU,CHA,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,2.727e-01,3.846e-01,4.828e-01,4.545e-01,4.545e-01
+SSP2EU,CHA,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,2.727e-01,3.846e-01,4.828e-01,4.545e-01,4.545e-01
+SSP2EU,CHA,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,3.008e-04,1.053e-02,3.860e-02,8.414e-02,8.414e-02
 SSP2EU,DEU,,,,,Cycle,trn_pass,S3S,linear,2.500e-02,2.500e-02,2.500e-02,1.875e-01,1.875e-01
-SSP2EU,DEU,,,,,Domestic Aviation,trn_pass,S3S,linear,6.250e-05,6.250e-05,6.250e-05,6.250e-05,6.250e-05
-SSP2EU,DEU,,,,,Domestic Ship,trn_freight,S3S,linear,2.088e-03,2.088e-03,2.088e-03,2.088e-03,2.088e-03
-SSP2EU,DEU,,,,,Freight Rail,trn_freight,S3S,linear,2.749e-02,2.749e-02,2.749e-02,2.749e-02,2.749e-02
+SSP2EU,DEU,,,,,Domestic Aviation,trn_pass,S3S,linear,5.965e-05,5.965e-05,5.965e-05,5.965e-05,5.965e-05
+SSP2EU,DEU,,,,,Domestic Ship,trn_freight,S3S,linear,2.127e-03,2.127e-03,2.127e-03,2.127e-03,2.127e-03
+SSP2EU,DEU,,,,,Freight Rail,trn_freight,S3S,linear,2.800e-02,2.800e-02,2.800e-02,2.800e-02,2.800e-02
 SSP2EU,DEU,,,,,HSR,trn_pass,S3S,linear,1.250e-04,2.500e-04,6.250e-04,6.250e-04,6.250e-04
 SSP2EU,DEU,,,,,International Aviation,trn_aviation_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,DEU,,,,,International Ship,trn_shipping_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,DEU,,,,,Passenger Rail,trn_pass,S3S,linear,2.500e-03,3.750e-03,3.750e-03,3.750e-03,3.750e-03
 SSP2EU,DEU,,,,,Walk,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,DEU,,,,,trn_freight_road,trn_freight,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP2EU,DEU,,,,,trn_pass_road,trn_pass,S3S,linear,7.500e-02,7.500e-02,7.500e-02,7.500e-02,7.500e-02
-SSP2EU,DEU,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,8.000e-02,8.000e-02,8.000e-02,1.500e-01,1.500e-01
+SSP2EU,DEU,,,,,trn_pass_road,trn_pass,S3S,linear,7.363e-02,7.363e-02,7.363e-02,7.363e-02,7.363e-02
+SSP2EU,DEU,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,8.149e-02,8.149e-02,8.149e-02,1.528e-01,1.528e-01
 SSP2EU,DEU,,,,trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,DEU,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,3.054e-02,3.054e-02,3.054e-02,3.054e-02,3.054e-02
 SSP2EU,DEU,,,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP2EU,DEU,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,4.724e-01,4.724e-01,4.724e-01,4.724e-01,4.724e-01
+SSP2EU,DEU,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,5.249e-01,5.249e-01,4.724e-01,4.724e-01,4.724e-01
 SSP2EU,DEU,,Large Car and SUV,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,DEU,,Midsize Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,2.716e-01,2.716e-01,2.716e-01,2.716e-01,2.716e-01
 SSP2EU,DEU,,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,2.183e-01,2.183e-01,2.183e-01,2.183e-01,2.183e-01
 SSP2EU,DEU,,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,6.630e-03,6.630e-03,6.630e-03,6.630e-03,6.630e-03
 SSP2EU,DEU,,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP2EU,DEU,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,4.803e-01,4.803e-01,4.803e-01,4.803e-01,4.803e-01
+SSP2EU,DEU,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,5.337e-01,5.337e-01,4.803e-01,4.803e-01,4.803e-01
 SSP2EU,DEU,,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,4.427e-01,4.427e-01,4.427e-01,4.427e-01,4.427e-01
 SSP2EU,DEU,,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,8.345e-02,8.345e-02,8.345e-02,8.345e-02,8.345e-02
 SSP2EU,DEU,,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,2.127e-01,2.127e-01,2.127e-01,2.127e-01,2.127e-01
 SSP2EU,DEU,,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,4.934e-01,4.934e-01,4.934e-01,4.934e-01,4.934e-01
 SSP2EU,DEU,,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP2EU,DEU,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP2EU,DEU,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP2EU,DEU,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP2EU,DEU,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.423e-01,4.034e-01,8.573e-01,8.573e-01
+SSP2EU,DEU,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.000e-02,2.500e-01,4.500e-01,4.500e-01
+SSP2EU,DEU,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.000e-02,2.500e-01,4.500e-01,4.500e-01
+SSP2EU,DEU,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.000e-02,2.500e-01,4.500e-01,4.500e-01
+SSP2EU,DEU,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.294e-01,3.669e-01,7.798e-01,7.798e-01
 SSP2EU,DEU,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,DEU,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,DEU,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP2EU,DEU,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.980e-01,6.750e-01,9.820e-01,9.820e-01
-SSP2EU,DEU,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.186e-01,3.631e-01,9.526e-01,9.526e-01
-SSP2EU,DEU,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.186e-01,3.631e-01,9.526e-01,9.526e-01
-SSP2EU,DEU,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.186e-01,3.631e-01,9.526e-01,9.526e-01
-SSP2EU,DEU,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.980e-01,6.750e-01,9.820e-01,9.820e-01
-SSP2EU,DEU,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.473e-03,1.799e-02,5.000e-02,5.000e-02
-SSP2EU,DEU,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,8.031e-02,3.320e-01,2.193e-01,2.193e-01
-SSP2EU,DEU,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.967e-02,1.259e-01,1.500e-01,1.500e-01
-SSP2EU,DEU,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.967e-02,1.259e-01,1.500e-01,1.500e-01
-SSP2EU,DEU,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.967e-02,1.259e-01,1.500e-01,1.500e-01
-SSP2EU,DEU,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,8.031e-02,3.320e-01,2.193e-01,2.193e-01
+SSP2EU,DEU,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.524e-01,6.784e-01,8.709e-01,8.709e-01
+SSP2EU,DEU,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.402e-01,3.649e-01,8.448e-01,8.448e-01
+SSP2EU,DEU,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.402e-01,3.649e-01,8.448e-01,8.448e-01
+SSP2EU,DEU,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.402e-01,3.649e-01,8.448e-01,8.448e-01
+SSP2EU,DEU,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.524e-01,6.784e-01,8.709e-01,8.709e-01
+SSP2EU,DEU,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.249e-03,1.636e-02,4.548e-02,4.548e-02
+SSP2EU,DEU,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,9.497e-02,3.925e-01,1.837e-01,1.837e-01
+SSP2EU,DEU,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.508e-02,1.489e-01,1.257e-01,1.257e-01
+SSP2EU,DEU,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.508e-02,1.489e-01,1.257e-01,1.257e-01
+SSP2EU,DEU,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.508e-02,1.489e-01,1.257e-01,1.257e-01
+SSP2EU,DEU,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,9.497e-02,3.925e-01,1.837e-01,1.837e-01
 SSP2EU,DEU,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0.000e+00,8.315e-07,4.540e-05,1.192e-01,1.192e-01
 SSP2EU,DEU,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,DEU,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
@@ -8724,59 +8724,59 @@ SSP2EU,DEU,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_roa
 SSP2EU,DEU,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,DEU,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,DEU,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP2EU,DEU,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,3.948e-02,6.475e-02,1.153e-01,1.731e-01,1.731e-01
-SSP2EU,DEU,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,2.615e-02,4.142e-02,1.030e-01,2.055e-01,2.055e-01
-SSP2EU,DEU,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.105e-02,7.895e-02,1.842e-01,1.842e-01
-SSP2EU,DEU,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.105e-02,7.895e-02,1.842e-01,1.842e-01
-SSP2EU,DEU,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.105e-02,7.895e-02,1.842e-01,1.842e-01
-SSP2EU,DEU,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.105e-02,7.895e-02,1.842e-01,1.842e-01
+SSP2EU,DEU,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,3.948e-02,4.981e-02,8.870e-02,1.332e-01,1.332e-01
+SSP2EU,DEU,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,2.615e-02,4.142e-02,1.030e-01,1.713e-01,1.713e-01
+SSP2EU,DEU,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.105e-02,7.895e-02,1.535e-01,1.535e-01
+SSP2EU,DEU,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.105e-02,7.895e-02,1.535e-01,1.535e-01
+SSP2EU,DEU,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.105e-02,7.895e-02,1.535e-01,1.535e-01
+SSP2EU,DEU,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.105e-02,7.895e-02,1.535e-01,1.535e-01
 SSP2EU,ECE,,,,,Cycle,trn_pass,S3S,linear,1.942e-02,1.942e-02,9.709e-02,1.092e-01,1.092e-01
-SSP2EU,ECE,,,,,Domestic Aviation,trn_pass,S3S,linear,7.313e-05,7.313e-05,7.313e-05,2.057e-05,2.057e-05
-SSP2EU,ECE,,,,,Domestic Ship,trn_freight,S3S,linear,3.893e-04,3.893e-04,3.893e-04,3.893e-04,3.893e-04
-SSP2EU,ECE,,,,,Freight Rail,trn_freight,S3S,linear,5.909e-02,5.909e-02,5.909e-02,5.909e-02,5.909e-02
+SSP2EU,ECE,,,,,Domestic Aviation,trn_pass,S3S,linear,6.979e-05,6.979e-05,6.979e-05,1.963e-05,1.963e-05
+SSP2EU,ECE,,,,,Domestic Ship,trn_freight,S3S,linear,3.966e-04,3.966e-04,3.966e-04,3.966e-04,3.966e-04
+SSP2EU,ECE,,,,,Freight Rail,trn_freight,S3S,linear,6.019e-02,6.019e-02,5.417e-02,5.417e-02,5.417e-02
 SSP2EU,ECE,,,,,HSR,trn_pass,S3S,linear,1.139e-04,1.708e-04,4.555e-04,3.202e-04,3.202e-04
 SSP2EU,ECE,,,,,International Aviation,trn_aviation_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,ECE,,,,,International Ship,trn_shipping_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,ECE,,,,,Passenger Rail,trn_pass,S3S,linear,6.799e-03,6.799e-03,9.065e-03,3.824e-03,3.824e-03
 SSP2EU,ECE,,,,,Walk,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,ECE,,,,,trn_freight_road,trn_freight,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP2EU,ECE,,,,,trn_pass_road,trn_pass,S3S,linear,8.972e-01,8.972e-01,7.177e-01,1.615e-01,1.615e-01
-SSP2EU,ECE,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,1.664e-01,1.664e-01,1.109e-01,1.109e-01,1.109e-01
+SSP2EU,ECE,,,,,trn_pass_road,trn_pass,S3S,linear,6.166e-01,6.166e-01,4.933e-01,1.268e-01,1.268e-01
+SSP2EU,ECE,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,2.712e-01,2.543e-01,1.469e-01,1.130e-01,1.130e-01
 SSP2EU,ECE,,,,trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,ECE,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,6.159e-03,6.159e-03,6.159e-03,6.159e-03,6.159e-03
 SSP2EU,ECE,,,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP2EU,ECE,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,3.451e-01,3.451e-01,3.451e-01,3.451e-01,3.451e-01
+SSP2EU,ECE,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,4.706e-01,4.706e-01,4.601e-01,4.314e-01,4.314e-01
 SSP2EU,ECE,,Large Car and SUV,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,7.825e-01,7.825e-01,7.825e-01,7.825e-01,7.825e-01
 SSP2EU,ECE,,Midsize Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,ECE,,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,5.321e-02,5.321e-02,5.321e-02,5.321e-02,5.321e-02
 SSP2EU,ECE,,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,4.728e-04,4.728e-04,4.728e-04,4.728e-04,4.728e-04
 SSP2EU,ECE,,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP2EU,ECE,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,4.683e-01,4.683e-01,4.683e-01,4.683e-01,4.683e-01
+SSP2EU,ECE,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,6.386e-01,6.386e-01,6.244e-01,5.854e-01,5.854e-01
 SSP2EU,ECE,,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,6.161e-01,6.161e-01,6.161e-01,6.161e-01,6.161e-01
 SSP2EU,ECE,,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.384e-01,1.384e-01,1.384e-01,1.384e-01,1.384e-01
 SSP2EU,ECE,,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.370e-01,1.370e-01,1.370e-01,1.370e-01,1.370e-01
 SSP2EU,ECE,,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.691e-01,1.691e-01,1.691e-01,1.691e-01,1.691e-01
 SSP2EU,ECE,,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP2EU,ECE,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP2EU,ECE,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP2EU,ECE,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP2EU,ECE,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.423e-01,5.379e-01,1.000e+00,1.000e+00
+SSP2EU,ECE,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.000e-02,1.900e-01,4.300e-01,4.300e-01
+SSP2EU,ECE,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.000e-02,1.900e-01,4.300e-01,4.300e-01
+SSP2EU,ECE,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.000e-02,1.900e-01,4.300e-01,4.300e-01
+SSP2EU,ECE,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.553e-01,5.283e-01,1.000e+00,1.000e+00
 SSP2EU,ECE,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,ECE,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,ECE,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP2EU,ECE,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.960e-02,1.500e-01,2.946e-01,2.946e-01
-SSP2EU,ECE,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.371e-02,8.068e-02,2.858e-01,2.858e-01
-SSP2EU,ECE,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.371e-02,8.068e-02,2.858e-01,2.858e-01
-SSP2EU,ECE,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.371e-02,8.068e-02,2.858e-01,2.858e-01
-SSP2EU,ECE,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.960e-02,1.500e-01,2.946e-01,2.946e-01
-SSP2EU,ECE,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.236e-02,1.799e-02,8.748e-02,8.748e-02
-SSP2EU,ECE,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.339e-02,4.743e-02,1.462e-01,1.462e-01
-SSP2EU,ECE,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.945e-03,1.799e-02,1.000e-01,1.000e-01
-SSP2EU,ECE,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.945e-03,1.799e-02,1.000e-01,1.000e-01
-SSP2EU,ECE,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.945e-03,1.799e-02,1.000e-01,1.000e-01
-SSP2EU,ECE,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.339e-02,4.743e-02,1.462e-01,1.462e-01
+SSP2EU,ECE,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.504e-02,1.455e-01,2.786e-01,2.786e-01
+SSP2EU,ECE,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.588e-02,7.826e-02,2.703e-01,2.703e-01
+SSP2EU,ECE,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.588e-02,7.826e-02,2.703e-01,2.703e-01
+SSP2EU,ECE,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.588e-02,7.826e-02,2.703e-01,2.703e-01
+SSP2EU,ECE,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.504e-02,1.455e-01,2.786e-01,2.786e-01
+SSP2EU,ECE,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.349e-02,1.963e-02,8.748e-02,8.748e-02
+SSP2EU,ECE,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.461e-02,5.750e-02,6.382e-02,6.382e-02
+SSP2EU,ECE,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.396e-03,2.181e-02,4.365e-02,4.365e-02
+SSP2EU,ECE,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.396e-03,2.181e-02,4.365e-02,4.365e-02
+SSP2EU,ECE,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.396e-03,2.181e-02,4.365e-02,4.365e-02
+SSP2EU,ECE,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.461e-02,5.750e-02,6.382e-02,6.382e-02
 SSP2EU,ECE,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0.000e+00,8.315e-07,4.540e-05,1.192e-01,1.192e-01
-SSP2EU,ECE,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,8.748e-01,8.748e-01
+SSP2EU,ECE,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,8.017e-01,8.017e-01
 SSP2EU,ECE,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,ECE,Liquids,Domestic Ship_tmp_vehicletype,Domestic Ship_tmp_subsector_L1,Domestic Ship_tmp_subsector_L2,Domestic Ship,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,ECE,Liquids,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,5.870e-01,5.870e-01,5.870e-01,5.870e-01,5.870e-01
@@ -8791,57 +8791,57 @@ SSP2EU,ECE,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_roa
 SSP2EU,ECE,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,ECE,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,ECE,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP2EU,ECE,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP2EU,ECE,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP2EU,ECE,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP2EU,ECE,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
+SSP2EU,ECE,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e-02,2.000e-02,7.000e-02,9.000e-02,9.000e-02
+SSP2EU,ECE,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.000e-02,1.111e-01,1.867e-01,1.867e-01
+SSP2EU,ECE,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.000e-02,1.111e-01,1.867e-01,1.867e-01
+SSP2EU,ECE,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.000e-02,1.111e-01,1.867e-01,1.867e-01
 SSP2EU,ECE,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP2EU,ECE,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP2EU,ECS,,,,,Cycle,trn_pass,S3S,linear,7.196e-03,2.159e-02,8.635e-02,8.738e-02,8.738e-02
-SSP2EU,ECS,,,,,Domestic Aviation,trn_pass,S3S,linear,2.566e-03,2.566e-03,2.566e-03,3.895e-04,3.895e-04
-SSP2EU,ECS,,,,,Domestic Ship,trn_freight,S3S,linear,3.878e-03,3.878e-03,3.878e-03,3.878e-03,3.878e-03
-SSP2EU,ECS,,,,,Freight Rail,trn_freight,S3S,linear,5.867e-02,5.867e-02,5.867e-02,5.867e-02,5.867e-02
-SSP2EU,ECS,,,,,HSR,trn_pass,S3S,linear,1.956e-04,1.956e-04,5.216e-04,4.000e-04,4.000e-04
+SSP2EU,ECE,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.000e-02,1.111e-01,1.867e-01,1.867e-01
+SSP2EU,ECS,,,,,Cycle,trn_pass,S3S,linear,1.092e-02,3.277e-02,1.311e-01,8.738e-02,8.738e-02
+SSP2EU,ECS,,,,,Domestic Aviation,trn_pass,S3S,linear,3.717e-03,3.717e-03,3.717e-03,3.717e-04,3.717e-04
+SSP2EU,ECS,,,,,Domestic Ship,trn_freight,S3S,linear,3.950e-03,3.950e-03,3.591e-03,3.950e-03,3.950e-03
+SSP2EU,ECS,,,,,Freight Rail,trn_freight,S3S,linear,5.976e-02,5.976e-02,5.433e-02,5.379e-02,5.379e-02
+SSP2EU,ECS,,,,,HSR,trn_pass,S3S,linear,2.969e-04,2.969e-04,7.917e-04,4.000e-04,4.000e-04
 SSP2EU,ECS,,,,,International Aviation,trn_aviation_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,ECS,,,,,International Ship,trn_shipping_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP2EU,ECS,,,,,Passenger Rail,trn_pass,S3S,linear,5.215e-03,6.953e-03,8.691e-03,2.638e-03,2.638e-03
-SSP2EU,ECS,,,,,Walk,trn_pass,S3S,linear,6.588e-01,6.588e-01,6.588e-01,1.000e+00,1.000e+00
+SSP2EU,ECS,,,,,Passenger Rail,trn_pass,S3S,linear,7.915e-03,1.055e-02,1.319e-02,2.638e-03,2.638e-03
+SSP2EU,ECS,,,,,Walk,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,ECS,,,,,trn_freight_road,trn_freight,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP2EU,ECS,,,,,trn_pass_road,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.518e-01,1.518e-01
-SSP2EU,ECS,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,1.140e-01,1.140e-01,7.980e-02,6.840e-02,6.840e-02
+SSP2EU,ECS,,,,,trn_pass_road,trn_pass,S3S,linear,7.451e-01,7.451e-01,7.451e-01,8.941e-02,8.941e-02
+SSP2EU,ECS,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,2.090e-01,1.742e-01,1.219e-01,1.045e-01,1.045e-01
 SSP2EU,ECS,,,,trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,ECS,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,2.175e-03,2.175e-03,2.175e-03,2.175e-03,2.175e-03
 SSP2EU,ECS,,,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP2EU,ECS,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,3.336e-01,3.336e-01,3.336e-01,3.336e-01,3.336e-01
+SSP2EU,ECS,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,5.004e-01,5.004e-01,5.004e-01,4.549e-01,4.549e-01
 SSP2EU,ECS,,Large Car and SUV,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,ECS,,Midsize Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,9.609e-01,9.609e-01,9.609e-01,9.609e-01,9.609e-01
 SSP2EU,ECS,,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.125e-01,1.125e-01,1.125e-01,1.125e-01,1.125e-01
 SSP2EU,ECS,,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,3.579e-02,3.579e-02,3.579e-02,3.579e-02,3.579e-02
 SSP2EU,ECS,,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP2EU,ECS,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,6.520e-01,6.520e-01,6.520e-01,6.520e-01,6.520e-01
+SSP2EU,ECS,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,9.780e-01,9.780e-01,9.780e-01,8.891e-01,8.891e-01
 SSP2EU,ECS,,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,ECS,,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,2.555e-01,2.555e-01,2.555e-01,2.555e-01,2.555e-01
 SSP2EU,ECS,,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,3.104e-01,3.104e-01,3.104e-01,3.104e-01,3.104e-01
 SSP2EU,ECS,,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.282e-01,1.282e-01,1.282e-01,1.282e-01,1.282e-01
 SSP2EU,ECS,,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,4.409e-01,4.409e-01,4.409e-01,4.409e-01,4.409e-01
-SSP2EU,ECS,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP2EU,ECS,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP2EU,ECS,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP2EU,ECS,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.743e-02,3.496e-01,8.573e-01,8.573e-01
+SSP2EU,ECS,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,3.200e-02,1.920e-01,4.200e-01,4.200e-01
+SSP2EU,ECS,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,3.200e-02,1.920e-01,4.200e-01,4.200e-01
+SSP2EU,ECS,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,3.200e-02,1.920e-01,4.200e-01,4.200e-01
+SSP2EU,ECS,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,9.315e-02,3.815e-01,8.420e-01,8.420e-01
 SSP2EU,ECS,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,ECS,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,ECS,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP2EU,ECS,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.192e-01,2.500e-01,2.946e-01,2.946e-01
-SSP2EU,ECS,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.743e-02,1.345e-01,2.858e-01,2.858e-01
-SSP2EU,ECS,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.743e-02,1.345e-01,2.858e-01,2.858e-01
-SSP2EU,ECS,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.743e-02,1.345e-01,2.858e-01,2.858e-01
-SSP2EU,ECS,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.192e-01,2.500e-01,2.946e-01,2.946e-01
-SSP2EU,ECS,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.473e-03,5.396e-02,1.000e-01,1.000e-01
-SSP2EU,ECS,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.339e-02,4.743e-02,7.311e-02,7.311e-02
-SSP2EU,ECS,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.945e-03,1.799e-02,5.000e-02,5.000e-02
-SSP2EU,ECS,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.945e-03,1.799e-02,5.000e-02,5.000e-02
-SSP2EU,ECS,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.945e-03,1.799e-02,5.000e-02,5.000e-02
-SSP2EU,ECS,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.339e-02,4.743e-02,7.311e-02,7.311e-02
+SSP2EU,ECS,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.041e-01,2.182e-01,2.893e-01,2.893e-01
+SSP2EU,ECS,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.140e-02,1.174e-01,2.807e-01,2.807e-01
+SSP2EU,ECS,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.140e-02,1.174e-01,2.807e-01,2.807e-01
+SSP2EU,ECS,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.140e-02,1.174e-01,2.807e-01,2.807e-01
+SSP2EU,ECS,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.041e-01,2.182e-01,2.893e-01,2.893e-01
+SSP2EU,ECS,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.698e-03,7.360e-02,1.091e-01,1.091e-01
+SSP2EU,ECS,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.461e-02,6.900e-02,7.977e-02,7.977e-02
+SSP2EU,ECS,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.396e-03,2.617e-02,5.456e-02,5.456e-02
+SSP2EU,ECS,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.396e-03,2.617e-02,5.456e-02,5.456e-02
+SSP2EU,ECS,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.396e-03,2.617e-02,5.456e-02,5.456e-02
+SSP2EU,ECS,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.461e-02,6.900e-02,7.977e-02,7.977e-02
 SSP2EU,ECS,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0.000e+00,8.315e-07,4.540e-05,1.192e-01,1.192e-01
 SSP2EU,ECS,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,ECS,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
@@ -8858,61 +8858,61 @@ SSP2EU,ECS,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_roa
 SSP2EU,ECS,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,ECS,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,ECS,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP2EU,ECS,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP2EU,ECS,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP2EU,ECS,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP2EU,ECS,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP2EU,ECS,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP2EU,ECS,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
+SSP2EU,ECS,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e-02,2.000e-02,6.250e-02,1.000e-01,1.000e-01
+SSP2EU,ECS,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e-05,1.300e-02,6.667e-02,1.400e-01,1.400e-01
+SSP2EU,ECS,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e-05,1.300e-02,6.667e-02,1.400e-01,1.400e-01
+SSP2EU,ECS,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e-05,1.300e-02,6.667e-02,1.400e-01,1.400e-01
+SSP2EU,ECS,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e-05,1.300e-02,6.667e-02,1.400e-01,1.400e-01
+SSP2EU,ECS,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e-05,1.300e-02,6.667e-02,1.400e-01,1.400e-01
 SSP2EU,ENC,,,,,Cycle,trn_pass,S3S,linear,2.500e-02,2.500e-02,5.556e-02,1.000e-01,1.000e-01
-SSP2EU,ENC,,,,,Domestic Aviation,trn_pass,S3S,linear,6.250e-05,6.250e-05,5.556e-05,2.500e-05,2.500e-05
-SSP2EU,ENC,,,,,Domestic Ship,trn_freight,S3S,linear,1.223e-02,1.223e-02,1.223e-02,1.223e-02,1.223e-02
-SSP2EU,ENC,,,,,Freight Rail,trn_freight,S3S,linear,2.875e-02,2.875e-02,2.875e-02,2.875e-02,2.875e-02
+SSP2EU,ENC,,,,,Domestic Aviation,trn_pass,S3S,linear,5.965e-05,5.965e-05,5.302e-05,2.386e-05,2.386e-05
+SSP2EU,ENC,,,,,Domestic Ship,trn_freight,S3S,linear,1.246e-02,1.246e-02,1.246e-02,1.246e-02,1.246e-02
+SSP2EU,ENC,,,,,Freight Rail,trn_freight,S3S,linear,2.928e-02,2.928e-02,2.928e-02,2.928e-02,2.928e-02
 SSP2EU,ENC,,,,,HSR,trn_pass,S3S,linear,1.250e-04,2.500e-04,2.222e-04,2.000e-04,2.000e-04
 SSP2EU,ENC,,,,,International Aviation,trn_aviation_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,ENC,,,,,International Ship,trn_shipping_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,ENC,,,,,Passenger Rail,trn_pass,S3S,linear,3.125e-03,3.125e-03,3.333e-03,2.000e-03,2.000e-03
 SSP2EU,ENC,,,,,Walk,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,ENC,,,,,trn_freight_road,trn_freight,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP2EU,ENC,,,,,trn_pass_road,trn_pass,S3S,linear,7.500e-02,7.500e-02,6.667e-02,3.000e-02,3.000e-02
-SSP2EU,ENC,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,2.000e-01,1.500e-01,1.500e-01,1.500e-01,1.500e-01
+SSP2EU,ENC,,,,,trn_pass_road,trn_pass,S3S,linear,7.363e-02,7.363e-02,6.545e-02,2.945e-02,2.945e-02
+SSP2EU,ENC,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,2.037e-01,1.528e-01,1.528e-01,1.528e-01,1.528e-01
 SSP2EU,ENC,,,,trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,ENC,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,3.014e-02,3.014e-02,3.014e-02,3.014e-02,3.014e-02
 SSP2EU,ENC,,,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP2EU,ENC,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,3.559e-01,3.559e-01,3.559e-01,3.559e-01,3.559e-01
+SSP2EU,ENC,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,3.955e-01,3.955e-01,3.955e-01,3.559e-01,3.559e-01
 SSP2EU,ENC,,Large Car and SUV,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,ENC,,Midsize Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.960e-01,1.960e-01,1.960e-01,1.960e-01,1.960e-01
-SSP2EU,ENC,,Mini Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,2.357e-07,2.357e-07,2.357e-07,2.357e-07,2.357e-07
+SSP2EU,ENC,,Mini Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,2.619e-07,2.619e-07,2.619e-07,2.357e-07,2.357e-07
 SSP2EU,ENC,,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.576e-01,1.576e-01,1.576e-01,1.576e-01,1.576e-01
 SSP2EU,ENC,,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,3.751e-02,3.751e-02,3.751e-02,3.751e-02,3.751e-02
 SSP2EU,ENC,,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP2EU,ENC,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.963e-01,1.963e-01,1.963e-01,1.963e-01,1.963e-01
+SSP2EU,ENC,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,2.181e-01,2.181e-01,2.181e-01,1.963e-01,1.963e-01
 SSP2EU,ENC,,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,ENC,,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.002e-01,1.002e-01,1.002e-01,1.002e-01,1.002e-01
 SSP2EU,ENC,,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,3.593e-01,3.593e-01,3.593e-01,3.593e-01,3.593e-01
 SSP2EU,ENC,,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,4.374e-01,4.374e-01,4.374e-01,4.374e-01,4.374e-01
 SSP2EU,ENC,,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,4.946e-01,4.946e-01,4.946e-01,4.946e-01,4.946e-01
 SSP2EU,ENC,,Van,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.049e-03,1.049e-03,1.049e-03,1.049e-03,1.049e-03
-SSP2EU,ENC,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP2EU,ENC,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP2EU,ENC,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP2EU,ENC,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.371e-01,6.724e-01,1.000e+00,1.000e+00
+SSP2EU,ENC,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,5.000e-02,2.300e-01,5.000e-01,5.000e-01
+SSP2EU,ENC,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,5.000e-02,2.300e-01,5.000e-01,5.000e-01
+SSP2EU,ENC,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,5.000e-02,2.300e-01,5.000e-01,5.000e-01
+SSP2EU,ENC,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.157e-01,7.227e-01,1.000e+00,1.000e+00
 SSP2EU,ENC,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,ENC,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,ENC,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP2EU,ENC,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.622e-01,6.000e-01,9.820e-01,9.820e-01
-SSP2EU,ENC,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.043e-01,3.227e-01,9.526e-01,9.526e-01
-SSP2EU,ENC,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.043e-01,3.227e-01,9.526e-01,9.526e-01
-SSP2EU,ENC,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.043e-01,3.227e-01,9.526e-01,9.526e-01
-SSP2EU,ENC,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.622e-01,6.000e-01,9.820e-01,9.820e-01
-SSP2EU,ENC,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.236e-02,5.396e-02,1.312e-01,1.312e-01
-SSP2EU,ENC,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.693e-02,2.371e-01,1.462e-01,1.462e-01
-SSP2EU,ENC,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-02,8.993e-02,1.000e-01,1.000e-01
-SSP2EU,ENC,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-02,8.993e-02,1.000e-01,1.000e-01
-SSP2EU,ENC,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-02,8.993e-02,1.000e-01,1.000e-01
-SSP2EU,ENC,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.693e-02,2.371e-01,1.462e-01,1.462e-01
+SSP2EU,ENC,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.101e-01,6.386e-01,9.289e-01,9.289e-01
+SSP2EU,ENC,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.234e-01,3.434e-01,9.011e-01,9.011e-01
+SSP2EU,ENC,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.234e-01,3.434e-01,9.011e-01,9.011e-01
+SSP2EU,ENC,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.234e-01,3.434e-01,9.011e-01,9.011e-01
+SSP2EU,ENC,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.101e-01,6.386e-01,9.289e-01,9.289e-01
+SSP2EU,ENC,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.124e-02,5.800e-02,1.021e-01,1.021e-01
+SSP2EU,ENC,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,7.914e-02,2.804e-01,1.729e-01,1.729e-01
+SSP2EU,ENC,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.924e-02,1.063e-01,1.183e-01,1.183e-01
+SSP2EU,ENC,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.924e-02,1.063e-01,1.183e-01,1.183e-01
+SSP2EU,ENC,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.924e-02,1.063e-01,1.183e-01,1.183e-01
+SSP2EU,ENC,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,7.914e-02,2.804e-01,1.729e-01,1.729e-01
 SSP2EU,ENC,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0.000e+00,8.315e-07,4.540e-05,1.192e-01,1.192e-01
-SSP2EU,ENC,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,5.249e-01,5.249e-01
+SSP2EU,ENC,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,5.426e-01,5.426e-01
 SSP2EU,ENC,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,ENC,Liquids,Domestic Ship_tmp_vehicletype,Domestic Ship_tmp_subsector_L1,Domestic Ship_tmp_subsector_L2,Domestic Ship,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,ENC,Liquids,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1.341e-01,1.341e-01,1.341e-01,1.341e-01,1.341e-01
@@ -8927,30 +8927,30 @@ SSP2EU,ENC,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_roa
 SSP2EU,ENC,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,ENC,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,ENC,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP2EU,ENC,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,2.533e-02,5.098e-02,1.023e-01,1.075e-01,1.075e-01
+SSP2EU,ENC,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,2.533e-02,3.921e-02,9.298e-02,1.011e-01,1.011e-01
 SSP2EU,ENC,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
 SSP2EU,ENC,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
 SSP2EU,ENC,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
 SSP2EU,ENC,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
 SSP2EU,ENC,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
 SSP2EU,ESC,,,,,Cycle,trn_pass,S3S,linear,1.942e-02,2.184e-02,4.369e-02,1.638e-01,1.638e-01
-SSP2EU,ESC,,,,,Domestic Aviation,trn_pass,S3S,linear,1.347e-04,3.789e-05,3.789e-05,7.579e-05,7.579e-05
-SSP2EU,ESC,,,,,Domestic Ship,trn_freight,S3S,linear,1.187e-02,1.187e-02,1.187e-02,1.187e-02,1.187e-02
-SSP2EU,ESC,,,,,Freight Rail,trn_freight,S3S,linear,4.020e-03,4.020e-03,4.020e-03,4.020e-03,4.020e-03
+SSP2EU,ESC,,,,,Domestic Aviation,trn_pass,S3S,linear,1.286e-04,3.616e-05,3.616e-05,7.233e-05,7.233e-05
+SSP2EU,ESC,,,,,Domestic Ship,trn_freight,S3S,linear,1.209e-02,1.209e-02,1.209e-02,1.209e-02,1.209e-02
+SSP2EU,ESC,,,,,Freight Rail,trn_freight,S3S,linear,4.094e-03,4.094e-03,4.094e-03,4.094e-03,4.094e-03
 SSP2EU,ESC,,,,,HSR,trn_pass,S3S,linear,6.613e-04,1.860e-04,6.200e-04,6.200e-04,6.200e-04
 SSP2EU,ESC,,,,,International Aviation,trn_aviation_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,ESC,,,,,International Ship,trn_shipping_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,ESC,,,,,Passenger Rail,trn_pass,S3S,linear,3.195e-03,2.696e-03,2.696e-03,4.044e-03,4.044e-03
 SSP2EU,ESC,,,,,Walk,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,ESC,,,,,trn_freight_road,trn_freight,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP2EU,ESC,,,,,trn_pass_road,trn_pass,S3S,linear,1.832e-01,1.030e-01,8.242e-02,6.594e-02,6.594e-02
-SSP2EU,ESC,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,6.591e-02,6.591e-02,6.591e-02,9.887e-02,9.887e-02
+SSP2EU,ESC,,,,,trn_pass_road,trn_pass,S3S,linear,1.798e-01,1.011e-01,8.092e-02,6.473e-02,6.473e-02
+SSP2EU,ESC,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,6.714e-02,6.714e-02,6.714e-02,1.007e-01,1.007e-01
 SSP2EU,ESC,,,,trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP2EU,ESC,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.687e-01,1.687e-01,1.687e-01,1.687e-01,1.687e-01
+SSP2EU,ESC,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.205e-01,1.125e-01,1.125e-01,1.125e-01,1.125e-01
 SSP2EU,ESC,,,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,ESC,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,3.942e-01,3.942e-01,3.942e-01,3.942e-01,3.942e-01
-SSP2EU,ESC,,Large Car and SUV,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,8.712e-01,8.712e-01,8.712e-01,8.712e-01,8.712e-01
-SSP2EU,ESC,,Midsize Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,2.323e-01,2.323e-01,2.323e-01,2.323e-01,2.323e-01
+SSP2EU,ESC,,Large Car and SUV,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,8.712e-01,7.840e-01,8.712e-01,8.712e-01,8.712e-01
+SSP2EU,ESC,,Midsize Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,2.323e-01,2.091e-01,2.323e-01,2.323e-01,2.323e-01
 SSP2EU,ESC,,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.009e-01,1.009e-01,1.009e-01,1.009e-01,1.009e-01
 SSP2EU,ESC,,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,6.375e-02,6.375e-02,6.375e-02,6.375e-02,6.375e-02
 SSP2EU,ESC,,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
@@ -8960,24 +8960,24 @@ SSP2EU,ESC,,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_s
 SSP2EU,ESC,,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,2.234e-01,2.234e-01,2.234e-01,2.234e-01,2.234e-01
 SSP2EU,ESC,,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,2.172e-01,2.172e-01,2.172e-01,2.172e-01,2.172e-01
 SSP2EU,ESC,,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP2EU,ESC,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP2EU,ESC,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP2EU,ESC,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP2EU,ESC,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.423e-01,4.034e-01,9.526e-01,9.526e-01
+SSP2EU,ESC,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.000e-02,2.200e-01,4.200e-01,4.200e-01
+SSP2EU,ESC,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.000e-02,2.200e-01,4.200e-01,4.200e-01
+SSP2EU,ESC,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.000e-02,2.200e-01,4.200e-01,4.200e-01
+SSP2EU,ESC,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.359e-01,3.816e-01,8.448e-01,8.448e-01
 SSP2EU,ESC,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,ESC,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,ESC,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP2EU,ESC,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.384e-01,5.000e-01,9.820e-01,9.820e-01
-SSP2EU,ESC,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,9.485e-02,2.689e-01,9.526e-01,9.526e-01
-SSP2EU,ESC,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,9.485e-02,2.689e-01,9.526e-01,9.526e-01
-SSP2EU,ESC,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,9.485e-02,2.689e-01,9.526e-01,9.526e-01
-SSP2EU,ESC,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.384e-01,5.000e-01,9.820e-01,9.820e-01
-SSP2EU,ESC,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.236e-02,5.396e-02,1.000e-01,1.000e-01
-SSP2EU,ESC,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.693e-02,4.743e-02,1.462e-01,1.462e-01
-SSP2EU,ESC,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-02,1.799e-02,1.000e-01,1.000e-01
-SSP2EU,ESC,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-02,1.799e-02,1.000e-01,1.000e-01
-SSP2EU,ESC,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-02,1.799e-02,1.000e-01,1.000e-01
-SSP2EU,ESC,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.693e-02,4.743e-02,1.462e-01,1.462e-01
+SSP2EU,ESC,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.819e-01,5.321e-01,7.741e-01,7.741e-01
+SSP2EU,ESC,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.122e-01,2.862e-01,7.509e-01,7.509e-01
+SSP2EU,ESC,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.122e-01,2.862e-01,7.509e-01,7.509e-01
+SSP2EU,ESC,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.122e-01,2.862e-01,7.509e-01,7.509e-01
+SSP2EU,ESC,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.819e-01,5.321e-01,7.741e-01,7.741e-01
+SSP2EU,ESC,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.124e-02,6.380e-02,7.883e-02,7.883e-02
+SSP2EU,ESC,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,7.914e-02,5.608e-02,1.441e-01,1.441e-01
+SSP2EU,ESC,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.924e-02,2.127e-02,9.854e-02,9.854e-02
+SSP2EU,ESC,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.924e-02,2.127e-02,9.854e-02,9.854e-02
+SSP2EU,ESC,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.924e-02,2.127e-02,9.854e-02,9.854e-02
+SSP2EU,ESC,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,7.914e-02,5.608e-02,1.441e-01,1.441e-01
 SSP2EU,ESC,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0.000e+00,8.315e-07,4.540e-05,1.192e-01,1.192e-01
 SSP2EU,ESC,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,ESC,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
@@ -8994,57 +8994,57 @@ SSP2EU,ESC,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_roa
 SSP2EU,ESC,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,ESC,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,ESC,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP2EU,ESC,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,2.742e-02,5.301e-02,1.042e-01,2.066e-01,2.066e-01
-SSP2EU,ESC,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SSP2EU,ESC,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SSP2EU,ESC,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SSP2EU,ESC,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SSP2EU,ESC,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
+SSP2EU,ESC,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,2.742e-02,4.078e-02,1.042e-01,1.721e-01,1.721e-01
+SSP2EU,ESC,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.535e-01,1.535e-01
+SSP2EU,ESC,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.535e-01,1.535e-01
+SSP2EU,ESC,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.535e-01,1.535e-01
+SSP2EU,ESC,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.535e-01,1.535e-01
+SSP2EU,ESC,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.535e-01,1.535e-01
 SSP2EU,ESW,,,,,Cycle,trn_pass,S3S,linear,1.942e-02,3.884e-02,5.825e-02,1.019e-01,1.019e-01
-SSP2EU,ESW,,,,,Domestic Aviation,trn_pass,S3S,linear,7.179e-04,7.179e-04,5.744e-04,1.346e-04,1.346e-04
-SSP2EU,ESW,,,,,Domestic Ship,trn_freight,S3S,linear,6.018e-03,6.018e-03,6.018e-03,6.018e-03,6.018e-03
-SSP2EU,ESW,,,,,Freight Rail,trn_freight,S3S,linear,1.394e-02,1.394e-02,1.394e-02,1.394e-02,1.394e-02
+SSP2EU,ESW,,,,,Domestic Aviation,trn_pass,S3S,linear,6.852e-04,6.852e-04,5.482e-04,1.285e-04,1.285e-04
+SSP2EU,ESW,,,,,Domestic Ship,trn_freight,S3S,linear,6.130e-03,6.130e-03,6.130e-03,6.130e-03,6.130e-03
+SSP2EU,ESW,,,,,Freight Rail,trn_freight,S3S,linear,1.420e-02,1.420e-02,1.420e-02,1.420e-02,1.420e-02
 SSP2EU,ESW,,,,,HSR,trn_pass,S3S,linear,9.579e-04,9.579e-04,9.579e-04,3.592e-04,3.592e-04
 SSP2EU,ESW,,,,,International Aviation,trn_aviation_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,ESW,,,,,International Ship,trn_shipping_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,ESW,,,,,Passenger Rail,trn_pass,S3S,linear,3.621e-03,3.621e-03,5.432e-03,2.037e-03,2.037e-03
 SSP2EU,ESW,,,,,Walk,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,ESW,,,,,trn_freight_road,trn_freight,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP2EU,ESW,,,,,trn_pass_road,trn_pass,S3S,linear,1.411e-01,1.129e-01,1.129e-01,3.175e-02,3.175e-02
-SSP2EU,ESW,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,5.667e-02,5.667e-02,7.083e-02,1.063e-01,1.063e-01
+SSP2EU,ESW,,,,,trn_pass_road,trn_pass,S3S,linear,1.385e-01,1.108e-01,1.108e-01,3.117e-02,3.117e-02
+SSP2EU,ESW,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,5.772e-02,5.772e-02,7.215e-02,1.082e-01,1.082e-01
 SSP2EU,ESW,,,,trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP2EU,ESW,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,8.570e-02,8.570e-02,8.570e-02,8.570e-02,8.570e-02
+SSP2EU,ESW,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,7.141e-02,7.141e-02,7.141e-02,6.592e-02,6.592e-02
 SSP2EU,ESW,,,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP2EU,ESW,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,5.153e-01,5.153e-01,5.153e-01,5.153e-01,5.153e-01
+SSP2EU,ESW,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,5.725e-01,5.725e-01,5.725e-01,5.725e-01,5.725e-01
 SSP2EU,ESW,,Large Car and SUV,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,ESW,,Midsize Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,2.963e-01,2.963e-01,2.963e-01,2.963e-01,2.963e-01
 SSP2EU,ESW,,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,9.741e-02,9.741e-02,9.741e-02,9.741e-02,9.741e-02
 SSP2EU,ESW,,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.669e-01,1.669e-01,1.669e-01,1.669e-01,1.669e-01
 SSP2EU,ESW,,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP2EU,ESW,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,4.003e-01,4.003e-01,4.003e-01,4.003e-01,4.003e-01
+SSP2EU,ESW,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,4.448e-01,4.448e-01,4.448e-01,4.448e-01,4.448e-01
 SSP2EU,ESW,,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,2.850e-01,2.850e-01,2.850e-01,2.850e-01,2.850e-01
 SSP2EU,ESW,,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,6.043e-02,6.043e-02,6.043e-02,6.043e-02,6.043e-02
 SSP2EU,ESW,,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,8.424e-02,8.424e-02,8.424e-02,8.424e-02,8.424e-02
 SSP2EU,ESW,,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,4.041e-01,4.041e-01,4.041e-01,4.041e-01,4.041e-01
 SSP2EU,ESW,,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP2EU,ESW,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP2EU,ESW,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP2EU,ESW,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP2EU,ESW,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.186e-01,2.689e-01,6.668e-01,6.668e-01
+SSP2EU,ESW,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.800e-02,2.160e-01,4.200e-01,4.200e-01
+SSP2EU,ESW,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.800e-02,2.160e-01,4.200e-01,4.200e-01
+SSP2EU,ESW,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.800e-02,2.160e-01,4.200e-01,4.200e-01
+SSP2EU,ESW,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.078e-02,1.164e-01,2.935e-01,6.237e-01,6.237e-01
 SSP2EU,ESW,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,7.295e-01,7.633e-01,8.309e-01,9.662e-01,9.662e-01
 SSP2EU,ESW,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,ESW,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP2EU,ESW,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.576e-01,7.000e-01,9.820e-01,9.820e-01
-SSP2EU,ESW,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.423e-01,3.765e-01,9.526e-01,9.526e-01
-SSP2EU,ESW,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.423e-01,3.765e-01,9.526e-01,9.526e-01
-SSP2EU,ESW,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.423e-01,3.765e-01,9.526e-01,9.526e-01
-SSP2EU,ESW,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.576e-01,7.000e-01,9.820e-01,9.820e-01
-SSP2EU,ESW,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.473e-03,1.799e-02,7.500e-02,7.500e-02
-SSP2EU,ESW,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.693e-02,2.371e-01,1.462e-01,1.462e-01
-SSP2EU,ESW,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-02,8.993e-02,1.000e-01,1.000e-01
-SSP2EU,ESW,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-02,8.993e-02,1.000e-01,1.000e-01
-SSP2EU,ESW,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-02,8.993e-02,1.000e-01,1.000e-01
-SSP2EU,ESW,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.693e-02,2.371e-01,1.462e-01,1.462e-01
+SSP2EU,ESW,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.902e-01,6.875e-01,1.000e+00,1.000e+00
+SSP2EU,ESW,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.553e-01,3.698e-01,1.000e+00,1.000e+00
+SSP2EU,ESW,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.553e-01,3.698e-01,1.000e+00,1.000e+00
+SSP2EU,ESW,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.553e-01,3.698e-01,1.000e+00,1.000e+00
+SSP2EU,ESW,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.902e-01,6.875e-01,1.000e+00,1.000e+00
+SSP2EU,ESW,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,2.248e-03,2.698e-03,1.963e-02,5.846e-02,5.846e-02
+SSP2EU,ESW,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,7.303e-02,2.588e-01,1.489e-01,1.489e-01
+SSP2EU,ESW,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.698e-02,9.813e-02,1.050e-01,1.050e-01
+SSP2EU,ESW,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.698e-02,9.813e-02,1.050e-01,1.050e-01
+SSP2EU,ESW,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.698e-02,9.813e-02,1.050e-01,1.050e-01
+SSP2EU,ESW,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,7.303e-02,2.588e-01,1.489e-01,1.489e-01
 SSP2EU,ESW,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0.000e+00,8.315e-07,4.540e-05,1.192e-01,1.192e-01
 SSP2EU,ESW,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,ESW,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
@@ -9056,39 +9056,39 @@ SSP2EU,ESW,Liquids,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,tr
 SSP2EU,ESW,Liquids,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,ESW,Liquids,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,ESW,Liquids,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,5.162e-01,5.162e-01,5.162e-01,5.162e-01,5.162e-01
-SSP2EU,ESW,Liquids,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP2EU,ESW,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP2EU,ESW,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP2EU,ESW,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP2EU,ESW,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP2EU,ESW,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SSP2EU,ESW,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SSP2EU,ESW,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SSP2EU,ESW,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SSP2EU,ESW,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SSP2EU,ESW,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
+SSP2EU,ESW,Liquids,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,9.332e-01,9.332e-01
+SSP2EU,ESW,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,9.620e-01,9.620e-01
+SSP2EU,ESW,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,9.620e-01,9.620e-01
+SSP2EU,ESW,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,9.620e-01,9.620e-01
+SSP2EU,ESW,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,9.332e-01,9.332e-01
+SSP2EU,ESW,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.754e-02,2.632e-02,7.895e-02,1.316e-01,1.316e-01
+SSP2EU,ESW,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.719e-01,1.719e-01
+SSP2EU,ESW,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.772e-01,1.772e-01
+SSP2EU,ESW,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.772e-01,1.772e-01
+SSP2EU,ESW,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.772e-01,1.772e-01
+SSP2EU,ESW,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.719e-01,1.719e-01
 SSP2EU,EWN,,,,,Cycle,trn_pass,S3S,linear,1.000e-02,1.000e-02,5.000e-02,1.000e-01,1.000e-01
-SSP2EU,EWN,,,,,Domestic Aviation,trn_pass,S3S,linear,5.000e-05,5.000e-05,5.000e-05,5.000e-06,5.000e-06
-SSP2EU,EWN,,,,,Domestic Ship,trn_freight,S3S,linear,6.147e-03,6.830e-03,6.147e-03,6.147e-03,6.147e-03
-SSP2EU,EWN,,,,,Freight Rail,trn_freight,S3S,linear,1.246e-02,1.385e-02,1.246e-02,1.246e-02,1.246e-02
+SSP2EU,EWN,,,,,Domestic Aviation,trn_pass,S3S,linear,4.772e-05,4.772e-05,4.772e-05,4.772e-06,4.772e-06
+SSP2EU,EWN,,,,,Domestic Ship,trn_freight,S3S,linear,6.261e-03,6.957e-03,6.261e-03,6.261e-03,6.261e-03
+SSP2EU,EWN,,,,,Freight Rail,trn_freight,S3S,linear,1.270e-02,1.411e-02,1.270e-02,1.270e-02,1.270e-02
 SSP2EU,EWN,,,,,HSR,trn_pass,S3S,linear,1.000e-04,1.000e-04,4.000e-04,2.000e-04,2.000e-04
 SSP2EU,EWN,,,,,International Aviation,trn_aviation_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,EWN,,,,,International Ship,trn_shipping_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,EWN,,,,,Passenger Rail,trn_pass,S3S,linear,2.000e-03,3.000e-03,3.000e-03,2.000e-03,2.000e-03
 SSP2EU,EWN,,,,,Walk,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,EWN,,,,,trn_freight_road,trn_freight,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP2EU,EWN,,,,,trn_pass_road,trn_pass,S3S,linear,6.000e-02,6.000e-02,6.000e-02,3.000e-02,3.000e-02
-SSP2EU,EWN,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,1.000e-01,1.000e-01,1.000e-01,1.500e-01,1.500e-01
+SSP2EU,EWN,,,,,trn_pass_road,trn_pass,S3S,linear,5.891e-02,5.891e-02,5.891e-02,2.945e-02,2.945e-02
+SSP2EU,EWN,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,1.019e-01,1.019e-01,1.019e-01,1.528e-01,1.528e-01
 SSP2EU,EWN,,,,trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,EWN,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,4.166e-02,4.166e-02,4.166e-02,4.166e-02,4.166e-02
 SSP2EU,EWN,,,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP2EU,EWN,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,3.886e-01,3.886e-01,3.886e-01,3.886e-01,3.886e-01
+SSP2EU,EWN,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,4.317e-01,4.317e-01,3.886e-01,3.886e-01,3.886e-01
 SSP2EU,EWN,,Large Car and SUV,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,EWN,,Midsize Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,2.283e-01,2.283e-01,2.283e-01,2.283e-01,2.283e-01
 SSP2EU,EWN,,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.183e-01,1.183e-01,1.183e-01,1.183e-01,1.183e-01
 SSP2EU,EWN,,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,4.339e-02,4.339e-02,4.339e-02,4.339e-02,4.339e-02
 SSP2EU,EWN,,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP2EU,EWN,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,4.377e-01,4.377e-01,4.377e-01,4.377e-01,4.377e-01
+SSP2EU,EWN,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,4.864e-01,4.864e-01,4.377e-01,4.377e-01,4.377e-01
 SSP2EU,EWN,,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,EWN,,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.164e-01,1.164e-01,1.164e-01,1.164e-01,1.164e-01
 SSP2EU,EWN,,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,5.225e-01,5.225e-01,5.225e-01,5.225e-01,5.225e-01
@@ -9097,21 +9097,21 @@ SSP2EU,EWN,,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_
 SSP2EU,EWN,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1.000e-03,6.000e-02,2.450e-01,4.500e-01,4.500e-01
 SSP2EU,EWN,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1.000e-03,6.000e-02,2.450e-01,4.500e-01,4.500e-01
 SSP2EU,EWN,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1.000e-03,6.000e-02,2.450e-01,4.500e-01,4.500e-01
-SSP2EU,EWN,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.958e-02,2.323e-01,4.763e-01,4.763e-01
+SSP2EU,EWN,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,8.794e-02,2.197e-01,5.006e-01,5.006e-01
 SSP2EU,EWN,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,EWN,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,EWN,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP2EU,EWN,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.550e-01,6.500e-01,8.729e-01,8.729e-01
-SSP2EU,EWN,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.165e-02,3.496e-01,8.467e-01,8.467e-01
-SSP2EU,EWN,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.165e-02,3.496e-01,8.467e-01,8.467e-01
-SSP2EU,EWN,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.165e-02,3.496e-01,8.467e-01,8.467e-01
-SSP2EU,EWN,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.550e-01,6.500e-01,8.729e-01,8.729e-01
-SSP2EU,EWN,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.573e-03,6.540e-03,1.667e-02,1.667e-02
-SSP2EU,EWN,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,9.370e-03,4.743e-02,4.061e-02,4.061e-02
-SSP2EU,EWN,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.462e-03,1.799e-02,2.778e-02,2.778e-02
-SSP2EU,EWN,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.462e-03,1.799e-02,2.778e-02,2.778e-02
-SSP2EU,EWN,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.462e-03,1.799e-02,2.778e-02,2.778e-02
-SSP2EU,EWN,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,9.370e-03,4.743e-02,4.061e-02,4.061e-02
+SSP2EU,EWN,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.436e-01,6.405e-01,9.031e-01,9.031e-01
+SSP2EU,EWN,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.367e-01,3.445e-01,8.760e-01,8.760e-01
+SSP2EU,EWN,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.367e-01,3.445e-01,8.760e-01,8.760e-01
+SSP2EU,EWN,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.367e-01,3.445e-01,8.760e-01,8.760e-01
+SSP2EU,EWN,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.436e-01,6.405e-01,9.031e-01,9.031e-01
+SSP2EU,EWN,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.861e-03,7.734e-03,2.190e-02,2.190e-02
+SSP2EU,EWN,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.385e-02,1.059e-01,6.003e-02,6.003e-02
+SSP2EU,EWN,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.116e-03,4.017e-02,4.106e-02,4.106e-02
+SSP2EU,EWN,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.116e-03,4.017e-02,4.106e-02,4.106e-02
+SSP2EU,EWN,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.116e-03,4.017e-02,4.106e-02,4.106e-02
+SSP2EU,EWN,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.385e-02,1.059e-01,6.003e-02,6.003e-02
 SSP2EU,EWN,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0.000e+00,8.315e-07,4.540e-05,1.192e-01,1.192e-01
 SSP2EU,EWN,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,EWN,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
@@ -9128,26 +9128,26 @@ SSP2EU,EWN,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_roa
 SSP2EU,EWN,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,EWN,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,EWN,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP2EU,EWN,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,8.070e-03,3.107e-02,6.282e-02,8.745e-02,8.745e-02
-SSP2EU,EWN,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,8.171e-04,2.711e-02,7.970e-02,1.027e-01,1.027e-01
-SSP2EU,EWN,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.023e-01,1.023e-01
-SSP2EU,EWN,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.023e-01,1.023e-01
-SSP2EU,EWN,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.023e-01,1.023e-01
-SSP2EU,EWN,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.023e-01,1.023e-01
+SSP2EU,EWN,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,8.070e-03,3.107e-02,6.282e-02,9.716e-02,9.716e-02
+SSP2EU,EWN,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,8.171e-04,3.389e-02,8.856e-02,1.284e-01,1.284e-01
+SSP2EU,EWN,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.289e-02,8.772e-02,1.279e-01,1.279e-01
+SSP2EU,EWN,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.289e-02,8.772e-02,1.279e-01,1.279e-01
+SSP2EU,EWN,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.289e-02,8.772e-02,1.279e-01,1.279e-01
+SSP2EU,EWN,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.289e-02,8.772e-02,1.279e-01,1.279e-01
 SSP2EU,FRA,,,,,Cycle,trn_pass,S3S,linear,1.942e-02,2.184e-02,3.641e-02,1.019e-01,1.019e-01
-SSP2EU,FRA,,,,,Domestic Aviation,trn_pass,S3S,linear,1.225e-04,6.891e-05,4.594e-05,2.297e-05,2.297e-05
-SSP2EU,FRA,,,,,Domestic Ship,trn_freight,S3S,linear,3.357e-03,3.357e-03,3.357e-03,3.357e-03,3.357e-03
-SSP2EU,FRA,,,,,Freight Rail,trn_freight,S3S,linear,1.766e-02,1.766e-02,1.766e-02,1.766e-02,1.766e-02
+SSP2EU,FRA,,,,,Domestic Aviation,trn_pass,S3S,linear,1.169e-04,6.577e-05,4.385e-05,2.192e-05,2.192e-05
+SSP2EU,FRA,,,,,Domestic Ship,trn_freight,S3S,linear,3.419e-03,3.419e-03,3.419e-03,3.419e-03,3.419e-03
+SSP2EU,FRA,,,,,Freight Rail,trn_freight,S3S,linear,1.799e-02,1.799e-02,1.799e-02,1.799e-02,1.799e-02
 SSP2EU,FRA,,,,,HSR,trn_pass,S3S,linear,3.359e-04,2.267e-04,2.015e-04,2.015e-04,2.015e-04
 SSP2EU,FRA,,,,,International Aviation,trn_aviation_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,FRA,,,,,International Ship,trn_shipping_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,FRA,,,,,Passenger Rail,trn_pass,S3S,linear,3.972e-03,2.979e-03,1.986e-03,1.986e-03,1.986e-03
 SSP2EU,FRA,,,,,Walk,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,FRA,,,,,trn_freight_road,trn_freight,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP2EU,FRA,,,,,trn_pass_road,trn_pass,S3S,linear,9.224e-02,5.188e-02,3.459e-02,2.767e-02,2.767e-02
-SSP2EU,FRA,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,7.788e-02,8.566e-02,9.345e-02,1.402e-01,1.402e-01
+SSP2EU,FRA,,,,,trn_pass_road,trn_pass,S3S,linear,9.055e-02,5.094e-02,3.396e-02,2.717e-02,2.717e-02
+SSP2EU,FRA,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,7.932e-02,8.726e-02,9.519e-02,1.428e-01,1.428e-01
 SSP2EU,FRA,,,,trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP2EU,FRA,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,9.470e-02,9.470e-02,9.470e-02,9.470e-02,9.470e-02
+SSP2EU,FRA,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,7.285e-02,7.285e-02,7.285e-02,6.764e-02,6.764e-02
 SSP2EU,FRA,,,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,FRA,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,6.352e-01,6.352e-01,6.352e-01,6.352e-01,6.352e-01
 SSP2EU,FRA,,Large Car and SUV,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
@@ -9161,26 +9161,26 @@ SSP2EU,FRA,,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_s
 SSP2EU,FRA,,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.602e-01,1.602e-01,1.602e-01,1.602e-01,1.602e-01
 SSP2EU,FRA,,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,4.011e-01,4.011e-01,4.011e-01,4.011e-01,4.011e-01
 SSP2EU,FRA,,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,3.755e-01,3.755e-01,3.755e-01,3.755e-01,3.755e-01
-SSP2EU,FRA,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP2EU,FRA,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP2EU,FRA,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP2EU,FRA,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.423e-01,4.303e-01,1.000e+00,1.000e+00
+SSP2EU,FRA,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.000e-02,2.400e-01,4.200e-01,4.200e-01
+SSP2EU,FRA,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.000e-02,2.400e-01,4.200e-01,4.200e-01
+SSP2EU,FRA,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.000e-02,2.400e-01,4.200e-01,4.200e-01
+SSP2EU,FRA,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.402e-02,1.682e-01,4.579e-01,9.531e-01,9.531e-01
 SSP2EU,FRA,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,FRA,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,FRA,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP2EU,FRA,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.980e-01,7.500e-01,9.820e-01,9.820e-01
-SSP2EU,FRA,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.186e-01,4.034e-01,9.526e-01,9.526e-01
-SSP2EU,FRA,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.186e-01,4.034e-01,9.526e-01,9.526e-01
-SSP2EU,FRA,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.186e-01,4.034e-01,9.526e-01,9.526e-01
-SSP2EU,FRA,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.980e-01,7.500e-01,9.820e-01,9.820e-01
-SSP2EU,FRA,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.236e-02,1.799e-02,9.544e-02,9.544e-02
-SSP2EU,FRA,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.693e-02,4.743e-02,1.462e-01,1.462e-01
-SSP2EU,FRA,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-02,1.799e-02,1.000e-01,1.000e-01
-SSP2EU,FRA,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-02,1.799e-02,1.000e-01,1.000e-01
-SSP2EU,FRA,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-02,1.799e-02,1.000e-01,1.000e-01
-SSP2EU,FRA,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.693e-02,4.743e-02,1.462e-01,1.462e-01
+SSP2EU,FRA,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.171e-01,6.651e-01,9.087e-01,9.087e-01
+SSP2EU,FRA,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.262e-01,3.578e-01,8.815e-01,8.815e-01
+SSP2EU,FRA,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.262e-01,3.578e-01,8.815e-01,8.815e-01
+SSP2EU,FRA,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.262e-01,3.578e-01,8.815e-01,8.815e-01
+SSP2EU,FRA,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.171e-01,6.651e-01,9.087e-01,9.087e-01
+SSP2EU,FRA,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.218e-02,1.462e-02,2.127e-02,8.186e-02,8.186e-02
+SSP2EU,FRA,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,7.914e-02,2.337e-01,1.503e-01,1.503e-01
+SSP2EU,FRA,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.924e-02,8.861e-02,1.028e-01,1.028e-01
+SSP2EU,FRA,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.924e-02,8.861e-02,1.028e-01,1.028e-01
+SSP2EU,FRA,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.924e-02,8.861e-02,1.028e-01,1.028e-01
+SSP2EU,FRA,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,7.914e-02,2.337e-01,1.503e-01,1.503e-01
 SSP2EU,FRA,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0.000e+00,8.315e-07,4.540e-05,1.192e-01,1.192e-01
-SSP2EU,FRA,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,9.544e-01,9.544e-01
+SSP2EU,FRA,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,FRA,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,FRA,Liquids,Domestic Ship_tmp_vehicletype,Domestic Ship_tmp_subsector_L1,Domestic Ship_tmp_subsector_L2,Domestic Ship,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,FRA,Liquids,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1.608e-01,1.608e-01,1.608e-01,1.608e-01,1.608e-01
@@ -9195,26 +9195,26 @@ SSP2EU,FRA,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_roa
 SSP2EU,FRA,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,FRA,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,FRA,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP2EU,FRA,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.758e-01,1.758e-01
-SSP2EU,FRA,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SSP2EU,FRA,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SSP2EU,FRA,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SSP2EU,FRA,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SSP2EU,FRA,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SSP2EU,IND,,,,,Cycle,trn_pass,S3S,linear,2.632e-03,4.364e-03,9.091e-03,1.000e-01,1.000e-01
-SSP2EU,IND,,,,,Domestic Aviation,trn_pass,S3S,linear,9.589e-02,1.091e-01,1.000e-01,2.000e-01,2.000e-01
-SSP2EU,IND,,,,,Domestic Ship,trn_freight,S3S,linear,1.180e-03,1.180e-03,1.073e-03,9.075e-04,9.075e-04
-SSP2EU,IND,,,,,Freight Rail,trn_freight,S3S,linear,1.889e-01,1.889e-01,1.717e-01,1.453e-01,1.453e-01
-SSP2EU,IND,,,,,HSR,trn_pass,S3S,linear,0.000e+00,4.364e-05,1.000e-04,3.000e-04,3.000e-04
+SSP2EU,FRA,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.535e-02,2.632e-02,7.895e-02,1.417e-01,1.417e-01
+SSP2EU,FRA,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,6.579e-02,1.602e-01,1.602e-01
+SSP2EU,FRA,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,6.579e-02,1.602e-01,1.602e-01
+SSP2EU,FRA,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,6.579e-02,1.602e-01,1.602e-01
+SSP2EU,FRA,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,6.579e-02,1.602e-01,1.602e-01
+SSP2EU,FRA,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,6.579e-02,1.602e-01,1.602e-01
+SSP2EU,IND,,,,,Cycle,trn_pass,S3S,linear,1.915e-02,3.175e-02,4.630e-02,1.000e-01,1.000e-01
+SSP2EU,IND,,,,,Domestic Aviation,trn_pass,S3S,linear,6.659e-01,7.575e-01,4.861e-01,1.909e-01,1.909e-01
+SSP2EU,IND,,,,,Domestic Ship,trn_freight,S3S,linear,1.202e-03,1.202e-03,1.092e-03,9.244e-04,9.244e-04
+SSP2EU,IND,,,,,Freight Rail,trn_freight,S3S,linear,1.924e-01,1.924e-01,1.574e-01,1.332e-01,1.332e-01
+SSP2EU,IND,,,,,HSR,trn_pass,S3S,linear,0.000e+00,3.175e-04,5.093e-04,3.000e-04,3.000e-04
 SSP2EU,IND,,,,,International Aviation,trn_aviation_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,IND,,,,,International Ship,trn_shipping_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP2EU,IND,,,,,Passenger Rail,trn_pass,S3S,linear,6.842e-04,8.000e-04,1.091e-03,4.000e-03,4.000e-03
-SSP2EU,IND,,,,,Walk,trn_pass,S3S,linear,1.316e-01,9.455e-02,1.818e-01,1.000e+00,1.000e+00
+SSP2EU,IND,,,,,Passenger Rail,trn_pass,S3S,linear,4.978e-03,5.820e-03,5.556e-03,4.000e-03,4.000e-03
+SSP2EU,IND,,,,,Walk,trn_pass,S3S,linear,9.573e-01,6.879e-01,9.260e-01,1.000e+00,1.000e+00
 SSP2EU,IND,,,,,trn_freight_road,trn_freight,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP2EU,IND,,,,,trn_pass_road,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP2EU,IND,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,1.188e-01,7.143e-02,3.231e-02,3.231e-02,3.231e-02
-SSP2EU,IND,,,,trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP2EU,IND,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,3.027e-03,2.668e-03,1.949e-03,5.108e-04,5.108e-04
+SSP2EU,IND,,,,,trn_pass_road,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,2.945e-01,2.945e-01
+SSP2EU,IND,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,1.000e+00,3.638e-01,1.645e-01,9.872e-02,9.872e-02
+SSP2EU,IND,,,,trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,9.180e-01,1.000e+00,1.000e+00,1.000e+00,1.000e+00
+SSP2EU,IND,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.816e-02,1.867e-02,2.923e-02,5.108e-02,5.108e-02
 SSP2EU,IND,,,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,IND,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,IND,,Mini Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,6.374e-03,6.374e-03,6.374e-03,6.374e-03,6.374e-03
@@ -9225,24 +9225,24 @@ SSP2EU,IND,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,
 SSP2EU,IND,,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.853e-01,1.853e-01,1.853e-01,1.853e-01,1.853e-01
 SSP2EU,IND,,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.987e-01,1.987e-01,1.987e-01,1.987e-01,1.987e-01
 SSP2EU,IND,,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP2EU,IND,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP2EU,IND,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP2EU,IND,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP2EU,IND,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.743e-02,2.689e-01,7.621e-01,7.621e-01
+SSP2EU,IND,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.000e-01,3.600e-01,3.780e-01,3.780e-01
+SSP2EU,IND,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.000e-01,3.600e-01,3.780e-01,3.780e-01
+SSP2EU,IND,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.000e-01,3.600e-01,3.780e-01,3.780e-01
+SSP2EU,IND,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,5.175e-02,2.935e-01,6.653e-01,6.653e-01
 SSP2EU,IND,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,IND,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,IND,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,8.340e-01,8.547e-01,8.962e-01,9.792e-01,9.792e-01
-SSP2EU,IND,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.576e-02,1.000e-01,9.820e-02,9.820e-02
-SSP2EU,IND,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.423e-02,5.379e-02,9.526e-02,9.526e-02
-SSP2EU,IND,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,3.000e-01,2.000e-01,1.000e-01,1.000e-01
-SSP2EU,IND,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,3.000e-01,2.000e-01,1.000e-01,1.000e-01
-SSP2EU,IND,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.576e-02,1.000e-01,9.820e-02,9.820e-02
-SSP2EU,IND,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.473e-03,1.799e-02,5.000e-02,5.000e-02
-SSP2EU,IND,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.693e-03,9.485e-03,1.462e-02,1.462e-02
-SSP2EU,IND,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-03,3.597e-03,1.000e-02,1.000e-02
-SSP2EU,IND,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,2.000e-01,2.000e-02,2.000e-02
-SSP2EU,IND,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,2.000e-01,2.000e-02,2.000e-02
-SSP2EU,IND,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.693e-03,9.485e-03,1.462e-02,1.462e-02
+SSP2EU,IND,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.787e-02,6.365e-02,6.430e-02,6.430e-02
+SSP2EU,IND,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.109e-02,3.424e-02,6.237e-02,6.237e-02
+SSP2EU,IND,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,2.338e-01,1.273e-01,6.547e-02,6.547e-02
+SSP2EU,IND,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,2.338e-01,1.273e-01,6.547e-02,6.547e-02
+SSP2EU,IND,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.787e-02,6.365e-02,6.430e-02,6.430e-02
+SSP2EU,IND,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.698e-03,1.963e-02,5.456e-02,5.456e-02
+SSP2EU,IND,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.217e-03,8.625e-03,1.595e-03,1.595e-03
+SSP2EU,IND,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.927e-03,3.271e-03,1.091e-03,1.091e-03
+SSP2EU,IND,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,7.794e-01,1.819e-01,2.182e-03,2.182e-03
+SSP2EU,IND,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,7.794e-01,1.819e-01,2.182e-03,2.182e-03
+SSP2EU,IND,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.217e-03,8.625e-03,1.595e-03,1.595e-03
 SSP2EU,IND,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0.000e+00,8.315e-07,4.540e-05,1.192e-01,1.192e-01
 SSP2EU,IND,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,IND,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
@@ -9256,27 +9256,27 @@ SSP2EU,IND,Liquids,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,tr
 SSP2EU,IND,Liquids,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,IND,Liquids,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,IND,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP2EU,IND,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP2EU,IND,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
+SSP2EU,IND,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,9.164e-01,1.000e+00,1.000e+00,1.000e+00,1.000e+00
+SSP2EU,IND,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,9.164e-01,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,IND,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,IND,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,2.408e-01,2.086e-01,2.105e-01,1.903e-01,1.903e-01
-SSP2EU,IND,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,8.768e-02,1.117e-01,7.985e-02,2.557e-02,2.557e-02
-SSP2EU,IND,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,3.947e-02,1.842e-02,1.842e-02
-SSP2EU,IND,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,5.000e-01,1.000e-01,1.000e-01
-SSP2EU,IND,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,5.000e-01,1.000e-01,1.000e-01
-SSP2EU,IND,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,3.947e-02,1.842e-02,1.842e-02
+SSP2EU,IND,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,8.768e-02,7.978e-02,6.655e-02,2.557e-02,2.557e-02
+SSP2EU,IND,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.880e-02,3.289e-02,1.842e-02,1.842e-02
+SSP2EU,IND,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,9.164e-01,7.143e-01,4.167e-01,1.000e-01,1.000e-01
+SSP2EU,IND,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,9.164e-01,7.143e-01,4.167e-01,1.000e-01,1.000e-01
+SSP2EU,IND,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.880e-02,3.289e-02,1.842e-02,1.842e-02
 SSP2EU,JPN,,,,,Cycle,trn_pass,S3S,linear,1.743e-02,1.743e-02,3.486e-02,1.961e-02,1.961e-02
-SSP2EU,JPN,,,,,Domestic Aviation,trn_pass,S3S,linear,1.811e-04,2.174e-04,3.261e-04,9.170e-05,9.170e-05
-SSP2EU,JPN,,,,,Domestic Ship,trn_freight,S3S,linear,1.146e-02,1.146e-02,1.146e-02,1.146e-02,1.146e-02
-SSP2EU,JPN,,,,,Freight Rail,trn_freight,S3S,linear,2.781e-03,2.781e-03,2.781e-03,2.781e-03,2.781e-03
+SSP2EU,JPN,,,,,Domestic Aviation,trn_pass,S3S,linear,1.729e-04,2.075e-04,3.112e-04,8.752e-05,8.752e-05
+SSP2EU,JPN,,,,,Domestic Ship,trn_freight,S3S,linear,1.167e-02,1.111e-02,1.167e-02,1.167e-02,1.167e-02
+SSP2EU,JPN,,,,,Freight Rail,trn_freight,S3S,linear,2.833e-03,2.698e-03,2.833e-03,2.833e-03,2.833e-03
 SSP2EU,JPN,,,,,HSR,trn_pass,S3S,linear,4.081e-04,4.081e-04,4.591e-04,1.291e-04,1.291e-04
 SSP2EU,JPN,,,,,International Aviation,trn_aviation_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,JPN,,,,,International Ship,trn_shipping_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,JPN,,,,,Passenger Rail,trn_pass,S3S,linear,6.084e-03,6.084e-03,7.000e-03,2.281e-03,2.281e-03
 SSP2EU,JPN,,,,,Walk,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,JPN,,,,,trn_freight_road,trn_freight,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP2EU,JPN,,,,,trn_pass_road,trn_pass,S3S,linear,7.245e-02,7.770e-02,7.770e-02,2.185e-02,2.185e-02
-SSP2EU,JPN,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,5.971e-02,5.971e-02,5.971e-02,5.971e-02,5.971e-02
+SSP2EU,JPN,,,,,trn_pass_road,trn_pass,S3S,linear,7.113e-02,7.629e-02,7.629e-02,2.146e-02,2.146e-02
+SSP2EU,JPN,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,6.081e-02,6.081e-02,6.081e-02,6.081e-02,6.081e-02
 SSP2EU,JPN,,,,trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,JPN,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,5.491e-02,5.491e-02,5.491e-02,5.491e-02,5.491e-02
 SSP2EU,JPN,,,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
@@ -9289,24 +9289,24 @@ SSP2EU,JPN,,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_
 SSP2EU,JPN,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.286e-01,1.286e-01,1.286e-01,1.286e-01,1.286e-01
 SSP2EU,JPN,,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,JPN,,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,5.896e-01,5.896e-01,5.896e-01,5.896e-01,5.896e-01
-SSP2EU,JPN,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP2EU,JPN,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP2EU,JPN,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP2EU,JPN,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.091e-01,1.793e-01,3.810e-01,3.810e-01
+SSP2EU,JPN,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.600e-01,5.280e-01,1.000e+00,1.000e+00
+SSP2EU,JPN,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.600e-01,5.280e-01,1.000e+00,1.000e+00
+SSP2EU,JPN,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.600e-01,5.280e-01,1.000e+00,1.000e+00
+SSP2EU,JPN,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,9.673e-02,1.794e-01,3.754e-01,3.754e-01
 SSP2EU,JPN,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,JPN,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,JPN,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP2EU,JPN,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.252e-01,3.529e-01,8.183e-01,8.183e-01
-SSP2EU,JPN,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,6.364e-02,1.333e-01,8.333e-01,8.333e-01
-SSP2EU,JPN,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,6.364e-02,1.333e-01,8.333e-01,8.333e-01
-SSP2EU,JPN,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,6.364e-02,1.333e-01,8.333e-01,8.333e-01
-SSP2EU,JPN,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.252e-01,3.529e-01,8.183e-01,8.183e-01
-SSP2EU,JPN,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,6.182e-02,1.319e-01,1.000e-01,1.000e-01
-SSP2EU,JPN,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.104e-01,2.511e-01,3.046e-01,3.046e-01
-SSP2EU,JPN,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,4.167e-01,4.167e-01
-SSP2EU,JPN,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,4.167e-01,4.167e-01
-SSP2EU,JPN,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,4.167e-01,4.167e-01
-SSP2EU,JPN,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.104e-01,2.511e-01,3.046e-01,3.046e-01
+SSP2EU,JPN,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.332e-01,3.414e-01,8.870e-01,8.870e-01
+SSP2EU,JPN,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,5.727e-02,1.200e-01,9.032e-01,9.032e-01
+SSP2EU,JPN,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,5.727e-02,1.200e-01,9.032e-01,9.032e-01
+SSP2EU,JPN,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,5.727e-02,1.200e-01,9.032e-01,9.032e-01
+SSP2EU,JPN,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.332e-01,3.414e-01,8.870e-01,8.870e-01
+SSP2EU,JPN,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,6.091e-02,1.200e-01,9.854e-02,9.854e-02
+SSP2EU,JPN,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.306e-01,2.699e-01,2.701e-01,2.701e-01
+SSP2EU,JPN,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,3.695e-01,3.695e-01
+SSP2EU,JPN,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,3.695e-01,3.695e-01
+SSP2EU,JPN,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,3.695e-01,3.695e-01
+SSP2EU,JPN,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.306e-01,2.699e-01,2.701e-01,2.701e-01
 SSP2EU,JPN,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0.000e+00,8.315e-07,4.540e-05,1.192e-01,1.192e-01
 SSP2EU,JPN,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,JPN,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
@@ -9314,41 +9314,41 @@ SSP2EU,JPN,Liquids,Domestic Ship_tmp_vehicletype,Domestic Ship_tmp_subsector_L1,
 SSP2EU,JPN,Liquids,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,8.837e-01,8.837e-01,8.837e-01,8.837e-01,8.837e-01
 SSP2EU,JPN,Liquids,International Aviation_tmp_vehicletype,International Aviation_tmp_subsector_L1,International Aviation_tmp_subsector_L2,International Aviation,trn_aviation_intl,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,JPN,Liquids,International Ship_tmp_vehicletype,International Ship_tmp_subsector_L1,International Ship_tmp_subsector_L2,International Ship,trn_shipping_intl,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP2EU,JPN,Liquids,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP2EU,JPN,Liquids,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP2EU,JPN,Liquids,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
+SSP2EU,JPN,Liquids,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,9.921e-01,9.921e-01
+SSP2EU,JPN,Liquids,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,9.921e-01,9.921e-01
+SSP2EU,JPN,Liquids,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,9.921e-01,9.921e-01
 SSP2EU,JPN,Liquids,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,3.433e-02,3.433e-02,3.433e-02,3.433e-02,3.433e-02
 SSP2EU,JPN,Liquids,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP2EU,JPN,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,6.061e-02,1.889e-01,1.000e+00,1.000e+00
-SSP2EU,JPN,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,6.061e-02,1.889e-01,1.000e+00,1.000e+00
-SSP2EU,JPN,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,6.061e-02,1.889e-01,1.000e+00,1.000e+00
+SSP2EU,JPN,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,8.457e-01,5.126e-02,1.757e-01,1.000e+00,1.000e+00
+SSP2EU,JPN,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,8.457e-01,5.126e-02,1.757e-01,1.000e+00,1.000e+00
+SSP2EU,JPN,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,8.457e-01,5.126e-02,1.757e-01,1.000e+00,1.000e+00
 SSP2EU,JPN,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP2EU,JPN,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,7.895e-03,1.579e-02,2.303e-02,2.303e-02
-SSP2EU,JPN,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.316e-02,4.644e-02,4.605e-02,4.605e-02
-SSP2EU,JPN,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,3.030e-02,1.111e-01,2.500e-01,2.500e-01
-SSP2EU,JPN,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,3.030e-02,1.111e-01,2.500e-01,2.500e-01
-SSP2EU,JPN,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,3.030e-02,1.111e-01,2.500e-01,2.500e-01
-SSP2EU,JPN,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.316e-02,4.644e-02,4.605e-02,4.605e-02
-SSP2EU,LAM,,,,,Cycle,trn_pass,S3S,linear,9.812e-03,1.852e-02,4.629e-02,2.315e-01,2.315e-01
-SSP2EU,LAM,,,,,Domestic Aviation,trn_pass,S3S,linear,8.407e-03,1.058e-02,2.644e-02,1.983e-02,1.983e-02
-SSP2EU,LAM,,,,,Domestic Ship,trn_freight,S3S,linear,9.523e-03,9.523e-03,8.658e-03,7.936e-03,7.936e-03
-SSP2EU,LAM,,,,,Freight Rail,trn_freight,S3S,linear,4.694e-02,4.694e-02,4.268e-02,3.912e-02,3.912e-02
-SSP2EU,LAM,,,,,HSR,trn_pass,S3S,linear,4.709e-03,2.465e-01,2.465e-01,2.465e-01,2.465e-01
+SSP2EU,JPN,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,6.579e-03,1.215e-02,1.919e-02,1.919e-02
+SSP2EU,JPN,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.316e-02,4.222e-02,3.838e-02,3.838e-02
+SSP2EU,JPN,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,8.457e-01,2.563e-02,9.397e-02,2.083e-01,2.083e-01
+SSP2EU,JPN,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,8.457e-01,2.563e-02,9.397e-02,2.083e-01,2.083e-01
+SSP2EU,JPN,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,8.457e-01,2.563e-02,9.397e-02,2.083e-01,2.083e-01
+SSP2EU,JPN,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.316e-02,4.222e-02,3.838e-02,3.838e-02
+SSP2EU,LAM,,,,,Cycle,trn_pass,S3S,linear,1.091e-02,2.182e-02,5.455e-02,2.728e-01,2.728e-01
+SSP2EU,LAM,,,,,Domestic Aviation,trn_pass,S3S,linear,8.921e-03,1.190e-02,2.974e-02,2.230e-02,2.230e-02
+SSP2EU,LAM,,,,,Domestic Ship,trn_freight,S3S,linear,9.700e-03,9.700e-03,8.908e-03,6.736e-03,6.736e-03
+SSP2EU,LAM,,,,,Freight Rail,trn_freight,S3S,linear,4.782e-02,4.782e-02,4.391e-02,3.985e-02,3.985e-02
+SSP2EU,LAM,,,,,HSR,trn_pass,S3S,linear,5.236e-03,2.905e-01,2.905e-01,2.905e-01,2.905e-01
 SSP2EU,LAM,,,,,International Aviation,trn_aviation_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,LAM,,,,,International Ship,trn_shipping_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP2EU,LAM,,,,,Passenger Rail,trn_pass,S3S,linear,1.348e-01,1.272e-01,1.272e-01,8.482e-02,8.482e-02
-SSP2EU,LAM,,,,,Walk,trn_pass,S3S,linear,8.993e-01,8.486e-01,8.486e-01,8.486e-01,8.486e-01
+SSP2EU,LAM,,,,,Passenger Rail,trn_pass,S3S,linear,1.499e-01,1.499e-01,1.499e-01,9.996e-02,9.996e-02
+SSP2EU,LAM,,,,,Walk,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,LAM,,,,,trn_freight_road,trn_freight,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP2EU,LAM,,,,,trn_pass_road,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP2EU,LAM,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,1.732e-01,1.083e-01,8.662e-02,8.662e-02,8.662e-02
+SSP2EU,LAM,,,,,trn_pass_road,trn_pass,S3S,linear,6.550e-01,6.942e-01,6.942e-01,8.099e-01,8.099e-01
+SSP2EU,LAM,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,2.647e-01,1.654e-01,1.323e-01,1.323e-01,1.323e-01
 SSP2EU,LAM,,,,trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,LAM,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.377e-01,1.377e-01,1.377e-01,1.377e-01,1.377e-01
 SSP2EU,LAM,,,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,LAM,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP2EU,LAM,,Large Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,5.465e-02,5.465e-02,5.465e-02,5.465e-02,5.465e-02
-SSP2EU,LAM,,Large Car and SUV,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,6.039e-01,6.039e-01,6.039e-01,6.039e-01,6.039e-01
-SSP2EU,LAM,,Light Truck and SUV,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,2.182e-01,2.182e-01,2.182e-01,2.182e-01,2.182e-01
-SSP2EU,LAM,,Midsize Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,7.979e-02,7.979e-02,7.979e-02,7.979e-02,7.979e-02
+SSP2EU,LAM,,Large Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,3.279e-02,3.935e-02,4.099e-02,4.372e-02,4.372e-02
+SSP2EU,LAM,,Large Car and SUV,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,3.624e-01,4.348e-01,4.529e-01,4.831e-01,4.831e-01
+SSP2EU,LAM,,Light Truck and SUV,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.309e-01,1.571e-01,1.636e-01,1.745e-01,1.745e-01
+SSP2EU,LAM,,Midsize Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,4.788e-02,5.745e-02,5.984e-02,6.383e-02,6.383e-02
 SSP2EU,LAM,,Mini Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.226e-02,1.226e-02,1.226e-02,1.226e-02,1.226e-02
 SSP2EU,LAM,,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,4.580e-04,4.580e-04,4.580e-04,4.580e-04,4.580e-04
 SSP2EU,LAM,,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
@@ -9359,27 +9359,27 @@ SSP2EU,LAM,,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_s
 SSP2EU,LAM,,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,LAM,,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,5.079e-04,5.079e-04,5.079e-04,5.079e-04,5.079e-04
 SSP2EU,LAM,,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.892e-01,1.892e-01,1.892e-01,1.892e-01,1.892e-01
-SSP2EU,LAM,,Van,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,2.455e-03,2.455e-03,2.455e-03,2.455e-03,2.455e-03
-SSP2EU,LAM,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP2EU,LAM,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP2EU,LAM,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP2EU,LAM,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.186e-01,5.379e-01,1.000e+00,1.000e+00
+SSP2EU,LAM,,Van,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.473e-03,1.768e-03,1.842e-03,1.964e-03,1.964e-03
+SSP2EU,LAM,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,5.600e-02,2.160e-01,5.040e-01,5.040e-01
+SSP2EU,LAM,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,5.600e-02,2.160e-01,5.040e-01,5.040e-01
+SSP2EU,LAM,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,5.600e-02,2.160e-01,5.040e-01,5.040e-01
+SSP2EU,LAM,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.294e-01,5.869e-01,1.000e+00,1.000e+00
 SSP2EU,LAM,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,6.810e-02,1.846e-01,4.176e-01,8.835e-01,8.835e-01
 SSP2EU,LAM,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,LAM,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP2EU,LAM,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,7.947e-02,2.000e-01,2.400e-01,2.400e-01
-SSP2EU,LAM,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.162e-02,1.076e-01,2.329e-01,2.329e-01
-SSP2EU,LAM,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.162e-02,1.076e-01,2.329e-01,2.329e-01
-SSP2EU,LAM,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.162e-02,1.076e-01,2.329e-01,2.329e-01
-SSP2EU,LAM,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,7.947e-02,2.000e-01,2.400e-01,2.400e-01
-SSP2EU,LAM,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.473e-03,1.799e-02,6.561e-02,6.561e-02
-SSP2EU,LAM,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,8.924e-03,5.691e-02,8.123e-02,8.123e-02
-SSP2EU,LAM,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.297e-03,2.158e-02,5.556e-02,5.556e-02
-SSP2EU,LAM,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.297e-03,2.158e-02,5.556e-02,5.556e-02
-SSP2EU,LAM,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.297e-03,2.158e-02,5.556e-02,5.556e-02
-SSP2EU,LAM,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,8.924e-03,5.691e-02,8.123e-02,8.123e-02
+SSP2EU,LAM,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.041e-01,1.964e-01,2.357e-01,2.357e-01
+SSP2EU,LAM,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.140e-02,1.057e-01,2.287e-01,2.287e-01
+SSP2EU,LAM,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.140e-02,1.057e-01,2.287e-01,2.287e-01
+SSP2EU,LAM,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.140e-02,1.057e-01,2.287e-01,2.287e-01
+SSP2EU,LAM,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.041e-01,1.964e-01,2.357e-01,2.357e-01
+SSP2EU,LAM,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.698e-03,1.963e-02,6.561e-02,6.561e-02
+SSP2EU,LAM,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,9.738e-03,6.210e-02,8.864e-02,8.864e-02
+SSP2EU,LAM,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.598e-03,2.355e-02,6.062e-02,6.062e-02
+SSP2EU,LAM,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.598e-03,2.355e-02,6.062e-02,6.062e-02
+SSP2EU,LAM,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.598e-03,2.355e-02,6.062e-02,6.062e-02
+SSP2EU,LAM,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,9.738e-03,6.210e-02,8.864e-02,8.864e-02
 SSP2EU,LAM,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0.000e+00,8.315e-07,4.540e-05,1.192e-01,1.192e-01
-SSP2EU,LAM,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,7.217e-01,7.217e-01
+SSP2EU,LAM,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,7.275e-01,7.275e-01
 SSP2EU,LAM,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,LAM,Liquids,Domestic Ship_tmp_vehicletype,Domestic Ship_tmp_subsector_L1,Domestic Ship_tmp_subsector_L2,Domestic Ship,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,LAM,Liquids,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
@@ -9394,55 +9394,55 @@ SSP2EU,LAM,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_roa
 SSP2EU,LAM,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,LAM,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,LAM,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP2EU,LAM,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,2.689e-02,4.725e-02,1.037e-01,1.353e-01,1.353e-01
+SSP2EU,LAM,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,2.689e-02,4.725e-02,1.037e-01,1.240e-01,1.240e-01
 SSP2EU,LAM,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.754e-02,3.158e-02,6.140e-02,6.140e-02
 SSP2EU,LAM,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.754e-02,3.158e-02,6.140e-02,6.140e-02
 SSP2EU,LAM,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.754e-02,3.158e-02,6.140e-02,6.140e-02
 SSP2EU,LAM,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.754e-02,3.158e-02,6.140e-02,6.140e-02
 SSP2EU,LAM,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.754e-02,3.158e-02,6.140e-02,6.140e-02
 SSP2EU,MEA,,,,,Cycle,trn_pass,S3S,linear,1.660e-02,1.660e-02,1.660e-02,4.149e-02,4.149e-02
-SSP2EU,MEA,,,,,Domestic Aviation,trn_pass,S3S,linear,8.929e-03,5.953e-03,1.786e-02,2.381e-02,2.381e-02
-SSP2EU,MEA,,,,,Domestic Ship,trn_freight,S3S,linear,2.022e-03,2.022e-03,2.022e-03,2.022e-03,2.022e-03
-SSP2EU,MEA,,,,,Freight Rail,trn_freight,S3S,linear,3.143e-03,3.143e-03,3.143e-03,3.143e-03,3.143e-03
+SSP2EU,MEA,,,,,Domestic Aviation,trn_pass,S3S,linear,8.522e-03,5.681e-03,1.704e-02,2.500e-02,2.500e-02
+SSP2EU,MEA,,,,,Domestic Ship,trn_freight,S3S,linear,2.060e-03,2.060e-03,2.060e-03,2.060e-03,2.060e-03
+SSP2EU,MEA,,,,,Freight Rail,trn_freight,S3S,linear,3.202e-03,3.202e-03,3.202e-03,3.202e-03,3.202e-03
 SSP2EU,MEA,,,,,HSR,trn_pass,S3S,linear,0.000e+00,1.667e-02,1.667e-02,1.667e-02,1.667e-02
 SSP2EU,MEA,,,,,International Aviation,trn_aviation_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,MEA,,,,,International Ship,trn_shipping_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,MEA,,,,,Passenger Rail,trn_pass,S3S,linear,5.567e-04,1.113e-03,1.113e-03,1.856e-03,1.856e-03
 SSP2EU,MEA,,,,,Walk,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,MEA,,,,,trn_freight_road,trn_freight,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP2EU,MEA,,,,,trn_pass_road,trn_pass,S3S,linear,6.395e-01,7.197e-01,7.197e-01,7.197e-01,7.197e-01
-SSP2EU,MEA,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,2.627e-01,1.226e-01,6.131e-02,4.905e-02,4.905e-02
+SSP2EU,MEA,,,,,trn_pass_road,trn_pass,S3S,linear,3.767e-01,4.239e-01,3.815e-01,3.815e-01,3.815e-01
+SSP2EU,MEA,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,2.676e-01,1.873e-01,9.367e-02,7.493e-02,7.493e-02
 SSP2EU,MEA,,,,trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP2EU,MEA,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,7.508e-03,7.508e-03,7.508e-03,7.508e-03,7.508e-03
+SSP2EU,MEA,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.502e-02,1.502e-02,1.502e-02,1.502e-02,1.502e-02
 SSP2EU,MEA,,,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP2EU,MEA,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,4.732e-01,4.732e-01,4.732e-01,4.732e-01,4.732e-01
+SSP2EU,MEA,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,5.257e-01,4.732e-01,4.337e-01,3.943e-01,3.943e-01
 SSP2EU,MEA,,Large Car and SUV,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP2EU,MEA,,Mini Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,3.955e-02,3.955e-02,3.955e-02,3.955e-02,3.955e-02
+SSP2EU,MEA,,Mini Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,4.395e-02,3.955e-02,3.626e-02,3.296e-02,3.296e-02
 SSP2EU,MEA,,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,MEA,,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,MEA,,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP2EU,MEA,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.864e-01,1.864e-01,1.864e-01,1.864e-01,1.864e-01
+SSP2EU,MEA,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,2.071e-01,1.864e-01,1.709e-01,1.553e-01,1.553e-01
 SSP2EU,MEA,,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.304e-01,1.304e-01,1.304e-01,1.304e-01,1.304e-01
 SSP2EU,MEA,,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,2.013e-01,2.013e-01,2.013e-01,2.013e-01,2.013e-01
 SSP2EU,MEA,,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP2EU,MEA,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP2EU,MEA,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP2EU,MEA,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP2EU,MEA,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.743e-02,2.958e-01,6.549e-01,6.549e-01
+SSP2EU,MEA,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.200e-01,2.160e-01,2.100e-01,2.100e-01
+SSP2EU,MEA,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.200e-01,2.160e-01,2.100e-01,2.100e-01
+SSP2EU,MEA,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.200e-01,2.160e-01,2.100e-01,2.100e-01
+SSP2EU,MEA,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,5.175e-02,2.935e-01,6.497e-01,6.497e-01
 SSP2EU,MEA,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,4.021e-01,4.768e-01,6.263e-01,9.253e-01,9.253e-01
 SSP2EU,MEA,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,MEA,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP2EU,MEA,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.960e-02,1.000e-01,1.403e-01,1.403e-01
-SSP2EU,MEA,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.371e-02,5.379e-02,1.361e-01,1.361e-01
-SSP2EU,MEA,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.429e-01,2.000e-01,1.429e-01,1.429e-01
-SSP2EU,MEA,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.429e-01,2.000e-01,1.429e-01,1.429e-01
-SSP2EU,MEA,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.960e-02,1.000e-01,1.403e-01,1.403e-01
-SSP2EU,MEA,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.473e-03,1.799e-02,6.250e-02,6.250e-02
-SSP2EU,MEA,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.346e-03,9.485e-03,4.177e-02,4.177e-02
-SSP2EU,MEA,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.236e-03,3.597e-03,2.857e-02,2.857e-02
-SSP2EU,MEA,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.429e-01,2.000e-01,5.714e-02,5.714e-02
-SSP2EU,MEA,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.429e-01,2.000e-01,5.714e-02,5.714e-02
-SSP2EU,MEA,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.346e-03,9.485e-03,4.177e-02,4.177e-02
+SSP2EU,MEA,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.504e-02,1.091e-01,1.392e-01,1.392e-01
+SSP2EU,MEA,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.588e-02,5.869e-02,1.350e-01,1.350e-01
+SSP2EU,MEA,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.559e-01,2.182e-01,1.417e-01,1.417e-01
+SSP2EU,MEA,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.559e-01,2.182e-01,1.417e-01,1.417e-01
+SSP2EU,MEA,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.504e-02,1.091e-01,1.392e-01,1.392e-01
+SSP2EU,MEA,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.698e-03,1.784e-02,5.580e-02,5.580e-02
+SSP2EU,MEA,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.652e-03,1.035e-02,4.144e-04,4.144e-04
+SSP2EU,MEA,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.349e-03,3.925e-03,2.834e-04,2.834e-04
+SSP2EU,MEA,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.559e-01,2.182e-01,5.669e-04,5.669e-04
+SSP2EU,MEA,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.559e-01,2.182e-01,5.669e-04,5.669e-04
+SSP2EU,MEA,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.652e-03,1.035e-02,4.144e-04,4.144e-04
 SSP2EU,MEA,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0.000e+00,8.315e-07,4.540e-05,1.192e-01,1.192e-01
 SSP2EU,MEA,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,MEA,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
@@ -9456,27 +9456,27 @@ SSP2EU,MEA,Liquids,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,tr
 SSP2EU,MEA,Liquids,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,7.852e-02,7.852e-02,7.852e-02,7.852e-02,7.852e-02
 SSP2EU,MEA,Liquids,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,MEA,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP2EU,MEA,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,2.857e-01,1.000e+00,1.000e+00,1.000e+00
-SSP2EU,MEA,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,2.857e-01,1.000e+00,1.000e+00,1.000e+00
+SSP2EU,MEA,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,9.164e-01,2.857e-01,1.000e+00,1.000e+00,1.000e+00
+SSP2EU,MEA,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,9.164e-01,2.857e-01,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,MEA,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP2EU,MEA,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.342e-02,3.938e-02,9.130e-02,1.220e-01,1.220e-01
-SSP2EU,MEA,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,9.283e-04,9.527e-02,4.788e-02,5.285e-02,5.285e-02
-SSP2EU,MEA,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,9.211e-02,4.737e-02,5.263e-02,5.263e-02
-SSP2EU,MEA,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,6.000e-01,2.857e-01,2.857e-01
-SSP2EU,MEA,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,6.000e-01,2.857e-01,2.857e-01
-SSP2EU,MEA,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,9.211e-02,4.737e-02,5.263e-02,5.263e-02
+SSP2EU,MEA,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.342e-02,3.938e-02,8.300e-02,1.109e-01,1.109e-01
+SSP2EU,MEA,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,9.283e-04,9.527e-02,4.788e-02,4.804e-02,4.804e-02
+SSP2EU,MEA,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,9.211e-02,4.737e-02,4.785e-02,4.785e-02
+SSP2EU,MEA,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,9.164e-01,1.000e+00,6.000e-01,2.597e-01,2.597e-01
+SSP2EU,MEA,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,9.164e-01,1.000e+00,6.000e-01,2.597e-01,2.597e-01
+SSP2EU,MEA,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,9.211e-02,4.737e-02,4.785e-02,4.785e-02
 SSP2EU,NEN,,,,,Cycle,trn_pass,S3S,linear,3.033e-03,3.024e-03,2.621e-03,1.820e-02,1.820e-02
-SSP2EU,NEN,,,,,Domestic Aviation,trn_pass,S3S,linear,7.555e-06,7.895e-06,2.566e-06,1.497e-06,1.497e-06
-SSP2EU,NEN,,,,,Domestic Ship,trn_freight,S3S,linear,3.117e-02,3.117e-02,3.117e-02,3.117e-02,3.117e-02
-SSP2EU,NEN,,,,,Freight Rail,trn_freight,S3S,linear,1.890e-02,1.890e-02,1.890e-02,1.890e-02,1.890e-02
+SSP2EU,NEN,,,,,Domestic Aviation,trn_pass,S3S,linear,7.210e-06,7.535e-06,2.449e-06,1.428e-06,1.428e-06
+SSP2EU,NEN,,,,,Domestic Ship,trn_freight,S3S,linear,3.175e-02,3.175e-02,3.175e-02,3.175e-02,3.175e-02
+SSP2EU,NEN,,,,,Freight Rail,trn_freight,S3S,linear,1.925e-02,1.925e-02,1.925e-02,1.925e-02,1.925e-02
 SSP2EU,NEN,,,,,HSR,trn_pass,S3S,linear,2.000e-05,4.532e-05,7.364e-06,5.523e-06,5.523e-06
 SSP2EU,NEN,,,,,International Aviation,trn_aviation_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,NEN,,,,,International Ship,trn_shipping_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,NEN,,,,,Passenger Rail,trn_pass,S3S,linear,3.000e-06,2.967e-06,6.751e-07,3.215e-07,3.215e-07
 SSP2EU,NEN,,,,,Walk,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,NEN,,,,,trn_freight_road,trn_freight,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP2EU,NEN,,,,,trn_pass_road,trn_pass,S3S,linear,5.052e-02,6.996e-02,2.842e-02,2.368e-02,2.368e-02
-SSP2EU,NEN,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,1.263e-02,7.897e-03,3.948e-03,1.974e-03,1.974e-03
+SSP2EU,NEN,,,,,trn_pass_road,trn_pass,S3S,linear,4.960e-02,6.868e-02,2.790e-02,2.325e-02,2.325e-02
+SSP2EU,NEN,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,1.287e-02,8.044e-03,4.022e-03,2.011e-03,2.011e-03
 SSP2EU,NEN,,,,trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,NEN,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,3.994e-02,3.994e-02,3.994e-02,3.994e-02,3.994e-02
 SSP2EU,NEN,,,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
@@ -9494,24 +9494,24 @@ SSP2EU,NEN,,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_s
 SSP2EU,NEN,,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,6.397e-02,6.397e-02,6.397e-02,6.397e-02,6.397e-02
 SSP2EU,NEN,,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,3.433e-01,3.433e-01,3.433e-01,3.433e-01,3.433e-01
 SSP2EU,NEN,,Van,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,7.350e-03,7.350e-03,7.350e-03,7.350e-03,7.350e-03
-SSP2EU,NEN,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP2EU,NEN,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP2EU,NEN,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP2EU,NEN,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.743e-02,2.689e-01,9.526e-01,9.526e-01
+SSP2EU,NEN,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.000e-02,1.680e-01,2.940e-01,2.940e-01
+SSP2EU,NEN,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.000e-02,1.680e-01,2.940e-01,2.940e-01
+SSP2EU,NEN,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.000e-02,1.680e-01,2.940e-01,2.940e-01
+SSP2EU,NEN,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,5.608e-02,1.402e-01,4.134e-01,9.856e-01,9.856e-01
 SSP2EU,NEN,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,NEN,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,NEN,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP2EU,NEN,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.192e-01,5.000e-01,9.820e-01,9.820e-01
-SSP2EU,NEN,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.743e-02,2.689e-01,9.526e-01,9.526e-01
-SSP2EU,NEN,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.743e-02,2.689e-01,9.526e-01,9.526e-01
-SSP2EU,NEN,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.743e-02,2.689e-01,9.526e-01,9.526e-01
-SSP2EU,NEN,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.192e-01,5.000e-01,9.820e-01,9.820e-01
-SSP2EU,NEN,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.473e-03,1.799e-02,5.000e-01,5.000e-01
-SSP2EU,NEN,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.693e-03,4.743e-02,7.311e-01,7.311e-01
-SSP2EU,NEN,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-03,1.799e-02,5.000e-01,5.000e-01
-SSP2EU,NEN,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-03,1.799e-02,5.000e-01,5.000e-01
-SSP2EU,NEN,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-03,1.799e-02,5.000e-01,5.000e-01
-SSP2EU,NEN,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.693e-03,4.743e-02,7.311e-01,7.311e-01
+SSP2EU,NEN,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.537e-01,5.912e-01,8.932e-01,8.932e-01
+SSP2EU,NEN,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.009e-01,3.180e-01,8.664e-01,8.664e-01
+SSP2EU,NEN,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.009e-01,3.180e-01,8.664e-01,8.664e-01
+SSP2EU,NEN,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.009e-01,3.180e-01,8.664e-01,8.664e-01
+SSP2EU,NEN,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.537e-01,5.912e-01,8.932e-01,8.932e-01
+SSP2EU,NEN,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.924e-03,2.127e-02,5.543e-02,5.543e-02
+SSP2EU,NEN,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,7.914e-03,1.682e-01,9.974e-02,9.974e-02
+SSP2EU,NEN,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.924e-03,6.380e-02,6.822e-02,6.822e-02
+SSP2EU,NEN,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.924e-03,6.380e-02,6.822e-02,6.822e-02
+SSP2EU,NEN,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.924e-03,6.380e-02,6.822e-02,6.822e-02
+SSP2EU,NEN,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,7.914e-03,1.682e-01,9.974e-02,9.974e-02
 SSP2EU,NEN,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0.000e+00,8.315e-07,4.540e-05,1.192e-01,1.192e-01
 SSP2EU,NEN,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,NEN,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
@@ -9528,59 +9528,59 @@ SSP2EU,NEN,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_roa
 SSP2EU,NEN,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,NEN,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,NEN,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP2EU,NEN,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,2.147e-02,4.722e-02,9.872e-02,2.017e-01,2.017e-01
-SSP2EU,NEN,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,6.427e-03,3.257e-02,8.487e-02,1.895e-01,1.895e-01
-SSP2EU,NEN,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SSP2EU,NEN,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SSP2EU,NEN,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SSP2EU,NEN,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
+SSP2EU,NEN,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,2.362e-02,3.778e-02,9.872e-02,1.261e-01,1.261e-01
+SSP2EU,NEN,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,6.427e-03,3.257e-02,8.487e-02,1.457e-01,1.457e-01
+SSP2EU,NEN,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.417e-01,1.417e-01
+SSP2EU,NEN,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.417e-01,1.417e-01
+SSP2EU,NEN,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.417e-01,1.417e-01
+SSP2EU,NEN,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.417e-01,1.417e-01
 SSP2EU,NES,,,,,Cycle,trn_pass,S3S,linear,8.738e-03,7.802e-03,9.929e-03,1.365e-02,1.365e-02
-SSP2EU,NES,,,,,Domestic Aviation,trn_pass,S3S,linear,4.947e-03,3.534e-03,1.499e-03,4.123e-04,4.123e-04
-SSP2EU,NES,,,,,Domestic Ship,trn_freight,S3S,linear,1.442e-02,1.442e-02,1.442e-02,1.442e-02,1.442e-02
-SSP2EU,NES,,,,,Freight Rail,trn_freight,S3S,linear,1.666e-02,1.666e-02,1.666e-02,1.666e-02,1.666e-02
+SSP2EU,NES,,,,,Domestic Aviation,trn_pass,S3S,linear,4.721e-03,3.372e-03,1.431e-03,3.935e-04,3.935e-04
+SSP2EU,NES,,,,,Domestic Ship,trn_freight,S3S,linear,1.468e-02,1.468e-02,1.468e-02,1.322e-02,1.322e-02
+SSP2EU,NES,,,,,Freight Rail,trn_freight,S3S,linear,1.697e-02,1.697e-02,1.697e-02,1.697e-02,1.697e-02
 SSP2EU,NES,,,,,HSR,trn_pass,S3S,linear,5.085e-04,3.632e-04,2.311e-04,1.271e-04,1.271e-04
 SSP2EU,NES,,,,,International Aviation,trn_aviation_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,NES,,,,,International Ship,trn_shipping_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,NES,,,,,Passenger Rail,trn_pass,S3S,linear,1.607e-03,1.148e-03,7.303e-04,4.017e-04,4.017e-04
 SSP2EU,NES,,,,,Walk,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,NES,,,,,trn_freight_road,trn_freight,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP2EU,NES,,,,,trn_pass_road,trn_pass,S3S,linear,9.258e-01,7.176e-01,4.566e-01,2.512e-01,2.512e-01
-SSP2EU,NES,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,5.499e-02,2.199e-02,1.100e-02,1.100e-02,1.100e-02
+SSP2EU,NES,,,,,trn_pass_road,trn_pass,S3S,linear,2.727e-01,2.818e-01,2.242e-01,1.233e-01,1.233e-01
+SSP2EU,NES,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,8.401e-02,3.734e-02,2.240e-02,2.240e-02,2.240e-02
 SSP2EU,NES,,,,trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,NES,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,4.923e-03,4.923e-03,4.923e-03,4.923e-03,4.923e-03
 SSP2EU,NES,,,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP2EU,NES,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,4.608e-01,4.608e-01,4.608e-01,4.608e-01,4.608e-01
+SSP2EU,NES,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,5.760e-01,5.760e-01,6.144e-01,6.144e-01,6.144e-01
 SSP2EU,NES,,Large Car and SUV,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,NES,,Midsize Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,2.352e-01,2.352e-01,2.352e-01,2.352e-01,2.352e-01
-SSP2EU,NES,,Mini Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.509e-03,1.509e-03,1.509e-03,1.509e-03,1.509e-03
+SSP2EU,NES,,Mini Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.886e-03,1.886e-03,2.012e-03,2.012e-03,2.012e-03
 SSP2EU,NES,,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.148e-02,1.148e-02,1.148e-02,1.148e-02,1.148e-02
 SSP2EU,NES,,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.337e-01,1.337e-01,1.337e-01,1.337e-01,1.337e-01
 SSP2EU,NES,,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP2EU,NES,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,7.460e-02,7.460e-02,7.460e-02,7.460e-02,7.460e-02
+SSP2EU,NES,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,9.325e-02,9.325e-02,9.946e-02,9.946e-02,9.946e-02
 SSP2EU,NES,,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,NES,,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,6.299e-02,6.299e-02,6.299e-02,6.299e-02,6.299e-02
 SSP2EU,NES,,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,3.651e-01,3.651e-01,3.651e-01,3.651e-01,3.651e-01
 SSP2EU,NES,,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,5.704e-01,5.704e-01,5.704e-01,5.704e-01,5.704e-01
 SSP2EU,NES,,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,4.799e-01,4.799e-01,4.799e-01,4.799e-01,4.799e-01
 SSP2EU,NES,,Van,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,2.880e-03,2.880e-03,2.880e-03,2.880e-03,2.880e-03
-SSP2EU,NES,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP2EU,NES,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP2EU,NES,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP2EU,NES,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.743e-02,2.689e-01,9.526e-01,9.526e-01
+SSP2EU,NES,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.000e-02,1.680e-01,3.360e-01,3.360e-01
+SSP2EU,NES,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.000e-02,1.680e-01,3.360e-01,3.360e-01
+SSP2EU,NES,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.000e-02,1.680e-01,3.360e-01,3.360e-01
+SSP2EU,NES,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,5.175e-02,1.739e-01,3.465e-01,3.465e-01
 SSP2EU,NES,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,2.081e-01,3.071e-01,5.050e-01,9.010e-01,9.010e-01
 SSP2EU,NES,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,NES,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP2EU,NES,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.192e-01,5.000e-01,9.820e-01,9.820e-01
-SSP2EU,NES,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.743e-02,2.689e-01,9.526e-01,9.526e-01
-SSP2EU,NES,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.743e-02,2.689e-01,9.526e-01,9.526e-01
-SSP2EU,NES,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.743e-02,2.689e-01,9.526e-01,9.526e-01
-SSP2EU,NES,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.192e-01,5.000e-01,9.820e-01,9.820e-01
-SSP2EU,NES,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.473e-03,1.799e-02,5.000e-01,5.000e-01
-SSP2EU,NES,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.693e-03,4.743e-02,7.311e-01,7.311e-01
-SSP2EU,NES,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-03,1.799e-02,5.000e-01,5.000e-01
-SSP2EU,NES,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-03,1.799e-02,5.000e-01,5.000e-01
-SSP2EU,NES,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-03,1.799e-02,5.000e-01,5.000e-01
-SSP2EU,NES,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.693e-03,4.743e-02,7.311e-01,7.311e-01
+SSP2EU,NES,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.138e-01,2.182e-01,3.215e-01,3.215e-01
+SSP2EU,NES,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.528e-02,1.174e-01,3.118e-01,3.118e-01
+SSP2EU,NES,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.528e-02,1.174e-01,3.118e-01,3.118e-01
+SSP2EU,NES,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.528e-02,1.174e-01,3.118e-01,3.118e-01
+SSP2EU,NES,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.138e-01,2.182e-01,3.215e-01,3.215e-01
+SSP2EU,NES,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.698e-03,1.454e-02,3.637e-02,3.637e-02
+SSP2EU,NES,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,9.129e-03,3.833e-02,8.376e-02,8.376e-02
+SSP2EU,NES,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.373e-03,1.454e-02,5.729e-02,5.729e-02
+SSP2EU,NES,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.373e-03,1.454e-02,5.729e-02,5.729e-02
+SSP2EU,NES,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.373e-03,1.454e-02,5.729e-02,5.729e-02
+SSP2EU,NES,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,9.129e-03,3.833e-02,8.376e-02,8.376e-02
 SSP2EU,NES,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0.000e+00,8.315e-07,4.540e-05,1.192e-01,1.192e-01
 SSP2EU,NES,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,NES,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
@@ -9597,63 +9597,63 @@ SSP2EU,NES,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_roa
 SSP2EU,NES,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,NES,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,NES,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP2EU,NES,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,3.476e-03,2.970e-02,8.215e-02,1.870e-01,1.870e-01
-SSP2EU,NES,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SSP2EU,NES,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SSP2EU,NES,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SSP2EU,NES,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SSP2EU,NES,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
-SSP2EU,OAS,,,,,Cycle,trn_pass,S3S,linear,1.256e-02,2.493e-02,3.323e-02,8.309e-02,8.309e-02
-SSP2EU,OAS,,,,,Domestic Aviation,trn_pass,S3S,linear,2.574e-02,2.661e-02,3.726e-02,7.983e-02,7.983e-02
-SSP2EU,OAS,,,,,Domestic Ship,trn_freight,S3S,linear,3.645e-02,3.645e-02,2.804e-02,3.645e-02,3.645e-02
-SSP2EU,OAS,,,,,Freight Rail,trn_freight,S3S,linear,4.649e-02,4.649e-02,3.576e-02,4.649e-02,4.649e-02
-SSP2EU,OAS,,,,,HSR,trn_pass,S3S,linear,9.660e-04,2.997e-03,2.997e-03,3.995e-03,3.995e-03
+SSP2EU,NES,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,3.476e-03,2.970e-02,6.085e-02,7.482e-02,7.482e-02
+SSP2EU,NES,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.289e-02,8.772e-02,1.289e-01,1.289e-01
+SSP2EU,NES,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.289e-02,8.772e-02,1.289e-01,1.289e-01
+SSP2EU,NES,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.289e-02,8.772e-02,1.289e-01,1.289e-01
+SSP2EU,NES,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.289e-02,8.772e-02,1.289e-01,1.289e-01
+SSP2EU,NES,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.289e-02,8.772e-02,1.289e-01,1.289e-01
+SSP2EU,OAS,,,,,Cycle,trn_pass,S3S,linear,1.256e-02,3.616e-02,4.821e-02,1.205e-01,1.205e-01
+SSP2EU,OAS,,,,,Domestic Aviation,trn_pass,S3S,linear,2.456e-02,3.684e-02,5.158e-02,1.326e-01,1.326e-01
+SSP2EU,OAS,,,,,Domestic Ship,trn_freight,S3S,linear,3.712e-02,3.375e-02,2.856e-02,2.700e-02,2.700e-02
+SSP2EU,OAS,,,,,Freight Rail,trn_freight,S3S,linear,4.736e-02,4.305e-02,3.643e-02,3.444e-02,3.444e-02
+SSP2EU,OAS,,,,,HSR,trn_pass,S3S,linear,9.660e-04,4.347e-03,4.347e-03,5.796e-03,5.796e-03
 SSP2EU,OAS,,,,,International Aviation,trn_aviation_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,OAS,,,,,International Ship,trn_shipping_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP2EU,OAS,,,,,Passenger Rail,trn_pass,S3S,linear,7.701e-04,7.963e-04,1.194e-03,1.593e-03,1.593e-03
-SSP2EU,OAS,,,,,Walk,trn_pass,S3S,linear,1.000e+00,6.893e-01,6.893e-01,6.893e-01,6.893e-01
+SSP2EU,OAS,,,,,Passenger Rail,trn_pass,S3S,linear,7.701e-04,1.155e-03,1.733e-03,2.310e-03,2.310e-03
+SSP2EU,OAS,,,,,Walk,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,OAS,,,,,trn_freight_road,trn_freight,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP2EU,OAS,,,,,trn_pass_road,trn_pass,S3S,linear,8.721e-01,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP2EU,OAS,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,2.403e-01,1.402e-01,5.510e-02,5.510e-02,5.510e-02
+SSP2EU,OAS,,,,,trn_pass_road,trn_pass,S3S,linear,4.452e-01,5.697e-01,5.697e-01,7.121e-01,7.121e-01
+SSP2EU,OAS,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,4.352e-01,2.571e-01,1.122e-01,9.620e-02,9.620e-02
 SSP2EU,OAS,,,,trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP2EU,OAS,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,2.534e-02,2.233e-02,1.631e-02,4.276e-03,4.276e-03
+SSP2EU,OAS,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,3.520e-01,1.718e-01,1.631e-01,9.503e-02,9.503e-02
 SSP2EU,OAS,,,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP2EU,OAS,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,6.745e-03,6.745e-03,6.745e-03,6.745e-03,6.745e-03
+SSP2EU,OAS,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,2.698e-03,2.811e-03,4.216e-03,5.621e-03,5.621e-03
 SSP2EU,OAS,,Large Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,3.018e-01,3.018e-01,3.018e-01,3.018e-01,3.018e-01
 SSP2EU,OAS,,Large Car and SUV,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,6.459e-04,6.459e-04,6.459e-04,6.459e-04,6.459e-04
 SSP2EU,OAS,,Light Truck and SUV,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,OAS,,Midsize Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,2.500e-04,2.500e-04,2.500e-04,2.500e-04,2.500e-04
-SSP2EU,OAS,,Mini Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,6.938e-05,6.938e-05,6.938e-05,6.938e-05,6.938e-05
+SSP2EU,OAS,,Mini Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,2.775e-05,2.891e-05,4.336e-05,5.782e-05,5.782e-05
 SSP2EU,OAS,,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,7.762e-03,7.762e-03,7.762e-03,7.762e-03,7.762e-03
 SSP2EU,OAS,,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,OAS,,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,6.391e-03,6.391e-03,6.391e-03,6.391e-03,6.391e-03
-SSP2EU,OAS,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,8.508e-03,8.508e-03,8.508e-03,8.508e-03,8.508e-03
+SSP2EU,OAS,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,3.403e-03,3.545e-03,5.318e-03,7.090e-03,7.090e-03
 SSP2EU,OAS,,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,3.765e-01,3.765e-01,3.765e-01,3.765e-01,3.765e-01
 SSP2EU,OAS,,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,4.784e-01,4.784e-01,4.784e-01,4.784e-01,4.784e-01
 SSP2EU,OAS,,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.365e-03,1.365e-03,1.365e-03,1.365e-03,1.365e-03
 SSP2EU,OAS,,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,7.361e-04,7.361e-04,7.361e-04,7.361e-04,7.361e-04
 SSP2EU,OAS,,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,OAS,,Van,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.027e-05,1.027e-05,1.027e-05,1.027e-05,1.027e-05
-SSP2EU,OAS,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP2EU,OAS,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1.452e-05,1.452e-05,1.452e-05,1.452e-05,1.452e-05
-SSP2EU,OAS,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP2EU,OAS,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.423e-01,6.724e-01,1.000e+00,1.000e+00
+SSP2EU,OAS,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.400e-02,1.680e-01,2.940e-01,2.940e-01
+SSP2EU,OAS,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.400e-02,1.680e-01,2.940e-01,2.940e-01
+SSP2EU,OAS,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.400e-02,1.680e-01,2.940e-01,2.940e-01
+SSP2EU,OAS,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.411e-01,6.670e-01,1.000e+00,1.000e+00
 SSP2EU,OAS,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1.733e-01,2.767e-01,4.833e-01,8.967e-01,8.967e-01
 SSP2EU,OAS,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,OAS,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,3.530e-01,4.338e-01,5.956e-01,9.191e-01,9.191e-01
-SSP2EU,OAS,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.973e-02,6.250e-02,7.856e-02,7.856e-02
-SSP2EU,OAS,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.581e-02,3.362e-02,7.621e-02,7.621e-02
-SSP2EU,OAS,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.581e-02,3.362e-02,7.621e-02,7.621e-02
-SSP2EU,OAS,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.581e-02,3.362e-02,7.621e-02,7.621e-02
-SSP2EU,OAS,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.973e-02,6.250e-02,7.856e-02,7.856e-02
-SSP2EU,OAS,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.473e-03,1.799e-02,6.561e-02,6.561e-02
-SSP2EU,OAS,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.115e-02,1.186e-02,2.924e-02,2.924e-02
-SSP2EU,OAS,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.121e-03,4.497e-03,2.000e-02,2.000e-02
-SSP2EU,OAS,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.121e-03,4.497e-03,2.000e-02,2.000e-02
-SSP2EU,OAS,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.121e-03,4.497e-03,2.000e-02,2.000e-02
-SSP2EU,OAS,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.115e-02,1.186e-02,2.924e-02,2.924e-02
+SSP2EU,OAS,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.469e-02,5.456e-02,7.144e-02,7.144e-02
+SSP2EU,OAS,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.380e-02,2.935e-02,6.930e-02,6.930e-02
+SSP2EU,OAS,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.380e-02,2.935e-02,6.930e-02,6.930e-02
+SSP2EU,OAS,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.380e-02,2.935e-02,6.930e-02,6.930e-02
+SSP2EU,OAS,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,3.469e-02,5.456e-02,7.144e-02,7.144e-02
+SSP2EU,OAS,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.453e-03,1.784e-02,7.290e-02,7.290e-02
+SSP2EU,OAS,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.217e-02,1.294e-02,2.127e-02,2.127e-02
+SSP2EU,OAS,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.497e-03,4.907e-03,1.455e-02,1.455e-02
+SSP2EU,OAS,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.497e-03,4.907e-03,1.455e-02,1.455e-02
+SSP2EU,OAS,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.497e-03,4.907e-03,1.455e-02,1.455e-02
+SSP2EU,OAS,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.217e-02,1.294e-02,2.127e-02,2.127e-02
 SSP2EU,OAS,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0.000e+00,8.315e-07,4.540e-05,1.192e-01,1.192e-01
-SSP2EU,OAS,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,6.561e-01,6.561e-01
+SSP2EU,OAS,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,6.681e-01,6.681e-01
 SSP2EU,OAS,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,OAS,Liquids,Domestic Ship_tmp_vehicletype,Domestic Ship_tmp_subsector_L1,Domestic Ship_tmp_subsector_L2,Domestic Ship,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,OAS,Liquids,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
@@ -9668,58 +9668,58 @@ SSP2EU,OAS,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_roa
 SSP2EU,OAS,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,OAS,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,OAS,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP2EU,OAS,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.967e-01,2.178e-01,2.601e-01,2.261e-01,2.261e-01
-SSP2EU,OAS,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,4.535e-04,8.919e-03,3.968e-02,7.383e-02,7.383e-02
-SSP2EU,OAS,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,8.772e-03,3.947e-02,7.368e-02,7.368e-02
-SSP2EU,OAS,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.395e-01,5.404e-02,1.037e-01,1.192e-01,1.192e-01
-SSP2EU,OAS,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,2.466e-01,8.882e-02,1.531e-01,1.542e-01,1.542e-01
-SSP2EU,OAS,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,8.772e-03,3.947e-02,7.368e-02,7.368e-02
-SSP2EU,REF,,,,,Cycle,trn_pass,S3S,linear,4.737e-03,4.737e-03,2.369e-02,7.824e-02,7.824e-02
-SSP2EU,REF,,,,,Domestic Aviation,trn_pass,S3S,linear,1.287e-02,1.232e-02,1.540e-02,1.454e-02,1.454e-02
-SSP2EU,REF,,,,,Domestic Ship,trn_freight,S3S,linear,7.096e-03,7.096e-03,7.096e-03,7.096e-03,7.096e-03
-SSP2EU,REF,,,,,Freight Rail,trn_freight,S3S,linear,1.272e-01,1.272e-01,1.272e-01,1.272e-01,1.272e-01
-SSP2EU,REF,,,,,HSR,trn_pass,S3S,linear,0.000e+00,8.000e-04,8.000e-04,7.550e-04,7.550e-04
+SSP2EU,OAS,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.967e-01,1.980e-01,2.365e-01,2.303e-01,2.303e-01
+SSP2EU,OAS,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,4.535e-04,8.919e-03,3.968e-02,6.153e-02,6.153e-02
+SSP2EU,OAS,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,8.772e-03,3.947e-02,6.140e-02,6.140e-02
+SSP2EU,OAS,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.395e-01,5.404e-02,1.037e-01,9.933e-02,9.933e-02
+SSP2EU,OAS,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,2.466e-01,8.882e-02,1.531e-01,1.285e-01,1.285e-01
+SSP2EU,OAS,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,8.772e-03,3.947e-02,6.140e-02,6.140e-02
+SSP2EU,REF,,,,,Cycle,trn_pass,S3S,linear,1.379e-02,1.206e-02,6.031e-02,7.824e-02,7.824e-02
+SSP2EU,REF,,,,,Domestic Aviation,trn_pass,S3S,linear,3.574e-02,2.995e-02,3.743e-02,1.387e-02,1.387e-02
+SSP2EU,REF,,,,,Domestic Ship,trn_freight,S3S,linear,7.227e-03,7.227e-03,7.227e-03,7.227e-03,7.227e-03
+SSP2EU,REF,,,,,Freight Rail,trn_freight,S3S,linear,1.296e-01,1.296e-01,1.296e-01,1.296e-01,1.296e-01
+SSP2EU,REF,,,,,HSR,trn_pass,S3S,linear,0.000e+00,2.037e-03,2.037e-03,7.550e-04,7.550e-04
 SSP2EU,REF,,,,,International Aviation,trn_aviation_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,REF,,,,,International Ship,trn_shipping_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP2EU,REF,,,,,Passenger Rail,trn_pass,S3S,linear,2.366e-03,4.731e-03,5.914e-03,1.116e-02,1.116e-02
-SSP2EU,REF,,,,,Walk,trn_pass,S3S,linear,3.179e-01,3.179e-01,3.179e-01,1.000e+00,1.000e+00
+SSP2EU,REF,,,,,Passenger Rail,trn_pass,S3S,linear,6.884e-03,1.205e-02,1.506e-02,1.116e-02,1.116e-02
+SSP2EU,REF,,,,,Walk,trn_pass,S3S,linear,9.251e-01,8.095e-01,8.095e-01,1.000e+00,1.000e+00
 SSP2EU,REF,,,,,trn_freight_road,trn_freight,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP2EU,REF,,,,,trn_pass_road,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,9.437e-01,9.437e-01
-SSP2EU,REF,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,1.186e-01,9.148e-02,7.623e-02,6.099e-02,6.099e-02
+SSP2EU,REF,,,,,trn_pass_road,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,4.633e-01,4.633e-01
+SSP2EU,REF,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,2.684e-01,1.864e-01,1.553e-01,1.242e-01,1.242e-01
 SSP2EU,REF,,,,trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,REF,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,3.698e-01,3.698e-01,3.698e-01,3.698e-01,3.698e-01
 SSP2EU,REF,,,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP2EU,REF,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,2.227e-01,2.227e-01,2.227e-01,2.227e-01,2.227e-01
+SSP2EU,REF,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,4.455e-01,4.176e-01,4.176e-01,3.818e-01,3.818e-01
 SSP2EU,REF,,Large Car and SUV,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,REF,,Midsize Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.842e-01,1.842e-01,1.842e-01,1.842e-01,1.842e-01
-SSP2EU,REF,,Mini Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,7.127e-05,7.127e-05,7.127e-05,7.127e-05,7.127e-05
+SSP2EU,REF,,Mini Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.425e-04,1.336e-04,1.336e-04,1.222e-04,1.222e-04
 SSP2EU,REF,,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,3.376e-03,3.376e-03,3.376e-03,3.376e-03,3.376e-03
 SSP2EU,REF,,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,REF,,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,4.141e-01,4.141e-01,4.141e-01,4.141e-01,4.141e-01
-SSP2EU,REF,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.254e-02,1.254e-02,1.254e-02,1.254e-02,1.254e-02
+SSP2EU,REF,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,2.508e-02,2.351e-02,2.351e-02,2.150e-02,2.150e-02
 SSP2EU,REF,,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,REF,,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,5.081e-03,5.081e-03,5.081e-03,5.081e-03,5.081e-03
 SSP2EU,REF,,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,5.837e-01,5.837e-01,5.837e-01,5.837e-01,5.837e-01
 SSP2EU,REF,,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.888e-01,1.888e-01,1.888e-01,1.888e-01,1.888e-01
 SSP2EU,REF,,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.676e-02,1.676e-02,1.676e-02,1.676e-02,1.676e-02
-SSP2EU,REF,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP2EU,REF,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,6.589e-03,6.589e-03,6.589e-03,6.589e-03,6.589e-03
-SSP2EU,REF,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP2EU,REF,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.743e-02,3.227e-01,9.526e-01,9.526e-01
+SSP2EU,REF,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.000e-02,1.680e-01,3.360e-01,3.360e-01
+SSP2EU,REF,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.000e-02,1.680e-01,3.360e-01,3.360e-01
+SSP2EU,REF,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.000e-02,1.680e-01,3.360e-01,3.360e-01
+SSP2EU,REF,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,7.245e-02,3.202e-01,7.425e-01,7.425e-01
 SSP2EU,REF,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,REF,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,REF,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP2EU,REF,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.192e-01,3.000e-01,3.928e-01,3.928e-01
-SSP2EU,REF,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.743e-02,1.614e-01,3.810e-01,3.810e-01
-SSP2EU,REF,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.743e-02,1.614e-01,3.810e-01,3.810e-01
-SSP2EU,REF,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.743e-02,1.614e-01,3.810e-01,3.810e-01
-SSP2EU,REF,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.192e-01,3.000e-01,3.928e-01,3.928e-01
-SSP2EU,REF,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.473e-03,3.597e-02,1.000e-01,1.000e-01
-SSP2EU,REF,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.024e-02,4.743e-02,7.311e-02,7.311e-02
-SSP2EU,REF,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.225e-02,1.799e-02,5.000e-02,5.000e-02
-SSP2EU,REF,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.225e-02,1.799e-02,5.000e-02,5.000e-02
-SSP2EU,REF,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.225e-02,1.799e-02,5.000e-02,5.000e-02
-SSP2EU,REF,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.024e-02,4.743e-02,7.311e-02,7.311e-02
+SSP2EU,REF,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.183e-01,2.678e-01,3.957e-01,3.957e-01
+SSP2EU,REF,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.705e-02,1.441e-01,3.838e-01,3.838e-01
+SSP2EU,REF,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.705e-02,1.441e-01,3.838e-01,3.838e-01
+SSP2EU,REF,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.705e-02,1.441e-01,3.838e-01,3.838e-01
+SSP2EU,REF,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.183e-01,2.678e-01,3.957e-01,3.957e-01
+SSP2EU,REF,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.698e-03,3.569e-02,6.236e-02,6.236e-02
+SSP2EU,REF,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.975e-02,4.705e-02,5.523e-02,5.523e-02
+SSP2EU,REF,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.208e-02,1.784e-02,3.777e-02,3.777e-02
+SSP2EU,REF,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.208e-02,1.784e-02,3.777e-02,3.777e-02
+SSP2EU,REF,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.208e-02,1.784e-02,3.777e-02,3.777e-02
+SSP2EU,REF,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.975e-02,4.705e-02,5.523e-02,5.523e-02
 SSP2EU,REF,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0.000e+00,8.315e-07,4.540e-05,1.192e-01,1.192e-01
 SSP2EU,REF,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,REF,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
@@ -9736,26 +9736,26 @@ SSP2EU,REF,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_roa
 SSP2EU,REF,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,REF,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,REF,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP2EU,REF,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.400e-02,3.994e-02,7.347e-02,1.369e-01,1.369e-01
-SSP2EU,REF,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,4.158e-02,6.680e-02,1.172e-01,1.745e-01,1.745e-01
-SSP2EU,REF,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.474e-01,1.474e-01
-SSP2EU,REF,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,6.311e-02,8.776e-02,1.371e-01,1.886e-01,1.886e-01
-SSP2EU,REF,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,3.048e-02,5.599e-02,1.070e-01,1.673e-01,1.673e-01
-SSP2EU,REF,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.474e-01,1.474e-01
-SSP2EU,SSA,,,,,Cycle,trn_pass,S3S,linear,1.388e-02,1.795e-02,2.915e-02,3.279e-02,3.279e-02
-SSP2EU,SSA,,,,,Domestic Aviation,trn_pass,S3S,linear,9.013e-03,5.100e-02,4.140e-02,6.209e-03,6.209e-03
-SSP2EU,SSA,,,,,Domestic Ship,trn_freight,S3S,linear,1.467e-03,1.467e-03,1.467e-03,1.467e-03,1.467e-03
-SSP2EU,SSA,,,,,Freight Rail,trn_freight,S3S,linear,1.634e-02,1.634e-02,1.634e-02,1.634e-02,1.634e-02
-SSP2EU,SSA,,,,,HSR,trn_pass,S3S,linear,1.475e-05,2.003e-05,6.504e-02,9.756e-03,9.756e-03
+SSP2EU,REF,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.400e-02,3.195e-02,6.011e-02,7.825e-02,7.825e-02
+SSP2EU,REF,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,3.465e-02,6.073e-02,9.593e-02,1.342e-01,1.342e-01
+SSP2EU,REF,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.392e-02,6.459e-02,1.134e-01,1.134e-01
+SSP2EU,REF,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,5.259e-02,7.979e-02,1.122e-01,1.450e-01,1.450e-01
+SSP2EU,REF,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,2.540e-02,5.090e-02,8.756e-02,1.287e-01,1.287e-01
+SSP2EU,REF,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.392e-02,6.459e-02,1.134e-01,1.134e-01
+SSP2EU,SSA,,,,,Cycle,trn_pass,S3S,linear,1.388e-02,1.987e-02,2.915e-02,3.279e-02,3.279e-02
+SSP2EU,SSA,,,,,Domestic Aviation,trn_pass,S3S,linear,8.602e-03,5.387e-02,3.951e-02,5.926e-03,5.926e-03
+SSP2EU,SSA,,,,,Domestic Ship,trn_freight,S3S,linear,1.495e-03,1.495e-03,1.495e-03,1.495e-03,1.495e-03
+SSP2EU,SSA,,,,,Freight Rail,trn_freight,S3S,linear,1.665e-02,1.665e-02,1.665e-02,1.498e-02,1.498e-02
+SSP2EU,SSA,,,,,HSR,trn_pass,S3S,linear,1.475e-05,2.217e-05,6.504e-02,9.756e-03,9.756e-03
 SSP2EU,SSA,,,,,International Aviation,trn_aviation_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,SSA,,,,,International Ship,trn_shipping_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP2EU,SSA,,,,,Passenger Rail,trn_pass,S3S,linear,6.024e-04,1.559e-03,2.530e-03,5.693e-04,5.693e-04
-SSP2EU,SSA,,,,,Walk,trn_pass,S3S,linear,1.000e+00,9.034e-01,1.000e+00,1.000e+00,1.000e+00
+SSP2EU,SSA,,,,,Passenger Rail,trn_pass,S3S,linear,6.024e-04,1.725e-03,2.530e-03,5.693e-04,5.693e-04
+SSP2EU,SSA,,,,,Walk,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,SSA,,,,,trn_freight_road,trn_freight,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP2EU,SSA,,,,,trn_pass_road,trn_pass,S3S,linear,8.902e-01,1.000e+00,9.741e-01,9.741e-02,9.741e-02
-SSP2EU,SSA,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,2.477e-01,1.270e-01,7.328e-02,9.526e-02,9.526e-02
+SSP2EU,SSA,,,,,trn_pass_road,trn_pass,S3S,linear,2.622e-01,3.260e-01,2.869e-01,4.781e-02,4.781e-02
+SSP2EU,SSA,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,7.568e-01,3.234e-01,1.493e-01,9.703e-02,9.703e-02
 SSP2EU,SSA,,,,trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP2EU,SSA,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,3.928e-02,3.928e-02,3.928e-02,3.928e-02,3.928e-02
+SSP2EU,SSA,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,2.619e-02,2.619e-02,2.619e-02,3.928e-02,3.928e-02
 SSP2EU,SSA,,,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,SSA,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,SSA,,Large Car and SUV,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,3.022e-03,3.022e-03,3.022e-03,3.022e-03,3.022e-03
@@ -9770,24 +9770,24 @@ SSP2EU,SSA,,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_s
 SSP2EU,SSA,,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,4.207e-06,4.207e-06,4.207e-06,4.207e-06,4.207e-06
 SSP2EU,SSA,,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,SSA,,Van,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,7.570e-05,7.570e-05,7.570e-05,7.570e-05,7.570e-05
-SSP2EU,SSA,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP2EU,SSA,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP2EU,SSA,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP2EU,SSA,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.743e-02,4.034e-01,9.526e-01,9.526e-01
+SSP2EU,SSA,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.000e-01,2.160e-01,3.360e-01,3.360e-01
+SSP2EU,SSA,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.000e-01,2.160e-01,3.360e-01,3.360e-01
+SSP2EU,SSA,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.000e-01,2.160e-01,3.360e-01,3.360e-01
+SSP2EU,SSA,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,6.210e-02,3.962e-01,8.470e-01,8.470e-01
 SSP2EU,SSA,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,SSA,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,SSA,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP2EU,SSA,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.384e-02,1.000e-01,1.511e-01,1.511e-01
-SSP2EU,SSA,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,9.485e-03,5.379e-02,1.465e-01,1.465e-01
-SSP2EU,SSA,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,9.485e-03,5.379e-02,1.465e-01,1.465e-01
-SSP2EU,SSA,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,9.485e-03,5.379e-02,1.465e-01,1.465e-01
-SSP2EU,SSA,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.384e-02,1.000e-01,1.511e-01,1.511e-01
-SSP2EU,SSA,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.473e-03,1.799e-02,7.500e-02,7.500e-02
-SSP2EU,SSA,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.693e-03,4.743e-02,2.812e-02,2.812e-02
-SSP2EU,SSA,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-03,1.799e-02,1.923e-02,1.923e-02
-SSP2EU,SSA,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-03,1.799e-02,1.923e-02,1.923e-02
-SSP2EU,SSA,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-03,1.799e-02,1.923e-02,1.923e-02
-SSP2EU,SSA,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.693e-03,4.743e-02,2.812e-02,2.812e-02
+SSP2EU,SSA,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.602e-02,1.007e-01,1.511e-01,1.511e-01
+SSP2EU,SSA,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.035e-02,5.418e-02,1.466e-01,1.466e-01
+SSP2EU,SSA,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.035e-02,5.418e-02,1.466e-01,1.466e-01
+SSP2EU,SSA,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.035e-02,5.418e-02,1.466e-01,1.466e-01
+SSP2EU,SSA,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.602e-02,1.007e-01,1.511e-01,1.511e-01
+SSP2EU,SSA,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.698e-03,1.963e-02,4.850e-02,4.850e-02
+SSP2EU,SSA,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,7.303e-03,1.194e-02,2.045e-02,2.045e-02
+SSP2EU,SSA,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.698e-03,4.529e-03,1.399e-02,1.399e-02
+SSP2EU,SSA,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.698e-03,4.529e-03,1.399e-02,1.399e-02
+SSP2EU,SSA,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.698e-03,4.529e-03,1.399e-02,1.399e-02
+SSP2EU,SSA,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,7.303e-03,1.194e-02,2.045e-02,2.045e-02
 SSP2EU,SSA,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0.000e+00,8.315e-07,4.540e-05,1.192e-01,1.192e-01
 SSP2EU,SSA,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,SSA,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
@@ -9804,59 +9804,59 @@ SSP2EU,SSA,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_roa
 SSP2EU,SSA,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,SSA,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,SSA,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP2EU,SSA,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,3.981e-04,2.670e-02,5.552e-02,9.227e-02,9.227e-02
-SSP2EU,SSA,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,7.085e-02,7.085e-02
-SSP2EU,SSA,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,7.085e-02,7.085e-02
-SSP2EU,SSA,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,7.085e-02,7.085e-02
-SSP2EU,SSA,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,7.085e-02,7.085e-02
-SSP2EU,SSA,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,7.085e-02,7.085e-02
+SSP2EU,SSA,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,3.981e-04,2.670e-02,4.997e-02,6.835e-02,6.835e-02
+SSP2EU,SSA,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,4.251e-02,5.904e-02,5.904e-02
+SSP2EU,SSA,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,4.251e-02,5.904e-02,5.904e-02
+SSP2EU,SSA,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,4.251e-02,5.904e-02,5.904e-02
+SSP2EU,SSA,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,4.251e-02,5.904e-02,5.904e-02
+SSP2EU,SSA,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,4.251e-02,5.904e-02,5.904e-02
 SSP2EU,UKI,,,,,Cycle,trn_pass,S3S,linear,2.500e-02,1.092e-02,3.277e-02,6.553e-02,6.553e-02
-SSP2EU,UKI,,,,,Domestic Aviation,trn_pass,S3S,linear,6.250e-05,9.365e-06,9.365e-06,9.365e-06,9.365e-06
-SSP2EU,UKI,,,,,Domestic Ship,trn_freight,S3S,linear,8.512e-03,8.512e-03,8.512e-03,8.512e-03,8.512e-03
-SSP2EU,UKI,,,,,Freight Rail,trn_freight,S3S,linear,6.067e-03,6.067e-03,6.067e-03,6.067e-03,6.067e-03
+SSP2EU,UKI,,,,,Domestic Aviation,trn_pass,S3S,linear,5.965e-05,8.938e-06,8.938e-06,8.938e-06,8.938e-06
+SSP2EU,UKI,,,,,Domestic Ship,trn_freight,S3S,linear,8.670e-03,8.670e-03,8.670e-03,8.670e-03,8.670e-03
+SSP2EU,UKI,,,,,Freight Rail,trn_freight,S3S,linear,6.180e-03,6.180e-03,6.180e-03,6.180e-03,6.180e-03
 SSP2EU,UKI,,,,,HSR,trn_pass,S3S,linear,1.250e-04,1.334e-04,1.779e-04,2.224e-04,2.224e-04
 SSP2EU,UKI,,,,,International Aviation,trn_aviation_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,UKI,,,,,International Ship,trn_shipping_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,UKI,,,,,Passenger Rail,trn_pass,S3S,linear,3.125e-03,2.502e-03,1.876e-03,1.876e-03,1.876e-03
 SSP2EU,UKI,,,,,Walk,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,UKI,,,,,trn_freight_road,trn_freight,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP2EU,UKI,,,,,trn_pass_road,trn_pass,S3S,linear,7.500e-02,5.325e-02,3.408e-02,3.408e-02,3.408e-02
-SSP2EU,UKI,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,2.500e-01,2.010e-01,1.843e-01,1.675e-01,1.675e-01
+SSP2EU,UKI,,,,,trn_pass_road,trn_pass,S3S,linear,7.363e-02,5.228e-02,3.346e-02,3.346e-02,3.346e-02
+SSP2EU,UKI,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,2.546e-01,2.048e-01,1.877e-01,1.706e-01,1.706e-01
 SSP2EU,UKI,,,,trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,UKI,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,3.935e-02,3.935e-02,3.935e-02,3.935e-02,3.935e-02
 SSP2EU,UKI,,,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP2EU,UKI,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,4.864e-01,4.864e-01,4.864e-01,4.864e-01,4.864e-01
+SSP2EU,UKI,,Compact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,5.404e-01,5.404e-01,4.864e-01,4.864e-01,4.864e-01
 SSP2EU,UKI,,Large Car and SUV,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,UKI,,Midsize Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,2.616e-01,2.616e-01,2.616e-01,2.616e-01,2.616e-01
-SSP2EU,UKI,,Mini Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,4.751e-07,4.751e-07,4.751e-07,4.751e-07,4.751e-07
+SSP2EU,UKI,,Mini Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,5.279e-07,5.279e-07,4.751e-07,4.751e-07,4.751e-07
 SSP2EU,UKI,,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,2.088e-02,2.088e-02,2.088e-02,2.088e-02,2.088e-02
 SSP2EU,UKI,,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,3.798e-03,3.798e-03,3.798e-03,3.798e-03,3.798e-03
 SSP2EU,UKI,,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP2EU,UKI,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,5.119e-01,5.119e-01,5.119e-01,5.119e-01,5.119e-01
+SSP2EU,UKI,,Subcompact Car,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,5.688e-01,5.688e-01,5.119e-01,5.119e-01,5.119e-01
 SSP2EU,UKI,,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,UKI,,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,4.528e-02,4.528e-02,4.528e-02,4.528e-02,4.528e-02
 SSP2EU,UKI,,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,9.437e-02,9.437e-02,9.437e-02,9.437e-02,9.437e-02
 SSP2EU,UKI,,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,5.696e-01,5.696e-01,5.696e-01,5.696e-01,5.696e-01
 SSP2EU,UKI,,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,7.765e-01,7.765e-01,7.765e-01,7.765e-01,7.765e-01
 SSP2EU,UKI,,Van,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,2.681e-03,2.681e-03,2.681e-03,2.681e-03,2.681e-03
-SSP2EU,UKI,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP2EU,UKI,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP2EU,UKI,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP2EU,UKI,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.186e-01,3.227e-01,8.573e-01,8.573e-01
+SSP2EU,UKI,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,5.000e-02,2.000e-01,3.700e-01,3.700e-01
+SSP2EU,UKI,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,5.000e-02,2.000e-01,3.700e-01,3.700e-01
+SSP2EU,UKI,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,5.000e-02,2.000e-01,3.700e-01,3.700e-01
+SSP2EU,UKI,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,2.500e-02,1.168e-01,3.434e-01,7.434e-01,7.434e-01
 SSP2EU,UKI,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,8.260e-01,8.478e-01,8.913e-01,9.783e-01,9.783e-01
 SSP2EU,UKI,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,UKI,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP2EU,UKI,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.384e-01,5.500e-01,8.838e-01,8.838e-01
-SSP2EU,UKI,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,9.485e-02,2.958e-01,8.573e-01,8.573e-01
-SSP2EU,UKI,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,9.485e-02,2.958e-01,8.573e-01,8.573e-01
-SSP2EU,UKI,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,9.485e-02,2.958e-01,8.573e-01,8.573e-01
-SSP2EU,UKI,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.384e-01,5.500e-01,8.838e-01,8.838e-01
-SSP2EU,UKI,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.236e-02,1.799e-02,1.000e-01,1.000e-01
-SSP2EU,UKI,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.693e-02,1.897e-01,1.462e-01,1.462e-01
-SSP2EU,UKI,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-02,7.194e-02,1.000e-01,1.000e-01
-SSP2EU,UKI,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-02,7.194e-02,1.000e-01,1.000e-01
-SSP2EU,UKI,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.473e-02,7.194e-02,1.000e-01,1.000e-01
-SSP2EU,UKI,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.693e-02,1.897e-01,1.462e-01,1.462e-01
+SSP2EU,UKI,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.819e-01,5.853e-01,8.360e-01,8.360e-01
+SSP2EU,UKI,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.122e-01,3.148e-01,8.110e-01,8.110e-01
+SSP2EU,UKI,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.122e-01,3.148e-01,8.110e-01,8.110e-01
+SSP2EU,UKI,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.122e-01,3.148e-01,8.110e-01,8.110e-01
+SSP2EU,UKI,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.819e-01,5.853e-01,8.360e-01,8.360e-01
+SSP2EU,UKI,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,2.500e-05,1.218e-02,2.127e-02,7.883e-02,7.883e-02
+SSP2EU,UKI,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,7.914e-02,2.243e-01,1.729e-01,1.729e-01
+SSP2EU,UKI,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.924e-02,8.507e-02,1.182e-01,1.182e-01
+SSP2EU,UKI,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.924e-02,8.507e-02,1.182e-01,1.182e-01
+SSP2EU,UKI,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.924e-02,8.507e-02,1.182e-01,1.182e-01
+SSP2EU,UKI,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,7.914e-02,2.243e-01,1.729e-01,1.729e-01
 SSP2EU,UKI,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0.000e+00,8.315e-07,4.540e-05,1.192e-01,1.192e-01
 SSP2EU,UKI,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,UKI,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
@@ -9873,24 +9873,24 @@ SSP2EU,UKI,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_roa
 SSP2EU,UKI,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,UKI,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,UKI,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP2EU,UKI,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,3.616e-04,2.667e-02,7.928e-02,1.845e-01,1.845e-01
+SSP2EU,UKI,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,9.040e-04,2.222e-02,7.928e-02,1.230e-01,1.230e-01
 SSP2EU,UKI,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
 SSP2EU,UKI,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
 SSP2EU,UKI,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
 SSP2EU,UKI,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
 SSP2EU,UKI,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.632e-02,7.895e-02,1.842e-01,1.842e-01
 SSP2EU,USA,,,,,Cycle,trn_pass,S3S,linear,8.197e-03,8.197e-03,8.197e-03,4.098e-02,4.098e-02
-SSP2EU,USA,,,,,Domestic Aviation,trn_pass,S3S,linear,1.057e-03,1.600e-03,1.800e-03,1.100e-03,1.100e-03
-SSP2EU,USA,,,,,Domestic Ship,trn_freight,S3S,linear,3.208e-03,3.208e-03,3.208e-03,3.208e-03,3.208e-03
-SSP2EU,USA,,,,,Freight Rail,trn_freight,S3S,linear,3.364e-02,3.364e-02,3.364e-02,3.364e-02,3.364e-02
+SSP2EU,USA,,,,,Domestic Aviation,trn_pass,S3S,linear,1.009e-03,1.527e-03,1.718e-03,1.050e-03,1.050e-03
+SSP2EU,USA,,,,,Domestic Ship,trn_freight,S3S,linear,3.267e-03,3.267e-03,3.267e-03,3.267e-03,3.267e-03
+SSP2EU,USA,,,,,Freight Rail,trn_freight,S3S,linear,3.427e-02,3.427e-02,3.427e-02,3.427e-02,3.427e-02
 SSP2EU,USA,,,,,HSR,trn_pass,S3S,linear,4.530e-06,4.530e-06,4.530e-06,2.265e-04,2.265e-04
 SSP2EU,USA,,,,,International Aviation,trn_aviation_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,USA,,,,,International Ship,trn_shipping_intl,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,USA,,,,,Passenger Rail,trn_pass,S3S,linear,1.933e-03,1.933e-03,1.933e-03,9.665e-04,9.665e-04
 SSP2EU,USA,,,,,Walk,trn_pass,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,USA,,,,,trn_freight_road,trn_freight,S3S,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP2EU,USA,,,,,trn_pass_road,trn_pass,S3S,linear,1.329e-01,1.329e-01,1.276e-01,6.647e-02,6.647e-02
-SSP2EU,USA,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,8.561e-02,1.070e-01,1.070e-01,1.213e-01,1.213e-01
+SSP2EU,USA,,,,,trn_pass_road,trn_pass,S3S,linear,1.305e-01,1.305e-01,1.253e-01,6.526e-02,6.526e-02
+SSP2EU,USA,,,,Bus,trn_pass_road,trn_pass,S2S3,linear,8.720e-02,1.090e-01,1.090e-01,1.235e-01,1.235e-01
 SSP2EU,USA,,,,trn_pass_road_LDV,trn_pass_road,trn_pass,S2S3,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,USA,,,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,3.805e-02,3.805e-02,3.805e-02,3.805e-02,3.805e-02
 SSP2EU,USA,,,trn_pass_road_LDV_4W,trn_pass_road_LDV,trn_pass_road,trn_pass,S1S2,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
@@ -9903,29 +9903,29 @@ SSP2EU,USA,,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pas
 SSP2EU,USA,,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,USA,,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,7.057e-01,7.057e-01,7.057e-01,7.057e-01,7.057e-01
 SSP2EU,USA,,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP2EU,USA,,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP2EU,USA,,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
+SSP2EU,USA,,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,9.000e-01,1.000e+00,1.000e+00,1.000e+00,1.000e+00
+SSP2EU,USA,,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,9.000e-01,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,USA,,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,VS1,linear,6.263e-01,6.263e-01,6.263e-01,6.263e-01,6.263e-01
-SSP2EU,USA,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP2EU,USA,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP2EU,USA,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,0.000e+00,0.000e+00,0.000e+00,0.000e+00
-SSP2EU,USA,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.423e-01,5.379e-01,1.000e+00,1.000e+00
+SSP2EU,USA,BEV,Moped,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.400e-02,2.160e-01,3.780e-01,3.780e-01
+SSP2EU,USA,BEV,Motorcycle (50-250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.400e-02,2.160e-01,3.780e-01,3.780e-01
+SSP2EU,USA,BEV,Motorcycle (>250cc),trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,trn_pass,FV,linear,0.000e+00,4.400e-02,2.160e-01,3.780e-01,3.780e-01
+SSP2EU,USA,Electric,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,1.122e-01,5.382e-01,1.000e+00,1.000e+00
 SSP2EU,USA,Electric,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,0.000e+00,1.250e-01,3.750e-01,8.750e-01,8.750e-01
 SSP2EU,USA,Electric,HSR_tmp_vehicletype,HSR_tmp_subsector_L1,HSR_tmp_subsector_L2,HSR,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,USA,Electric,Passenger Rail_tmp_vehicletype,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_subsector_L2,Passenger Rail,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP2EU,USA,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.980e-02,2.500e-01,7.856e-01,7.856e-01
-SSP2EU,USA,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.186e-02,1.345e-01,7.621e-01,7.621e-01
-SSP2EU,USA,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,3.000e-02,2.500e-01,5.000e-01,8.000e-01,8.000e-01
-SSP2EU,USA,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,3.000e-02,2.500e-01,5.000e-01,8.000e-01,8.000e-01
-SSP2EU,USA,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,2.980e-02,2.500e-01,7.856e-01,7.856e-01
-SSP2EU,USA,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.473e-02,1.799e-02,6.999e-02,6.999e-02
-SSP2EU,USA,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.339e-03,1.423e-02,1.462e-01,1.462e-01
-SSP2EU,USA,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.945e-04,5.396e-03,1.000e-01,1.000e-01
-SSP2EU,USA,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,5.000e-02,2.000e-01,3.000e-01,2.000e-01,2.000e-01
-SSP2EU,USA,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,5.000e-02,2.000e-01,3.000e-01,2.000e-01,2.000e-01
-SSP2EU,USA,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.339e-03,1.423e-02,1.462e-01,1.462e-01
+SSP2EU,USA,Electric,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.626e-02,2.323e-01,6.967e-01,6.967e-01
+SSP2EU,USA,Electric,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,6.470e-03,1.249e-01,6.758e-01,6.758e-01
+SSP2EU,USA,Electric,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,3.547e-02,1.364e-01,4.645e-01,7.095e-01,7.095e-01
+SSP2EU,USA,Electric,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,3.547e-02,1.364e-01,4.645e-01,7.095e-01,7.095e-01
+SSP2EU,USA,Electric,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.626e-02,2.323e-01,6.967e-01,6.967e-01
+SSP2EU,USA,FCEV,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,0.000e+00,2.436e-02,1.636e-02,7.776e-02,7.776e-02
+SSP2EU,USA,FCEV,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.218e-03,1.202e-02,1.008e-01,1.008e-01
+SSP2EU,USA,FCEV,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.498e-04,4.557e-03,6.897e-02,6.897e-02
+SSP2EU,USA,FCEV,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,5.912e-02,1.819e-01,2.534e-01,1.379e-01,1.379e-01
+SSP2EU,USA,FCEV,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,5.912e-02,1.819e-01,2.534e-01,1.379e-01,1.379e-01
+SSP2EU,USA,FCEV,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,1.218e-03,1.202e-02,1.008e-01,1.008e-01
 SSP2EU,USA,Hydrogen,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,0.000e+00,8.315e-07,4.540e-05,1.192e-01,1.192e-01
-SSP2EU,USA,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,6.999e-01,6.999e-01
+SSP2EU,USA,Liquids,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,7.892e-01,7.892e-01
 SSP2EU,USA,Liquids,Domestic Aviation_tmp_vehicletype,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_subsector_L2,Domestic Aviation,trn_pass,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,USA,Liquids,Domestic Ship_tmp_vehicletype,Domestic Ship_tmp_subsector_L1,Domestic Ship_tmp_subsector_L2,Domestic Ship,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,USA,Liquids,Freight Rail_tmp_vehicletype,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_subsector_L2,Freight Rail,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
@@ -9940,12 +9940,12 @@ SSP2EU,USA,Liquids,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_roa
 SSP2EU,USA,Liquids,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,USA,Liquids,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
 SSP2EU,USA,Liquids,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e+00,1.000e+00,1.000e+00,1.000e+00,1.000e+00
-SSP2EU,USA,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,8.478e-02,1.089e-01,1.570e-01,1.773e-01,1.773e-01
-SSP2EU,USA,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.263e-03,3.158e-02,7.368e-02,7.368e-02
-SSP2EU,USA,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.263e-03,3.158e-02,7.368e-02,7.368e-02
-SSP2EU,USA,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e-01,2.000e-01,4.000e-01,4.000e-01,4.000e-01
-SSP2EU,USA,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,1.000e-01,2.000e-01,4.000e-01,4.000e-01,4.000e-01
-SSP2EU,USA,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,5.263e-03,3.158e-02,7.368e-02,7.368e-02
+SSP2EU,USA,NG,Bus_tmp_vehicletype,Bus_tmp_subsector_L1,Bus,trn_pass_road,trn_pass,FV,linear,8.478e-02,9.072e-02,1.208e-01,1.666e-01,1.666e-01
+SSP2EU,USA,NG,Truck (0-3.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.049e-03,2.256e-02,6.140e-02,6.140e-02
+SSP2EU,USA,NG,Truck (18t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.049e-03,2.256e-02,6.140e-02,6.140e-02
+SSP2EU,USA,NG,Truck (26t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,5.000e-03,1.538e-01,2.857e-01,3.333e-01,3.333e-01
+SSP2EU,USA,NG,Truck (40t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,5.000e-03,1.538e-01,2.857e-01,3.333e-01,3.333e-01
+SSP2EU,USA,NG,Truck (7.5t),trn_freight_road_tmp_subsector_L1,trn_freight_road_tmp_subsector_L2,trn_freight_road,trn_freight,FV,linear,0.000e+00,4.049e-03,2.256e-02,6.140e-02,6.140e-02
 SSP5,CAZ,,,,,Cycle,trn_pass,S3S,linear,1.911e-02,3.822e-02,3.822e-02,7.645e-02,7.645e-02
 SSP5,CAZ,,,,,Domestic Aviation,trn_pass,S3S,linear,1.500e-03,1.600e-03,1.900e-03,2.000e-03,2.000e-03
 SSP5,CAZ,,,,,Domestic Ship,trn_freight,S3S,linear,1.554e-02,1.554e-02,1.554e-02,1.554e-02,1.554e-02


### PR DESCRIPTION
After the final tuning of SSP2, which included the uptake of BEV Two Wheelers, all other REMIND scenarios are updated. 
This was also a fix to a version control bug, where the SDP scenarios got overwritten. 

To do: The SDP scenarios now need to be readjusted with the updated SSP2 sw trends as new basis 