### PR TITLE
Adjust PhOP for Trucks and Busses in standard scenarios

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '2179929'
+ValidationKey: '2357040'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'edgeTransport: Prepare EDGE Transport Data for the REMIND model'
-version: 1.1.1
-date-released: '2023-10-09'
+version: 1.2.0
+date-released: '2023-10-12'
 abstract: EDGE-T is a fork of the GCAM transport module https://jgcri.github.io/gcam-doc/energy.html#transportation
   with a high level of detail in its representation of technological and modal options.
   It is a partial equilibrium model with a nested multinomial logit structure and

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: edgeTransport
 Title: Prepare EDGE Transport Data for the REMIND model
-Version: 1.1.1
+Version: 1.2.0
 Authors@R: c(
     person("Alois", "Dirnaichner", email = "dirnaichner@pik-potsdam.de", role = c("aut", "cre")),
     person("Marianna", "Rottoli", email = "rottoli@pik-potsdam.de", role = "aut"),
@@ -15,7 +15,7 @@ Encoding: UTF-8
 LazyData: true
 RoxygenNote: 7.2.3
 VignetteBuilder: knitr
-Date: 2023-10-09
+Date: 2023-10-12
 Config/testthat/edition: 3
 Imports:
     rmndt,

--- a/R/incotrend.R
+++ b/R/incotrend.R
@@ -279,16 +279,35 @@ Hybrid Electric,Liquids")
     ## remove L2 and L3 from mitab to avoid a join on these sectors
     FVtarget <- mitab[level == "FV"][, c("subsector_L2", "subsector_L3") := NULL][FVtarget, on = c("FV_vehvar", "FV_techvar", "regioncat")]
 
-    if(tech_scen %in% c("PhOP", "Mix3", "Mix4", "HydrHype4", "ECEMF_HighEl_ModEff", "ECEMF_HighEl_HighEff", "ECEMF_HighEl_LifestCha", "ECEMF_HighH2_ModEff", "ECEMF_HighH2_HighEff", "ECEMF_HighH2_LifestCha")){
+    if (tech_scen %in% c("Mix3", "Mix4", "HydrHype4", "ECEMF_HighEl_ModEff", "ECEMF_HighEl_HighEff", "ECEMF_HighEl_LifestCha", "ECEMF_HighH2_ModEff", "ECEMF_HighH2_HighEff", "ECEMF_HighH2_LifestCha")){
 
-      FVtarget_all = FVtarget[!(technology %in% c("Liquids","NG") & subsector_L1 %in% c("trn_freight_road_tmp_subsector_L1", "Bus_tmp_subsector_L1") & region %in% c("DEU", "ECE", "ECS", "ENC", "ESC", "ESW", "EWN", "FRA"))]
+      FVtarget_all = FVtarget[!(technology %in% c("Liquids","NG") & subsector_L1 %in% c("trn_freight_road_tmp_subsector_L1", "Bus_tmp_subsector_L1") & region %in% c("DEU", "ECE", "ECS", "ENC", "ESC", "ESW", "EWN", "FRA", "UKI"))]
 
       FVtarget_all[, value := ifelse(
         is.na(target), value, apply_logistic_trends(year, target, symmyr, speed) * value),
         by=c("region", "vehicle_type", "technology")]
 
       ## ICE trucks and buses
-      FVtarget_tb = FVtarget[subsector_L1 %in% c("trn_freight_road_tmp_subsector_L1", "Bus_tmp_subsector_L1") & technology %in% c("Liquids", "NG") & region %in% c("DEU", "ECE", "ECS", "ENC", "ESC", "ESW", "EWN", "FRA")]
+      FVtarget_tb = FVtarget[subsector_L1 %in% c("trn_freight_road_tmp_subsector_L1", "Bus_tmp_subsector_L1") & technology %in% c("Liquids", "NG") & region %in% c("DEU", "ECE", "ECS", "ENC", "ESC", "ESW", "EWN", "FRA", "UKI")]
+      FVtarget_tb[, value := ifelse(year==2025,0.98*value[year==2015],value),by = c("region","technology")]
+      FVtarget_tb[, value := ifelse(year==2030,0.75*value[year==2015],value),by = c("region","technology")]
+      FVtarget_tb[, value := ifelse(year==2035,0.3*value[year==2015],value),by = c("region","technology")]
+      FVtarget_tb[, value := ifelse(year==2040,0.2*value[year==2015],value),by = c("region","technology")]
+      FVtarget_tb[, value := ifelse(year==2045,0.1*value[year==2015],value),by = c("region","technology")]
+      FVtarget_tb[year>=2045, value := 0.05]
+
+      FVtarget=rbind(FVtarget_all,FVtarget_tb)
+
+    } else if (tech_scen == "PhOP") {
+
+      FVtarget_all = FVtarget[!(technology %in% c("Liquids","NG") & subsector_L1 %in% c("trn_freight_road_tmp_subsector_L1", "Bus_tmp_subsector_L1") & region %in% c("DEU", "ECE", "ECS", "ENC", "ESC", "ESW", "EWN", "FRA", "UKI"))]
+
+      FVtarget_all[, value := ifelse(
+        is.na(target), value, apply_logistic_trends(year, target, symmyr, speed) * value),
+        by=c("region", "vehicle_type", "technology")]
+
+      ## ICE trucks and buses
+      FVtarget_tb = FVtarget[subsector_L1 %in% c("trn_freight_road_tmp_subsector_L1", "Bus_tmp_subsector_L1") & technology %in% c("Liquids", "NG") & region %in% c("DEU", "ECE", "ECS", "ENC", "ESC", "ESW", "EWN", "FRA", "UKI")]
       FVtarget_tb[, value := ifelse(year==2020,0.9*value[year==2015],value),by = c("region","technology")]
       FVtarget_tb[, value := ifelse(year==2025,0.6*value[year==2015],value),by = c("region","technology")]
       FVtarget_tb[, value := ifelse(year==2030,0.3*value[year==2015],value),by = c("region","technology")]
@@ -297,7 +316,7 @@ Hybrid Electric,Liquids")
 
       FVtarget=rbind(FVtarget_all,FVtarget_tb)
 
-    } else{
+    } else {
 
       FVtarget[, value := ifelse(
         is.na(target), value, apply_logistic_trends(year, target, symmyr, speed) * value),

--- a/R/logit.R
+++ b/R/logit.R
@@ -575,7 +575,7 @@ toolCalculateLogitIncost <- function(prices,
 
     if(tech_scen %in% c("PhOP", "Mix3", "Mix4", "HydrHype4", "ECEMF_HighEl_ModEff", "ECEMF_HighEl_HighEff", "ECEMF_HighEl_LifestCha", "ECEMF_HighH2_ModEff", "ECEMF_HighH2_HighEff", "ECEMF_HighH2_LifestCha") & t>= 2030){
       ## phase-out of all light-duty vehicle ICEs
-      EUreg <- c("DEU", "ECE", "ECS", "ENC", "ESC", "ESW", "EWN", "FRA", "EU27", "EUR")
+      EUreg <- c("DEU", "ECE", "ECS", "ENC", "ESC", "ESW", "EWN", "FRA", "UKI", "EUR")
 
       if(t>=2030 & t<=2032){
         floorEU <- linIncrease(t, 2030, floor, 2032, 0.35)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Prepare EDGE Transport Data for the REMIND model
 
-R package **edgeTransport**, version **1.1.1**
+R package **edgeTransport**, version **1.2.0**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/edgeTransport)](https://cran.r-project.org/package=edgeTransport)  [![R build status](https://github.com/pik-piam/edgeTransport/workflows/check/badge.svg)](https://github.com/pik-piam/edgeTransport/actions) [![codecov](https://codecov.io/gh/pik-piam/edgeTransport/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/edgeTransport) [![r-universe](https://pik-piam.r-universe.dev/badges/edgeTransport)](https://pik-piam.r-universe.dev/builds)
 
@@ -46,7 +46,7 @@ In case of questions / problems please contact Alois Dirnaichner <dirnaichner@pi
 
 To cite package **edgeTransport** in publications use:
 
-Dirnaichner A, Rottoli M, Hoppe J (2023). _edgeTransport: Prepare EDGE Transport Data for the REMIND model_. R package version 1.1.1, <https://github.com/pik-piam/edgeTransport>.
+Dirnaichner A, Rottoli M, Hoppe J (2023). _edgeTransport: Prepare EDGE Transport Data for the REMIND model_. R package version 1.2.0, <https://github.com/pik-piam/edgeTransport>.
 
 A BibTeX entry for LaTeX users is
 
@@ -55,7 +55,7 @@ A BibTeX entry for LaTeX users is
   title = {edgeTransport: Prepare EDGE Transport Data for the REMIND model},
   author = {Alois Dirnaichner and Marianna Rottoli and Johanna Hoppe},
   year = {2023},
-  note = {R package version 1.1.1},
+  note = {R package version 1.2.0},
   url = {https://github.com/pik-piam/edgeTransport},
 }
 ```

--- a/inst/Rmd/compareScenarios_Transport/csEDGET_04_stock_and_sales.Rmd
+++ b/inst/Rmd/compareScenarios_Transport/csEDGET_04_stock_and_sales.Rmd
@@ -15,7 +15,7 @@ items <- c(
   )
 
 showAreaAndBarPlots(data, items, tot, orderVars = "user")
-showAreaAndBarPlots(data, items, tot, fill=TRUE, orderVars = "user")
+showAreaAndBarPlots(data, items, tot, fill = TRUE, orderVars = "user")
 ```
 
 ## LDV Sales by vehicle size
@@ -32,7 +32,7 @@ items <- c(
        "Sales|Transport|LDV|Van"
   )
 showAreaAndBarPlots(data, items, tot, orderVars = "user")
-showAreaAndBarPlots(data, items, tot, fill=TRUE, orderVars = "user")
+showAreaAndBarPlots(data, items, tot, fill = TRUE, orderVars = "user")
 ```
 
 ## LDV Stock by technology
@@ -46,7 +46,7 @@ items <- c(
        "Stock|Transport|LDV|Subcompact Car|NG"
   )
 showAreaAndBarPlots(data, items, tot, orderVars = "user")
-showAreaAndBarPlots(data, items, tot, fill=TRUE, orderVars = "user")
+showAreaAndBarPlots(data, items, tot, fill = TRUE, orderVars = "user")
 ```
 
 ## LDV Sales by technology
@@ -60,7 +60,7 @@ items <- c(
        "Sales|Transport|LDV|Subcompact Car|NG"
   )
 showAreaAndBarPlots(data, items, tot, orderVars = "user")
-showAreaAndBarPlots(data, items, tot, fill=TRUE, orderVars = "user")
+showAreaAndBarPlots(data, items, tot, fill = TRUE, orderVars = "user")
 ```
 
 ## LDV Stock by technology
@@ -74,7 +74,7 @@ items <- c(
        "Stock|Transport|LDV|Large Car and SUV|NG"
   )
 showAreaAndBarPlots(data, items, tot, orderVars = "user")
-showAreaAndBarPlots(data, items, tot, fill=TRUE, orderVars = "user")
+showAreaAndBarPlots(data, items, tot, fill = TRUE, orderVars = "user")
 ```
 
 ## LDV Sales by technology
@@ -88,7 +88,7 @@ items <- c(
        "Sales|Transport|LDV|Large Car and SUV|NG"
   )
 showAreaAndBarPlots(data, items, tot, orderVars = "user")
-showAreaAndBarPlots(data, items, tot, fill=TRUE, orderVars = "user")
+showAreaAndBarPlots(data, items, tot, fill = TRUE, orderVars = "user")
 ```
 
 
@@ -104,92 +104,121 @@ items <- c(
   )
 
 showAreaAndBarPlots(data, items, tot, orderVars = "user")
-showAreaAndBarPlots(data, items, tot, fill=TRUE, orderVars = "user")
+showAreaAndBarPlots(data, items, tot, fill = TRUE, orderVars = "user")
 ```
 
 
-## Truck stock by size
+<!-- ## Truck stock by size -->
+<!-- ```{r} -->
+<!-- tot <- "Stock|Transport|Truck" -->
+<!-- items <- c( -->
+<!--        "Stock|Transport|Truck|Truck (0-3.5t)", -->
+<!--        "Stock|Transport|Truck|Truck (7.5t)", -->
+<!--        "Stock|Transport|Truck|Truck (18t)", -->
+<!--        "Stock|Transport|Truck|Truck (26t)", -->
+<!--        "Stock|Transport|Truck|Truck (40t)" -->
+<!--   ) -->
+
+<!-- showAreaAndBarPlots(data, items, tot, orderVars = "user") -->
+<!-- showAreaAndBarPlots(data, items, tot, fill = TRUE, orderVars = "user") -->
+<!-- ``` -->
+
+<!-- ## Truck sales by size -->
+<!-- ```{r} -->
+<!-- tot <- "Sales|Transport|Truck" -->
+<!-- items <- c( -->
+<!--        "Sales|Transport|Truck|Truck (0-3.5t)", -->
+<!--        "Sales|Transport|Truck|Truck (7.5t)", -->
+<!--        "Sales|Transport|Truck|Truck (18t)", -->
+<!--        "Sales|Transport|Truck|Truck (26t)", -->
+<!--        "Sales|Transport|Truck|Truck (40t)" -->
+<!--   ) -->
+
+<!-- showAreaAndBarPlots(data, items, tot, orderVars = "user") -->
+<!-- showAreaAndBarPlots(data, items, tot, fill = TRUE, orderVars = "user") -->
+<!-- ``` -->
+
+## Truck stock by technology
 ```{r}
 tot <- "Stock|Transport|Truck"
 items <- c(
-       "Stock|Transport|Truck|Truck (0-3.5t)",
-       "Stock|Transport|Truck|Truck (7.5t)",
-       "Stock|Transport|Truck|Truck (18t)",
-       "Stock|Transport|Truck|Truck (26t)",
-       "Stock|Transport|Truck|Truck (40t)"
+       "Stock|Transport|Truck|Electric",
+       "Stock|Transport|Truck|FCEV",
+       "Stock|Transport|Truck|Liquids",
+       "Stock|Transport|Truck|NG"
   )
 
 showAreaAndBarPlots(data, items, tot, orderVars = "user")
-showAreaAndBarPlots(data, items, tot, fill=TRUE, orderVars = "user")
+showAreaAndBarPlots(data, items, tot, fill = TRUE, orderVars = "user")
 ```
 
-## Truck sales by size
+## Truck sales by technology
 ```{r}
 tot <- "Sales|Transport|Truck"
 items <- c(
-       "Sales|Transport|Truck|Truck (0-3.5t)",
-       "Sales|Transport|Truck|Truck (7.5t)",
-       "Sales|Transport|Truck|Truck (18t)",
-       "Sales|Transport|Truck|Truck (26t)",
-       "Sales|Transport|Truck|Truck (40t)"
+       "Sales|Transport|Truck|Electric",
+       "Sales|Transport|Truck|FCEV",
+       "Sales|Transport|Truck|Liquids",
+       "Sales|Transport|Truck|NG"
   )
 
 showAreaAndBarPlots(data, items, tot, orderVars = "user")
-showAreaAndBarPlots(data, items, tot, fill=TRUE, orderVars = "user")
+showAreaAndBarPlots(data, items, tot, fill = TRUE, orderVars = "user")
 ```
 
-## Small Truck stock by technology
-```{r}
-tot <- "Stock|Transport|Truck|Truck (0-3.5t)"
-items <- c(
-       "Stock|Transport|Truck|Truck (0-3.5t)|Electric",
-       "Stock|Transport|Truck|Truck (0-3.5t)|FCEV",
-       "Stock|Transport|Truck|Truck (0-3.5t)|Liquids",
-       "Stock|Transport|Truck|Truck (0-3.5t)|NG"
-  )
 
-showAreaAndBarPlots(data, items, tot, orderVars = "user")
-showAreaAndBarPlots(data, items, tot, fill=TRUE, orderVars = "user")
-```
+<!-- ## Small Truck stock by technology -->
+<!-- ```{r} -->
+<!-- tot <- "Stock|Transport|Truck|Truck (0-3.5t)" -->
+<!-- items <- c( -->
+<!--        "Stock|Transport|Truck|Truck (0-3.5t)|Electric", -->
+<!--        "Stock|Transport|Truck|Truck (0-3.5t)|FCEV", -->
+<!--        "Stock|Transport|Truck|Truck (0-3.5t)|Liquids", -->
+<!--        "Stock|Transport|Truck|Truck (0-3.5t)|NG" -->
+<!--   ) -->
 
-## Small Truck sales by technology
-```{r}
-tot <- "Sales|Transport|Truck|Truck (0-3.5t)"
-items <- c(
-       "Sales|Transport|Truck|Truck (0-3.5t)|Electric",
-       "Sales|Transport|Truck|Truck (0-3.5t)|FCEV",
-       "Sales|Transport|Truck|Truck (0-3.5t)|Liquids",
-       "Sales|Transport|Truck|Truck (0-3.5t)|NG"
-  )
+<!-- showAreaAndBarPlots(data, items, tot, orderVars = "user") -->
+<!-- showAreaAndBarPlots(data, items, tot, fill = TRUE, orderVars = "user") -->
+<!-- ``` -->
 
-showAreaAndBarPlots(data, items, tot, orderVars = "user")
-showAreaAndBarPlots(data, items, tot, fill=TRUE, orderVars = "user")
-```
+<!-- ## Small Truck sales by technology -->
+<!-- ```{r} -->
+<!-- tot <- "Sales|Transport|Truck|Truck (0-3.5t)" -->
+<!-- items <- c( -->
+<!--        "Sales|Transport|Truck|Truck (0-3.5t)|Electric", -->
+<!--        "Sales|Transport|Truck|Truck (0-3.5t)|FCEV", -->
+<!--        "Sales|Transport|Truck|Truck (0-3.5t)|Liquids", -->
+<!--        "Sales|Transport|Truck|Truck (0-3.5t)|NG" -->
+<!--   ) -->
 
-## Large Truck stock by technology
-```{r}
-tot <- "Stock|Transport|Truck|Truck (40t)"
-items <- c(
-       "Stock|Transport|Truck|Truck (40t)|Electric",
-       "Stock|Transport|Truck|Truck (40t)|FCEV",
-       "Stock|Transport|Truck|Truck (40t)|Liquids",
-       "Stock|Transport|Truck|Truck (40t)|NG"
-  )
+<!-- showAreaAndBarPlots(data, items, tot, orderVars = "user") -->
+<!-- showAreaAndBarPlots(data, items, tot, fill = TRUE, orderVars = "user") -->
+<!-- ``` -->
 
-showAreaAndBarPlots(data, items, tot, orderVars = "user")
-showAreaAndBarPlots(data, items, tot, fill=TRUE, orderVars = "user")
-```
+<!-- ## Large Truck stock by technology -->
+<!-- ```{r} -->
+<!-- tot <- "Stock|Transport|Truck|Truck (40t)" -->
+<!-- items <- c( -->
+<!--        "Stock|Transport|Truck|Truck (40t)|Electric", -->
+<!--        "Stock|Transport|Truck|Truck (40t)|FCEV", -->
+<!--        "Stock|Transport|Truck|Truck (40t)|Liquids", -->
+<!--        "Stock|Transport|Truck|Truck (40t)|NG" -->
+<!--   ) -->
 
-## Large Truck sales by technology
-```{r}
-tot <- "Sales|Transport|Truck|Truck (40t)"
-items <- c(
-       "Sales|Transport|Truck|Truck (40t)|Electric",
-       "Sales|Transport|Truck|Truck (40t)|FCEV",
-       "Sales|Transport|Truck|Truck (40t)|Liquids",
-       "Sales|Transport|Truck|Truck (40t)|NG"
-  )
+<!-- showAreaAndBarPlots(data, items, tot, orderVars = "user") -->
+<!-- showAreaAndBarPlots(data, items, tot, fill = TRUE, orderVars = "user") -->
+<!-- ``` -->
 
-showAreaAndBarPlots(data, items, tot, orderVars = "user")
-showAreaAndBarPlots(data, items, tot, fill=TRUE, orderVars = "user")
-```
+<!-- ## Large Truck sales by technology -->
+<!-- ```{r} -->
+<!-- tot <- "Sales|Transport|Truck|Truck (40t)" -->
+<!-- items <- c( -->
+<!--        "Sales|Transport|Truck|Truck (40t)|Electric", -->
+<!--        "Sales|Transport|Truck|Truck (40t)|FCEV", -->
+<!--        "Sales|Transport|Truck|Truck (40t)|Liquids", -->
+<!--        "Sales|Transport|Truck|Truck (40t)|NG" -->
+<!--   ) -->
+
+<!-- showAreaAndBarPlots(data, items, tot, orderVars = "user") -->
+<!-- showAreaAndBarPlots(data, items, tot, fill = TRUE, orderVars = "user") -->
+<!-- ``` -->


### PR DESCRIPTION
- The assumptions on the phaseout of ICEs in Trucks and Busses within EUR were a bit to optimistic for the standard scenarios
- PhOP in its original form is kept
- Preference trends were adjusted for trucks and busses in the standard scenarios
- UKI is included again as UK proposed an ICE ban as well for 2035 [original announcement](https://www.gov.uk/government/news/government-takes-historic-step-towards-net-zero-with-end-of-sale-of-new-petrol-and-diesel-cars-by-2030), [now postponed to 2035 ](https://www.fleetnews.co.uk/news/latest-fleet-news/electric-fleet-news/2023/09/20/industry-reacts-to-talk-of-delay-to-2030-new-car-and-van-fossil-fuel-ban)
-Test runs and CompareScenarios can be found here /p/projects/edget/20231012_PR234_Adjust PhOP for Trucks and Busses and include UKI 
- mip choice of colorcode is not working at the moment for specific truck vehicle classes. They are temporarily removed from the compScen 