### PR TITLE
Fix POP changes in EDGE-T

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '5262549'
+ValidationKey: '5286592'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "edgeTransport: Prepare EDGE Transport Data for the REMIND model",
-  "version": "0.27.1",
+  "version": "0.27.2",
   "description": "<p>EDGE-T is a fork of the GCAM transport module https://jgcri.github.io/gcam-doc/energy.html#transportation with a high level of detail in its representation of technological and modal options. It is a partial equilibrium model with a nested multinomial logit structure and relies on the modified logit formulation. Most of the sources are not publicly available. PIK-internal users can find the sources in the distributed file system in the folder `/p/projects/rd3mod/inputdata/sources/EDGE-Transport-Standalone`.<\/p>",
   "creators": [
     {

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: edgeTransport
 Title: Prepare EDGE Transport Data for the REMIND model
-Version: 0.27.1
+Version: 0.27.2
 Authors@R: c(
     person("Alois", "Dirnaichner", email = "dirnaichner@pik-potsdam.de", role = c("aut", "cre")),
     person("Marianna", "Rottoli", email = "rottoli@pik-potsdam.de", role = "aut"),
@@ -15,7 +15,7 @@ Encoding: UTF-8
 LazyData: true
 RoxygenNote: 7.2.3
 VignetteBuilder: knitr
-Date: 2023-03-03
+Date: 2023-03-20
 Config/testthat/edition: 3
 Imports:
     rmndt,

--- a/R/mrremind.R
+++ b/R/mrremind.R
@@ -18,7 +18,7 @@ toolMrremind <- function(SSP_scen, REMIND2ISO_MAPPING, cache_folder){
     POP_country = readRDS(file.path(cache_folder, "POP_country.RDS"))
     trsp_incent = readRDS(file.path(cache_folder, "trasp_incent.RDS"))
   }else{
-    IEAbal <- calcOutput(type = "IO", subtype = "IEA_output", aggregate = TRUE, regionmapping = "regionmapping_21_EU11.csv")    
+    IEAbal <- calcOutput(type = "IO", subtype = "IEA_output", aggregate = TRUE, regionmapping = "regionmapping_21_EU11.csv")
    GDP_country = {
       x <- calcOutput("GDP", aggregate = F)
       getSets(x)[1] <- "ISO3"
@@ -67,6 +67,7 @@ toolMrremind <- function(SSP_scen, REMIND2ISO_MAPPING, cache_folder){
   POP = merge(POP_country, REMIND2ISO_MAPPING, by.x = "iso2c", by.y = "iso")
   POP = POP[,.(value = sum(value)), by = c("region", "year")]
   setnames(POP_country, old = c("iso2c", "variable"), new = c("iso", "POP"),skip_absent=TRUE)
+  POP <- POP[year %in% unique(GDP_country$year)]
 
   GDP_POP=merge(GDP,POP[,.(region,year,POP_val=value)],all = TRUE,by=c("region","year"))
   GDP_POP[,GDP_cap:=weight/POP_val]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Prepare EDGE Transport Data for the REMIND model
 
-R package **edgeTransport**, version **0.27.1**
+R package **edgeTransport**, version **0.27.2**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/edgeTransport)](https://cran.r-project.org/package=edgeTransport)  [![R build status](https://github.com/pik-piam/edgeTransport/workflows/check/badge.svg)](https://github.com/pik-piam/edgeTransport/actions) [![codecov](https://codecov.io/gh/pik-piam/edgeTransport/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/edgeTransport) [![r-universe](https://pik-piam.r-universe.dev/badges/edgeTransport)](https://pik-piam.r-universe.dev/builds)
 
@@ -46,7 +46,7 @@ In case of questions / problems please contact Alois Dirnaichner <dirnaichner@pi
 
 To cite package **edgeTransport** in publications use:
 
-Dirnaichner A, Rottoli M, Hoppe J (2023). _edgeTransport: Prepare EDGE Transport Data for the REMIND model_. R package version 0.27.1, <https://github.com/pik-piam/edgeTransport>.
+Dirnaichner A, Rottoli M, Hoppe J (2023). _edgeTransport: Prepare EDGE Transport Data for the REMIND model_. R package version 0.27.2, <https://github.com/pik-piam/edgeTransport>.
 
 A BibTeX entry for LaTeX users is
 
@@ -55,7 +55,7 @@ A BibTeX entry for LaTeX users is
   title = {edgeTransport: Prepare EDGE Transport Data for the REMIND model},
   author = {Alois Dirnaichner and Marianna Rottoli and Johanna Hoppe},
   year = {2023},
-  note = {R package version 0.27.1},
+  note = {R package version 0.27.2},
   url = {https://github.com/pik-piam/edgeTransport},
 }
 ```


### PR DESCRIPTION
Due to a change in mrcommons the Population data is provided for more timesteps. This fix is needed, so that EDGE-T can handle the new data resolution. Note that this is a quick fix. After the refactoring all input data should be checked and normed to EDGE-T structure and timesteps