### PR TITLE
exclude PRtest from pre-commit.ci

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,8 @@
 # testthat snapshots are machine-generated regression tests that
 # have to be preserved exactly as they are
-exclude: '^tests/testthat/_snaps/.*$'
+# PRtest is a routine manually generated and is used independetly 
+# but stored in edgeTRansport package for versioning
+exclude: '^(tests/testthat/_snaps/.*$|tests/PRtest/)'
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: 2c9f875913ee60ca25ce70243dc24d5b6415598c  # frozen: v4.6.0


### PR DESCRIPTION
## Purpose of this PR

the PRtest added in [https://github.com/pik-piam/edgeTransport/pull/294](https://github.com/pik-piam/edgeTransport/pull/294) are excluded from pre-commit.ci because they depend on additional packages not used for edgeTransport otherwise which we don't want to include as dependencies. This PR resolves the recent pre-commit.ci fails in edgeTransport.

