### PR TITLE
Remove smartlifestyle switch and add interface for demand scenario

### DIFF
--- a/R/demandRegression.R
+++ b/R/demandRegression.R
@@ -4,21 +4,24 @@
 #' @param tech_output historically calibrated demand
 #' @param price_baseline baseline prices
 #' @param GDP_POP GDP per capita
-#' @param smartlifestyle switch activating sustainable lifestyles
 #' @param ssp_factors table with SSP/SDP scenario factors to be added to the baseline elasticity trends
 #' @param regional_factors table with SSP/SDP and regionally specific factors to be added to the baseline elasticity trends
+#' @param demscen_factors table with reduction factors on the total demands,
+#'   example: demscen_factors <-
+#'   fread("demandScen,  region,sector,  year, factor
+#'          SSP2EU_lowEn,DEU,   trn_pass,2030, 0.5")
 #' @param SSP_scen REMIND SSP scenario
 #' @importFrom rmndt approx_dt
 #' @importFrom magrittr `%>%`
 #' @return transport demand projections
-#' @author Marianna Rottoli
+#' @author Marianna Rottoli, Alois Dirnaichner
 #'
 #' @importFrom data.table shift frank
 #' @export
 
 
-toolDemandReg <- function(tech_output, price_baseline, GDP_POP, smartlifestyle,
-                           SSP_scen, ssp_factors, regional_factors=NULL) {
+toolDemandReg <- function(tech_output, price_baseline, GDP_POP,
+                           SSP_scen, ssp_factors, regional_factors=NULL, demscen_factors=NULL) {
   rich <- var <- eps <- GDP_cap <- region <- eps1 <- eps2 <- GDP_val <- POP_val <- NULL
   index_GDP <- income_elasticity_freight_sm <- income_elasticity_freight_lo <- index_GDPcap <- NULL
   income_elasticity_pass_sm <- income_elasticity_pass_lo <- price_elasticity_pass_lo <- sector <- NULL
@@ -35,25 +38,15 @@ toolDemandReg <- function(tech_output, price_baseline, GDP_POP, smartlifestyle,
 
   facts <- ssp_factors[SSP_scenario == SSP_scen][, SSP_scenario := NULL]
 
-  income_el <- rbindlist(lapply(unique(facts$var), function(cat){
+  income_el <- rbindlist(lapply(unique(facts$var), function(cat) {
     appfun <- approxfun(
       x=facts[var == cat, gdp_cap],
       y=facts[var == cat, target], rule = 2)
     copy(gdp_pop)[, `:=`(var=cat, eps=appfun(GDP_cap))]
   }))
 
-  if (smartlifestyle) {
-    income_el[region =="REF" & var %in% c("income_elasticity_pass_lo", "income_elasticity_pass_sm"), eps := 0]
-    income_el[region %in% c("OAS", "MEA", "LAM") & var %in% c("income_elasticity_pass_lo", "income_elasticity_pass_sm"), eps := 0.1]
-    income_el[region %in% c("IND") & var %in% c("income_elasticity_pass_lo", "income_elasticity_pass_sm"), eps := 0.4]
-    income_el[region %in% c("CHA") & var %in% c("income_elasticity_pass_lo", "income_elasticity_pass_sm"), eps := 0.2]
-    income_el[region %in% c("SSA") & var %in% c("income_elasticity_pass_lo", "income_elasticity_pass_sm"), eps := 0.5]
-    income_el[region %in% c("EUR", "NEU", "USA", "CAZ", "JPN", "DEU", "ECE", "ECS", "ENC", "ESC", "ESW", "EWN", "FRA", "UKI", "NEN", "NES") & var %in% c("income_elasticity_pass_lo", "income_elasticity_pass_sm"), eps := 0.]
 
-  }
-
-
-  if(!is.null(regional_factors) && SSP_scen %in% unique(regional_factors$SSP_scenario)){
+  if(!is.null(regional_factors) && SSP_scen %in% unique(regional_factors$SSP_scenario)) {
     ## apply regional factors
     income_el <- regional_factors[SSP_scenario == SSP_scen][, SSP_scenario := NULL] %>%
       melt(id.vars = c("region", "var"), variable.name = "year", value.name = "region_factor") %>%
@@ -152,6 +145,16 @@ toolDemandReg <- function(tech_output, price_baseline, GDP_POP, smartlifestyle,
   D_star = melt(D_star, id.vars = c("region", "year"),
                   measure.vars = c("trn_aviation_intl", "trn_freight", "trn_pass", "trn_shipping_intl"))
   D_star = D_star[,.(region, year, demand = value, sector = variable)]
+
+  if (!is.null(demscen_factors)) {
+    D_star[, factor := demscen_factors[.SD, factor, on=c("region", "sector", "year")]]
+    mods <- D_star[!is.na(factor)]
+    if (nrow(mods) > 0) {
+      D_star[year <= 2020, factor := 1]
+      D_star[, factor := na.approx(factor, x=year, rule=2), by=c("region", "sector")]
+      D_star[, demand := factor * demand][, "factor" := NULL]
+    }
+  }
 
   return(D_star)
 

--- a/R/generateEDGEdata.R
+++ b/R/generateEDGEdata.R
@@ -11,7 +11,7 @@
 #' @param cache_folder folder hosting a "local" cache (this is not the mrremid cache, it is specific to EDGE-T).
 #' @param SSP_scen SSP or SDP scenario
 #' @param tech_scen EDGE-T technology scenario. Options are: ConvCase, ElecEra, HydrHype (working with SSP2 only!)
-#' @param smartlifestyle If True, GDP demand regression provides lower overall demand levels.
+#' @param demScen Demand scenario, used to apply reduction factors on total demands from the regression.
 #' @param storeRDS optional saving of intermediate RDS files, only possible if output folder is not NULL
 #' @param gdxPath optional path to a GDX file to load price signals from a REMIND run.
 #' @param preftab path to file with trends for share weights
@@ -31,13 +31,13 @@
 
 
 toolGenerateEDGEdata <- function(input_folder, output_folder, cache_folder = NULL,
-                             SSP_scen = "SSP2", tech_scen = "Mix", smartlifestyle = FALSE,
+                             SSP_scen = "SSP2", tech_scen = "Mix", demScen = NULL,
                              storeRDS = FALSE,
                              gdxPath = NULL,
                              preftab = NULL, plot.report = FALSE,
                              mitab4W.path = NULL, mitab.path = NULL,
                              ssp_demreg.path = NULL, regional_demreg.path = NULL, FEPricetab = NULL,
-                             int_improvetab = NULL){
+                             int_improvetab = NULL) {
   scenario <- scenario_name <- vehicle_type <- type <- `.` <- CountryCode <- RegionCode <-
     technology <- non_fuel_price <- tot_price <- fuel_price_pkm <- subsector_L1 <- loadFactor <-
       ratio <- Year <- value <- DP_cap <- region <- weight <- MJ <- variable.unit <-
@@ -49,12 +49,7 @@ toolGenerateEDGEdata <- function(input_folder, output_folder, cache_folder = NUL
     storeRDS <- FALSE
   }
 
-
-
-  ## stopifnot(tech_scen %in% c("ConvCase", "Mix", "ElecEra", "HydrHype"))
-  EDGE_scenario <- if(smartlifestyle) paste0(tech_scen, "Wise") else tech_scen
-
-  folder <- paste0(SSP_scen, "-", EDGE_scenario, "_", format(Sys.time(), "%Y-%m-%d_%H.%M.%S"))
+  folder <- paste0(SSP_scen, "-", tech_scen, "_", format(Sys.time(), "%Y-%m-%d_%H.%M.%S"))
 
   if(!is.null(cache_folder) && !dir.exists(cache_folder)){
     dir.create(cache_folder)
@@ -92,9 +87,8 @@ toolGenerateEDGEdata <- function(input_folder, output_folder, cache_folder = NUL
   EDGE2teESmap = fread(system.file("extdata", "mapping_EDGE_REMIND_transport_categories.csv", package = "edgeTransport"))
   EDGE2CESmap = fread(system.file("extdata", "mapping_CESnodes_EDGE.csv", package = "edgeTransport"))
 
-  print(paste0("You selected the ", EDGE_scenario, " transport scenario."))
+  print(paste0("You selected the ", tech_scen, " transport scenario."))
   print(paste0("You selected the ", SSP_scen, " socio-economic scenario."))
-  print(paste0("You selected the option to include lifestyle changes to: ", smartlifestyle))
 
   #################################################
   ## LVL 0 scripts
@@ -151,7 +145,7 @@ toolGenerateEDGEdata <- function(input_folder, output_folder, cache_folder = NUL
     UCD_output= UCD_output, PSI_costs = PSI_costs, altCosts = altCosts,
     PSI_int=PSI_int, CHN_trucks = CHN_trucks, EU_data = EU_data,
     trsp_incent = mrr$trsp_incent, GDP_MER = mrr$GDP_POP_MER_country, fcr_veh = fcr_veh, nper_amort_veh=nper_amort_veh,
-    GCAM_data = GCAM_data, smartlifestyle = smartlifestyle, SSP_scen = SSP_scen, years = years,
+    GCAM_data = GCAM_data, SSP_scen = SSP_scen, years = years,
     REMIND2ISO_MAPPING = REMIND2ISO_MAPPING)
 
   if(storeRDS)
@@ -255,7 +249,6 @@ toolGenerateEDGEdata <- function(input_folder, output_folder, cache_folder = NUL
     calibdem = REMINDdat$dem,
     years = years,
     GDP_POP_MER = mrr$GDP_POP_MER,
-    smartlifestyle = smartlifestyle,
     tech_scen = tech_scen,
     SSP_scen = SSP_scen,
     mitab = mitab
@@ -350,7 +343,6 @@ toolGenerateEDGEdata <- function(input_folder, output_folder, cache_folder = NUL
                                                            price_baseline = prices$S3S,
                                                            GDP_POP = mrr$GDP_POP,
                                                            REMIND_scenario = SSP_scen,
-                                                           smartlifestyle = smartlifestyle,
                                                            ICCT_data = IntAv_Prep,
                                                            input_folder = input_folder,
                                                            Baseline_Run = TRUE)
@@ -362,7 +354,6 @@ toolGenerateEDGEdata <- function(input_folder, output_folder, cache_folder = NUL
                                                       price_baseline = prices$S3S,
                                                       GDP_POP = mrr$GDP_POP,
                                                       REMIND_scenario = SSP_scen,
-                                                      smartlifestyle = smartlifestyle,
                                                       ICCT_data = IntAv_Prep,
                                                       RPK_cap_baseline = NAVIGATE_intl_dem_base,
                                                       input_folder = input_folder,
@@ -391,14 +382,21 @@ toolGenerateEDGEdata <- function(input_folder, output_folder, cache_folder = NUL
         regional_demreg.path <- system.file("extdata", "regional_regression_factors.csv", package="edgeTransport")
       }
       reg_demreg_tab <- fread(regional_demreg.path, header = TRUE)
+
+      demscen_factors <- NULL
+      if (!is.null(demScen)) {
+        ## demscen.path <- system.file("extdata", "demscen_factors.csv", package="edgeTransport")
+        demscen.path <- "~/git/edgeTransport/inst/extdata/demscen_factors.csv"
+        demscen_factors <- fread(demscen.path, header = TRUE)[demScen == demandScen]
+      }
       ## demand in million km
       dem_regr = toolDemandReg(tech_output = REMINDdat$dem,
-                                price_baseline = prices$S3S,
-                                GDP_POP = mrr$GDP_POP,
-                                smartlifestyle = smartlifestyle,
-                                SSP_scen = SSP_scen,
-                                ssp_factors = ssp_demreg_tab,
-                                regional_factors = reg_demreg_tab)
+                               price_baseline = prices$S3S,
+                               GDP_POP = mrr$GDP_POP,
+                               SSP_scen = SSP_scen,
+                               ssp_factors = ssp_demreg_tab,
+                               regional_factors = reg_demreg_tab,
+                               demscen_factors = demscen_factors)
       if(storeRDS)
         saveRDS(dem_regr, file = level2path("demand_regression.RDS"))
 
@@ -576,7 +574,7 @@ toolGenerateEDGEdata <- function(input_folder, output_folder, cache_folder = NUL
     annual_mileage = REMINDdat$AM,
     demISO = merged_data$dem,
     SSP_scen = SSP_scen,
-    EDGE_scenario = EDGE_scenario,
+    EDGE_scenario = tech_scen,
     level2path = level2path,
     output_folder = output_folder)
 
@@ -599,7 +597,7 @@ toolGenerateEDGEdata <- function(input_folder, output_folder, cache_folder = NUL
 #' @param cache_folder folder hosting a "local" cache (this is not the mrremid cache, it is specific to EDGE-T).
 #' @param SSP_scen SSP or SDP scenario
 #' @param tech_scen EDGE-T technology scenario. Options are: ConvCase, ElecEra, HydrHype (working with SSP2 only!)
-#' @param smartlifestyle If True, GDP demand regression provides lower overall demand levels.
+#' @param demScen Demand scenario, used to apply reduction factors on total demands from the regression.
 #' @param storeRDS optional saving of intermediate RDS files, only possible if output folder is not NULL
 #' @param gdxPath optional path to a GDX file to load price signals from a REMIND run.
 #' @param preftab path to file with trends for share weights
@@ -615,7 +613,7 @@ toolGenerateEDGEdata <- function(input_folder, output_folder, cache_folder = NUL
 
 calcgenerateEDGEdata <- function(input_folder, output_folder,
                                  cache_folder = NULL, SSP_scen = "SSP2",
-                                 tech_scen = "Mix", smartlifestyle = FALSE,
+                                 tech_scen = "Mix", demScen = NULL,
                                  storeRDS = FALSE,
                                  gdxPath = NULL,
                                  preftab = NULL, plot.report = FALSE,
@@ -625,7 +623,7 @@ calcgenerateEDGEdata <- function(input_folder, output_folder,
 
   return(list(
     x = toolGenerateEDGEdata(input_folder, output_folder, cache_folder,  SSP_scen,
-                         tech_scen, smartlifestyle, storeRDS,
+                         tech_scen, demScen, storeRDS,
                          gdxPath, preftab, plot.report,
                          mitab4W.path, mitab.path, ssp_demreg.path,
                          regional_demreg.path),

--- a/R/generateEDGEdata.R
+++ b/R/generateEDGEdata.R
@@ -385,8 +385,7 @@ toolGenerateEDGEdata <- function(input_folder, output_folder, cache_folder = NUL
 
       demscen_factors <- NULL
       if (!is.null(demScen)) {
-        ## demscen.path <- system.file("extdata", "demscen_factors.csv", package="edgeTransport")
-        demscen.path <- "~/git/edgeTransport/inst/extdata/demscen_factors.csv"
+        demscen.path <- system.file("extdata", "demscen_factors.csv", package="edgeTransport")
         demscen_factors <- fread(demscen.path, header = TRUE)[demScen == demandScen]
       }
       ## demand in million km

--- a/R/generateEDGEdata.R
+++ b/R/generateEDGEdata.R
@@ -553,7 +553,9 @@ toolGenerateEDGEdata <- function(input_folder, output_folder, cache_folder = NUL
                     unique(calibration_output$list_SW$VS1_final_SW[,c("region", "vehicle_type")]),
                     by =c("region", "vehicle_type"))
 
-
+  if (is.null(demScen)) {
+    demScen <- SSP_scen
+  }
 
   ## save the output csv files or create a list of objects
   EDGETrData = toolCreateOutput(
@@ -573,6 +575,7 @@ toolGenerateEDGEdata <- function(input_folder, output_folder, cache_folder = NUL
     annual_mileage = REMINDdat$AM,
     demISO = merged_data$dem,
     SSP_scen = SSP_scen,
+    DEM_scen = demScen,
     EDGE_scenario = tech_scen,
     level2path = level2path,
     output_folder = output_folder)

--- a/R/incotrend.R
+++ b/R/incotrend.R
@@ -6,7 +6,6 @@
 #' @param incocost inconvenience costs for 4wheelers
 #' @param years time steps
 #' @param GDP_POP_MER GDP population on MER base
-#' @param smartlifestyle switch activating sustainable lifestyles
 #' @param tech_scen technology at the center of the policy packages
 #' @param SSP_scen SSP or SDP scenario
 #' @param mitab mitigation pathways table
@@ -17,7 +16,7 @@
 
 
 toolPreftrend <- function(SWS, ptab, calibdem, incocost, years, GDP_POP_MER,
-                           smartlifestyle, tech_scen, SSP_scen, mitab) {
+                           tech_scen, SSP_scen, mitab) {
   subsector_L1 <- gdp_pop <- technology <- tot_price <- sw <- logit.exponent <- NULL
   logit_type <- `.` <- region <- vehicle_type <- subsector_L2 <- subsector_L3 <- NULL
   sector <- V1 <- tech_output <- V2 <- GDP_cap <- value <- convsymmBEVlongDist <- NULL

--- a/R/mergeDat.R
+++ b/R/mergeDat.R
@@ -14,7 +14,6 @@
 #' @param trsp_incent transport incentives on capital costs
 #' @param fcr_veh annualization factor for LDVs
 #' @param nper_amort_veh years of amortization which a LDV
-#' @param smartlifestyle switch activatinf sustainable lifestyles
 #' @param SSP_scen REMIND SSP scenario
 #' @param REMIND2ISO_MAPPING REMIND regional mapping
 #' @param ariadne_adjustments adjust intensity levels according to the ARIADNE project.
@@ -24,7 +23,7 @@
 #' @author Marianna Rottoli, Alois Dirnaichner
 
 toolMergeDat <- function(UCD_output, EU_data, PSI_costs, GDP_MER, altCosts, CHN_trucks, GCAM_data,
-                         PSI_int, trsp_incent, fcr_veh, nper_amort_veh, smartlifestyle,
+                         PSI_int, trsp_incent, fcr_veh, nper_amort_veh,
                          SSP_scen, years, REMIND2ISO_MAPPING, ariadne_adjustments = TRUE) {
 
   vkm.veh <- value <- variable <- conv_pkm_MJ <- conv_vkm_MJ <- ratio <- MJ_km <- sector_fuel <-
@@ -49,24 +48,19 @@ toolMergeDat <- function(UCD_output, EU_data, PSI_costs, GDP_MER, altCosts, CHN_
 
   LF = rbind(LF_EU, GCAM_data$load_factor[!(iso %in% unique(LF_EU$iso) & vehicle_type %in% unique(LF_EU$vehicle_type))])
 
-  ## set target for LF for LDVs
-  target_LF = if(smartlifestyle) 0.2 else 0
-  target_year = if(smartlifestyle) 2060 else 2080
-
-  if(SSP_scen == "SDP_RC"){
+  if (SSP_scen == "SDP_RC") {
     target_LF = 0.3
     target_year = 2060
-  }
-
-  LF[
-    subsector_L1 == "trn_pass_road_LDV_4W" &
+    LF[
+      subsector_L1 == "trn_pass_road_LDV_4W" &
       year >= 2020 & year <= target_year,
-    loadFactor := loadFactor * (1 + target_LF*(year - 2020)/(target_year - 2020))]
+      loadFactor := loadFactor * (1 + target_LF*(year - 2020)/(target_year - 2020))]
 
-  LF[
-    subsector_L1 == "trn_pass_road_LDV_4W" &
+    LF[
+      subsector_L1 == "trn_pass_road_LDV_4W" &
       year >= target_year,
-    loadFactor := loadFactor * (1 + target_LF)]
+      loadFactor := loadFactor * (1 + target_LF)]
+  }
 
   ## LF for electric and h2 trucks/buses assumed ot be the same as liquids
   LF = rbind(LF,

--- a/R/regressionNAVIGATE.R
+++ b/R/regressionNAVIGATE.R
@@ -10,7 +10,6 @@
 #' @param COVID_dir folder where input data is about COVID
 #' @param Baseline_Run switch: is it a baseline or an intl aviation run
 #' @param REMIND_scenario SSP scenario
-#' @param smartlifestyle switch activating sustainable lifestyles
 #' @importFrom rmndt approx_dt
 #' @return transport demand projections
 #' @author Sebastian Franz
@@ -20,7 +19,7 @@
 
 
 
-toolDemandRegNAVIGATEIntl <- function(tech_output, price_baseline, GDP_POP, ICCT_data, RPK_cap_baseline, input_folder, COVID_dir="COVID", REMIND_scenario, smartlifestyle, Baseline_Run) {
+toolDemandRegNAVIGATEIntl <- function(tech_output, price_baseline, GDP_POP, ICCT_data, RPK_cap_baseline, input_folder, COVID_dir="COVID", REMIND_scenario, Baseline_Run) {
   
   rich <- var <- eps <- GDP_cap <- region <- eps1 <- eps2 <- GDP_val <- POP_val <- NULL
   index_GDP <- income_elasticity_freight_sm <- income_elasticity_freight_lo <- index_GDPcap <- NULL
@@ -159,15 +158,6 @@ toolDemandRegNAVIGATEIntl <- function(tech_output, price_baseline, GDP_POP, ICCT
   price_el[region %in% c("IND") & var %in% c("income_elasticity_pass_sm"), eps := 0.5]
   price_el[region %in% c("SSA", "CHA") & var %in% c("income_elasticity_pass_sm"), eps := 0.3]
   price_el[region %in% c("EUR", "NEU", "USA", "CAZ", "JPN", "DEU", "ECE", "ECS", "ENC", "ESC", "ESW", "EWN", "FRA", "UKI", "NEN", "NES") & var %in% c("income_elasticity_pass_lo", "income_elasticity_pass_sm"), eps := 0.1]
-  
-  if (smartlifestyle) {
-    price_el[region =="REF" & var %in% c("income_elasticity_pass_lo", "income_elasticity_pass_sm"), eps := 0]
-    price_el[region %in% c("OAS", "MEA", "LAM") & var %in% c("income_elasticity_pass_lo", "income_elasticity_pass_sm"), eps := 0.1]
-    price_el[region %in% c("IND") & var %in% c("income_elasticity_pass_lo", "income_elasticity_pass_sm"), eps := 0.4]
-    price_el[region %in% c("CHA") & var %in% c("income_elasticity_pass_lo", "income_elasticity_pass_sm"), eps := 0.2]
-    price_el[region %in% c("SSA") & var %in% c("income_elasticity_pass_lo", "income_elasticity_pass_sm"), eps := 0.5]
-    price_el[region %in% c("EUR", "NEU", "USA", "CAZ", "JPN", "DEU", "ECE", "ECS", "ENC", "ESC", "ESW", "EWN", "FRA", "UKI", "NEN", "NES") & var %in% c("income_elasticity_pass_lo", "income_elasticity_pass_sm"), eps := 0]
-  }
   
   price_el[region %in% c("IND", "OAS", "SSA", "MEA") & var %in% c("income_elasticity_pass_lo_L","income_elasticity_pass_lo_B"), eps := 0.25]
   


### PR DESCRIPTION
The factors for the selected demand scenario are read from
`extdata/demscen_factors.csv`. Factors are applied directly to the
demand. Missing years are linearly interpolated. The yearly resolution is arbitrary, but
years have to be > 2020 to affect the demand.