### PR TITLE
let toolIterativeEDGETransport be called from scripts

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '4306353'
+ValidationKey: '4327456'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "edgeTransport: Prepare EDGE Transport Data for the REMIND model",
-  "version": "0.22.3",
+  "version": "0.22.4",
   "description": "<p>EDGE-T is a fork of the GCAM transport module https://jgcri.github.io/gcam-doc/energy.html#transportation with a high level of detail in its representation of technological and modal options. It is a partial equilibrium model with a nested multinomial logit structure and relies on the modified logit formulation. Most of the sources are not publicly available. PIK-internal users can find the sources in the distributed file system in the folder `/p/projects/rd3mod/inputdata/sources/EDGE-Transport-Standalone`.<\/p>",
   "creators": [
     {

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: edgeTransport
 Title: Prepare EDGE Transport Data for the REMIND model
-Version: 0.22.3
+Version: 0.22.4
 Authors@R: c(
     person("Alois", "Dirnaichner", email = "dirnaichner@pik-potsdam.de", role = c("aut", "cre")),
     person("Marianna", "Rottoli", email = "rottoli@pik-potsdam.de", role = "aut"))
@@ -13,7 +13,7 @@ Encoding: UTF-8
 LazyData: true
 RoxygenNote: 7.2.1
 VignetteBuilder: knitr
-Date: 2022-11-15
+Date: 2022-11-23
 Config/testthat/edition: 3
 Imports:
     rmndt,

--- a/R/iterativeEDGETransport.R
+++ b/R/iterativeEDGETransport.R
@@ -280,7 +280,7 @@ toolIterativeEDGETransport <- function(reporting=FALSE) {
 
     fwrite(vint, vintfile, col.names=TRUE, append=TRUE)
 
-    quit()
+    return()
   }
 
   num_veh_stations = toolVehicleStations(

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Prepare EDGE Transport Data for the REMIND model
 
-R package **edgeTransport**, version **0.22.3**
+R package **edgeTransport**, version **0.22.4**
 
-[![CRAN status](https://www.r-pkg.org/badges/version/edgeTransport)](https://cran.r-project.org/package=edgeTransport)  [![R build status](https://github.com/johannah-pik/edgeTransport/workflows/check/badge.svg)](https://github.com/johannah-pik/edgeTransport/actions) [![codecov](https://codecov.io/gh/johannah-pik/edgeTransport/branch/master/graph/badge.svg)](https://app.codecov.io/gh/johannah-pik/edgeTransport) [![r-universe](https://pik-piam.r-universe.dev/badges/edgeTransport)](https://pik-piam.r-universe.dev/ui#builds)
+[![CRAN status](https://www.r-pkg.org/badges/version/edgeTransport)](https://cran.r-project.org/package=edgeTransport)  [![R build status](https://github.com/orichters/edgeTransport/workflows/check/badge.svg)](https://github.com/orichters/edgeTransport/actions) [![codecov](https://codecov.io/gh/orichters/edgeTransport/branch/master/graph/badge.svg)](https://app.codecov.io/gh/orichters/edgeTransport) [![r-universe](https://pik-piam.r-universe.dev/badges/edgeTransport)](https://pik-piam.r-universe.dev/ui#builds)
 
 ## Purpose and Functionality
 
@@ -46,7 +46,7 @@ In case of questions / problems please contact Alois Dirnaichner <dirnaichner@pi
 
 To cite package **edgeTransport** in publications use:
 
-Dirnaichner A, Rottoli M (2022). _edgeTransport: Prepare EDGE Transport Data for the REMIND model_. R package version 0.22.3.
+Dirnaichner A, Rottoli M (2022). _edgeTransport: Prepare EDGE Transport Data for the REMIND model_. R package version 0.22.4.
 
 A BibTeX entry for LaTeX users is
 
@@ -55,6 +55,6 @@ A BibTeX entry for LaTeX users is
   title = {edgeTransport: Prepare EDGE Transport Data for the REMIND model},
   author = {Alois Dirnaichner and Marianna Rottoli},
   year = {2022},
-  note = {R package version 0.22.3},
+  note = {R package version 0.22.4},
 }
 ```


### PR DESCRIPTION
using `quit()` in a function terminates the `R` session, which is not really friendly and does not allow to call this function from an `R` script. `return()` just returns `NULL` and ends the function, which I guess what is intended here.

Question: shouldn't [those two filenames](https://github.com/pik-piam/edgeTransport/blob/1ebe4f3be9906356bdcb1576dc78bc04317aee9f/R/iterativeEDGETransport.R#L121-L122) also have a `datapath()` around the filename?
