### PR TITLE
add URL to description, and credit where credit is due

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '4346775'
+ValidationKey: '4347900'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -8,6 +8,9 @@
     },
     {
       "name": "Rottoli, Marianna"
+    },
+    {
+      "name": "Hoppe, Johanna"
     }
   ]
 }

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,17 +3,19 @@ Title: Prepare EDGE Transport Data for the REMIND model
 Version: 0.22.5
 Authors@R: c(
     person("Alois", "Dirnaichner", email = "dirnaichner@pik-potsdam.de", role = c("aut", "cre")),
-    person("Marianna", "Rottoli", email = "rottoli@pik-potsdam.de", role = "aut"))
+    person("Marianna", "Rottoli", email = "rottoli@pik-potsdam.de", role = "aut"),
+    person("Johanna", "Hoppe", role = "aut"))
 Description: EDGE-T is a fork of the GCAM transport module https://jgcri.github.io/gcam-doc/energy.html#transportation with a high level of detail in its representation of technological and modal options. It is a partial equilibrium model with a nested multinomial logit structure and relies on the modified logit formulation. Most of the sources are not publicly available. PIK-internal users can find the sources in the distributed file system in the folder `/p/projects/rd3mod/inputdata/sources/EDGE-Transport-Standalone`.
 Depends:
     R (>= 3.1),
     data.table (>= 1.11.0)
 License: GPL-3
+URL: https://github.com/pik-piam/edgeTransport
 Encoding: UTF-8
 LazyData: true
 RoxygenNote: 7.2.1
 VignetteBuilder: knitr
-Date: 2022-11-23
+Date: 2022-11-28
 Config/testthat/edition: 3
 Imports:
     rmndt,

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 R package **edgeTransport**, version **0.22.5**
 
-[![CRAN status](https://www.r-pkg.org/badges/version/edgeTransport)](https://cran.r-project.org/package=edgeTransport)  [![R build status](https://github.com/johannah-pik/edgeTransport/workflows/check/badge.svg)](https://github.com/johannah-pik/edgeTransport/actions) [![codecov](https://codecov.io/gh/johannah-pik/edgeTransport/branch/master/graph/badge.svg)](https://app.codecov.io/gh/johannah-pik/edgeTransport) [![r-universe](https://pik-piam.r-universe.dev/badges/edgeTransport)](https://pik-piam.r-universe.dev/ui#builds)
+[![CRAN status](https://www.r-pkg.org/badges/version/edgeTransport)](https://cran.r-project.org/package=edgeTransport)  [![R build status](https://github.com/pik-piam/edgeTransport/workflows/check/badge.svg)](https://github.com/pik-piam/edgeTransport/actions) [![codecov](https://codecov.io/gh/pik-piam/edgeTransport/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/edgeTransport) [![r-universe](https://pik-piam.r-universe.dev/badges/edgeTransport)](https://pik-piam.r-universe.dev/ui#builds)
 
 ## Purpose and Functionality
 
@@ -46,15 +46,16 @@ In case of questions / problems please contact Alois Dirnaichner <dirnaichner@pi
 
 To cite package **edgeTransport** in publications use:
 
-Dirnaichner A, Rottoli M (2022). _edgeTransport: Prepare EDGE Transport Data for the REMIND model_. R package version 0.22.5.
+Dirnaichner A, Rottoli M, Hoppe J (2022). _edgeTransport: Prepare EDGE Transport Data for the REMIND model_. R package version 0.22.5, <URL: https://github.com/pik-piam/edgeTransport>.
 
 A BibTeX entry for LaTeX users is
 
  ```latex
 @Manual{,
   title = {edgeTransport: Prepare EDGE Transport Data for the REMIND model},
-  author = {Alois Dirnaichner and Marianna Rottoli},
+  author = {Alois Dirnaichner and Marianna Rottoli and Johanna Hoppe},
   year = {2022},
   note = {R package version 0.22.5},
+  url = {https://github.com/pik-piam/edgeTransport},
 }
 ```

--- a/man/edgeTransport-package.Rd
+++ b/man/edgeTransport-package.Rd
@@ -8,12 +8,20 @@
 \description{
 EDGE-T is a fork of the GCAM transport module https://jgcri.github.io/gcam-doc/energy.html#transportation with a high level of detail in its representation of technological and modal options. It is a partial equilibrium model with a nested multinomial logit structure and relies on the modified logit formulation. Most of the sources are not publicly available. PIK-internal users can find the sources in the distributed file system in the folder `/p/projects/rd3mod/inputdata/sources/EDGE-Transport-Standalone`.
 }
+\seealso{
+Useful links:
+\itemize{
+  \item \url{https://github.com/pik-piam/edgeTransport}
+}
+
+}
 \author{
 \strong{Maintainer}: Alois Dirnaichner \email{dirnaichner@pik-potsdam.de}
 
 Authors:
 \itemize{
   \item Marianna Rottoli \email{rottoli@pik-potsdam.de}
+  \item Johanna Hoppe
 }
 
 }


### PR DESCRIPTION
Pascal told me that one can add the url to the description such that it does not use the individual fork links.
Also add you to the author list, credit where credit is due…