### PR TITLE
Delete call for non-existent bus data (GCAMBug)

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '6043140'
+ValidationKey: '1955900'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
     -   id: mixed-line-ending
 
 -   repo: https://github.com/lorenzwalthert/precommit
-    rev: v0.3.2.9007
+    rev: v0.3.2.9013
     hooks:
     -   id: parsable-R
     -   id: deps-in-desc

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'edgeTransport: Prepare EDGE Transport Data for the REMIND model'
-version: 0.31.0
-date-released: '2023-05-17'
+version: 1.0.0
+date-released: '2023-07-21'
 abstract: EDGE-T is a fork of the GCAM transport module https://jgcri.github.io/gcam-doc/energy.html#transportation
   with a high level of detail in its representation of technological and modal options.
   It is a partial equilibrium model with a nested multinomial logit structure and

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: edgeTransport
 Title: Prepare EDGE Transport Data for the REMIND model
-Version: 0.31.0
+Version: 1.0.0
 Authors@R: c(
     person("Alois", "Dirnaichner", email = "dirnaichner@pik-potsdam.de", role = c("aut", "cre")),
     person("Marianna", "Rottoli", email = "rottoli@pik-potsdam.de", role = "aut"),
@@ -15,7 +15,7 @@ Encoding: UTF-8
 LazyData: true
 RoxygenNote: 7.2.3
 VignetteBuilder: knitr
-Date: 2023-05-17
+Date: 2023-07-21
 Config/testthat/edition: 3
 Imports:
     rmndt,

--- a/Makefile
+++ b/Makefile
@@ -11,8 +11,9 @@ HELP_PARSING = 'm <- readLines("Makefile");\
 help:           ## Show this help.
 	@Rscript -e $(HELP_PARSING)
 
-build:          ## Build the package using lucode2::buildLibrary().
-	Rscript -e 'lucode2::buildLibrary()'
+build:          ## Build the package using lucode2::buildLibrary(). You can pass the
+                ## updateType with 'make build u=3'
+	Rscript -e 'lucode2::buildLibrary(updateType = "$(u)")'
 
 check:          ## Build documentation and vignettes, run testthat tests,
                 ## and check if code etiquette is followed using lucode2::check().

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Prepare EDGE Transport Data for the REMIND model
 
-R package **edgeTransport**, version **0.31.0**
+R package **edgeTransport**, version **1.0.0**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/edgeTransport)](https://cran.r-project.org/package=edgeTransport)  [![R build status](https://github.com/pik-piam/edgeTransport/workflows/check/badge.svg)](https://github.com/pik-piam/edgeTransport/actions) [![codecov](https://codecov.io/gh/pik-piam/edgeTransport/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/edgeTransport) [![r-universe](https://pik-piam.r-universe.dev/badges/edgeTransport)](https://pik-piam.r-universe.dev/builds)
 
@@ -46,7 +46,7 @@ In case of questions / problems please contact Alois Dirnaichner <dirnaichner@pi
 
 To cite package **edgeTransport** in publications use:
 
-Dirnaichner A, Rottoli M, Hoppe J (2023). _edgeTransport: Prepare EDGE Transport Data for the REMIND model_. R package version 0.31.0, <https://github.com/pik-piam/edgeTransport>.
+Dirnaichner A, Rottoli M, Hoppe J (2023). _edgeTransport: Prepare EDGE Transport Data for the REMIND model_. R package version 1.0.0, <https://github.com/pik-piam/edgeTransport>.
 
 A BibTeX entry for LaTeX users is
 
@@ -55,7 +55,7 @@ A BibTeX entry for LaTeX users is
   title = {edgeTransport: Prepare EDGE Transport Data for the REMIND model},
   author = {Alois Dirnaichner and Marianna Rottoli and Johanna Hoppe},
   year = {2023},
-  note = {R package version 0.31.0},
+  note = {R package version 1.0.0},
   url = {https://github.com/pik-piam/edgeTransport},
 }
 ```

--- a/inst/extdata/mapping_EDGECES.csv
+++ b/inst/extdata/mapping_EDGECES.csv
@@ -5,8 +5,6 @@ trn_pass,trn_pass_road_LDV,Hydrogen,feh2t_p_sm
 trn_pass,trn_pass_road_LDV,NG,fegat_p_sm
 trn_pass,Bus,Liquids,fedie_p_sm
 trn_pass,Bus,NG,fegat_p_sm
-trn_pass,trn_pass_road_bus,Liquids,fedie_p_sm
-trn_pass,trn_pass_road_bus,NG,fegat_p_sm
 trn_pass,Domestic Aviation_tmp_subsector_L2,Liquids,fedie_p_sm
 trn_pass,Domestic Aviation_tmp_subsector_L2,Hydrogen,feh2t_p_sm
 trn_pass,HSR_tmp_subsector_L2,Electricity,feelt_p_sm
@@ -15,7 +13,6 @@ trn_pass,Passenger Rail_tmp_subsector_L2,Liquids,fedie_p_sm
 trn_freight,trn_freight_road_tmp_subsector_L2,Liquids,fedie_f_sm
 trn_freight,trn_freight_road_tmp_subsector_L2,NG,fegat_f_sm
 trn_freight,Domestic Ship_tmp_subsector_L2,Liquids,fedie_f_sm
-trn_freight,Freight Rail_tmp_subsector_L2,Coal,fedie_f_sm
 trn_freight,Freight Rail_tmp_subsector_L2,Electricity,feelt_f_sm
 trn_freight,Freight Rail_tmp_subsector_L2,Liquids,fedie_f_sm
 trn_aviation_intl,International Aviation_tmp_subsector_L2,Liquids,fedie_p_lo


### PR DESCRIPTION
This call dates back to the initial data provided by GCAM and UCD ("Bus" was divided into "Light and Heavy Bus" but we merged this before (https://github.com/pik-piam/edgeTransport/blob/75cadc8e7cad6215010475b19c74cf8a745fa278/R/sharesIntensitiesDemand.R#L104). Now, for some reason, the mapping on these technologies was kept and caused NAs (fedie_p_sm is "broken" by the NAs generating from trn_pass,trn_pass_road_bus,Liquids,fedie_p_sm, fegat_p_sm from trn_pass,trn_pass_road_bus,NG,fegat_p_sm etc). I just deleted the categories trn_pass,trn_pass_road_bus,Liquids,fedie_p_sm, fegat_p_sm from trn_pass,trn_pass_road_bus,NG,fegat_p_sm etc