### PR TITLE
SSP2 BEV-PhaseIn

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '4592640'
+ValidationKey: '4614225'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '4614225'
+ValidationKey: '4634432'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '4634432'
+ValidationKey: '4614225'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'edgeTransport: Prepare EDGE Transport Data for the REMIND model'
-version: 2.3.2
-date-released: '2024-09-10'
+version: 2.3.1
+date-released: '2024-09-09'
 abstract: EDGE-T is a fork of the GCAM transport module https://jgcri.github.io/gcam-doc/energy.html#transportation
   with a high level of detail in its representation of technological and modal options.
   It is a partial equilibrium model with a nested multinomial logit structure and

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'edgeTransport: Prepare EDGE Transport Data for the REMIND model'
-version: 2.3.1
-date-released: '2024-09-09'
+version: 2.3.2
+date-released: '2024-09-10'
 abstract: EDGE-T is a fork of the GCAM transport module https://jgcri.github.io/gcam-doc/energy.html#transportation
   with a high level of detail in its representation of technological and modal options.
   It is a partial equilibrium model with a nested multinomial logit structure and

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'edgeTransport: Prepare EDGE Transport Data for the REMIND model'
-version: 2.3.0
-date-released: '2024-09-02'
+version: 2.3.1
+date-released: '2024-09-09'
 abstract: EDGE-T is a fork of the GCAM transport module https://jgcri.github.io/gcam-doc/energy.html#transportation
   with a high level of detail in its representation of technological and modal options.
   It is a partial equilibrium model with a nested multinomial logit structure and

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: edgeTransport
 Title: Prepare EDGE Transport Data for the REMIND model
-Version: 2.3.2
+Version: 2.3.1
 Authors@R: c(
     person("Johanna", "Hoppe", , "johanna.hoppe@pik-potsdam.de", role = c("aut", "cre"),
            comment = c(ORCID = "0009-0004-6753-5090")),
@@ -18,7 +18,7 @@ Encoding: UTF-8
 LazyData: true
 RoxygenNote: 7.3.2
 VignetteBuilder: knitr
-Date: 2024-09-10
+Date: 2024-09-09
 Config/testthat/edition: 3
 Imports:
     rmndt,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: edgeTransport
 Title: Prepare EDGE Transport Data for the REMIND model
-Version: 2.3.0
+Version: 2.3.1
 Authors@R: c(
     person("Johanna", "Hoppe", , "johanna.hoppe@pik-potsdam.de", role = c("aut", "cre"),
            comment = c(ORCID = "0009-0004-6753-5090")),
@@ -18,7 +18,7 @@ Encoding: UTF-8
 LazyData: true
 RoxygenNote: 7.3.2
 VignetteBuilder: knitr
-Date: 2024-09-02
+Date: 2024-09-09
 Config/testthat/edition: 3
 Imports:
     rmndt,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: edgeTransport
 Title: Prepare EDGE Transport Data for the REMIND model
-Version: 2.3.1
+Version: 2.3.2
 Authors@R: c(
     person("Johanna", "Hoppe", , "johanna.hoppe@pik-potsdam.de", role = c("aut", "cre"),
            comment = c(ORCID = "0009-0004-6753-5090")),
@@ -18,7 +18,7 @@ Encoding: UTF-8
 LazyData: true
 RoxygenNote: 7.3.2
 VignetteBuilder: knitr
-Date: 2024-09-09
+Date: 2024-09-10
 Config/testthat/edition: 3
 Imports:
     rmndt,

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Prepare EDGE Transport Data for the REMIND model
 
-R package **edgeTransport**, version **2.3.0**
+R package **edgeTransport**, version **2.3.1**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/edgeTransport)](https://cran.r-project.org/package=edgeTransport)  [![R build status](https://github.com/pik-piam/edgeTransport/workflows/check/badge.svg)](https://github.com/pik-piam/edgeTransport/actions) [![codecov](https://codecov.io/gh/pik-piam/edgeTransport/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/edgeTransport) [![r-universe](https://pik-piam.r-universe.dev/badges/edgeTransport)](https://pik-piam.r-universe.dev/builds)
 
@@ -46,7 +46,7 @@ In case of questions / problems please contact Johanna Hoppe <johanna.hoppe@pik-
 
 To cite package **edgeTransport** in publications use:
 
-Hoppe J, Dirnaichner A, Rottoli M, Muessel J (2024). _edgeTransport: Prepare EDGE Transport Data for the REMIND model_. R package version 2.3.0, <https://github.com/pik-piam/edgeTransport>.
+Hoppe J, Dirnaichner A, Rottoli M, Muessel J (2024). _edgeTransport: Prepare EDGE Transport Data for the REMIND model_. R package version 2.3.1, <https://github.com/pik-piam/edgeTransport>.
 
 A BibTeX entry for LaTeX users is
 
@@ -55,7 +55,7 @@ A BibTeX entry for LaTeX users is
   title = {edgeTransport: Prepare EDGE Transport Data for the REMIND model},
   author = {Johanna Hoppe and Alois Dirnaichner and Marianna Rottoli and Jarusch Muessel},
   year = {2024},
-  note = {R package version 2.3.0},
+  note = {R package version 2.3.1},
   url = {https://github.com/pik-piam/edgeTransport},
 }
 ```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Prepare EDGE Transport Data for the REMIND model
 
-R package **edgeTransport**, version **2.3.2**
+R package **edgeTransport**, version **2.3.1**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/edgeTransport)](https://cran.r-project.org/package=edgeTransport)  [![R build status](https://github.com/pik-piam/edgeTransport/workflows/check/badge.svg)](https://github.com/pik-piam/edgeTransport/actions) [![codecov](https://codecov.io/gh/pik-piam/edgeTransport/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/edgeTransport) [![r-universe](https://pik-piam.r-universe.dev/badges/edgeTransport)](https://pik-piam.r-universe.dev/builds)
 
@@ -46,7 +46,7 @@ In case of questions / problems please contact Johanna Hoppe <johanna.hoppe@pik-
 
 To cite package **edgeTransport** in publications use:
 
-Hoppe J, Dirnaichner A, Rottoli M, Muessel J (2024). _edgeTransport: Prepare EDGE Transport Data for the REMIND model_. R package version 2.3.2, <https://github.com/pik-piam/edgeTransport>.
+Hoppe J, Dirnaichner A, Rottoli M, Muessel J (2024). _edgeTransport: Prepare EDGE Transport Data for the REMIND model_. R package version 2.3.1, <https://github.com/pik-piam/edgeTransport>.
 
 A BibTeX entry for LaTeX users is
 
@@ -55,7 +55,7 @@ A BibTeX entry for LaTeX users is
   title = {edgeTransport: Prepare EDGE Transport Data for the REMIND model},
   author = {Johanna Hoppe and Alois Dirnaichner and Marianna Rottoli and Jarusch Muessel},
   year = {2024},
-  note = {R package version 2.3.2},
+  note = {R package version 2.3.1},
   url = {https://github.com/pik-piam/edgeTransport},
 }
 ```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Prepare EDGE Transport Data for the REMIND model
 
-R package **edgeTransport**, version **2.3.1**
+R package **edgeTransport**, version **2.3.2**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/edgeTransport)](https://cran.r-project.org/package=edgeTransport)  [![R build status](https://github.com/pik-piam/edgeTransport/workflows/check/badge.svg)](https://github.com/pik-piam/edgeTransport/actions) [![codecov](https://codecov.io/gh/pik-piam/edgeTransport/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/edgeTransport) [![r-universe](https://pik-piam.r-universe.dev/badges/edgeTransport)](https://pik-piam.r-universe.dev/builds)
 
@@ -46,7 +46,7 @@ In case of questions / problems please contact Johanna Hoppe <johanna.hoppe@pik-
 
 To cite package **edgeTransport** in publications use:
 
-Hoppe J, Dirnaichner A, Rottoli M, Muessel J (2024). _edgeTransport: Prepare EDGE Transport Data for the REMIND model_. R package version 2.3.1, <https://github.com/pik-piam/edgeTransport>.
+Hoppe J, Dirnaichner A, Rottoli M, Muessel J (2024). _edgeTransport: Prepare EDGE Transport Data for the REMIND model_. R package version 2.3.2, <https://github.com/pik-piam/edgeTransport>.
 
 A BibTeX entry for LaTeX users is
 
@@ -55,7 +55,7 @@ A BibTeX entry for LaTeX users is
   title = {edgeTransport: Prepare EDGE Transport Data for the REMIND model},
   author = {Johanna Hoppe and Alois Dirnaichner and Marianna Rottoli and Jarusch Muessel},
   year = {2024},
-  note = {R package version 2.3.1},
+  note = {R package version 2.3.2},
   url = {https://github.com/pik-piam/edgeTransport},
 }
 ```

--- a/inst/extdata/scenParIncoCost.csv
+++ b/inst/extdata/scenParIncoCost.csv
@@ -169,38 +169,38 @@ SSP2;HydrHype4;LDV|4W;Liquids;targetYear;2027
 SSP2;HydrHype4;LDV|4W;Liquids;targetValue;0.2
 SSP2;HydrHype4;LDV|4W;Hybrid electric;ratioPHEV;0.5
 SSP2;Mix1;LDV|4W;BEV;startYear;2025
-SSP2;Mix1;LDV|4W;BEV;startValue;0.5
+SSP2;Mix1;LDV|4W;BEV;startValue;1.2
 SSP2;Mix1;LDV|4W;BEV;targetYear;2035
 SSP2;Mix1;LDV|4W;BEV;targetValue;0
-SSP2;Mix1;LDV|4W;Liquids;startYear;2020
-SSP2;Mix1;LDV|4W;Liquids;targetYear;2027
+SSP2;Mix1;LDV|4W;Liquids;startYear;2022
+SSP2;Mix1;LDV|4W;Liquids;targetYear;2030
 SSP2;Mix1;LDV|4W;Liquids;targetValue;0
 SSP2;Mix1;LDV|4W;Hybrid electric;ratioPHEV;0.5
 SSP2;Mix2;LDV|4W;BEV;startYear;2025
-SSP2;Mix2;LDV|4W;BEV;startValue;0.5
+SSP2;Mix2;LDV|4W;BEV;startValue;0.8
 SSP2;Mix2;LDV|4W;BEV;targetYear;2035
 SSP2;Mix2;LDV|4W;BEV;targetValue;0.15
-SSP2;Mix2;LDV|4W;Liquids;startYear;2020
-SSP2;Mix2;LDV|4W;Liquids;targetYear;2027
-SSP2;Mix2;LDV|4W;Liquids;targetValue;0.05
+SSP2;Mix2;LDV|4W;Liquids;startYear;2022
+SSP2;Mix2;LDV|4W;Liquids;targetYear;2030
+SSP2;Mix2;LDV|4W;Liquids;targetValue;0.1
 SSP2;Mix2;LDV|4W;Hybrid electric;ratioPHEV;0.5
 SSP2;Mix3;LDV|4W;BEV;startYear;2025
-SSP2;Mix3;LDV|4W;BEV;startValue;0.5
+SSP2;Mix3;LDV|4W;BEV;startValue;0.4
 SSP2;Mix3;LDV|4W;BEV;targetYear;2035
-SSP2;Mix3;LDV|4W;BEV;targetValue;0.1
-SSP2;Mix3;LDV|4W;Liquids;startYear;2020
-SSP2;Mix3;LDV|4W;Liquids;targetYear;2045
-SSP2;Mix3;LDV|4W;Liquids;targetValue;1
-SSP2;Mix3;LDV|4W;Hybrid electric;ratioPHEV;0.5
+SSP2;Mix3;LDV|4W;BEV;targetValue;0
+SSP2;Mix3;LDV|4W;Liquids;startYear;2022
+SSP2;Mix3;LDV|4W;Liquids;targetYear;2055
+SSP2;Mix3;LDV|4W;Liquids;targetValue;0.5
+SSP2;Mix3;LDV|4W;Hybrid electric;ratioPHEV;1
 SSP2;Mix4;LDV|4W;BEV;startYear;2025
-SSP2;Mix4;LDV|4W;BEV;startValue;0.5
-SSP2;Mix4;LDV|4W;BEV;targetYear;2035
+SSP2;Mix4;LDV|4W;BEV;startValue;0.1
+SSP2;Mix4;LDV|4W;BEV;targetYear;2045
 SSP2;Mix4;LDV|4W;BEV;targetValue;0
-SSP2;Mix4;LDV|4W;Liquids;startYear;2020
-SSP2;Mix4;LDV|4W;Liquids;targetYear;2040
-SSP2;Mix4;LDV|4W;Liquids;targetValue;1.2
-SSP2;Mix4;LDV|4W;Hybrid electric;ratioPHEV;0.5
-SSP2EU;CAMP_lscStrong;LDV|4W;BEV;startYear;2025
+SSP2;Mix4;LDV|4W;Liquids;startYear;2022
+SSP2;Mix4;LDV|4W;Liquids;targetYear;2055
+SSP2;Mix4;LDV|4W;Liquids;targetValue;0.8
+SSP2;Mix4;LDV|4W;Hybrid electric;ratioPHEV;1.5
+SSP2EU;CAMP_lscStrong;LDV|4W;BEV;startYear;
 SSP2EU;CAMP_lscStrong;LDV|4W;BEV;startValue;0.5
 SSP2EU;CAMP_lscStrong;LDV|4W;BEV;targetYear;2030
 SSP2EU;CAMP_lscStrong;LDV|4W;BEV;targetValue;0

--- a/inst/extdata/scenParIncoCost.csv
+++ b/inst/extdata/scenParIncoCost.csv
@@ -200,7 +200,7 @@ SSP2;Mix4;LDV|4W;Liquids;startYear;2022
 SSP2;Mix4;LDV|4W;Liquids;targetYear;2055
 SSP2;Mix4;LDV|4W;Liquids;targetValue;0.8
 SSP2;Mix4;LDV|4W;Hybrid electric;ratioPHEV;1.5
-SSP2EU;CAMP_lscStrong;LDV|4W;BEV;startYear;
+SSP2EU;CAMP_lscStrong;LDV|4W;BEV;startYear;2025
 SSP2EU;CAMP_lscStrong;LDV|4W;BEV;startValue;0.5
 SSP2EU;CAMP_lscStrong;LDV|4W;BEV;targetYear;2030
 SSP2EU;CAMP_lscStrong;LDV|4W;BEV;targetValue;0


### PR DESCRIPTION
As in this [PR](https://github.com/pik-piam/edgeTransport/pull/272), now I update the values for SSP2 (before only for SSP2EU). 

The corresponding compScen can be found here: ``/p/projects/edget/PRchangeLog/BEVPhaseIn/Plots_09_09_24``

