### PR TITLE
exclude DEU from IEA harmonization

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '2158310'
+ValidationKey: '2179929'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
     -   id: mixed-line-ending
 
 -   repo: https://github.com/lorenzwalthert/precommit
-    rev: v0.3.2.9019
+    rev: v0.3.2.9021
     hooks:
     -   id: parsable-R
     -   id: deps-in-desc

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'edgeTransport: Prepare EDGE Transport Data for the REMIND model'
-version: 1.1.0
-date-released: '2023-09-21'
+version: 1.1.1
+date-released: '2023-10-09'
 abstract: EDGE-T is a fork of the GCAM transport module https://jgcri.github.io/gcam-doc/energy.html#transportation
   with a high level of detail in its representation of technological and modal options.
   It is a partial equilibrium model with a nested multinomial logit structure and

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: edgeTransport
 Title: Prepare EDGE Transport Data for the REMIND model
-Version: 1.1.0
+Version: 1.1.1
 Authors@R: c(
     person("Alois", "Dirnaichner", email = "dirnaichner@pik-potsdam.de", role = c("aut", "cre")),
     person("Marianna", "Rottoli", email = "rottoli@pik-potsdam.de", role = "aut"),
@@ -15,7 +15,7 @@ Encoding: UTF-8
 LazyData: true
 RoxygenNote: 7.2.3
 VignetteBuilder: knitr
-Date: 2023-09-21
+Date: 2023-10-09
 Config/testthat/edition: 3
 Imports:
     rmndt,

--- a/R/IEAharmonization.R
+++ b/R/IEAharmonization.R
@@ -109,8 +109,9 @@ toolIEAharmonization <- function(int, demKm, IEA) {
     tech_output=tech_output[, c("region","technology","vehicle_type", "factor_intensity")]
 
     ## harmonize data
+    # leave out DEU as it was carefully adjusted by Alois to meet Ariadne data
     merged_intensity <- tech_output[vehicle_intensity, on=c("region", "technology", "vehicle_type")]
-    merged_intensity[, EJ_Mpkm_final := EJ_Mpkm * factor_intensity]
+    merged_intensity[!region == "DEU", EJ_Mpkm_final := EJ_Mpkm * factor_intensity]
     ## if there is no harmonization data, lets use the existing one
     merged_intensity[is.na(EJ_Mpkm_final), EJ_Mpkm_final := EJ_Mpkm]
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Prepare EDGE Transport Data for the REMIND model
 
-R package **edgeTransport**, version **1.1.0**
+R package **edgeTransport**, version **1.1.1**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/edgeTransport)](https://cran.r-project.org/package=edgeTransport)  [![R build status](https://github.com/pik-piam/edgeTransport/workflows/check/badge.svg)](https://github.com/pik-piam/edgeTransport/actions) [![codecov](https://codecov.io/gh/pik-piam/edgeTransport/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/edgeTransport) [![r-universe](https://pik-piam.r-universe.dev/badges/edgeTransport)](https://pik-piam.r-universe.dev/builds)
 
@@ -46,7 +46,7 @@ In case of questions / problems please contact Alois Dirnaichner <dirnaichner@pi
 
 To cite package **edgeTransport** in publications use:
 
-Dirnaichner A, Rottoli M, Hoppe J (2023). _edgeTransport: Prepare EDGE Transport Data for the REMIND model_. R package version 1.1.0, <https://github.com/pik-piam/edgeTransport>.
+Dirnaichner A, Rottoli M, Hoppe J (2023). _edgeTransport: Prepare EDGE Transport Data for the REMIND model_. R package version 1.1.1, <https://github.com/pik-piam/edgeTransport>.
 
 A BibTeX entry for LaTeX users is
 
@@ -55,7 +55,7 @@ A BibTeX entry for LaTeX users is
   title = {edgeTransport: Prepare EDGE Transport Data for the REMIND model},
   author = {Alois Dirnaichner and Marianna Rottoli and Johanna Hoppe},
   year = {2023},
-  note = {R package version 1.1.0},
+  note = {R package version 1.1.1},
   url = {https://github.com/pik-piam/edgeTransport},
 }
 ```


### PR DESCRIPTION
Transport final energy ist too low for DEU and was better in previous ARIADNE runs:
- In October 21 a [bug](https://github.com/pik-piam/edgeTransport/commit/cab45c471a1ce4e90d2a7579762b0a0d66805a83) was introduced that excluded all EUR countries from harmonization (IEA data was loaded only for H12 regions)
- In the context of harmonization processes within Ariadne, the energy intensity data for DEU was adjusted manually in accordance to DLR values ([PR in July 2022](https://github.com/pik-piam/edgeTransport/commit/e1b34cfcef00ed50b84f42d78930655d7bdb4422))
- In November 2022 the [Bug was fixed](https://github.com/pik-piam/edgeTransport/pull/204) so that DEU was again part of the IEA harmonization. Apparently, this made it worse for DEU as it was applied on top of the manual adjustments

We now exclude DEU from the IEA harmonization process in order to get back on the manually adjusted values
Runs and CompScen here: /p/projects/edget/20231009_PR233_Exclude DEU from IEA harmonization