### PR TITLE
Update BEV PhaseIn

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '42318160'
+ValidationKey: '42518720'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@
 exclude: '^tests/testthat/_snaps/.*$'
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: 2c9f875913ee60ca25ce70243dc24d5b6415598c  # frozen: v4.6.0
+    rev: cef0300fd0fc4d2a87a85fa2093c6b283ea36f4b  # frozen: v5.0.0
     hooks:
     -   id: check-case-conflict
     -   id: check-json
@@ -15,7 +15,7 @@ repos:
     -   id: mixed-line-ending
 
 -   repo: https://github.com/lorenzwalthert/precommit
-    rev: bae853d82da476eee0e0a57960ee6b741a3b3fb7  # frozen: v0.4.3
+    rev: 3b70240796cdccbe1474b0176560281aaded97e6  # frozen: v0.4.3.9003
     hooks:
     -   id: parsable-R
     -   id: deps-in-desc

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,7 +2,7 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'edgeTransport: Prepare EDGE Transport Data for the REMIND model'
-version: 2.11.0
+version: 2.12.0
 date-released: '2024-11-29'
 abstract: EDGE-T is a fork of the GCAM transport module https://jgcri.github.io/gcam-doc/energy.html#transportation
   with a high level of detail in its representation of technological and modal options.

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: edgeTransport
 Title: Prepare EDGE Transport Data for the REMIND model
-Version: 2.11.0
+Version: 2.12.0
 Authors@R: c(
     person("Johanna", "Hoppe", , "johanna.hoppe@pik-potsdam.de", role = c("aut", "cre"),
            comment = c(ORCID = "0009-0004-6753-5090")),

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Prepare EDGE Transport Data for the REMIND model
 
-R package **edgeTransport**, version **2.11.0**
+R package **edgeTransport**, version **2.12.0**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/edgeTransport)](https://cran.r-project.org/package=edgeTransport)  [![R build status](https://github.com/pik-piam/edgeTransport/workflows/check/badge.svg)](https://github.com/pik-piam/edgeTransport/actions) [![codecov](https://codecov.io/gh/pik-piam/edgeTransport/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/edgeTransport) [![r-universe](https://pik-piam.r-universe.dev/badges/edgeTransport)](https://pik-piam.r-universe.dev/builds)
 
@@ -46,7 +46,7 @@ In case of questions / problems please contact Johanna Hoppe <johanna.hoppe@pik-
 
 To cite package **edgeTransport** in publications use:
 
-Hoppe J, Dirnaichner A, Rottoli M, Muessel J (2024). _edgeTransport: Prepare EDGE Transport Data for the REMIND model_. R package version 2.11.0, <https://github.com/pik-piam/edgeTransport>.
+Hoppe J, Dirnaichner A, Rottoli M, Muessel J (2024). _edgeTransport: Prepare EDGE Transport Data for the REMIND model_. R package version 2.12.0, <https://github.com/pik-piam/edgeTransport>.
 
 A BibTeX entry for LaTeX users is
 
@@ -55,7 +55,7 @@ A BibTeX entry for LaTeX users is
   title = {edgeTransport: Prepare EDGE Transport Data for the REMIND model},
   author = {Johanna Hoppe and Alois Dirnaichner and Marianna Rottoli and Jarusch Muessel},
   year = {2024},
-  note = {R package version 2.11.0},
+  note = {R package version 2.12.0},
   url = {https://github.com/pik-piam/edgeTransport},
 }
 ```

--- a/inst/extdata/genParIncoCostStartVal.csv
+++ b/inst/extdata/genParIncoCostStartVal.csv
@@ -1,43 +1,43 @@
 region;incoCostType;FVvehvar;technology;unit;1990;2005;2010;2020
-GLO;Model availability;LDV|4W;BEV;US$2017/veh;123136;123136;123136;16008
+GLO;Model availability;LDV|4W;BEV;US$2017/veh;123136;123136;123136;17000
 GLO;Model availability;LDV|4W;FCEV;US$2017/veh;123136;123136;123136;86195
 GLO;Model availability;LDV|4W;Gases;US$2017/veh;123136;123136;123136;98509
-GLO;Model availability;LDV|4W;Hybrid electric;US$2017/veh;123136;123136;123136;73882
+GLO;Model availability;LDV|4W;Hybrid electric;US$2017/veh;123136;123136;123136;75000
 GLO;ICE inconvenience;LDV|4W;Liquids;US$2017/veh;0;0;0;0
-GLO;Risk aversion;LDV|4W;BEV;US$2017/veh;4680;4680;4680;4926
+GLO;Risk aversion;LDV|4W;BEV;US$2017/veh;4680;4680;4680;5000
 GLO;Risk aversion;LDV|4W;FCEV;US$2017/veh;4680;4680;4680;4680
 GLO;Risk aversion;LDV|4W;Gases;US$2017/veh;4680;4680;4680;4680
-GLO;Risk aversion;LDV|4W;Hybrid electric;US$2017/veh;4680;4680;4680;4680
-GLO;Range anxiety;LDV|4W;BEV;US$2017/veh;123136;123136;123136;80039
-GLO;Stations availability;LDV|4W;BEV;US$2017/veh;1232;1232;1232;1232
-GLO;Stations availability;LDV|4W;Hybrid electric;US$2017/veh;1232;1232;1232;1232
+GLO;Risk aversion;LDV|4W;Hybrid electric;US$2017/veh;4680;4680;4680;5000
+GLO;Range anxiety;LDV|4W;BEV;US$2017/veh;123136;123136;123136;87000
+GLO;Stations availability;LDV|4W;BEV;US$2017/veh;1232;1232;1232;1500
+GLO;Stations availability;LDV|4W;Hybrid electric;US$2017/veh;1232;1232;1232;1500
 GLO;Stations availability;LDV|4W;FCEV;US$2017/veh;123136;123136;123136;123136
 GLO;Stations availability;LDV|4W;Gases;US$2017/veh;123136;123136;123136;123136
-EUR;Model availability;LDV|4W;BEV;US$2017/veh;123136;123136;123136;13545
+EUR;Model availability;LDV|4W;BEV;US$2017/veh;123136;123136;123136;14000
 EUR;Model availability;LDV|4W;FCEV;US$2017/veh;123136;123136;123136;86195
 EUR;Model availability;LDV|4W;Gases;US$2017/veh;123136;123136;123136;98509
-EUR;Model availability;LDV|4W;Hybrid electric;US$2017/veh;123136;123136;123136;73882
+EUR;Model availability;LDV|4W;Hybrid electric;US$2017/veh;123136;123136;123136;74000
 EUR;ICE inconvenience;LDV|4W;Liquids;US$2017/veh;0;0;0;0
 EUR;Risk aversion;LDV|4W;BEV;US$2017/veh;4680;4680;4680;5542
 EUR;Risk aversion;LDV|4W;FCEV;US$2017/veh;4680;4680;4680;6157
 EUR;Risk aversion;LDV|4W;Gases;US$2017/veh;4680;4680;4680;8620
 EUR;Risk aversion;LDV|4W;Hybrid electric;US$2017/veh;4680;4680;4680;3695
-EUR;Range anxiety;LDV|4W;BEV;US$2017/veh;123136;123136;123136;86195
+EUR;Range anxiety;LDV|4W;BEV;US$2017/veh;123136;123136;123136;87000
 EUR;Stations availability;LDV|4W;BEV;US$2017/veh;1232;1232;1232;2463
 EUR;Stations availability;LDV|4W;Hybrid electric;US$2017/veh;1232;1232;1232;1232
 EUR;Stations availability;LDV|4W;FCEV;US$2017/veh;123136;123136;123136;147763
 EUR;Stations availability;LDV|4W;Gases;US$2017/veh;123136;123136;123136;197018
-CHA;Model availability;LDV|4W;BEV;US$2017/veh;123136;123136;123136;11083
+CHA;Model availability;LDV|4W;BEV;US$2017/veh;123136;123136;123136;0
 CHA;Model availability;LDV|4W;FCEV;US$2017/veh;123136;123136;123136;86195
 CHA;Model availability;LDV|4W;Gases;US$2017/veh;123136;123136;123136;98509
 CHA;Model availability;LDV|4W;Hybrid electric;US$2017/veh;123136;123136;123136;61568
 CHA;ICE inconvenience;LDV|4W;Liquids;US$2017/veh;0;0;0;0
-CHA;Risk aversion;LDV|4W;BEV;US$2017/veh;4680;4680;4680;4680
+CHA;Risk aversion;LDV|4W;BEV;US$2017/veh;4680;4680;4680;0
 CHA;Risk aversion;LDV|4W;FCEV;US$2017/veh;4680;4680;4680;4680
 CHA;Risk aversion;LDV|4W;Gases;US$2017/veh;4680;4680;4680;4680
 CHA;Risk aversion;LDV|4W;Hybrid electric;US$2017/veh;4680;4680;4680;4680
-CHA;Range anxiety;LDV|4W;BEV;US$2017/veh;123136;123136;123136;73882
-CHA;Stations availability;LDV|4W;BEV;US$2017/veh;1232;1232;1232;1232
-CHA;Stations availability;LDV|4W;Hybrid electric;US$2017/veh;1232;1232;1232;1232
+CHA;Range anxiety;LDV|4W;BEV;US$2017/veh;123136;123136;123136;55000
+CHA;Stations availability;LDV|4W;BEV;US$2017/veh;1232;1232;1232;0
+CHA;Stations availability;LDV|4W;Hybrid electric;US$2017/veh;1232;1232;1232;1300
 CHA;Stations availability;LDV|4W;FCEV;US$2017/veh;123136;123136;123136;123136
 CHA;Stations availability;LDV|4W;Gases;US$2017/veh;123136;123136;123136;123136

--- a/inst/extdata/scenParIncoCost.csv
+++ b/inst/extdata/scenParIncoCost.csv
@@ -233,36 +233,36 @@ SSP2;HydrHype4;LDV|4W;Liquids;targetYear;2027
 SSP2;HydrHype4;LDV|4W;Liquids;targetValue;0.25
 SSP2;HydrHype4;LDV|4W;Hybrid electric;ratioPHEV;0.5
 SSP2;Mix1;LDV|4W;BEV;startYear;2025
-SSP2;Mix1;LDV|4W;BEV;startValue;1.48
-SSP2;Mix1;LDV|4W;BEV;targetYear;2035
-SSP2;Mix1;LDV|4W;BEV;targetValue;0
+SSP2;Mix1;LDV|4W;BEV;startValue;1.5
+SSP2;Mix1;LDV|4W;BEV;targetYear;2050
+SSP2;Mix1;LDV|4W;BEV;targetValue;0.3
 SSP2;Mix1;LDV|4W;Liquids;startYear;2022
-SSP2;Mix1;LDV|4W;Liquids;targetYear;2030
+SSP2;Mix1;LDV|4W;Liquids;targetYear;2050
 SSP2;Mix1;LDV|4W;Liquids;targetValue;0
 SSP2;Mix1;LDV|4W;Hybrid electric;ratioPHEV;0.5
 SSP2;Mix2;LDV|4W;BEV;startYear;2025
-SSP2;Mix2;LDV|4W;BEV;startValue;0.99
-SSP2;Mix2;LDV|4W;BEV;targetYear;2035
-SSP2;Mix2;LDV|4W;BEV;targetValue;0.18
+SSP2;Mix2;LDV|4W;BEV;startValue;1
+SSP2;Mix2;LDV|4W;BEV;targetYear;2050
+SSP2;Mix2;LDV|4W;BEV;targetValue;0.15
 SSP2;Mix2;LDV|4W;Liquids;startYear;2022
-SSP2;Mix2;LDV|4W;Liquids;targetYear;2030
-SSP2;Mix2;LDV|4W;Liquids;targetValue;0.12
+SSP2;Mix2;LDV|4W;Liquids;targetYear;2050
+SSP2;Mix2;LDV|4W;Liquids;targetValue;0.2
 SSP2;Mix2;LDV|4W;Hybrid electric;ratioPHEV;0.5
 SSP2;Mix3;LDV|4W;BEV;startYear;2025
-SSP2;Mix3;LDV|4W;BEV;startValue;0.49
-SSP2;Mix3;LDV|4W;BEV;targetYear;2035
+SSP2;Mix3;LDV|4W;BEV;startValue;0.7
+SSP2;Mix3;LDV|4W;BEV;targetYear;2050
 SSP2;Mix3;LDV|4W;BEV;targetValue;0
 SSP2;Mix3;LDV|4W;Liquids;startYear;2022
-SSP2;Mix3;LDV|4W;Liquids;targetYear;2055
-SSP2;Mix3;LDV|4W;Liquids;targetValue;0.62
+SSP2;Mix3;LDV|4W;Liquids;targetYear;2050
+SSP2;Mix3;LDV|4W;Liquids;targetValue;0.5
 SSP2;Mix3;LDV|4W;Hybrid electric;ratioPHEV;1
 SSP2;Mix4;LDV|4W;BEV;startYear;2025
-SSP2;Mix4;LDV|4W;BEV;startValue;0.12
-SSP2;Mix4;LDV|4W;BEV;targetYear;2045
+SSP2;Mix4;LDV|4W;BEV;startValue;0.15
+SSP2;Mix4;LDV|4W;BEV;targetYear;2050
 SSP2;Mix4;LDV|4W;BEV;targetValue;0
 SSP2;Mix4;LDV|4W;Liquids;startYear;2022
-SSP2;Mix4;LDV|4W;Liquids;targetYear;2055
-SSP2;Mix4;LDV|4W;Liquids;targetValue;0.99
+SSP2;Mix4;LDV|4W;Liquids;targetYear;2050
+SSP2;Mix4;LDV|4W;Liquids;targetValue;1
 SSP2;Mix4;LDV|4W;Hybrid electric;ratioPHEV;1.5
 SSP2;NAV_act;LDV|4W;BEV;startYear;2025
 SSP2;NAV_act;LDV|4W;BEV;startValue;0.62

--- a/inst/extdata/scenParPrefTrends.csv
+++ b/inst/extdata/scenParPrefTrends.csv
@@ -1,3757 +1,3757 @@
-SSPscen;transportPolScen;regionCat;technology;FVvehvar;subsectorL2;subsectorL1;level;target;symmyr;speed
-SDP;Mix2;above GDP cutoff;;;;Cycle;S1S;1;2050;10
-SDP;Mix2;above GDP cutoff;;;;Domestic Aviation;S1S;0.75;2035;10
-SDP;Mix2;above GDP cutoff;;;;Domestic Ship;S1S;1;2050;10
-SDP;Mix2;above GDP cutoff;;;;Freight Rail;S1S;1;2050;10
-SDP;Mix2;above GDP cutoff;;;;HSR;S1S;1;2050;10
-SDP;Mix2;above GDP cutoff;;;;Passenger Rail;S1S;1;2050;10
-SDP;Mix2;above GDP cutoff;;;;trn_freight_road;S1S;0.9;2035;10
-SDP;Mix2;above GDP cutoff;;;;trn_pass_road;S1S;0.9;2035;10
-SDP;Mix2;above GDP cutoff;;;;Walk;S1S;1;2050;10
-SDP;Mix2;below GDP cutoff;;;;Cycle;S1S;1;2050;10
-SDP;Mix2;below GDP cutoff;;;;Domestic Aviation;S1S;0.75;2035;10
-SDP;Mix2;below GDP cutoff;;;;Domestic Ship;S1S;1;2050;10
-SDP;Mix2;below GDP cutoff;;;;Freight Rail;S1S;1;2050;10
-SDP;Mix2;below GDP cutoff;;;;HSR;S1S;1;2050;10
-SDP;Mix2;below GDP cutoff;;;;Passenger Rail;S1S;1;2050;10
-SDP;Mix2;below GDP cutoff;;;;trn_freight_road;S1S;0.9;2035;10
-SDP;Mix2;below GDP cutoff;;;;trn_pass_road;S1S;0.9;2035;10
-SDP;Mix2;below GDP cutoff;;;;Walk;S1S;1;2050;10
-SDP;Mix2;above GDP cutoff;;;Bus;trn_pass_road;S2S1;1;2050;10
-SDP;Mix2;above GDP cutoff;;;trn_pass_road_LDV;trn_pass_road;S2S1;0.9;2035;10
-SDP;Mix2;below GDP cutoff;;;Bus;trn_pass_road;S2S1;1;2050;10
-SDP;Mix2;below GDP cutoff;;;trn_pass_road_LDV;trn_pass_road;S2S1;0.9;2035;10
-SDP;Mix2;above GDP cutoff;BEV;Bus;Bus;trn_pass_road;FV;2;2035;10
-SDP;Mix2;above GDP cutoff;FCEV;Bus;Bus;trn_pass_road;FV;2;2035;10
-SDP;Mix2;above GDP cutoff;Liquids;Bus;Bus;trn_pass_road;FV;1;2050;10
-SDP;Mix2;above GDP cutoff;Hydrogen;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SDP;Mix2;above GDP cutoff;Liquids;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SDP;Mix2;above GDP cutoff;Liquids;Ship;Domestic Ship_tmp_subsectorL2;Domestic Ship;FV;1;2050;10
-SDP;Mix2;above GDP cutoff;Electric;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SDP;Mix2;above GDP cutoff;Liquids;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SDP;Mix2;above GDP cutoff;Electric;Rail;HSR_tmp_subsectorL2;HSR;FV;1;2050;10
-SDP;Mix2;above GDP cutoff;Liquids;Aviation;International Aviation_tmp_subsectorL2;International Aviation;FV;1;2050;10
-SDP;Mix2;above GDP cutoff;Liquids;Ship;International Ship_tmp_subsectorL2;International Ship;FV;1;2050;10
-SDP;Mix2;above GDP cutoff;BEV;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SDP;Mix2;above GDP cutoff;Liquids;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SDP;Mix2;above GDP cutoff;Electric;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SDP;Mix2;above GDP cutoff;Liquids;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SDP;Mix2;above GDP cutoff;BEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;2;2035;10
-SDP;Mix2;above GDP cutoff;FCEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;2;2035;10
-SDP;Mix2;above GDP cutoff;Liquids;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;10
-SDP;Mix2;above GDP cutoff;BEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;2;2035;10
-SDP;Mix2;above GDP cutoff;FCEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;2;2035;10
-SDP;Mix2;above GDP cutoff;Liquids;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;10
-SDP;Mix2;below GDP cutoff;BEV;Bus;Bus;trn_pass_road;FV;1.5;2035;10
-SDP;Mix2;below GDP cutoff;FCEV;Bus;Bus;trn_pass_road;FV;1.5;2035;10
-SDP;Mix2;below GDP cutoff;Liquids;Bus;Bus;trn_pass_road;FV;1;2050;10
-SDP;Mix2;below GDP cutoff;Hydrogen;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SDP;Mix2;below GDP cutoff;Liquids;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SDP;Mix2;below GDP cutoff;Liquids;Ship;Domestic Ship_tmp_subsectorL2;Domestic Ship;FV;1;2050;10
-SDP;Mix2;below GDP cutoff;Electric;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SDP;Mix2;below GDP cutoff;Liquids;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SDP;Mix2;below GDP cutoff;Electric;Rail;HSR_tmp_subsectorL2;HSR;FV;1;2050;10
-SDP;Mix2;below GDP cutoff;Liquids;Aviation;International Aviation_tmp_subsectorL2;International Aviation;FV;1;2050;10
-SDP;Mix2;below GDP cutoff;Liquids;Ship;International Ship_tmp_subsectorL2;International Ship;FV;1;2050;10
-SDP;Mix2;below GDP cutoff;BEV;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SDP;Mix2;below GDP cutoff;Liquids;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SDP;Mix2;below GDP cutoff;Electric;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SDP;Mix2;below GDP cutoff;Liquids;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SDP;Mix2;below GDP cutoff;BEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1.5;2035;10
-SDP;Mix2;below GDP cutoff;FCEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1.5;2035;10
-SDP;Mix2;below GDP cutoff;Liquids;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;10
-SDP;Mix2;below GDP cutoff;BEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1.5;2035;10
-SDP;Mix2;below GDP cutoff;FCEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1.5;2035;10
-SDP;Mix2;below GDP cutoff;Liquids;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;10
-SDP;Mix3;above GDP cutoff;;;;Cycle;S1S;1;2050;10
-SDP;Mix3;above GDP cutoff;;;;Domestic Aviation;S1S;0.5;2035;10
-SDP;Mix3;above GDP cutoff;;;;Domestic Ship;S1S;1;2050;10
-SDP;Mix3;above GDP cutoff;;;;Freight Rail;S1S;1;2050;10
-SDP;Mix3;above GDP cutoff;;;;HSR;S1S;1;2050;10
-SDP;Mix3;above GDP cutoff;;;;Passenger Rail;S1S;1;2050;10
-SDP;Mix3;above GDP cutoff;;;;trn_freight_road;S1S;0.7;2035;10
-SDP;Mix3;above GDP cutoff;;;;trn_pass_road;S1S;0.7;2035;10
-SDP;Mix3;above GDP cutoff;;;;Walk;S1S;1;2050;10
-SDP;Mix3;below GDP cutoff;;;;Cycle;S1S;1;2050;10
-SDP;Mix3;below GDP cutoff;;;;Domestic Aviation;S1S;0.5;2035;10
-SDP;Mix3;below GDP cutoff;;;;Domestic Ship;S1S;1;2050;10
-SDP;Mix3;below GDP cutoff;;;;Freight Rail;S1S;1;2050;10
-SDP;Mix3;below GDP cutoff;;;;HSR;S1S;1;2050;10
-SDP;Mix3;below GDP cutoff;;;;Passenger Rail;S1S;1;2050;10
-SDP;Mix3;below GDP cutoff;;;;trn_freight_road;S1S;0.7;2035;10
-SDP;Mix3;below GDP cutoff;;;;trn_pass_road;S1S;0.7;2035;10
-SDP;Mix3;below GDP cutoff;;;;Walk;S1S;1;2050;10
-SDP;Mix3;above GDP cutoff;;;Bus;trn_pass_road;S2S1;1;2050;10
-SDP;Mix3;above GDP cutoff;;;trn_pass_road_LDV;trn_pass_road;S2S1;0.7;2035;10
-SDP;Mix3;below GDP cutoff;;;Bus;trn_pass_road;S2S1;1;2050;10
-SDP;Mix3;below GDP cutoff;;;trn_pass_road_LDV;trn_pass_road;S2S1;0.7;2035;10
-SDP;Mix3;above GDP cutoff;BEV;Bus;Bus;trn_pass_road;FV;4;2035;10
-SDP;Mix3;above GDP cutoff;FCEV;Bus;Bus;trn_pass_road;FV;4;2035;10
-SDP;Mix3;above GDP cutoff;Liquids;Bus;Bus;trn_pass_road;FV;1;2050;10
-SDP;Mix3;above GDP cutoff;Hydrogen;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SDP;Mix3;above GDP cutoff;Liquids;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SDP;Mix3;above GDP cutoff;Liquids;Ship;Domestic Ship_tmp_subsectorL2;Domestic Ship;FV;1;2050;10
-SDP;Mix3;above GDP cutoff;Electric;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SDP;Mix3;above GDP cutoff;Liquids;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SDP;Mix3;above GDP cutoff;Electric;Rail;HSR_tmp_subsectorL2;HSR;FV;1;2050;10
-SDP;Mix3;above GDP cutoff;Liquids;Aviation;International Aviation_tmp_subsectorL2;International Aviation;FV;1;2050;10
-SDP;Mix3;above GDP cutoff;Liquids;Ship;International Ship_tmp_subsectorL2;International Ship;FV;1;2050;10
-SDP;Mix3;above GDP cutoff;BEV;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SDP;Mix3;above GDP cutoff;Liquids;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SDP;Mix3;above GDP cutoff;Electric;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SDP;Mix3;above GDP cutoff;Liquids;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SDP;Mix3;above GDP cutoff;BEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;4;2035;10
-SDP;Mix3;above GDP cutoff;FCEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;4;2035;10
-SDP;Mix3;above GDP cutoff;Liquids;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;10
-SDP;Mix3;above GDP cutoff;BEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;7;2035;10
-SDP;Mix3;above GDP cutoff;FCEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;20;2035;10
-SDP;Mix3;above GDP cutoff;Liquids;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;10
-SDP;Mix3;below GDP cutoff;BEV;Bus;Bus;trn_pass_road;FV;3.5;2035;10
-SDP;Mix3;below GDP cutoff;FCEV;Bus;Bus;trn_pass_road;FV;3.5;2035;10
-SDP;Mix3;below GDP cutoff;Liquids;Bus;Bus;trn_pass_road;FV;1;2050;10
-SDP;Mix3;below GDP cutoff;Hydrogen;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SDP;Mix3;below GDP cutoff;Liquids;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SDP;Mix3;below GDP cutoff;Liquids;Ship;Domestic Ship_tmp_subsectorL2;Domestic Ship;FV;1;2050;10
-SDP;Mix3;below GDP cutoff;Electric;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SDP;Mix3;below GDP cutoff;Liquids;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SDP;Mix3;below GDP cutoff;Electric;Rail;HSR_tmp_subsectorL2;HSR;FV;1;2050;10
-SDP;Mix3;below GDP cutoff;Liquids;Aviation;International Aviation_tmp_subsectorL2;International Aviation;FV;1;2050;10
-SDP;Mix3;below GDP cutoff;Liquids;Ship;International Ship_tmp_subsectorL2;International Ship;FV;1;2050;10
-SDP;Mix3;below GDP cutoff;BEV;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SDP;Mix3;below GDP cutoff;Liquids;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SDP;Mix3;below GDP cutoff;Electric;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SDP;Mix3;below GDP cutoff;Liquids;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SDP;Mix3;below GDP cutoff;BEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;3.5;2035;10
-SDP;Mix3;below GDP cutoff;FCEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;3.5;2035;10
-SDP;Mix3;below GDP cutoff;Liquids;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;10
-SDP;Mix3;below GDP cutoff;BEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;5;2035;10
-SDP;Mix3;below GDP cutoff;FCEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;17;2035;10
-SDP;Mix3;below GDP cutoff;Liquids;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;10
-SDP;Mix4;above GDP cutoff;;;;Cycle;S1S;1;2050;10
-SDP;Mix4;above GDP cutoff;;;;Domestic Aviation;S1S;0.25;2035;10
-SDP;Mix4;above GDP cutoff;;;;Domestic Ship;S1S;1;2050;10
-SDP;Mix4;above GDP cutoff;;;;Freight Rail;S1S;1;2050;10
-SDP;Mix4;above GDP cutoff;;;;HSR;S1S;1;2050;10
-SDP;Mix4;above GDP cutoff;;;;Passenger Rail;S1S;1;2050;10
-SDP;Mix4;above GDP cutoff;;;;trn_freight_road;S1S;0.5;2035;10
-SDP;Mix4;above GDP cutoff;;;;trn_pass_road;S1S;0.5;2035;10
-SDP;Mix4;above GDP cutoff;;;;Walk;S1S;1;2050;10
-SDP;Mix4;below GDP cutoff;;;;Cycle;S1S;1;2050;10
-SDP;Mix4;below GDP cutoff;;;;Domestic Aviation;S1S;0.25;2035;10
-SDP;Mix4;below GDP cutoff;;;;Domestic Ship;S1S;1;2050;10
-SDP;Mix4;below GDP cutoff;;;;Freight Rail;S1S;1;2050;10
-SDP;Mix4;below GDP cutoff;;;;HSR;S1S;1;2050;10
-SDP;Mix4;below GDP cutoff;;;;Passenger Rail;S1S;1;2050;10
-SDP;Mix4;below GDP cutoff;;;;trn_freight_road;S1S;0.5;2035;10
-SDP;Mix4;below GDP cutoff;;;;trn_pass_road;S1S;0.5;2035;10
-SDP;Mix4;below GDP cutoff;;;;Walk;S1S;1;2050;10
-SDP;Mix4;above GDP cutoff;;;Bus;trn_pass_road;S2S1;1;2050;10
-SDP;Mix4;above GDP cutoff;;;trn_pass_road_LDV;trn_pass_road;S2S1;0.5;2035;10
-SDP;Mix4;below GDP cutoff;;;Bus;trn_pass_road;S2S1;1;2050;10
-SDP;Mix4;below GDP cutoff;;;trn_pass_road_LDV;trn_pass_road;S2S1;0.5;2035;10
-SDP;Mix4;above GDP cutoff;BEV;Bus;Bus;trn_pass_road;FV;6;2035;10
-SDP;Mix4;above GDP cutoff;FCEV;Bus;Bus;trn_pass_road;FV;6;2035;10
-SDP;Mix4;above GDP cutoff;Liquids;Bus;Bus;trn_pass_road;FV;1;2050;10
-SDP;Mix4;above GDP cutoff;Hydrogen;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SDP;Mix4;above GDP cutoff;Liquids;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SDP;Mix4;above GDP cutoff;Liquids;Ship;Domestic Ship_tmp_subsectorL2;Domestic Ship;FV;1;2050;10
-SDP;Mix4;above GDP cutoff;Electric;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SDP;Mix4;above GDP cutoff;Liquids;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SDP;Mix4;above GDP cutoff;Electric;Rail;HSR_tmp_subsectorL2;HSR;FV;1;2050;10
-SDP;Mix4;above GDP cutoff;Liquids;Aviation;International Aviation_tmp_subsectorL2;International Aviation;FV;1;2050;10
-SDP;Mix4;above GDP cutoff;Liquids;Ship;International Ship_tmp_subsectorL2;International Ship;FV;1;2050;10
-SDP;Mix4;above GDP cutoff;BEV;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SDP;Mix4;above GDP cutoff;Liquids;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SDP;Mix4;above GDP cutoff;Electric;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SDP;Mix4;above GDP cutoff;Liquids;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SDP;Mix4;above GDP cutoff;BEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;6;2035;10
-SDP;Mix4;above GDP cutoff;FCEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;6;2035;10
-SDP;Mix4;above GDP cutoff;Liquids;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;10
-SDP;Mix4;above GDP cutoff;BEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;20;2035;10
-SDP;Mix4;above GDP cutoff;FCEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;100;2035;10
-SDP;Mix4;above GDP cutoff;Liquids;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;10
-SDP;Mix4;below GDP cutoff;BEV;Bus;Bus;trn_pass_road;FV;5;2035;10
-SDP;Mix4;below GDP cutoff;FCEV;Bus;Bus;trn_pass_road;FV;5;2035;10
-SDP;Mix4;below GDP cutoff;Liquids;Bus;Bus;trn_pass_road;FV;1;2050;10
-SDP;Mix4;below GDP cutoff;Hydrogen;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SDP;Mix4;below GDP cutoff;Liquids;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SDP;Mix4;below GDP cutoff;Liquids;Ship;Domestic Ship_tmp_subsectorL2;Domestic Ship;FV;1;2050;10
-SDP;Mix4;below GDP cutoff;Electric;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SDP;Mix4;below GDP cutoff;Liquids;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SDP;Mix4;below GDP cutoff;Electric;Rail;HSR_tmp_subsectorL2;HSR;FV;1;2050;10
-SDP;Mix4;below GDP cutoff;Liquids;Aviation;International Aviation_tmp_subsectorL2;International Aviation;FV;1;2050;10
-SDP;Mix4;below GDP cutoff;Liquids;Ship;International Ship_tmp_subsectorL2;International Ship;FV;1;2050;10
-SDP;Mix4;below GDP cutoff;BEV;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SDP;Mix4;below GDP cutoff;Liquids;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SDP;Mix4;below GDP cutoff;Electric;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SDP;Mix4;below GDP cutoff;Liquids;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SDP;Mix4;below GDP cutoff;BEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;5;2035;10
-SDP;Mix4;below GDP cutoff;FCEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;5;2035;10
-SDP;Mix4;below GDP cutoff;Liquids;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;10
-SDP;Mix4;below GDP cutoff;BEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;17;2035;10
-SDP;Mix4;below GDP cutoff;FCEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;85;2035;10
-SDP;Mix4;below GDP cutoff;Liquids;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;10
-SDP_EI;Mix2;above GDP cutoff;;;;Cycle;S1S;1;2050;10
-SDP_EI;Mix2;above GDP cutoff;;;;Domestic Aviation;S1S;0.75;2035;10
-SDP_EI;Mix2;above GDP cutoff;;;;Domestic Ship;S1S;1;2050;10
-SDP_EI;Mix2;above GDP cutoff;;;;Freight Rail;S1S;1;2050;10
-SDP_EI;Mix2;above GDP cutoff;;;;HSR;S1S;1;2050;10
-SDP_EI;Mix2;above GDP cutoff;;;;Passenger Rail;S1S;1;2050;10
-SDP_EI;Mix2;above GDP cutoff;;;;trn_freight_road;S1S;0.9;2035;10
-SDP_EI;Mix2;above GDP cutoff;;;;trn_pass_road;S1S;0.9;2035;10
-SDP_EI;Mix2;above GDP cutoff;;;;Walk;S1S;1;2050;10
-SDP_EI;Mix2;below GDP cutoff;;;;Cycle;S1S;1;2050;10
-SDP_EI;Mix2;below GDP cutoff;;;;Domestic Aviation;S1S;0.75;2035;10
-SDP_EI;Mix2;below GDP cutoff;;;;Domestic Ship;S1S;1;2050;10
-SDP_EI;Mix2;below GDP cutoff;;;;Freight Rail;S1S;1;2050;10
-SDP_EI;Mix2;below GDP cutoff;;;;HSR;S1S;1;2050;10
-SDP_EI;Mix2;below GDP cutoff;;;;Passenger Rail;S1S;1;2050;10
-SDP_EI;Mix2;below GDP cutoff;;;;trn_freight_road;S1S;0.9;2035;10
-SDP_EI;Mix2;below GDP cutoff;;;;trn_pass_road;S1S;0.9;2035;10
-SDP_EI;Mix2;below GDP cutoff;;;;Walk;S1S;1;2050;10
-SDP_EI;Mix2;above GDP cutoff;;;Bus;trn_pass_road;S2S1;1;2050;10
-SDP_EI;Mix2;above GDP cutoff;;;trn_pass_road_LDV;trn_pass_road;S2S1;0.9;2035;10
-SDP_EI;Mix2;below GDP cutoff;;;Bus;trn_pass_road;S2S1;1;2050;10
-SDP_EI;Mix2;below GDP cutoff;;;trn_pass_road_LDV;trn_pass_road;S2S1;0.9;2035;10
-SDP_EI;Mix2;above GDP cutoff;BEV;Bus;Bus;trn_pass_road;FV;2;2035;10
-SDP_EI;Mix2;above GDP cutoff;FCEV;Bus;Bus;trn_pass_road;FV;2;2035;10
-SDP_EI;Mix2;above GDP cutoff;Liquids;Bus;Bus;trn_pass_road;FV;1;2050;10
-SDP_EI;Mix2;above GDP cutoff;Hydrogen;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SDP_EI;Mix2;above GDP cutoff;Liquids;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SDP_EI;Mix2;above GDP cutoff;Liquids;Ship;Domestic Ship_tmp_subsectorL2;Domestic Ship;FV;1;2050;10
-SDP_EI;Mix2;above GDP cutoff;Electric;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SDP_EI;Mix2;above GDP cutoff;Liquids;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SDP_EI;Mix2;above GDP cutoff;Electric;Rail;HSR_tmp_subsectorL2;HSR;FV;1;2050;10
-SDP_EI;Mix2;above GDP cutoff;Liquids;Aviation;International Aviation_tmp_subsectorL2;International Aviation;FV;1;2050;10
-SDP_EI;Mix2;above GDP cutoff;Liquids;Ship;International Ship_tmp_subsectorL2;International Ship;FV;1;2050;10
-SDP_EI;Mix2;above GDP cutoff;BEV;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SDP_EI;Mix2;above GDP cutoff;Liquids;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SDP_EI;Mix2;above GDP cutoff;Electric;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SDP_EI;Mix2;above GDP cutoff;Liquids;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SDP_EI;Mix2;above GDP cutoff;BEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;2;2035;10
-SDP_EI;Mix2;above GDP cutoff;FCEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;2;2035;10
-SDP_EI;Mix2;above GDP cutoff;Liquids;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;10
-SDP_EI;Mix2;above GDP cutoff;BEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;2;2035;10
-SDP_EI;Mix2;above GDP cutoff;FCEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;2;2035;10
-SDP_EI;Mix2;above GDP cutoff;Liquids;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;10
-SDP_EI;Mix2;below GDP cutoff;BEV;Bus;Bus;trn_pass_road;FV;1.5;2035;10
-SDP_EI;Mix2;below GDP cutoff;FCEV;Bus;Bus;trn_pass_road;FV;1.5;2035;10
-SDP_EI;Mix2;below GDP cutoff;Liquids;Bus;Bus;trn_pass_road;FV;1;2050;10
-SDP_EI;Mix2;below GDP cutoff;Hydrogen;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SDP_EI;Mix2;below GDP cutoff;Liquids;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SDP_EI;Mix2;below GDP cutoff;Liquids;Ship;Domestic Ship_tmp_subsectorL2;Domestic Ship;FV;1;2050;10
-SDP_EI;Mix2;below GDP cutoff;Electric;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SDP_EI;Mix2;below GDP cutoff;Liquids;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SDP_EI;Mix2;below GDP cutoff;Electric;Rail;HSR_tmp_subsectorL2;HSR;FV;1;2050;10
-SDP_EI;Mix2;below GDP cutoff;Liquids;Aviation;International Aviation_tmp_subsectorL2;International Aviation;FV;1;2050;10
-SDP_EI;Mix2;below GDP cutoff;Liquids;Ship;International Ship_tmp_subsectorL2;International Ship;FV;1;2050;10
-SDP_EI;Mix2;below GDP cutoff;BEV;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SDP_EI;Mix2;below GDP cutoff;Liquids;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SDP_EI;Mix2;below GDP cutoff;Electric;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SDP_EI;Mix2;below GDP cutoff;Liquids;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SDP_EI;Mix2;below GDP cutoff;BEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1.5;2035;10
-SDP_EI;Mix2;below GDP cutoff;FCEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1.5;2035;10
-SDP_EI;Mix2;below GDP cutoff;Liquids;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;10
-SDP_EI;Mix2;below GDP cutoff;BEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1.5;2035;10
-SDP_EI;Mix2;below GDP cutoff;FCEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1.5;2035;10
-SDP_EI;Mix2;below GDP cutoff;Liquids;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;10
-SDP_EI;Mix3;above GDP cutoff;;;;Cycle;S1S;1;2050;10
-SDP_EI;Mix3;above GDP cutoff;;;;Domestic Aviation;S1S;0.5;2035;10
-SDP_EI;Mix3;above GDP cutoff;;;;Domestic Ship;S1S;1;2050;10
-SDP_EI;Mix3;above GDP cutoff;;;;Freight Rail;S1S;1;2050;10
-SDP_EI;Mix3;above GDP cutoff;;;;HSR;S1S;1;2050;10
-SDP_EI;Mix3;above GDP cutoff;;;;Passenger Rail;S1S;1;2050;10
-SDP_EI;Mix3;above GDP cutoff;;;;trn_freight_road;S1S;0.7;2035;10
-SDP_EI;Mix3;above GDP cutoff;;;;trn_pass_road;S1S;0.7;2035;10
-SDP_EI;Mix3;above GDP cutoff;;;;Walk;S1S;1;2050;10
-SDP_EI;Mix3;below GDP cutoff;;;;Cycle;S1S;1;2050;10
-SDP_EI;Mix3;below GDP cutoff;;;;Domestic Aviation;S1S;0.5;2035;10
-SDP_EI;Mix3;below GDP cutoff;;;;Domestic Ship;S1S;1;2050;10
-SDP_EI;Mix3;below GDP cutoff;;;;Freight Rail;S1S;1;2050;10
-SDP_EI;Mix3;below GDP cutoff;;;;HSR;S1S;1;2050;10
-SDP_EI;Mix3;below GDP cutoff;;;;Passenger Rail;S1S;1;2050;10
-SDP_EI;Mix3;below GDP cutoff;;;;trn_freight_road;S1S;0.7;2035;10
-SDP_EI;Mix3;below GDP cutoff;;;;trn_pass_road;S1S;0.7;2035;10
-SDP_EI;Mix3;below GDP cutoff;;;;Walk;S1S;1;2050;10
-SDP_EI;Mix3;above GDP cutoff;;;Bus;trn_pass_road;S2S1;1;2050;10
-SDP_EI;Mix3;above GDP cutoff;;;trn_pass_road_LDV;trn_pass_road;S2S1;0.7;2035;10
-SDP_EI;Mix3;below GDP cutoff;;;Bus;trn_pass_road;S2S1;1;2050;10
-SDP_EI;Mix3;below GDP cutoff;;;trn_pass_road_LDV;trn_pass_road;S2S1;0.7;2035;10
-SDP_EI;Mix3;above GDP cutoff;BEV;Bus;Bus;trn_pass_road;FV;4;2035;10
-SDP_EI;Mix3;above GDP cutoff;FCEV;Bus;Bus;trn_pass_road;FV;4;2035;10
-SDP_EI;Mix3;above GDP cutoff;Liquids;Bus;Bus;trn_pass_road;FV;1;2050;10
-SDP_EI;Mix3;above GDP cutoff;Hydrogen;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SDP_EI;Mix3;above GDP cutoff;Liquids;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SDP_EI;Mix3;above GDP cutoff;Liquids;Ship;Domestic Ship_tmp_subsectorL2;Domestic Ship;FV;1;2050;10
-SDP_EI;Mix3;above GDP cutoff;Electric;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SDP_EI;Mix3;above GDP cutoff;Liquids;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SDP_EI;Mix3;above GDP cutoff;Electric;Rail;HSR_tmp_subsectorL2;HSR;FV;1;2050;10
-SDP_EI;Mix3;above GDP cutoff;Liquids;Aviation;International Aviation_tmp_subsectorL2;International Aviation;FV;1;2050;10
-SDP_EI;Mix3;above GDP cutoff;Liquids;Ship;International Ship_tmp_subsectorL2;International Ship;FV;1;2050;10
-SDP_EI;Mix3;above GDP cutoff;BEV;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SDP_EI;Mix3;above GDP cutoff;Liquids;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SDP_EI;Mix3;above GDP cutoff;Electric;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SDP_EI;Mix3;above GDP cutoff;Liquids;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SDP_EI;Mix3;above GDP cutoff;BEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;4;2035;10
-SDP_EI;Mix3;above GDP cutoff;FCEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;4;2035;10
-SDP_EI;Mix3;above GDP cutoff;Liquids;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;10
-SDP_EI;Mix3;above GDP cutoff;BEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;7;2035;10
-SDP_EI;Mix3;above GDP cutoff;FCEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;20;2035;10
-SDP_EI;Mix3;above GDP cutoff;Liquids;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;10
-SDP_EI;Mix3;below GDP cutoff;BEV;Bus;Bus;trn_pass_road;FV;3.5;2035;10
-SDP_EI;Mix3;below GDP cutoff;FCEV;Bus;Bus;trn_pass_road;FV;3.5;2035;10
-SDP_EI;Mix3;below GDP cutoff;Liquids;Bus;Bus;trn_pass_road;FV;1;2050;10
-SDP_EI;Mix3;below GDP cutoff;Hydrogen;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SDP_EI;Mix3;below GDP cutoff;Liquids;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SDP_EI;Mix3;below GDP cutoff;Liquids;Ship;Domestic Ship_tmp_subsectorL2;Domestic Ship;FV;1;2050;10
-SDP_EI;Mix3;below GDP cutoff;Electric;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SDP_EI;Mix3;below GDP cutoff;Liquids;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SDP_EI;Mix3;below GDP cutoff;Electric;Rail;HSR_tmp_subsectorL2;HSR;FV;1;2050;10
-SDP_EI;Mix3;below GDP cutoff;Liquids;Aviation;International Aviation_tmp_subsectorL2;International Aviation;FV;1;2050;10
-SDP_EI;Mix3;below GDP cutoff;Liquids;Ship;International Ship_tmp_subsectorL2;International Ship;FV;1;2050;10
-SDP_EI;Mix3;below GDP cutoff;BEV;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SDP_EI;Mix3;below GDP cutoff;Liquids;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SDP_EI;Mix3;below GDP cutoff;Electric;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SDP_EI;Mix3;below GDP cutoff;Liquids;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SDP_EI;Mix3;below GDP cutoff;BEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;3.5;2035;10
-SDP_EI;Mix3;below GDP cutoff;FCEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;3.5;2035;10
-SDP_EI;Mix3;below GDP cutoff;Liquids;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;10
-SDP_EI;Mix3;below GDP cutoff;BEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;5;2035;10
-SDP_EI;Mix3;below GDP cutoff;FCEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;17;2035;10
-SDP_EI;Mix3;below GDP cutoff;Liquids;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;10
-SDP_EI;Mix4;above GDP cutoff;;;;Cycle;S1S;1;2050;10
-SDP_EI;Mix4;above GDP cutoff;;;;Domestic Aviation;S1S;0.25;2035;10
-SDP_EI;Mix4;above GDP cutoff;;;;Domestic Ship;S1S;1;2050;10
-SDP_EI;Mix4;above GDP cutoff;;;;Freight Rail;S1S;1;2050;10
-SDP_EI;Mix4;above GDP cutoff;;;;HSR;S1S;1;2050;10
-SDP_EI;Mix4;above GDP cutoff;;;;Passenger Rail;S1S;1;2050;10
-SDP_EI;Mix4;above GDP cutoff;;;;trn_freight_road;S1S;0.5;2035;10
-SDP_EI;Mix4;above GDP cutoff;;;;trn_pass_road;S1S;0.5;2035;10
-SDP_EI;Mix4;above GDP cutoff;;;;Walk;S1S;1;2050;10
-SDP_EI;Mix4;below GDP cutoff;;;;Cycle;S1S;1;2050;10
-SDP_EI;Mix4;below GDP cutoff;;;;Domestic Aviation;S1S;0.25;2035;10
-SDP_EI;Mix4;below GDP cutoff;;;;Domestic Ship;S1S;1;2050;10
-SDP_EI;Mix4;below GDP cutoff;;;;Freight Rail;S1S;1;2050;10
-SDP_EI;Mix4;below GDP cutoff;;;;HSR;S1S;1;2050;10
-SDP_EI;Mix4;below GDP cutoff;;;;Passenger Rail;S1S;1;2050;10
-SDP_EI;Mix4;below GDP cutoff;;;;trn_freight_road;S1S;0.5;2035;10
-SDP_EI;Mix4;below GDP cutoff;;;;trn_pass_road;S1S;0.5;2035;10
-SDP_EI;Mix4;below GDP cutoff;;;;Walk;S1S;1;2050;10
-SDP_EI;Mix4;above GDP cutoff;;;Bus;trn_pass_road;S2S1;1;2050;10
-SDP_EI;Mix4;above GDP cutoff;;;trn_pass_road_LDV;trn_pass_road;S2S1;0.5;2035;10
-SDP_EI;Mix4;below GDP cutoff;;;Bus;trn_pass_road;S2S1;1;2050;10
-SDP_EI;Mix4;below GDP cutoff;;;trn_pass_road_LDV;trn_pass_road;S2S1;0.5;2035;10
-SDP_EI;Mix4;above GDP cutoff;BEV;Bus;Bus;trn_pass_road;FV;6;2035;10
-SDP_EI;Mix4;above GDP cutoff;FCEV;Bus;Bus;trn_pass_road;FV;6;2035;10
-SDP_EI;Mix4;above GDP cutoff;Liquids;Bus;Bus;trn_pass_road;FV;1;2050;10
-SDP_EI;Mix4;above GDP cutoff;Hydrogen;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SDP_EI;Mix4;above GDP cutoff;Liquids;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SDP_EI;Mix4;above GDP cutoff;Liquids;Ship;Domestic Ship_tmp_subsectorL2;Domestic Ship;FV;1;2050;10
-SDP_EI;Mix4;above GDP cutoff;Electric;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SDP_EI;Mix4;above GDP cutoff;Liquids;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SDP_EI;Mix4;above GDP cutoff;Electric;Rail;HSR_tmp_subsectorL2;HSR;FV;1;2050;10
-SDP_EI;Mix4;above GDP cutoff;Liquids;Aviation;International Aviation_tmp_subsectorL2;International Aviation;FV;1;2050;10
-SDP_EI;Mix4;above GDP cutoff;Liquids;Ship;International Ship_tmp_subsectorL2;International Ship;FV;1;2050;10
-SDP_EI;Mix4;above GDP cutoff;BEV;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SDP_EI;Mix4;above GDP cutoff;Liquids;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SDP_EI;Mix4;above GDP cutoff;Electric;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SDP_EI;Mix4;above GDP cutoff;Liquids;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SDP_EI;Mix4;above GDP cutoff;BEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;6;2035;10
-SDP_EI;Mix4;above GDP cutoff;FCEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;6;2035;10
-SDP_EI;Mix4;above GDP cutoff;Liquids;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;10
-SDP_EI;Mix4;above GDP cutoff;BEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;20;2035;10
-SDP_EI;Mix4;above GDP cutoff;FCEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;100;2035;10
-SDP_EI;Mix4;above GDP cutoff;Liquids;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;10
-SDP_EI;Mix4;below GDP cutoff;BEV;Bus;Bus;trn_pass_road;FV;5;2035;10
-SDP_EI;Mix4;below GDP cutoff;FCEV;Bus;Bus;trn_pass_road;FV;5;2035;10
-SDP_EI;Mix4;below GDP cutoff;Liquids;Bus;Bus;trn_pass_road;FV;1;2050;10
-SDP_EI;Mix4;below GDP cutoff;Hydrogen;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SDP_EI;Mix4;below GDP cutoff;Liquids;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SDP_EI;Mix4;below GDP cutoff;Liquids;Ship;Domestic Ship_tmp_subsectorL2;Domestic Ship;FV;1;2050;10
-SDP_EI;Mix4;below GDP cutoff;Electric;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SDP_EI;Mix4;below GDP cutoff;Liquids;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SDP_EI;Mix4;below GDP cutoff;Electric;Rail;HSR_tmp_subsectorL2;HSR;FV;1;2050;10
-SDP_EI;Mix4;below GDP cutoff;Liquids;Aviation;International Aviation_tmp_subsectorL2;International Aviation;FV;1;2050;10
-SDP_EI;Mix4;below GDP cutoff;Liquids;Ship;International Ship_tmp_subsectorL2;International Ship;FV;1;2050;10
-SDP_EI;Mix4;below GDP cutoff;BEV;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SDP_EI;Mix4;below GDP cutoff;Liquids;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SDP_EI;Mix4;below GDP cutoff;Electric;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SDP_EI;Mix4;below GDP cutoff;Liquids;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SDP_EI;Mix4;below GDP cutoff;BEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;5;2035;10
-SDP_EI;Mix4;below GDP cutoff;FCEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;5;2035;10
-SDP_EI;Mix4;below GDP cutoff;Liquids;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;10
-SDP_EI;Mix4;below GDP cutoff;BEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;17;2035;10
-SDP_EI;Mix4;below GDP cutoff;FCEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;85;2035;10
-SDP_EI;Mix4;below GDP cutoff;Liquids;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;10
-SDP_MC;Mix2;above GDP cutoff;;;;Cycle;S1S;1;2050;10
-SDP_MC;Mix2;above GDP cutoff;;;;Domestic Aviation;S1S;0.75;2035;10
-SDP_MC;Mix2;above GDP cutoff;;;;Domestic Ship;S1S;1;2050;10
-SDP_MC;Mix2;above GDP cutoff;;;;Freight Rail;S1S;1;2050;10
-SDP_MC;Mix2;above GDP cutoff;;;;HSR;S1S;1;2050;10
-SDP_MC;Mix2;above GDP cutoff;;;;Passenger Rail;S1S;1;2050;10
-SDP_MC;Mix2;above GDP cutoff;;;;trn_freight_road;S1S;0.9;2035;10
-SDP_MC;Mix2;above GDP cutoff;;;;trn_pass_road;S1S;0.9;2035;10
-SDP_MC;Mix2;above GDP cutoff;;;;Walk;S1S;1;2050;10
-SDP_MC;Mix2;below GDP cutoff;;;;Cycle;S1S;1;2050;10
-SDP_MC;Mix2;below GDP cutoff;;;;Domestic Aviation;S1S;0.75;2035;10
-SDP_MC;Mix2;below GDP cutoff;;;;Domestic Ship;S1S;1;2050;10
-SDP_MC;Mix2;below GDP cutoff;;;;Freight Rail;S1S;1;2050;10
-SDP_MC;Mix2;below GDP cutoff;;;;HSR;S1S;1;2050;10
-SDP_MC;Mix2;below GDP cutoff;;;;Passenger Rail;S1S;1;2050;10
-SDP_MC;Mix2;below GDP cutoff;;;;trn_freight_road;S1S;0.9;2035;10
-SDP_MC;Mix2;below GDP cutoff;;;;trn_pass_road;S1S;0.9;2035;10
-SDP_MC;Mix2;below GDP cutoff;;;;Walk;S1S;1;2050;10
-SDP_MC;Mix2;above GDP cutoff;;;Bus;trn_pass_road;S2S1;1;2050;10
-SDP_MC;Mix2;above GDP cutoff;;;trn_pass_road_LDV;trn_pass_road;S2S1;0.9;2035;10
-SDP_MC;Mix2;below GDP cutoff;;;Bus;trn_pass_road;S2S1;1;2050;10
-SDP_MC;Mix2;below GDP cutoff;;;trn_pass_road_LDV;trn_pass_road;S2S1;0.9;2035;10
-SDP_MC;Mix2;above GDP cutoff;BEV;Bus;Bus;trn_pass_road;FV;2;2035;10
-SDP_MC;Mix2;above GDP cutoff;FCEV;Bus;Bus;trn_pass_road;FV;2;2035;10
-SDP_MC;Mix2;above GDP cutoff;Liquids;Bus;Bus;trn_pass_road;FV;1;2050;10
-SDP_MC;Mix2;above GDP cutoff;Hydrogen;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SDP_MC;Mix2;above GDP cutoff;Liquids;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SDP_MC;Mix2;above GDP cutoff;Liquids;Ship;Domestic Ship_tmp_subsectorL2;Domestic Ship;FV;1;2050;10
-SDP_MC;Mix2;above GDP cutoff;Electric;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SDP_MC;Mix2;above GDP cutoff;Liquids;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SDP_MC;Mix2;above GDP cutoff;Electric;Rail;HSR_tmp_subsectorL2;HSR;FV;1;2050;10
-SDP_MC;Mix2;above GDP cutoff;Liquids;Aviation;International Aviation_tmp_subsectorL2;International Aviation;FV;1;2050;10
-SDP_MC;Mix2;above GDP cutoff;Liquids;Ship;International Ship_tmp_subsectorL2;International Ship;FV;1;2050;10
-SDP_MC;Mix2;above GDP cutoff;BEV;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SDP_MC;Mix2;above GDP cutoff;Liquids;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SDP_MC;Mix2;above GDP cutoff;Electric;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SDP_MC;Mix2;above GDP cutoff;Liquids;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SDP_MC;Mix2;above GDP cutoff;BEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;2;2035;10
-SDP_MC;Mix2;above GDP cutoff;FCEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;2;2035;10
-SDP_MC;Mix2;above GDP cutoff;Liquids;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;10
-SDP_MC;Mix2;above GDP cutoff;BEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;2;2035;10
-SDP_MC;Mix2;above GDP cutoff;FCEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;2;2035;10
-SDP_MC;Mix2;above GDP cutoff;Liquids;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;10
-SDP_MC;Mix2;below GDP cutoff;BEV;Bus;Bus;trn_pass_road;FV;1.5;2035;10
-SDP_MC;Mix2;below GDP cutoff;FCEV;Bus;Bus;trn_pass_road;FV;1.5;2035;10
-SDP_MC;Mix2;below GDP cutoff;Liquids;Bus;Bus;trn_pass_road;FV;1;2050;10
-SDP_MC;Mix2;below GDP cutoff;Hydrogen;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SDP_MC;Mix2;below GDP cutoff;Liquids;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SDP_MC;Mix2;below GDP cutoff;Liquids;Ship;Domestic Ship_tmp_subsectorL2;Domestic Ship;FV;1;2050;10
-SDP_MC;Mix2;below GDP cutoff;Electric;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SDP_MC;Mix2;below GDP cutoff;Liquids;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SDP_MC;Mix2;below GDP cutoff;Electric;Rail;HSR_tmp_subsectorL2;HSR;FV;1;2050;10
-SDP_MC;Mix2;below GDP cutoff;Liquids;Aviation;International Aviation_tmp_subsectorL2;International Aviation;FV;1;2050;10
-SDP_MC;Mix2;below GDP cutoff;Liquids;Ship;International Ship_tmp_subsectorL2;International Ship;FV;1;2050;10
-SDP_MC;Mix2;below GDP cutoff;BEV;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SDP_MC;Mix2;below GDP cutoff;Liquids;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SDP_MC;Mix2;below GDP cutoff;Electric;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SDP_MC;Mix2;below GDP cutoff;Liquids;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SDP_MC;Mix2;below GDP cutoff;BEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1.5;2035;10
-SDP_MC;Mix2;below GDP cutoff;FCEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1.5;2035;10
-SDP_MC;Mix2;below GDP cutoff;Liquids;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;10
-SDP_MC;Mix2;below GDP cutoff;BEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1.5;2035;10
-SDP_MC;Mix2;below GDP cutoff;FCEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1.5;2035;10
-SDP_MC;Mix2;below GDP cutoff;Liquids;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;10
-SDP_MC;Mix3;above GDP cutoff;;;;Cycle;S1S;1;2050;10
-SDP_MC;Mix3;above GDP cutoff;;;;Domestic Aviation;S1S;0.5;2035;10
-SDP_MC;Mix3;above GDP cutoff;;;;Domestic Ship;S1S;1;2050;10
-SDP_MC;Mix3;above GDP cutoff;;;;Freight Rail;S1S;1;2050;10
-SDP_MC;Mix3;above GDP cutoff;;;;HSR;S1S;1;2050;10
-SDP_MC;Mix3;above GDP cutoff;;;;Passenger Rail;S1S;1;2050;10
-SDP_MC;Mix3;above GDP cutoff;;;;trn_freight_road;S1S;0.7;2035;10
-SDP_MC;Mix3;above GDP cutoff;;;;trn_pass_road;S1S;0.7;2035;10
-SDP_MC;Mix3;above GDP cutoff;;;;Walk;S1S;1;2050;10
-SDP_MC;Mix3;below GDP cutoff;;;;Cycle;S1S;1;2050;10
-SDP_MC;Mix3;below GDP cutoff;;;;Domestic Aviation;S1S;0.5;2035;10
-SDP_MC;Mix3;below GDP cutoff;;;;Domestic Ship;S1S;1;2050;10
-SDP_MC;Mix3;below GDP cutoff;;;;Freight Rail;S1S;1;2050;10
-SDP_MC;Mix3;below GDP cutoff;;;;HSR;S1S;1;2050;10
-SDP_MC;Mix3;below GDP cutoff;;;;Passenger Rail;S1S;1;2050;10
-SDP_MC;Mix3;below GDP cutoff;;;;trn_freight_road;S1S;0.7;2035;10
-SDP_MC;Mix3;below GDP cutoff;;;;trn_pass_road;S1S;0.7;2035;10
-SDP_MC;Mix3;below GDP cutoff;;;;Walk;S1S;1;2050;10
-SDP_MC;Mix3;above GDP cutoff;;;Bus;trn_pass_road;S2S1;1;2050;10
-SDP_MC;Mix3;above GDP cutoff;;;trn_pass_road_LDV;trn_pass_road;S2S1;0.7;2035;10
-SDP_MC;Mix3;below GDP cutoff;;;Bus;trn_pass_road;S2S1;1;2050;10
-SDP_MC;Mix3;below GDP cutoff;;;trn_pass_road_LDV;trn_pass_road;S2S1;0.7;2035;10
-SDP_MC;Mix3;above GDP cutoff;BEV;Bus;Bus;trn_pass_road;FV;4;2035;10
-SDP_MC;Mix3;above GDP cutoff;FCEV;Bus;Bus;trn_pass_road;FV;4;2035;10
-SDP_MC;Mix3;above GDP cutoff;Liquids;Bus;Bus;trn_pass_road;FV;1;2050;10
-SDP_MC;Mix3;above GDP cutoff;Hydrogen;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SDP_MC;Mix3;above GDP cutoff;Liquids;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SDP_MC;Mix3;above GDP cutoff;Liquids;Ship;Domestic Ship_tmp_subsectorL2;Domestic Ship;FV;1;2050;10
-SDP_MC;Mix3;above GDP cutoff;Electric;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SDP_MC;Mix3;above GDP cutoff;Liquids;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SDP_MC;Mix3;above GDP cutoff;Electric;Rail;HSR_tmp_subsectorL2;HSR;FV;1;2050;10
-SDP_MC;Mix3;above GDP cutoff;Liquids;Aviation;International Aviation_tmp_subsectorL2;International Aviation;FV;1;2050;10
-SDP_MC;Mix3;above GDP cutoff;Liquids;Ship;International Ship_tmp_subsectorL2;International Ship;FV;1;2050;10
-SDP_MC;Mix3;above GDP cutoff;BEV;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SDP_MC;Mix3;above GDP cutoff;Liquids;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SDP_MC;Mix3;above GDP cutoff;Electric;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SDP_MC;Mix3;above GDP cutoff;Liquids;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SDP_MC;Mix3;above GDP cutoff;BEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;4;2035;10
-SDP_MC;Mix3;above GDP cutoff;FCEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;4;2035;10
-SDP_MC;Mix3;above GDP cutoff;Liquids;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;10
-SDP_MC;Mix3;above GDP cutoff;BEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;7;2035;10
-SDP_MC;Mix3;above GDP cutoff;FCEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;20;2035;10
-SDP_MC;Mix3;above GDP cutoff;Liquids;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;10
-SDP_MC;Mix3;below GDP cutoff;BEV;Bus;Bus;trn_pass_road;FV;3.5;2035;10
-SDP_MC;Mix3;below GDP cutoff;FCEV;Bus;Bus;trn_pass_road;FV;3.5;2035;10
-SDP_MC;Mix3;below GDP cutoff;Liquids;Bus;Bus;trn_pass_road;FV;1;2050;10
-SDP_MC;Mix3;below GDP cutoff;Hydrogen;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SDP_MC;Mix3;below GDP cutoff;Liquids;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SDP_MC;Mix3;below GDP cutoff;Liquids;Ship;Domestic Ship_tmp_subsectorL2;Domestic Ship;FV;1;2050;10
-SDP_MC;Mix3;below GDP cutoff;Electric;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SDP_MC;Mix3;below GDP cutoff;Liquids;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SDP_MC;Mix3;below GDP cutoff;Electric;Rail;HSR_tmp_subsectorL2;HSR;FV;1;2050;10
-SDP_MC;Mix3;below GDP cutoff;Liquids;Aviation;International Aviation_tmp_subsectorL2;International Aviation;FV;1;2050;10
-SDP_MC;Mix3;below GDP cutoff;Liquids;Ship;International Ship_tmp_subsectorL2;International Ship;FV;1;2050;10
-SDP_MC;Mix3;below GDP cutoff;BEV;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SDP_MC;Mix3;below GDP cutoff;Liquids;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SDP_MC;Mix3;below GDP cutoff;Electric;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SDP_MC;Mix3;below GDP cutoff;Liquids;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SDP_MC;Mix3;below GDP cutoff;BEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;3.5;2035;10
-SDP_MC;Mix3;below GDP cutoff;FCEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;3.5;2035;10
-SDP_MC;Mix3;below GDP cutoff;Liquids;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;10
-SDP_MC;Mix3;below GDP cutoff;BEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;5;2035;10
-SDP_MC;Mix3;below GDP cutoff;FCEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;17;2035;10
-SDP_MC;Mix3;below GDP cutoff;Liquids;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;10
-SDP_MC;Mix4;above GDP cutoff;;;;Cycle;S1S;1;2050;10
-SDP_MC;Mix4;above GDP cutoff;;;;Domestic Aviation;S1S;0.25;2035;10
-SDP_MC;Mix4;above GDP cutoff;;;;Domestic Ship;S1S;1;2050;10
-SDP_MC;Mix4;above GDP cutoff;;;;Freight Rail;S1S;1;2050;10
-SDP_MC;Mix4;above GDP cutoff;;;;HSR;S1S;1;2050;10
-SDP_MC;Mix4;above GDP cutoff;;;;Passenger Rail;S1S;1;2050;10
-SDP_MC;Mix4;above GDP cutoff;;;;trn_freight_road;S1S;0.5;2035;10
-SDP_MC;Mix4;above GDP cutoff;;;;trn_pass_road;S1S;0.5;2035;10
-SDP_MC;Mix4;above GDP cutoff;;;;Walk;S1S;1;2050;10
-SDP_MC;Mix4;below GDP cutoff;;;;Cycle;S1S;1;2050;10
-SDP_MC;Mix4;below GDP cutoff;;;;Domestic Aviation;S1S;0.25;2035;10
-SDP_MC;Mix4;below GDP cutoff;;;;Domestic Ship;S1S;1;2050;10
-SDP_MC;Mix4;below GDP cutoff;;;;Freight Rail;S1S;1;2050;10
-SDP_MC;Mix4;below GDP cutoff;;;;HSR;S1S;1;2050;10
-SDP_MC;Mix4;below GDP cutoff;;;;Passenger Rail;S1S;1;2050;10
-SDP_MC;Mix4;below GDP cutoff;;;;trn_freight_road;S1S;0.5;2035;10
-SDP_MC;Mix4;below GDP cutoff;;;;trn_pass_road;S1S;0.5;2035;10
-SDP_MC;Mix4;below GDP cutoff;;;;Walk;S1S;1;2050;10
-SDP_MC;Mix4;above GDP cutoff;;;Bus;trn_pass_road;S2S1;1;2050;10
-SDP_MC;Mix4;above GDP cutoff;;;trn_pass_road_LDV;trn_pass_road;S2S1;0.5;2035;10
-SDP_MC;Mix4;below GDP cutoff;;;Bus;trn_pass_road;S2S1;1;2050;10
-SDP_MC;Mix4;below GDP cutoff;;;trn_pass_road_LDV;trn_pass_road;S2S1;0.5;2035;10
-SDP_MC;Mix4;above GDP cutoff;BEV;Bus;Bus;trn_pass_road;FV;6;2035;10
-SDP_MC;Mix4;above GDP cutoff;FCEV;Bus;Bus;trn_pass_road;FV;6;2035;10
-SDP_MC;Mix4;above GDP cutoff;Liquids;Bus;Bus;trn_pass_road;FV;1;2050;10
-SDP_MC;Mix4;above GDP cutoff;Hydrogen;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SDP_MC;Mix4;above GDP cutoff;Liquids;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SDP_MC;Mix4;above GDP cutoff;Liquids;Ship;Domestic Ship_tmp_subsectorL2;Domestic Ship;FV;1;2050;10
-SDP_MC;Mix4;above GDP cutoff;Electric;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SDP_MC;Mix4;above GDP cutoff;Liquids;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SDP_MC;Mix4;above GDP cutoff;Electric;Rail;HSR_tmp_subsectorL2;HSR;FV;1;2050;10
-SDP_MC;Mix4;above GDP cutoff;Liquids;Aviation;International Aviation_tmp_subsectorL2;International Aviation;FV;1;2050;10
-SDP_MC;Mix4;above GDP cutoff;Liquids;Ship;International Ship_tmp_subsectorL2;International Ship;FV;1;2050;10
-SDP_MC;Mix4;above GDP cutoff;BEV;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SDP_MC;Mix4;above GDP cutoff;Liquids;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SDP_MC;Mix4;above GDP cutoff;Electric;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SDP_MC;Mix4;above GDP cutoff;Liquids;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SDP_MC;Mix4;above GDP cutoff;BEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;6;2035;10
-SDP_MC;Mix4;above GDP cutoff;FCEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;6;2035;10
-SDP_MC;Mix4;above GDP cutoff;Liquids;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;10
-SDP_MC;Mix4;above GDP cutoff;BEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;20;2035;10
-SDP_MC;Mix4;above GDP cutoff;FCEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;100;2035;10
-SDP_MC;Mix4;above GDP cutoff;Liquids;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;10
-SDP_MC;Mix4;below GDP cutoff;BEV;Bus;Bus;trn_pass_road;FV;5;2035;10
-SDP_MC;Mix4;below GDP cutoff;FCEV;Bus;Bus;trn_pass_road;FV;5;2035;10
-SDP_MC;Mix4;below GDP cutoff;Liquids;Bus;Bus;trn_pass_road;FV;1;2050;10
-SDP_MC;Mix4;below GDP cutoff;Hydrogen;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SDP_MC;Mix4;below GDP cutoff;Liquids;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SDP_MC;Mix4;below GDP cutoff;Liquids;Ship;Domestic Ship_tmp_subsectorL2;Domestic Ship;FV;1;2050;10
-SDP_MC;Mix4;below GDP cutoff;Electric;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SDP_MC;Mix4;below GDP cutoff;Liquids;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SDP_MC;Mix4;below GDP cutoff;Electric;Rail;HSR_tmp_subsectorL2;HSR;FV;1;2050;10
-SDP_MC;Mix4;below GDP cutoff;Liquids;Aviation;International Aviation_tmp_subsectorL2;International Aviation;FV;1;2050;10
-SDP_MC;Mix4;below GDP cutoff;Liquids;Ship;International Ship_tmp_subsectorL2;International Ship;FV;1;2050;10
-SDP_MC;Mix4;below GDP cutoff;BEV;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SDP_MC;Mix4;below GDP cutoff;Liquids;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SDP_MC;Mix4;below GDP cutoff;Electric;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SDP_MC;Mix4;below GDP cutoff;Liquids;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SDP_MC;Mix4;below GDP cutoff;BEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;5;2035;10
-SDP_MC;Mix4;below GDP cutoff;FCEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;5;2035;10
-SDP_MC;Mix4;below GDP cutoff;Liquids;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;10
-SDP_MC;Mix4;below GDP cutoff;BEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;17;2035;10
-SDP_MC;Mix4;below GDP cutoff;FCEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;85;2035;10
-SDP_MC;Mix4;below GDP cutoff;Liquids;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;10
-SDP_RC;Mix2;above GDP cutoff;;;;Cycle;S1S;1;2050;10
-SDP_RC;Mix2;above GDP cutoff;;;;Domestic Aviation;S1S;0.75;2035;10
-SDP_RC;Mix2;above GDP cutoff;;;;Domestic Ship;S1S;1;2050;10
-SDP_RC;Mix2;above GDP cutoff;;;;Freight Rail;S1S;1;2050;10
-SDP_RC;Mix2;above GDP cutoff;;;;HSR;S1S;1;2050;10
-SDP_RC;Mix2;above GDP cutoff;;;;Passenger Rail;S1S;1;2050;10
-SDP_RC;Mix2;above GDP cutoff;;;;trn_freight_road;S1S;0.9;2035;10
-SDP_RC;Mix2;above GDP cutoff;;;;trn_pass_road;S1S;0.9;2035;10
-SDP_RC;Mix2;above GDP cutoff;;;;Walk;S1S;1;2050;10
-SDP_RC;Mix2;below GDP cutoff;;;;Cycle;S1S;1;2050;10
-SDP_RC;Mix2;below GDP cutoff;;;;Domestic Aviation;S1S;0.75;2035;10
-SDP_RC;Mix2;below GDP cutoff;;;;Domestic Ship;S1S;1;2050;10
-SDP_RC;Mix2;below GDP cutoff;;;;Freight Rail;S1S;1;2050;10
-SDP_RC;Mix2;below GDP cutoff;;;;HSR;S1S;1;2050;10
-SDP_RC;Mix2;below GDP cutoff;;;;Passenger Rail;S1S;1;2050;10
-SDP_RC;Mix2;below GDP cutoff;;;;trn_freight_road;S1S;0.9;2035;10
-SDP_RC;Mix2;below GDP cutoff;;;;trn_pass_road;S1S;0.9;2035;10
-SDP_RC;Mix2;below GDP cutoff;;;;Walk;S1S;1;2050;10
-SDP_RC;Mix2;above GDP cutoff;;;Bus;trn_pass_road;S2S1;1;2050;10
-SDP_RC;Mix2;above GDP cutoff;;;trn_pass_road_LDV;trn_pass_road;S2S1;0.9;2035;10
-SDP_RC;Mix2;below GDP cutoff;;;Bus;trn_pass_road;S2S1;1;2050;10
-SDP_RC;Mix2;below GDP cutoff;;;trn_pass_road_LDV;trn_pass_road;S2S1;0.9;2035;10
-SDP_RC;Mix2;above GDP cutoff;BEV;Bus;Bus;trn_pass_road;FV;2;2035;10
-SDP_RC;Mix2;above GDP cutoff;FCEV;Bus;Bus;trn_pass_road;FV;2;2035;10
-SDP_RC;Mix2;above GDP cutoff;Liquids;Bus;Bus;trn_pass_road;FV;1;2050;10
-SDP_RC;Mix2;above GDP cutoff;Hydrogen;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SDP_RC;Mix2;above GDP cutoff;Liquids;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SDP_RC;Mix2;above GDP cutoff;Liquids;Ship;Domestic Ship_tmp_subsectorL2;Domestic Ship;FV;1;2050;10
-SDP_RC;Mix2;above GDP cutoff;Electric;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SDP_RC;Mix2;above GDP cutoff;Liquids;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SDP_RC;Mix2;above GDP cutoff;Electric;Rail;HSR_tmp_subsectorL2;HSR;FV;1;2050;10
-SDP_RC;Mix2;above GDP cutoff;Liquids;Aviation;International Aviation_tmp_subsectorL2;International Aviation;FV;1;2050;10
-SDP_RC;Mix2;above GDP cutoff;Liquids;Ship;International Ship_tmp_subsectorL2;International Ship;FV;1;2050;10
-SDP_RC;Mix2;above GDP cutoff;BEV;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SDP_RC;Mix2;above GDP cutoff;Liquids;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SDP_RC;Mix2;above GDP cutoff;Electric;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SDP_RC;Mix2;above GDP cutoff;Liquids;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SDP_RC;Mix2;above GDP cutoff;BEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;2;2035;10
-SDP_RC;Mix2;above GDP cutoff;FCEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;2;2035;10
-SDP_RC;Mix2;above GDP cutoff;Liquids;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;10
-SDP_RC;Mix2;above GDP cutoff;BEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;2;2035;10
-SDP_RC;Mix2;above GDP cutoff;FCEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;2;2035;10
-SDP_RC;Mix2;above GDP cutoff;Liquids;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;10
-SDP_RC;Mix2;below GDP cutoff;BEV;Bus;Bus;trn_pass_road;FV;1.5;2035;10
-SDP_RC;Mix2;below GDP cutoff;FCEV;Bus;Bus;trn_pass_road;FV;1.5;2035;10
-SDP_RC;Mix2;below GDP cutoff;Liquids;Bus;Bus;trn_pass_road;FV;1;2050;10
-SDP_RC;Mix2;below GDP cutoff;Hydrogen;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SDP_RC;Mix2;below GDP cutoff;Liquids;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SDP_RC;Mix2;below GDP cutoff;Liquids;Ship;Domestic Ship_tmp_subsectorL2;Domestic Ship;FV;1;2050;10
-SDP_RC;Mix2;below GDP cutoff;Electric;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SDP_RC;Mix2;below GDP cutoff;Liquids;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SDP_RC;Mix2;below GDP cutoff;Electric;Rail;HSR_tmp_subsectorL2;HSR;FV;1;2050;10
-SDP_RC;Mix2;below GDP cutoff;Liquids;Aviation;International Aviation_tmp_subsectorL2;International Aviation;FV;1;2050;10
-SDP_RC;Mix2;below GDP cutoff;Liquids;Ship;International Ship_tmp_subsectorL2;International Ship;FV;1;2050;10
-SDP_RC;Mix2;below GDP cutoff;BEV;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SDP_RC;Mix2;below GDP cutoff;Liquids;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SDP_RC;Mix2;below GDP cutoff;Electric;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SDP_RC;Mix2;below GDP cutoff;Liquids;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SDP_RC;Mix2;below GDP cutoff;BEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1.5;2035;10
-SDP_RC;Mix2;below GDP cutoff;FCEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1.5;2035;10
-SDP_RC;Mix2;below GDP cutoff;Liquids;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;10
-SDP_RC;Mix2;below GDP cutoff;BEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1.5;2035;10
-SDP_RC;Mix2;below GDP cutoff;FCEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1.5;2035;10
-SDP_RC;Mix2;below GDP cutoff;Liquids;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;10
-SDP_RC;Mix3;above GDP cutoff;;;;Cycle;S1S;1;2050;10
-SDP_RC;Mix3;above GDP cutoff;;;;Domestic Aviation;S1S;0.5;2035;10
-SDP_RC;Mix3;above GDP cutoff;;;;Domestic Ship;S1S;1;2050;10
-SDP_RC;Mix3;above GDP cutoff;;;;Freight Rail;S1S;1;2050;10
-SDP_RC;Mix3;above GDP cutoff;;;;HSR;S1S;1;2050;10
-SDP_RC;Mix3;above GDP cutoff;;;;Passenger Rail;S1S;1;2050;10
-SDP_RC;Mix3;above GDP cutoff;;;;trn_freight_road;S1S;0.7;2035;10
-SDP_RC;Mix3;above GDP cutoff;;;;trn_pass_road;S1S;0.7;2035;10
-SDP_RC;Mix3;above GDP cutoff;;;;Walk;S1S;1;2050;10
-SDP_RC;Mix3;below GDP cutoff;;;;Cycle;S1S;1;2050;10
-SDP_RC;Mix3;below GDP cutoff;;;;Domestic Aviation;S1S;0.5;2035;10
-SDP_RC;Mix3;below GDP cutoff;;;;Domestic Ship;S1S;1;2050;10
-SDP_RC;Mix3;below GDP cutoff;;;;Freight Rail;S1S;1;2050;10
-SDP_RC;Mix3;below GDP cutoff;;;;HSR;S1S;1;2050;10
-SDP_RC;Mix3;below GDP cutoff;;;;Passenger Rail;S1S;1;2050;10
-SDP_RC;Mix3;below GDP cutoff;;;;trn_freight_road;S1S;0.7;2035;10
-SDP_RC;Mix3;below GDP cutoff;;;;trn_pass_road;S1S;0.7;2035;10
-SDP_RC;Mix3;below GDP cutoff;;;;Walk;S1S;1;2050;10
-SDP_RC;Mix3;above GDP cutoff;;;Bus;trn_pass_road;S2S1;1;2050;10
-SDP_RC;Mix3;above GDP cutoff;;;trn_pass_road_LDV;trn_pass_road;S2S1;0.7;2035;10
-SDP_RC;Mix3;below GDP cutoff;;;Bus;trn_pass_road;S2S1;1;2050;10
-SDP_RC;Mix3;below GDP cutoff;;;trn_pass_road_LDV;trn_pass_road;S2S1;0.7;2035;10
-SDP_RC;Mix3;above GDP cutoff;BEV;Bus;Bus;trn_pass_road;FV;4;2035;10
-SDP_RC;Mix3;above GDP cutoff;FCEV;Bus;Bus;trn_pass_road;FV;4;2035;10
-SDP_RC;Mix3;above GDP cutoff;Liquids;Bus;Bus;trn_pass_road;FV;1;2050;10
-SDP_RC;Mix3;above GDP cutoff;Hydrogen;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SDP_RC;Mix3;above GDP cutoff;Liquids;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SDP_RC;Mix3;above GDP cutoff;Liquids;Ship;Domestic Ship_tmp_subsectorL2;Domestic Ship;FV;1;2050;10
-SDP_RC;Mix3;above GDP cutoff;Electric;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SDP_RC;Mix3;above GDP cutoff;Liquids;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SDP_RC;Mix3;above GDP cutoff;Electric;Rail;HSR_tmp_subsectorL2;HSR;FV;1;2050;10
-SDP_RC;Mix3;above GDP cutoff;Liquids;Aviation;International Aviation_tmp_subsectorL2;International Aviation;FV;1;2050;10
-SDP_RC;Mix3;above GDP cutoff;Liquids;Ship;International Ship_tmp_subsectorL2;International Ship;FV;1;2050;10
-SDP_RC;Mix3;above GDP cutoff;BEV;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SDP_RC;Mix3;above GDP cutoff;Liquids;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SDP_RC;Mix3;above GDP cutoff;Electric;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SDP_RC;Mix3;above GDP cutoff;Liquids;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SDP_RC;Mix3;above GDP cutoff;BEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;4;2035;10
-SDP_RC;Mix3;above GDP cutoff;FCEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;4;2035;10
-SDP_RC;Mix3;above GDP cutoff;Liquids;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;10
-SDP_RC;Mix3;above GDP cutoff;BEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;7;2035;10
-SDP_RC;Mix3;above GDP cutoff;FCEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;20;2035;10
-SDP_RC;Mix3;above GDP cutoff;Liquids;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;10
-SDP_RC;Mix3;below GDP cutoff;BEV;Bus;Bus;trn_pass_road;FV;3.5;2035;10
-SDP_RC;Mix3;below GDP cutoff;FCEV;Bus;Bus;trn_pass_road;FV;3.5;2035;10
-SDP_RC;Mix3;below GDP cutoff;Liquids;Bus;Bus;trn_pass_road;FV;1;2050;10
-SDP_RC;Mix3;below GDP cutoff;Hydrogen;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SDP_RC;Mix3;below GDP cutoff;Liquids;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SDP_RC;Mix3;below GDP cutoff;Liquids;Ship;Domestic Ship_tmp_subsectorL2;Domestic Ship;FV;1;2050;10
-SDP_RC;Mix3;below GDP cutoff;Electric;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SDP_RC;Mix3;below GDP cutoff;Liquids;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SDP_RC;Mix3;below GDP cutoff;Electric;Rail;HSR_tmp_subsectorL2;HSR;FV;1;2050;10
-SDP_RC;Mix3;below GDP cutoff;Liquids;Aviation;International Aviation_tmp_subsectorL2;International Aviation;FV;1;2050;10
-SDP_RC;Mix3;below GDP cutoff;Liquids;Ship;International Ship_tmp_subsectorL2;International Ship;FV;1;2050;10
-SDP_RC;Mix3;below GDP cutoff;BEV;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SDP_RC;Mix3;below GDP cutoff;Liquids;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SDP_RC;Mix3;below GDP cutoff;Electric;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SDP_RC;Mix3;below GDP cutoff;Liquids;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SDP_RC;Mix3;below GDP cutoff;BEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;3.5;2035;10
-SDP_RC;Mix3;below GDP cutoff;FCEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;3.5;2035;10
-SDP_RC;Mix3;below GDP cutoff;Liquids;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;10
-SDP_RC;Mix3;below GDP cutoff;BEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;5;2035;10
-SDP_RC;Mix3;below GDP cutoff;FCEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;17;2035;10
-SDP_RC;Mix3;below GDP cutoff;Liquids;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;10
-SDP_RC;Mix4;above GDP cutoff;;;;Cycle;S1S;1;2050;10
-SDP_RC;Mix4;above GDP cutoff;;;;Domestic Aviation;S1S;0.25;2035;10
-SDP_RC;Mix4;above GDP cutoff;;;;Domestic Ship;S1S;1;2050;10
-SDP_RC;Mix4;above GDP cutoff;;;;Freight Rail;S1S;1;2050;10
-SDP_RC;Mix4;above GDP cutoff;;;;HSR;S1S;1;2050;10
-SDP_RC;Mix4;above GDP cutoff;;;;Passenger Rail;S1S;1;2050;10
-SDP_RC;Mix4;above GDP cutoff;;;;trn_freight_road;S1S;0.5;2035;10
-SDP_RC;Mix4;above GDP cutoff;;;;trn_pass_road;S1S;0.5;2035;10
-SDP_RC;Mix4;above GDP cutoff;;;;Walk;S1S;1;2050;10
-SDP_RC;Mix4;below GDP cutoff;;;;Cycle;S1S;1;2050;10
-SDP_RC;Mix4;below GDP cutoff;;;;Domestic Aviation;S1S;0.25;2035;10
-SDP_RC;Mix4;below GDP cutoff;;;;Domestic Ship;S1S;1;2050;10
-SDP_RC;Mix4;below GDP cutoff;;;;Freight Rail;S1S;1;2050;10
-SDP_RC;Mix4;below GDP cutoff;;;;HSR;S1S;1;2050;10
-SDP_RC;Mix4;below GDP cutoff;;;;Passenger Rail;S1S;1;2050;10
-SDP_RC;Mix4;below GDP cutoff;;;;trn_freight_road;S1S;0.5;2035;10
-SDP_RC;Mix4;below GDP cutoff;;;;trn_pass_road;S1S;0.5;2035;10
-SDP_RC;Mix4;below GDP cutoff;;;;Walk;S1S;1;2050;10
-SDP_RC;Mix4;above GDP cutoff;;;Bus;trn_pass_road;S2S1;1;2050;10
-SDP_RC;Mix4;above GDP cutoff;;;trn_pass_road_LDV;trn_pass_road;S2S1;0.5;2035;10
-SDP_RC;Mix4;below GDP cutoff;;;Bus;trn_pass_road;S2S1;1;2050;10
-SDP_RC;Mix4;below GDP cutoff;;;trn_pass_road_LDV;trn_pass_road;S2S1;0.5;2035;10
-SDP_RC;Mix4;above GDP cutoff;BEV;Bus;Bus;trn_pass_road;FV;6;2035;10
-SDP_RC;Mix4;above GDP cutoff;FCEV;Bus;Bus;trn_pass_road;FV;6;2035;10
-SDP_RC;Mix4;above GDP cutoff;Liquids;Bus;Bus;trn_pass_road;FV;1;2050;10
-SDP_RC;Mix4;above GDP cutoff;Hydrogen;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SDP_RC;Mix4;above GDP cutoff;Liquids;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SDP_RC;Mix4;above GDP cutoff;Liquids;Ship;Domestic Ship_tmp_subsectorL2;Domestic Ship;FV;1;2050;10
-SDP_RC;Mix4;above GDP cutoff;Electric;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SDP_RC;Mix4;above GDP cutoff;Liquids;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SDP_RC;Mix4;above GDP cutoff;Electric;Rail;HSR_tmp_subsectorL2;HSR;FV;1;2050;10
-SDP_RC;Mix4;above GDP cutoff;Liquids;Aviation;International Aviation_tmp_subsectorL2;International Aviation;FV;1;2050;10
-SDP_RC;Mix4;above GDP cutoff;Liquids;Ship;International Ship_tmp_subsectorL2;International Ship;FV;1;2050;10
-SDP_RC;Mix4;above GDP cutoff;BEV;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SDP_RC;Mix4;above GDP cutoff;Liquids;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SDP_RC;Mix4;above GDP cutoff;Electric;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SDP_RC;Mix4;above GDP cutoff;Liquids;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SDP_RC;Mix4;above GDP cutoff;BEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;6;2035;10
-SDP_RC;Mix4;above GDP cutoff;FCEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;6;2035;10
-SDP_RC;Mix4;above GDP cutoff;Liquids;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;10
-SDP_RC;Mix4;above GDP cutoff;BEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;20;2035;10
-SDP_RC;Mix4;above GDP cutoff;FCEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;100;2035;10
-SDP_RC;Mix4;above GDP cutoff;Liquids;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;10
-SDP_RC;Mix4;below GDP cutoff;BEV;Bus;Bus;trn_pass_road;FV;5;2035;10
-SDP_RC;Mix4;below GDP cutoff;FCEV;Bus;Bus;trn_pass_road;FV;5;2035;10
-SDP_RC;Mix4;below GDP cutoff;Liquids;Bus;Bus;trn_pass_road;FV;1;2050;10
-SDP_RC;Mix4;below GDP cutoff;Hydrogen;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SDP_RC;Mix4;below GDP cutoff;Liquids;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SDP_RC;Mix4;below GDP cutoff;Liquids;Ship;Domestic Ship_tmp_subsectorL2;Domestic Ship;FV;1;2050;10
-SDP_RC;Mix4;below GDP cutoff;Electric;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SDP_RC;Mix4;below GDP cutoff;Liquids;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SDP_RC;Mix4;below GDP cutoff;Electric;Rail;HSR_tmp_subsectorL2;HSR;FV;1;2050;10
-SDP_RC;Mix4;below GDP cutoff;Liquids;Aviation;International Aviation_tmp_subsectorL2;International Aviation;FV;1;2050;10
-SDP_RC;Mix4;below GDP cutoff;Liquids;Ship;International Ship_tmp_subsectorL2;International Ship;FV;1;2050;10
-SDP_RC;Mix4;below GDP cutoff;BEV;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SDP_RC;Mix4;below GDP cutoff;Liquids;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SDP_RC;Mix4;below GDP cutoff;Electric;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SDP_RC;Mix4;below GDP cutoff;Liquids;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SDP_RC;Mix4;below GDP cutoff;BEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;5;2035;10
-SDP_RC;Mix4;below GDP cutoff;FCEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;5;2035;10
-SDP_RC;Mix4;below GDP cutoff;Liquids;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;10
-SDP_RC;Mix4;below GDP cutoff;BEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;17;2035;10
-SDP_RC;Mix4;below GDP cutoff;FCEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;85;2035;10
-SDP_RC;Mix4;below GDP cutoff;Liquids;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;10
-SSP1;Mix2;above GDP cutoff;;;;Cycle;S1S;1;2050;10
-SSP1;Mix2;above GDP cutoff;;;;Domestic Aviation;S1S;0.75;2035;10
-SSP1;Mix2;above GDP cutoff;;;;Domestic Ship;S1S;1;2050;10
-SSP1;Mix2;above GDP cutoff;;;;Freight Rail;S1S;1;2050;10
-SSP1;Mix2;above GDP cutoff;;;;HSR;S1S;1;2050;10
-SSP1;Mix2;above GDP cutoff;;;;Passenger Rail;S1S;1;2050;10
-SSP1;Mix2;above GDP cutoff;;;;trn_freight_road;S1S;0.9;2035;10
-SSP1;Mix2;above GDP cutoff;;;;trn_pass_road;S1S;0.9;2035;10
-SSP1;Mix2;above GDP cutoff;;;;Walk;S1S;1;2050;10
-SSP1;Mix2;below GDP cutoff;;;;Cycle;S1S;1;2050;10
-SSP1;Mix2;below GDP cutoff;;;;Domestic Aviation;S1S;0.75;2035;10
-SSP1;Mix2;below GDP cutoff;;;;Domestic Ship;S1S;1;2050;10
-SSP1;Mix2;below GDP cutoff;;;;Freight Rail;S1S;1;2050;10
-SSP1;Mix2;below GDP cutoff;;;;HSR;S1S;1;2050;10
-SSP1;Mix2;below GDP cutoff;;;;Passenger Rail;S1S;1;2050;10
-SSP1;Mix2;below GDP cutoff;;;;trn_freight_road;S1S;0.9;2035;10
-SSP1;Mix2;below GDP cutoff;;;;trn_pass_road;S1S;0.9;2035;10
-SSP1;Mix2;below GDP cutoff;;;;Walk;S1S;1;2050;10
-SSP1;Mix2;above GDP cutoff;;;Bus;trn_pass_road;S2S1;1;2050;10
-SSP1;Mix2;above GDP cutoff;;;trn_pass_road_LDV;trn_pass_road;S2S1;0.9;2035;10
-SSP1;Mix2;below GDP cutoff;;;Bus;trn_pass_road;S2S1;1;2050;10
-SSP1;Mix2;below GDP cutoff;;;trn_pass_road_LDV;trn_pass_road;S2S1;0.9;2035;10
-SSP1;Mix2;above GDP cutoff;BEV;Bus;Bus;trn_pass_road;FV;2;2035;10
-SSP1;Mix2;above GDP cutoff;FCEV;Bus;Bus;trn_pass_road;FV;2;2035;10
-SSP1;Mix2;above GDP cutoff;Liquids;Bus;Bus;trn_pass_road;FV;1;2050;10
-SSP1;Mix2;above GDP cutoff;Hydrogen;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SSP1;Mix2;above GDP cutoff;Liquids;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SSP1;Mix2;above GDP cutoff;Liquids;Ship;Domestic Ship_tmp_subsectorL2;Domestic Ship;FV;1;2050;10
-SSP1;Mix2;above GDP cutoff;Electric;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SSP1;Mix2;above GDP cutoff;Liquids;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SSP1;Mix2;above GDP cutoff;Electric;Rail;HSR_tmp_subsectorL2;HSR;FV;1;2050;10
-SSP1;Mix2;above GDP cutoff;Liquids;Aviation;International Aviation_tmp_subsectorL2;International Aviation;FV;1;2050;10
-SSP1;Mix2;above GDP cutoff;Liquids;Ship;International Ship_tmp_subsectorL2;International Ship;FV;1;2050;10
-SSP1;Mix2;above GDP cutoff;BEV;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SSP1;Mix2;above GDP cutoff;Liquids;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SSP1;Mix2;above GDP cutoff;Electric;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SSP1;Mix2;above GDP cutoff;Liquids;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SSP1;Mix2;above GDP cutoff;BEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;2;2035;10
-SSP1;Mix2;above GDP cutoff;FCEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;2;2035;10
-SSP1;Mix2;above GDP cutoff;Liquids;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;10
-SSP1;Mix2;above GDP cutoff;BEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;2;2035;10
-SSP1;Mix2;above GDP cutoff;FCEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;2;2035;10
-SSP1;Mix2;above GDP cutoff;Liquids;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;10
-SSP1;Mix2;below GDP cutoff;BEV;Bus;Bus;trn_pass_road;FV;1.5;2035;10
-SSP1;Mix2;below GDP cutoff;FCEV;Bus;Bus;trn_pass_road;FV;1.5;2035;10
-SSP1;Mix2;below GDP cutoff;Liquids;Bus;Bus;trn_pass_road;FV;1;2050;10
-SSP1;Mix2;below GDP cutoff;Hydrogen;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SSP1;Mix2;below GDP cutoff;Liquids;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SSP1;Mix2;below GDP cutoff;Liquids;Ship;Domestic Ship_tmp_subsectorL2;Domestic Ship;FV;1;2050;10
-SSP1;Mix2;below GDP cutoff;Electric;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SSP1;Mix2;below GDP cutoff;Liquids;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SSP1;Mix2;below GDP cutoff;Electric;Rail;HSR_tmp_subsectorL2;HSR;FV;1;2050;10
-SSP1;Mix2;below GDP cutoff;Liquids;Aviation;International Aviation_tmp_subsectorL2;International Aviation;FV;1;2050;10
-SSP1;Mix2;below GDP cutoff;Liquids;Ship;International Ship_tmp_subsectorL2;International Ship;FV;1;2050;10
-SSP1;Mix2;below GDP cutoff;BEV;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SSP1;Mix2;below GDP cutoff;Liquids;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SSP1;Mix2;below GDP cutoff;Electric;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SSP1;Mix2;below GDP cutoff;Liquids;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SSP1;Mix2;below GDP cutoff;BEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1.5;2035;10
-SSP1;Mix2;below GDP cutoff;FCEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1.5;2035;10
-SSP1;Mix2;below GDP cutoff;Liquids;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;10
-SSP1;Mix2;below GDP cutoff;BEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1.5;2035;10
-SSP1;Mix2;below GDP cutoff;FCEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1.5;2035;10
-SSP1;Mix2;below GDP cutoff;Liquids;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;10
-SSP1;Mix3;above GDP cutoff;;;;Cycle;S1S;1;2050;10
-SSP1;Mix3;above GDP cutoff;;;;Domestic Aviation;S1S;0.5;2035;10
-SSP1;Mix3;above GDP cutoff;;;;Domestic Ship;S1S;1;2050;10
-SSP1;Mix3;above GDP cutoff;;;;Freight Rail;S1S;1;2050;10
-SSP1;Mix3;above GDP cutoff;;;;HSR;S1S;1;2050;10
-SSP1;Mix3;above GDP cutoff;;;;Passenger Rail;S1S;1;2050;10
-SSP1;Mix3;above GDP cutoff;;;;trn_freight_road;S1S;0.7;2035;10
-SSP1;Mix3;above GDP cutoff;;;;trn_pass_road;S1S;0.7;2035;10
-SSP1;Mix3;above GDP cutoff;;;;Walk;S1S;1;2050;10
-SSP1;Mix3;below GDP cutoff;;;;Cycle;S1S;1;2050;10
-SSP1;Mix3;below GDP cutoff;;;;Domestic Aviation;S1S;0.5;2035;10
-SSP1;Mix3;below GDP cutoff;;;;Domestic Ship;S1S;1;2050;10
-SSP1;Mix3;below GDP cutoff;;;;Freight Rail;S1S;1;2050;10
-SSP1;Mix3;below GDP cutoff;;;;HSR;S1S;1;2050;10
-SSP1;Mix3;below GDP cutoff;;;;Passenger Rail;S1S;1;2050;10
-SSP1;Mix3;below GDP cutoff;;;;trn_freight_road;S1S;0.7;2035;10
-SSP1;Mix3;below GDP cutoff;;;;trn_pass_road;S1S;0.7;2035;10
-SSP1;Mix3;below GDP cutoff;;;;Walk;S1S;1;2050;10
-SSP1;Mix3;above GDP cutoff;;;Bus;trn_pass_road;S2S1;1;2050;10
-SSP1;Mix3;above GDP cutoff;;;trn_pass_road_LDV;trn_pass_road;S2S1;0.7;2035;10
-SSP1;Mix3;below GDP cutoff;;;Bus;trn_pass_road;S2S1;1;2050;10
-SSP1;Mix3;below GDP cutoff;;;trn_pass_road_LDV;trn_pass_road;S2S1;0.7;2035;10
-SSP1;Mix3;above GDP cutoff;BEV;Bus;Bus;trn_pass_road;FV;4;2035;10
-SSP1;Mix3;above GDP cutoff;FCEV;Bus;Bus;trn_pass_road;FV;4;2035;10
-SSP1;Mix3;above GDP cutoff;Liquids;Bus;Bus;trn_pass_road;FV;1;2050;10
-SSP1;Mix3;above GDP cutoff;Hydrogen;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SSP1;Mix3;above GDP cutoff;Liquids;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SSP1;Mix3;above GDP cutoff;Liquids;Ship;Domestic Ship_tmp_subsectorL2;Domestic Ship;FV;1;2050;10
-SSP1;Mix3;above GDP cutoff;Electric;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SSP1;Mix3;above GDP cutoff;Liquids;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SSP1;Mix3;above GDP cutoff;Electric;Rail;HSR_tmp_subsectorL2;HSR;FV;1;2050;10
-SSP1;Mix3;above GDP cutoff;Liquids;Aviation;International Aviation_tmp_subsectorL2;International Aviation;FV;1;2050;10
-SSP1;Mix3;above GDP cutoff;Liquids;Ship;International Ship_tmp_subsectorL2;International Ship;FV;1;2050;10
-SSP1;Mix3;above GDP cutoff;BEV;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SSP1;Mix3;above GDP cutoff;Liquids;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SSP1;Mix3;above GDP cutoff;Electric;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SSP1;Mix3;above GDP cutoff;Liquids;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SSP1;Mix3;above GDP cutoff;BEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;4;2035;10
-SSP1;Mix3;above GDP cutoff;FCEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;4;2035;10
-SSP1;Mix3;above GDP cutoff;Liquids;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;10
-SSP1;Mix3;above GDP cutoff;BEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;7;2035;10
-SSP1;Mix3;above GDP cutoff;FCEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;20;2035;10
-SSP1;Mix3;above GDP cutoff;Liquids;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;10
-SSP1;Mix3;below GDP cutoff;BEV;Bus;Bus;trn_pass_road;FV;3.5;2035;10
-SSP1;Mix3;below GDP cutoff;FCEV;Bus;Bus;trn_pass_road;FV;3.5;2035;10
-SSP1;Mix3;below GDP cutoff;Liquids;Bus;Bus;trn_pass_road;FV;1;2050;10
-SSP1;Mix3;below GDP cutoff;Hydrogen;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SSP1;Mix3;below GDP cutoff;Liquids;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SSP1;Mix3;below GDP cutoff;Liquids;Ship;Domestic Ship_tmp_subsectorL2;Domestic Ship;FV;1;2050;10
-SSP1;Mix3;below GDP cutoff;Electric;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SSP1;Mix3;below GDP cutoff;Liquids;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SSP1;Mix3;below GDP cutoff;Electric;Rail;HSR_tmp_subsectorL2;HSR;FV;1;2050;10
-SSP1;Mix3;below GDP cutoff;Liquids;Aviation;International Aviation_tmp_subsectorL2;International Aviation;FV;1;2050;10
-SSP1;Mix3;below GDP cutoff;Liquids;Ship;International Ship_tmp_subsectorL2;International Ship;FV;1;2050;10
-SSP1;Mix3;below GDP cutoff;BEV;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SSP1;Mix3;below GDP cutoff;Liquids;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SSP1;Mix3;below GDP cutoff;Electric;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SSP1;Mix3;below GDP cutoff;Liquids;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SSP1;Mix3;below GDP cutoff;BEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;3.5;2035;10
-SSP1;Mix3;below GDP cutoff;FCEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;3.5;2035;10
-SSP1;Mix3;below GDP cutoff;Liquids;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;10
-SSP1;Mix3;below GDP cutoff;BEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;5;2035;10
-SSP1;Mix3;below GDP cutoff;FCEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;17;2035;10
-SSP1;Mix3;below GDP cutoff;Liquids;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;10
-SSP1;Mix4;above GDP cutoff;;;;Cycle;S1S;1;2050;10
-SSP1;Mix4;above GDP cutoff;;;;Domestic Aviation;S1S;0.25;2035;10
-SSP1;Mix4;above GDP cutoff;;;;Domestic Ship;S1S;1;2050;10
-SSP1;Mix4;above GDP cutoff;;;;Freight Rail;S1S;1;2050;10
-SSP1;Mix4;above GDP cutoff;;;;HSR;S1S;1;2050;10
-SSP1;Mix4;above GDP cutoff;;;;Passenger Rail;S1S;1;2050;10
-SSP1;Mix4;above GDP cutoff;;;;trn_freight_road;S1S;0.5;2035;10
-SSP1;Mix4;above GDP cutoff;;;;trn_pass_road;S1S;0.5;2035;10
-SSP1;Mix4;above GDP cutoff;;;;Walk;S1S;1;2050;10
-SSP1;Mix4;below GDP cutoff;;;;Cycle;S1S;1;2050;10
-SSP1;Mix4;below GDP cutoff;;;;Domestic Aviation;S1S;0.25;2035;10
-SSP1;Mix4;below GDP cutoff;;;;Domestic Ship;S1S;1;2050;10
-SSP1;Mix4;below GDP cutoff;;;;Freight Rail;S1S;1;2050;10
-SSP1;Mix4;below GDP cutoff;;;;HSR;S1S;1;2050;10
-SSP1;Mix4;below GDP cutoff;;;;Passenger Rail;S1S;1;2050;10
-SSP1;Mix4;below GDP cutoff;;;;trn_freight_road;S1S;0.5;2035;10
-SSP1;Mix4;below GDP cutoff;;;;trn_pass_road;S1S;0.5;2035;10
-SSP1;Mix4;below GDP cutoff;;;;Walk;S1S;1;2050;10
-SSP1;Mix4;above GDP cutoff;;;Bus;trn_pass_road;S2S1;1;2050;10
-SSP1;Mix4;above GDP cutoff;;;trn_pass_road_LDV;trn_pass_road;S2S1;0.5;2035;10
-SSP1;Mix4;below GDP cutoff;;;Bus;trn_pass_road;S2S1;1;2050;10
-SSP1;Mix4;below GDP cutoff;;;trn_pass_road_LDV;trn_pass_road;S2S1;0.5;2035;10
-SSP1;Mix4;above GDP cutoff;BEV;Bus;Bus;trn_pass_road;FV;6;2035;10
-SSP1;Mix4;above GDP cutoff;FCEV;Bus;Bus;trn_pass_road;FV;6;2035;10
-SSP1;Mix4;above GDP cutoff;Liquids;Bus;Bus;trn_pass_road;FV;1;2050;10
-SSP1;Mix4;above GDP cutoff;Hydrogen;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SSP1;Mix4;above GDP cutoff;Liquids;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SSP1;Mix4;above GDP cutoff;Liquids;Ship;Domestic Ship_tmp_subsectorL2;Domestic Ship;FV;1;2050;10
-SSP1;Mix4;above GDP cutoff;Electric;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SSP1;Mix4;above GDP cutoff;Liquids;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SSP1;Mix4;above GDP cutoff;Electric;Rail;HSR_tmp_subsectorL2;HSR;FV;1;2050;10
-SSP1;Mix4;above GDP cutoff;Liquids;Aviation;International Aviation_tmp_subsectorL2;International Aviation;FV;1;2050;10
-SSP1;Mix4;above GDP cutoff;Liquids;Ship;International Ship_tmp_subsectorL2;International Ship;FV;1;2050;10
-SSP1;Mix4;above GDP cutoff;BEV;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SSP1;Mix4;above GDP cutoff;Liquids;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SSP1;Mix4;above GDP cutoff;Electric;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SSP1;Mix4;above GDP cutoff;Liquids;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SSP1;Mix4;above GDP cutoff;BEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;6;2035;10
-SSP1;Mix4;above GDP cutoff;FCEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;6;2035;10
-SSP1;Mix4;above GDP cutoff;Liquids;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;10
-SSP1;Mix4;above GDP cutoff;BEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;20;2035;10
-SSP1;Mix4;above GDP cutoff;FCEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;100;2035;10
-SSP1;Mix4;above GDP cutoff;Liquids;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;10
-SSP1;Mix4;below GDP cutoff;BEV;Bus;Bus;trn_pass_road;FV;5;2035;10
-SSP1;Mix4;below GDP cutoff;FCEV;Bus;Bus;trn_pass_road;FV;5;2035;10
-SSP1;Mix4;below GDP cutoff;Liquids;Bus;Bus;trn_pass_road;FV;1;2050;10
-SSP1;Mix4;below GDP cutoff;Hydrogen;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SSP1;Mix4;below GDP cutoff;Liquids;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SSP1;Mix4;below GDP cutoff;Liquids;Ship;Domestic Ship_tmp_subsectorL2;Domestic Ship;FV;1;2050;10
-SSP1;Mix4;below GDP cutoff;Electric;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SSP1;Mix4;below GDP cutoff;Liquids;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SSP1;Mix4;below GDP cutoff;Electric;Rail;HSR_tmp_subsectorL2;HSR;FV;1;2050;10
-SSP1;Mix4;below GDP cutoff;Liquids;Aviation;International Aviation_tmp_subsectorL2;International Aviation;FV;1;2050;10
-SSP1;Mix4;below GDP cutoff;Liquids;Ship;International Ship_tmp_subsectorL2;International Ship;FV;1;2050;10
-SSP1;Mix4;below GDP cutoff;BEV;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SSP1;Mix4;below GDP cutoff;Liquids;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SSP1;Mix4;below GDP cutoff;Electric;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SSP1;Mix4;below GDP cutoff;Liquids;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SSP1;Mix4;below GDP cutoff;BEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;5;2035;10
-SSP1;Mix4;below GDP cutoff;FCEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;5;2035;10
-SSP1;Mix4;below GDP cutoff;Liquids;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;10
-SSP1;Mix4;below GDP cutoff;BEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;17;2035;10
-SSP1;Mix4;below GDP cutoff;FCEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;85;2035;10
-SSP1;Mix4;below GDP cutoff;Liquids;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;10
-SSP2;CAMP_lscStrong;CAZ;;;;Cycle;S1S;2.5;2040;10
-SSP2;CAMP_lscStrong;CAZ;;;;Domestic Aviation;S1S;0.3;2040;10
-SSP2;CAMP_lscStrong;CAZ;;;;Domestic Ship;S1S;1;2040;10
-SSP2;CAMP_lscStrong;CAZ;;;;Freight Rail;S1S;1;2040;10
-SSP2;CAMP_lscStrong;CAZ;;;;HSR;S1S;1.7;2040;10
-SSP2;CAMP_lscStrong;CAZ;;;;Passenger Rail;S1S;4;2040;10
-SSP2;CAMP_lscStrong;CAZ;;;;trn_freight_road;S1S;0.9;2040;10
-SSP2;CAMP_lscStrong;CAZ;;;;trn_pass_road;S1S;0.6;2040;10
-SSP2;CAMP_lscStrong;CAZ;;;;Walk;S1S;2.5;2040;10
-SSP2;CAMP_lscStrong;USA;;;;Cycle;S1S;2.5;2040;10
-SSP2;CAMP_lscStrong;USA;;;;Domestic Aviation;S1S;0.3;2040;10
-SSP2;CAMP_lscStrong;USA;;;;Domestic Ship;S1S;1;2040;10
-SSP2;CAMP_lscStrong;USA;;;;Freight Rail;S1S;1;2040;10
-SSP2;CAMP_lscStrong;USA;;;;HSR;S1S;1.7;2040;10
-SSP2;CAMP_lscStrong;USA;;;;Passenger Rail;S1S;4;2040;10
-SSP2;CAMP_lscStrong;USA;;;;trn_freight_road;S1S;0.9;2040;10
-SSP2;CAMP_lscStrong;USA;;;;trn_pass_road;S1S;0.6;2040;10
-SSP2;CAMP_lscStrong;USA;;;;Walk;S1S;2.5;2040;10
-SSP2;CAMP_lscStrong;above GDP cutoff;;;;Cycle;S1S;3;2040;10
-SSP2;CAMP_lscStrong;above GDP cutoff;;;;Domestic Aviation;S1S;0.3;2040;10
-SSP2;CAMP_lscStrong;above GDP cutoff;;;;Domestic Ship;S1S;1;2040;10
-SSP2;CAMP_lscStrong;above GDP cutoff;;;;Freight Rail;S1S;1;2040;10
-SSP2;CAMP_lscStrong;above GDP cutoff;;;;HSR;S1S;2;2040;10
-SSP2;CAMP_lscStrong;above GDP cutoff;;;;Passenger Rail;S1S;2;2040;10
-SSP2;CAMP_lscStrong;above GDP cutoff;;;;trn_freight_road;S1S;0.7;2040;10
-SSP2;CAMP_lscStrong;above GDP cutoff;;;;trn_pass_road;S1S;0.75;2040;10
-SSP2;CAMP_lscStrong;above GDP cutoff;;;;Walk;S1S;3;2040;10
-SSP2;CAMP_lscStrong;below GDP cutoff;;;;Cycle;S1S;2.5;2040;10
-SSP2;CAMP_lscStrong;below GDP cutoff;;;;Domestic Aviation;S1S;0.3;2040;10
-SSP2;CAMP_lscStrong;below GDP cutoff;;;;Domestic Ship;S1S;1;2040;10
-SSP2;CAMP_lscStrong;below GDP cutoff;;;;Freight Rail;S1S;1;2040;10
-SSP2;CAMP_lscStrong;below GDP cutoff;;;;HSR;S1S;2.8;2040;10
-SSP2;CAMP_lscStrong;below GDP cutoff;;;;Passenger Rail;S1S;1.5;2040;10
-SSP2;CAMP_lscStrong;below GDP cutoff;;;;trn_freight_road;S1S;0.9;2040;10
-SSP2;CAMP_lscStrong;below GDP cutoff;;;;trn_pass_road;S1S;0.7;2040;10
-SSP2;CAMP_lscStrong;below GDP cutoff;;;;Walk;S1S;2.5;2040;10
-SSP2;CAMP_lscStrong;CAZ;;;Bus;trn_pass_road;S2S1;3;2040;10
-SSP2;CAMP_lscStrong;CAZ;;;trn_pass_road_LDV;trn_pass_road;S2S1;0.7;2040;10
-SSP2;CAMP_lscStrong;USA;;;Bus;trn_pass_road;S2S1;2;2040;10
-SSP2;CAMP_lscStrong;USA;;;trn_pass_road_LDV;trn_pass_road;S2S1;0.7;2040;10
-SSP2;CAMP_lscStrong;above GDP cutoff;;;Bus;trn_pass_road;S2S1;2.5;2040;10
-SSP2;CAMP_lscStrong;above GDP cutoff;;;trn_pass_road_LDV;trn_pass_road;S2S1;0.75;2035;10
-SSP2;CAMP_lscStrong;below GDP cutoff;;;Bus;trn_pass_road;S2S1;2;2040;10
-SSP2;CAMP_lscStrong;below GDP cutoff;;;trn_pass_road_LDV;trn_pass_road;S2S1;1;2040;10
-SSP2;CAMP_lscStrong;CAZ;BEV;Bus;Bus;trn_pass_road;FV;2;2040;10
-SSP2;CAMP_lscStrong;CAZ;FCEV;Bus;Bus;trn_pass_road;FV;1.5;2040;10
-SSP2;CAMP_lscStrong;CAZ;Liquids;Bus;Bus;trn_pass_road;FV;1;2050;10
-SSP2;CAMP_lscStrong;CAZ;Hydrogen;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SSP2;CAMP_lscStrong;CAZ;Liquids;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SSP2;CAMP_lscStrong;CAZ;Liquids;Ship;Domestic Ship_tmp_subsectorL2;Domestic Ship;FV;1;2050;10
-SSP2;CAMP_lscStrong;CAZ;Electric;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SSP2;CAMP_lscStrong;CAZ;Liquids;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SSP2;CAMP_lscStrong;CAZ;Electric;Rail;HSR_tmp_subsectorL2;HSR;FV;1;2050;10
-SSP2;CAMP_lscStrong;CAZ;Liquids;Aviation;International Aviation_tmp_subsectorL2;International Aviation;FV;1;2050;10
-SSP2;CAMP_lscStrong;CAZ;Liquids;Ship;International Ship_tmp_subsectorL2;International Ship;FV;1;2050;10
-SSP2;CAMP_lscStrong;CAZ;BEV;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SSP2;CAMP_lscStrong;CAZ;Liquids;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SSP2;CAMP_lscStrong;CAZ;Electric;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SSP2;CAMP_lscStrong;CAZ;Liquids;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SSP2;CAMP_lscStrong;CAZ;BEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;3;2040;10
-SSP2;CAMP_lscStrong;CAZ;FCEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;2;2040;10
-SSP2;CAMP_lscStrong;CAZ;Liquids;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;10
-SSP2;CAMP_lscStrong;CAZ;BEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;3;2040;10
-SSP2;CAMP_lscStrong;CAZ;FCEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;2;2040;10
-SSP2;CAMP_lscStrong;CAZ;Liquids;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;10
-SSP2;CAMP_lscStrong;USA;BEV;Bus;Bus;trn_pass_road;FV;4;2035;10
-SSP2;CAMP_lscStrong;USA;FCEV;Bus;Bus;trn_pass_road;FV;2;2035;10
-SSP2;CAMP_lscStrong;USA;Liquids;Bus;Bus;trn_pass_road;FV;1;2050;10
-SSP2;CAMP_lscStrong;USA;Hydrogen;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SSP2;CAMP_lscStrong;USA;Liquids;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SSP2;CAMP_lscStrong;USA;Liquids;Ship;Domestic Ship_tmp_subsectorL2;Domestic Ship;FV;1;2050;10
-SSP2;CAMP_lscStrong;USA;Electric;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SSP2;CAMP_lscStrong;USA;Liquids;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SSP2;CAMP_lscStrong;USA;Electric;Rail;HSR_tmp_subsectorL2;HSR;FV;1;2050;10
-SSP2;CAMP_lscStrong;USA;Liquids;Aviation;International Aviation_tmp_subsectorL2;International Aviation;FV;1;2050;10
-SSP2;CAMP_lscStrong;USA;Liquids;Ship;International Ship_tmp_subsectorL2;International Ship;FV;1;2050;10
-SSP2;CAMP_lscStrong;USA;BEV;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SSP2;CAMP_lscStrong;USA;Liquids;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SSP2;CAMP_lscStrong;USA;Electric;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SSP2;CAMP_lscStrong;USA;Liquids;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SSP2;CAMP_lscStrong;USA;BEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;3;2035;10
-SSP2;CAMP_lscStrong;USA;FCEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;2;2035;10
-SSP2;CAMP_lscStrong;USA;Liquids;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;10
-SSP2;CAMP_lscStrong;USA;BEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;3;2035;10
-SSP2;CAMP_lscStrong;USA;FCEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;2;2035;10
-SSP2;CAMP_lscStrong;USA;Liquids;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;10
-SSP2;CAMP_lscStrong;above GDP cutoff;BEV;Bus;Bus;trn_pass_road;FV;2;2040;10
-SSP2;CAMP_lscStrong;above GDP cutoff;FCEV;Bus;Bus;trn_pass_road;FV;2;2040;10
-SSP2;CAMP_lscStrong;above GDP cutoff;Liquids;Bus;Bus;trn_pass_road;FV;1;2050;10
-SSP2;CAMP_lscStrong;above GDP cutoff;Hydrogen;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SSP2;CAMP_lscStrong;above GDP cutoff;Liquids;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SSP2;CAMP_lscStrong;above GDP cutoff;Liquids;Ship;Domestic Ship_tmp_subsectorL2;Domestic Ship;FV;1;2050;10
-SSP2;CAMP_lscStrong;above GDP cutoff;Electric;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;2;2050;10
-SSP2;CAMP_lscStrong;above GDP cutoff;Liquids;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;2;2050;10
-SSP2;CAMP_lscStrong;above GDP cutoff;Electric;Rail;HSR_tmp_subsectorL2;HSR;FV;2;2050;10
-SSP2;CAMP_lscStrong;above GDP cutoff;Liquids;Aviation;International Aviation_tmp_subsectorL2;International Aviation;FV;1;2050;10
-SSP2;CAMP_lscStrong;above GDP cutoff;Liquids;Ship;International Ship_tmp_subsectorL2;International Ship;FV;1;2050;10
-SSP2;CAMP_lscStrong;above GDP cutoff;BEV;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SSP2;CAMP_lscStrong;above GDP cutoff;Liquids;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SSP2;CAMP_lscStrong;above GDP cutoff;Electric;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;2;2050;10
-SSP2;CAMP_lscStrong;above GDP cutoff;Liquids;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;2;2050;10
-SSP2;CAMP_lscStrong;above GDP cutoff;BEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2040;10
-SSP2;CAMP_lscStrong;above GDP cutoff;FCEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2040;10
-SSP2;CAMP_lscStrong;above GDP cutoff;Liquids;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;10
-SSP2;CAMP_lscStrong;above GDP cutoff;BEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2040;10
-SSP2;CAMP_lscStrong;above GDP cutoff;FCEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2040;10
-SSP2;CAMP_lscStrong;above GDP cutoff;Liquids;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;10
-SSP2;CAMP_lscStrong;below GDP cutoff;BEV;Bus;Bus;trn_pass_road;FV;3;2040;10
-SSP2;CAMP_lscStrong;below GDP cutoff;FCEV;Bus;Bus;trn_pass_road;FV;1.5;2040;10
-SSP2;CAMP_lscStrong;below GDP cutoff;Liquids;Bus;Bus;trn_pass_road;FV;1;2050;10
-SSP2;CAMP_lscStrong;below GDP cutoff;Hydrogen;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SSP2;CAMP_lscStrong;below GDP cutoff;Liquids;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SSP2;CAMP_lscStrong;below GDP cutoff;Liquids;Ship;Domestic Ship_tmp_subsectorL2;Domestic Ship;FV;1;2050;10
-SSP2;CAMP_lscStrong;below GDP cutoff;Electric;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SSP2;CAMP_lscStrong;below GDP cutoff;Liquids;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SSP2;CAMP_lscStrong;below GDP cutoff;Electric;Rail;HSR_tmp_subsectorL2;HSR;FV;1;2050;10
-SSP2;CAMP_lscStrong;below GDP cutoff;Liquids;Aviation;International Aviation_tmp_subsectorL2;International Aviation;FV;1;2050;10
-SSP2;CAMP_lscStrong;below GDP cutoff;Liquids;Ship;International Ship_tmp_subsectorL2;International Ship;FV;1;2050;10
-SSP2;CAMP_lscStrong;below GDP cutoff;BEV;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SSP2;CAMP_lscStrong;below GDP cutoff;Liquids;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SSP2;CAMP_lscStrong;below GDP cutoff;Electric;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SSP2;CAMP_lscStrong;below GDP cutoff;Liquids;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SSP2;CAMP_lscStrong;below GDP cutoff;BEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;2;2040;10
-SSP2;CAMP_lscStrong;below GDP cutoff;FCEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1.5;2040;10
-SSP2;CAMP_lscStrong;below GDP cutoff;Liquids;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;10
-SSP2;CAMP_lscStrong;below GDP cutoff;BEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;2;2040;10
-SSP2;CAMP_lscStrong;below GDP cutoff;FCEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1.5;2040;10
-SSP2;CAMP_lscStrong;below GDP cutoff;Liquids;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;10
-SSP2;CAMP_lscWeak;CAZ;;;;Cycle;S1S;1.75;2040;10
-SSP2;CAMP_lscWeak;CAZ;;;;Domestic Aviation;S1S;0.53;2040;10
-SSP2;CAMP_lscWeak;CAZ;;;;Domestic Ship;S1S;1;2040;10
-SSP2;CAMP_lscWeak;CAZ;;;;Freight Rail;S1S;1;2040;10
-SSP2;CAMP_lscWeak;CAZ;;;;HSR;S1S;1.35;2040;10
-SSP2;CAMP_lscWeak;CAZ;;;;Passenger Rail;S1S;2;2040;10
-SSP2;CAMP_lscWeak;CAZ;;;;trn_freight_road;S1S;0.9;2040;10
-SSP2;CAMP_lscWeak;CAZ;;;;trn_pass_road;S1S;0.65;2040;10
-SSP2;CAMP_lscWeak;CAZ;;;;Walk;S1S;1.75;2040;10
-SSP2;CAMP_lscWeak;USA;;;;Cycle;S1S;1.75;2040;10
-SSP2;CAMP_lscWeak;USA;;;;Domestic Aviation;S1S;0.53;2040;10
-SSP2;CAMP_lscWeak;USA;;;;Domestic Ship;S1S;1;2040;10
-SSP2;CAMP_lscWeak;USA;;;;Freight Rail;S1S;1;2040;10
-SSP2;CAMP_lscWeak;USA;;;;HSR;S1S;1.35;2040;10
-SSP2;CAMP_lscWeak;USA;;;;Passenger Rail;S1S;2;2040;10
-SSP2;CAMP_lscWeak;USA;;;;trn_freight_road;S1S;0.9;2040;10
-SSP2;CAMP_lscWeak;USA;;;;trn_pass_road;S1S;0.65;2040;10
-SSP2;CAMP_lscWeak;USA;;;;Walk;S1S;1.75;2040;10
-SSP2;CAMP_lscWeak;above GDP cutoff;;;;Cycle;S1S;2.25;2040;10
-SSP2;CAMP_lscWeak;above GDP cutoff;;;;Domestic Aviation;S1S;0.4;2040;10
-SSP2;CAMP_lscWeak;above GDP cutoff;;;;Domestic Ship;S1S;1;2040;10
-SSP2;CAMP_lscWeak;above GDP cutoff;;;;Freight Rail;S1S;1;2040;10
-SSP2;CAMP_lscWeak;above GDP cutoff;;;;HSR;S1S;1.6;2040;10
-SSP2;CAMP_lscWeak;above GDP cutoff;;;;Passenger Rail;S1S;1.6;2040;10
-SSP2;CAMP_lscWeak;above GDP cutoff;;;;trn_freight_road;S1S;0.75;2040;10
-SSP2;CAMP_lscWeak;above GDP cutoff;;;;trn_pass_road;S1S;0.8;2040;10
-SSP2;CAMP_lscWeak;above GDP cutoff;;;;Walk;S1S;2.25;2040;10
-SSP2;CAMP_lscWeak;below GDP cutoff;;;;Cycle;S1S;1.75;2040;10
-SSP2;CAMP_lscWeak;below GDP cutoff;;;;Domestic Aviation;S1S;0.53;2040;10
-SSP2;CAMP_lscWeak;below GDP cutoff;;;;Domestic Ship;S1S;1;2040;10
-SSP2;CAMP_lscWeak;below GDP cutoff;;;;Freight Rail;S1S;1;2040;10
-SSP2;CAMP_lscWeak;below GDP cutoff;;;;HSR;S1S;1.9;2040;10
-SSP2;CAMP_lscWeak;below GDP cutoff;;;;Passenger Rail;S1S;1.25;2040;10
-SSP2;CAMP_lscWeak;below GDP cutoff;;;;trn_freight_road;S1S;0.9;2040;10
-SSP2;CAMP_lscWeak;below GDP cutoff;;;;trn_pass_road;S1S;0.8;2040;10
-SSP2;CAMP_lscWeak;below GDP cutoff;;;;Walk;S1S;1.75;2040;10
-SSP2;CAMP_lscWeak;CAZ;;;Bus;trn_pass_road;S2S1;2;2040;10
-SSP2;CAMP_lscWeak;CAZ;;;trn_pass_road_LDV;trn_pass_road;S2S1;0.7;2040;10
-SSP2;CAMP_lscWeak;USA;;;Bus;trn_pass_road;S2S1;1.5;2040;10
-SSP2;CAMP_lscWeak;USA;;;trn_pass_road_LDV;trn_pass_road;S2S1;0.7;2040;10
-SSP2;CAMP_lscWeak;above GDP cutoff;;;Bus;trn_pass_road;S2S1;2;2040;10
-SSP2;CAMP_lscWeak;above GDP cutoff;;;trn_pass_road_LDV;trn_pass_road;S2S1;0.8;2035;10
-SSP2;CAMP_lscWeak;below GDP cutoff;;;Bus;trn_pass_road;S2S1;1.5;2040;10
-SSP2;CAMP_lscWeak;below GDP cutoff;;;trn_pass_road_LDV;trn_pass_road;S2S1;0.95;2040;10
-SSP2;CAMP_lscWeak;CAZ;BEV;Bus;Bus;trn_pass_road;FV;2;2040;10
-SSP2;CAMP_lscWeak;CAZ;FCEV;Bus;Bus;trn_pass_road;FV;1.5;2040;10
-SSP2;CAMP_lscWeak;CAZ;Liquids;Bus;Bus;trn_pass_road;FV;1;2050;10
-SSP2;CAMP_lscWeak;CAZ;Hydrogen;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SSP2;CAMP_lscWeak;CAZ;Liquids;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SSP2;CAMP_lscWeak;CAZ;Liquids;Ship;Domestic Ship_tmp_subsectorL2;Domestic Ship;FV;1;2050;10
-SSP2;CAMP_lscWeak;CAZ;Electric;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SSP2;CAMP_lscWeak;CAZ;Liquids;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SSP2;CAMP_lscWeak;CAZ;Electric;Rail;HSR_tmp_subsectorL2;HSR;FV;1;2050;10
-SSP2;CAMP_lscWeak;CAZ;Liquids;Aviation;International Aviation_tmp_subsectorL2;International Aviation;FV;1;2050;10
-SSP2;CAMP_lscWeak;CAZ;Liquids;Ship;International Ship_tmp_subsectorL2;International Ship;FV;1;2050;10
-SSP2;CAMP_lscWeak;CAZ;BEV;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SSP2;CAMP_lscWeak;CAZ;Liquids;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SSP2;CAMP_lscWeak;CAZ;Electric;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SSP2;CAMP_lscWeak;CAZ;Liquids;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SSP2;CAMP_lscWeak;CAZ;BEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;3;2040;10
-SSP2;CAMP_lscWeak;CAZ;FCEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;2;2040;10
-SSP2;CAMP_lscWeak;CAZ;Liquids;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;10
-SSP2;CAMP_lscWeak;CAZ;BEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;3;2040;10
-SSP2;CAMP_lscWeak;CAZ;FCEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;2;2040;10
-SSP2;CAMP_lscWeak;CAZ;Liquids;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;10
-SSP2;CAMP_lscWeak;USA;BEV;Bus;Bus;trn_pass_road;FV;2;2035;10
-SSP2;CAMP_lscWeak;USA;FCEV;Bus;Bus;trn_pass_road;FV;2;2035;10
-SSP2;CAMP_lscWeak;USA;Liquids;Bus;Bus;trn_pass_road;FV;1;2050;10
-SSP2;CAMP_lscWeak;USA;Hydrogen;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SSP2;CAMP_lscWeak;USA;Liquids;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SSP2;CAMP_lscWeak;USA;Liquids;Ship;Domestic Ship_tmp_subsectorL2;Domestic Ship;FV;1;2050;10
-SSP2;CAMP_lscWeak;USA;Electric;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SSP2;CAMP_lscWeak;USA;Liquids;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SSP2;CAMP_lscWeak;USA;Electric;Rail;HSR_tmp_subsectorL2;HSR;FV;1;2050;10
-SSP2;CAMP_lscWeak;USA;Liquids;Aviation;International Aviation_tmp_subsectorL2;International Aviation;FV;1;2050;10
-SSP2;CAMP_lscWeak;USA;Liquids;Ship;International Ship_tmp_subsectorL2;International Ship;FV;1;2050;10
-SSP2;CAMP_lscWeak;USA;BEV;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SSP2;CAMP_lscWeak;USA;Liquids;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SSP2;CAMP_lscWeak;USA;Electric;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SSP2;CAMP_lscWeak;USA;Liquids;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SSP2;CAMP_lscWeak;USA;BEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;3;2035;10
-SSP2;CAMP_lscWeak;USA;FCEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;2;2035;10
-SSP2;CAMP_lscWeak;USA;Liquids;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;10
-SSP2;CAMP_lscWeak;USA;BEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;3;2035;10
-SSP2;CAMP_lscWeak;USA;FCEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;2;2035;10
-SSP2;CAMP_lscWeak;USA;Liquids;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;10
-SSP2;CAMP_lscWeak;above GDP cutoff;BEV;Bus;Bus;trn_pass_road;FV;2;2040;10
-SSP2;CAMP_lscWeak;above GDP cutoff;FCEV;Bus;Bus;trn_pass_road;FV;2;2040;10
-SSP2;CAMP_lscWeak;above GDP cutoff;Liquids;Bus;Bus;trn_pass_road;FV;1;2050;10
-SSP2;CAMP_lscWeak;above GDP cutoff;Hydrogen;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SSP2;CAMP_lscWeak;above GDP cutoff;Liquids;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SSP2;CAMP_lscWeak;above GDP cutoff;Liquids;Ship;Domestic Ship_tmp_subsectorL2;Domestic Ship;FV;1;2050;10
-SSP2;CAMP_lscWeak;above GDP cutoff;Electric;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1.5;2050;10
-SSP2;CAMP_lscWeak;above GDP cutoff;Liquids;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1.5;2050;10
-SSP2;CAMP_lscWeak;above GDP cutoff;Electric;Rail;HSR_tmp_subsectorL2;HSR;FV;1.5;2050;10
-SSP2;CAMP_lscWeak;above GDP cutoff;Liquids;Aviation;International Aviation_tmp_subsectorL2;International Aviation;FV;1;2050;10
-SSP2;CAMP_lscWeak;above GDP cutoff;Liquids;Ship;International Ship_tmp_subsectorL2;International Ship;FV;1;2050;10
-SSP2;CAMP_lscWeak;above GDP cutoff;BEV;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SSP2;CAMP_lscWeak;above GDP cutoff;Liquids;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SSP2;CAMP_lscWeak;above GDP cutoff;Electric;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1.5;2050;10
-SSP2;CAMP_lscWeak;above GDP cutoff;Liquids;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1.5;2050;10
-SSP2;CAMP_lscWeak;above GDP cutoff;BEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2040;10
-SSP2;CAMP_lscWeak;above GDP cutoff;FCEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2040;10
-SSP2;CAMP_lscWeak;above GDP cutoff;Liquids;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;10
-SSP2;CAMP_lscWeak;above GDP cutoff;BEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2040;10
-SSP2;CAMP_lscWeak;above GDP cutoff;FCEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2040;10
-SSP2;CAMP_lscWeak;above GDP cutoff;Liquids;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;10
-SSP2;CAMP_lscWeak;below GDP cutoff;BEV;Bus;Bus;trn_pass_road;FV;1.5;2040;10
-SSP2;CAMP_lscWeak;below GDP cutoff;FCEV;Bus;Bus;trn_pass_road;FV;1.5;2040;10
-SSP2;CAMP_lscWeak;below GDP cutoff;Liquids;Bus;Bus;trn_pass_road;FV;1;2050;10
-SSP2;CAMP_lscWeak;below GDP cutoff;Hydrogen;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SSP2;CAMP_lscWeak;below GDP cutoff;Liquids;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SSP2;CAMP_lscWeak;below GDP cutoff;Liquids;Ship;Domestic Ship_tmp_subsectorL2;Domestic Ship;FV;1;2050;10
-SSP2;CAMP_lscWeak;below GDP cutoff;Electric;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SSP2;CAMP_lscWeak;below GDP cutoff;Liquids;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SSP2;CAMP_lscWeak;below GDP cutoff;Electric;Rail;HSR_tmp_subsectorL2;HSR;FV;1;2050;10
-SSP2;CAMP_lscWeak;below GDP cutoff;Liquids;Aviation;International Aviation_tmp_subsectorL2;International Aviation;FV;1;2050;10
-SSP2;CAMP_lscWeak;below GDP cutoff;Liquids;Ship;International Ship_tmp_subsectorL2;International Ship;FV;1;2050;10
-SSP2;CAMP_lscWeak;below GDP cutoff;BEV;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SSP2;CAMP_lscWeak;below GDP cutoff;Liquids;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SSP2;CAMP_lscWeak;below GDP cutoff;Electric;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SSP2;CAMP_lscWeak;below GDP cutoff;Liquids;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SSP2;CAMP_lscWeak;below GDP cutoff;BEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;2;2040;10
-SSP2;CAMP_lscWeak;below GDP cutoff;FCEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1.5;2040;10
-SSP2;CAMP_lscWeak;below GDP cutoff;Liquids;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;10
-SSP2;CAMP_lscWeak;below GDP cutoff;BEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;2;2040;10
-SSP2;CAMP_lscWeak;below GDP cutoff;FCEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1.5;2040;10
-SSP2;CAMP_lscWeak;below GDP cutoff;Liquids;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;10
-SSP2;ECEMF_HighEl_HighEff;above GDP cutoff;;;;Cycle;S1S;1.5;2050;10
-SSP2;ECEMF_HighEl_HighEff;above GDP cutoff;;;;Domestic Aviation;S1S;0.5;2035;10
-SSP2;ECEMF_HighEl_HighEff;above GDP cutoff;;;;Domestic Ship;S1S;1.5;2050;10
-SSP2;ECEMF_HighEl_HighEff;above GDP cutoff;;;;Freight Rail;S1S;1.5;2050;10
-SSP2;ECEMF_HighEl_HighEff;above GDP cutoff;;;;HSR;S1S;1;2050;10
-SSP2;ECEMF_HighEl_HighEff;above GDP cutoff;;;;Passenger Rail;S1S;1.5;2050;10
-SSP2;ECEMF_HighEl_HighEff;above GDP cutoff;;;;trn_freight_road;S1S;0.7;2035;10
-SSP2;ECEMF_HighEl_HighEff;above GDP cutoff;;;;trn_pass_road;S1S;0.7;2035;10
-SSP2;ECEMF_HighEl_HighEff;above GDP cutoff;;;;Walk;S1S;1.5;2050;10
-SSP2;ECEMF_HighEl_HighEff;below GDP cutoff;;;;Cycle;S1S;1.5;2050;10
-SSP2;ECEMF_HighEl_HighEff;below GDP cutoff;;;;Domestic Aviation;S1S;0.5;2035;10
-SSP2;ECEMF_HighEl_HighEff;below GDP cutoff;;;;Domestic Ship;S1S;1.5;2050;10
-SSP2;ECEMF_HighEl_HighEff;below GDP cutoff;;;;Freight Rail;S1S;1.5;2050;10
-SSP2;ECEMF_HighEl_HighEff;below GDP cutoff;;;;HSR;S1S;1;2050;10
-SSP2;ECEMF_HighEl_HighEff;below GDP cutoff;;;;Passenger Rail;S1S;1.5;2050;10
-SSP2;ECEMF_HighEl_HighEff;below GDP cutoff;;;;trn_freight_road;S1S;0.7;2035;10
-SSP2;ECEMF_HighEl_HighEff;below GDP cutoff;;;;trn_pass_road;S1S;0.7;2035;10
-SSP2;ECEMF_HighEl_HighEff;below GDP cutoff;;;;Walk;S1S;1.5;2050;10
-SSP2;ECEMF_HighEl_HighEff;above GDP cutoff;;;Bus;trn_pass_road;S2S1;1.5;2050;10
-SSP2;ECEMF_HighEl_HighEff;above GDP cutoff;;;trn_pass_road_LDV;trn_pass_road;S2S1;0.7;2035;10
-SSP2;ECEMF_HighEl_HighEff;below GDP cutoff;;;Bus;trn_pass_road;S2S1;1.5;2050;10
-SSP2;ECEMF_HighEl_HighEff;below GDP cutoff;;;trn_pass_road_LDV;trn_pass_road;S2S1;0.7;2035;10
-SSP2;ECEMF_HighEl_HighEff;above GDP cutoff;BEV;Bus;Bus;trn_pass_road;FV;10;2035;15
-SSP2;ECEMF_HighEl_HighEff;above GDP cutoff;FCEV;Bus;Bus;trn_pass_road;FV;1.1;2035;5
-SSP2;ECEMF_HighEl_HighEff;above GDP cutoff;Liquids;Bus;Bus;trn_pass_road;FV;1;2050;10
-SSP2;ECEMF_HighEl_HighEff;above GDP cutoff;Hydrogen;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1.1;2050;5
-SSP2;ECEMF_HighEl_HighEff;above GDP cutoff;Liquids;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SSP2;ECEMF_HighEl_HighEff;above GDP cutoff;Liquids;Ship;Domestic Ship_tmp_subsectorL2;Domestic Ship;FV;1;2050;10
-SSP2;ECEMF_HighEl_HighEff;above GDP cutoff;Electric;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;5;2050;15
-SSP2;ECEMF_HighEl_HighEff;above GDP cutoff;Liquids;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SSP2;ECEMF_HighEl_HighEff;above GDP cutoff;Electric;Rail;HSR_tmp_subsectorL2;HSR;FV;5;2050;15
-SSP2;ECEMF_HighEl_HighEff;above GDP cutoff;Liquids;Aviation;International Aviation_tmp_subsectorL2;International Aviation;FV;1;2050;10
-SSP2;ECEMF_HighEl_HighEff;above GDP cutoff;Liquids;Ship;International Ship_tmp_subsectorL2;International Ship;FV;1;2050;10
-SSP2;ECEMF_HighEl_HighEff;above GDP cutoff;BEV;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;7;2050;15
-SSP2;ECEMF_HighEl_HighEff;above GDP cutoff;Liquids;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SSP2;ECEMF_HighEl_HighEff;above GDP cutoff;Electric;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;5;2050;15
-SSP2;ECEMF_HighEl_HighEff;above GDP cutoff;Liquids;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SSP2;ECEMF_HighEl_HighEff;above GDP cutoff;BEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;40;2040;3
-SSP2;ECEMF_HighEl_HighEff;above GDP cutoff;FCEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;10;2040;3
-SSP2;ECEMF_HighEl_HighEff;above GDP cutoff;Liquids;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;3
-SSP2;ECEMF_HighEl_HighEff;above GDP cutoff;BEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;50;2040;5
-SSP2;ECEMF_HighEl_HighEff;above GDP cutoff;FCEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;60;2040;3
-SSP2;ECEMF_HighEl_HighEff;above GDP cutoff;Liquids;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;3
-SSP2;ECEMF_HighEl_HighEff;below GDP cutoff;BEV;Bus;Bus;trn_pass_road;FV;13;2030;15
-SSP2;ECEMF_HighEl_HighEff;below GDP cutoff;FCEV;Bus;Bus;trn_pass_road;FV;1.1;2035;5
-SSP2;ECEMF_HighEl_HighEff;below GDP cutoff;Liquids;Bus;Bus;trn_pass_road;FV;1;2050;10
-SSP2;ECEMF_HighEl_HighEff;below GDP cutoff;Hydrogen;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;2;2050;5
-SSP2;ECEMF_HighEl_HighEff;below GDP cutoff;Liquids;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SSP2;ECEMF_HighEl_HighEff;below GDP cutoff;Liquids;Ship;Domestic Ship_tmp_subsectorL2;Domestic Ship;FV;1;2050;10
-SSP2;ECEMF_HighEl_HighEff;below GDP cutoff;Electric;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;6;2040;15
-SSP2;ECEMF_HighEl_HighEff;below GDP cutoff;Liquids;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SSP2;ECEMF_HighEl_HighEff;below GDP cutoff;Electric;Rail;HSR_tmp_subsectorL2;HSR;FV;6;2040;15
-SSP2;ECEMF_HighEl_HighEff;below GDP cutoff;Liquids;Aviation;International Aviation_tmp_subsectorL2;International Aviation;FV;1;2050;10
-SSP2;ECEMF_HighEl_HighEff;below GDP cutoff;Liquids;Ship;International Ship_tmp_subsectorL2;International Ship;FV;1;2050;10
-SSP2;ECEMF_HighEl_HighEff;below GDP cutoff;BEV;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;7;2030;15
-SSP2;ECEMF_HighEl_HighEff;below GDP cutoff;Liquids;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SSP2;ECEMF_HighEl_HighEff;below GDP cutoff;Electric;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;6;2040;15
-SSP2;ECEMF_HighEl_HighEff;below GDP cutoff;Liquids;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SSP2;ECEMF_HighEl_HighEff;below GDP cutoff;BEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;10;2040;3
-SSP2;ECEMF_HighEl_HighEff;below GDP cutoff;FCEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;10;2040;3
-SSP2;ECEMF_HighEl_HighEff;below GDP cutoff;Liquids;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;3
-SSP2;ECEMF_HighEl_HighEff;below GDP cutoff;BEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;5;2035;5
-SSP2;ECEMF_HighEl_HighEff;below GDP cutoff;FCEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;7;2035;3
-SSP2;ECEMF_HighEl_HighEff;below GDP cutoff;Liquids;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;3
-SSP2;ECEMF_HighEl_LifestCha;above GDP cutoff;;;;Cycle;S1S;2;2050;10
-SSP2;ECEMF_HighEl_LifestCha;above GDP cutoff;;;;Domestic Aviation;S1S;0.25;2035;10
-SSP2;ECEMF_HighEl_LifestCha;above GDP cutoff;;;;Domestic Ship;S1S;1.5;2050;10
-SSP2;ECEMF_HighEl_LifestCha;above GDP cutoff;;;;Freight Rail;S1S;1.5;2050;10
-SSP2;ECEMF_HighEl_LifestCha;above GDP cutoff;;;;HSR;S1S;1;2050;10
-SSP2;ECEMF_HighEl_LifestCha;above GDP cutoff;;;;Passenger Rail;S1S;2;2050;10
-SSP2;ECEMF_HighEl_LifestCha;above GDP cutoff;;;;trn_freight_road;S1S;0.7;2035;10
-SSP2;ECEMF_HighEl_LifestCha;above GDP cutoff;;;;trn_pass_road;S1S;0.5;2035;10
-SSP2;ECEMF_HighEl_LifestCha;above GDP cutoff;;;;Walk;S1S;2;2050;10
-SSP2;ECEMF_HighEl_LifestCha;below GDP cutoff;;;;Cycle;S1S;2;2050;10
-SSP2;ECEMF_HighEl_LifestCha;below GDP cutoff;;;;Domestic Aviation;S1S;0.25;2035;10
-SSP2;ECEMF_HighEl_LifestCha;below GDP cutoff;;;;Domestic Ship;S1S;1.5;2050;10
-SSP2;ECEMF_HighEl_LifestCha;below GDP cutoff;;;;Freight Rail;S1S;1.5;2050;10
-SSP2;ECEMF_HighEl_LifestCha;below GDP cutoff;;;;HSR;S1S;1;2050;10
-SSP2;ECEMF_HighEl_LifestCha;below GDP cutoff;;;;Passenger Rail;S1S;2;2050;10
-SSP2;ECEMF_HighEl_LifestCha;below GDP cutoff;;;;trn_freight_road;S1S;0.7;2035;10
-SSP2;ECEMF_HighEl_LifestCha;below GDP cutoff;;;;trn_pass_road;S1S;0.5;2035;10
-SSP2;ECEMF_HighEl_LifestCha;below GDP cutoff;;;;Walk;S1S;2;2050;10
-SSP2;ECEMF_HighEl_LifestCha;above GDP cutoff;;;Bus;trn_pass_road;S2S1;2;2050;10
-SSP2;ECEMF_HighEl_LifestCha;above GDP cutoff;;;trn_pass_road_LDV;trn_pass_road;S2S1;0.5;2035;10
-SSP2;ECEMF_HighEl_LifestCha;below GDP cutoff;;;Bus;trn_pass_road;S2S1;2;2050;10
-SSP2;ECEMF_HighEl_LifestCha;below GDP cutoff;;;trn_pass_road_LDV;trn_pass_road;S2S1;0.5;2035;10
-SSP2;ECEMF_HighEl_LifestCha;above GDP cutoff;BEV;Bus;Bus;trn_pass_road;FV;10;2035;15
-SSP2;ECEMF_HighEl_LifestCha;above GDP cutoff;FCEV;Bus;Bus;trn_pass_road;FV;1.1;2035;5
-SSP2;ECEMF_HighEl_LifestCha;above GDP cutoff;Liquids;Bus;Bus;trn_pass_road;FV;1;2050;10
-SSP2;ECEMF_HighEl_LifestCha;above GDP cutoff;Hydrogen;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1.1;2050;5
-SSP2;ECEMF_HighEl_LifestCha;above GDP cutoff;Liquids;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SSP2;ECEMF_HighEl_LifestCha;above GDP cutoff;Liquids;Ship;Domestic Ship_tmp_subsectorL2;Domestic Ship;FV;1;2050;10
-SSP2;ECEMF_HighEl_LifestCha;above GDP cutoff;Electric;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;5;2050;15
-SSP2;ECEMF_HighEl_LifestCha;above GDP cutoff;Liquids;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SSP2;ECEMF_HighEl_LifestCha;above GDP cutoff;Electric;Rail;HSR_tmp_subsectorL2;HSR;FV;5;2050;15
-SSP2;ECEMF_HighEl_LifestCha;above GDP cutoff;Liquids;Aviation;International Aviation_tmp_subsectorL2;International Aviation;FV;1;2050;10
-SSP2;ECEMF_HighEl_LifestCha;above GDP cutoff;Liquids;Ship;International Ship_tmp_subsectorL2;International Ship;FV;1;2050;10
-SSP2;ECEMF_HighEl_LifestCha;above GDP cutoff;BEV;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;7;2050;15
-SSP2;ECEMF_HighEl_LifestCha;above GDP cutoff;Liquids;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SSP2;ECEMF_HighEl_LifestCha;above GDP cutoff;Electric;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;5;2050;15
-SSP2;ECEMF_HighEl_LifestCha;above GDP cutoff;Liquids;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SSP2;ECEMF_HighEl_LifestCha;above GDP cutoff;BEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;40;2040;3
-SSP2;ECEMF_HighEl_LifestCha;above GDP cutoff;FCEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;10;2040;3
-SSP2;ECEMF_HighEl_LifestCha;above GDP cutoff;Liquids;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;3
-SSP2;ECEMF_HighEl_LifestCha;above GDP cutoff;BEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;50;2040;5
-SSP2;ECEMF_HighEl_LifestCha;above GDP cutoff;FCEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;60;2040;3
-SSP2;ECEMF_HighEl_LifestCha;above GDP cutoff;Liquids;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;3
-SSP2;ECEMF_HighEl_LifestCha;below GDP cutoff;BEV;Bus;Bus;trn_pass_road;FV;13;2030;15
-SSP2;ECEMF_HighEl_LifestCha;below GDP cutoff;FCEV;Bus;Bus;trn_pass_road;FV;1.1;2035;5
-SSP2;ECEMF_HighEl_LifestCha;below GDP cutoff;Liquids;Bus;Bus;trn_pass_road;FV;1;2050;10
-SSP2;ECEMF_HighEl_LifestCha;below GDP cutoff;Hydrogen;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;2;2050;5
-SSP2;ECEMF_HighEl_LifestCha;below GDP cutoff;Liquids;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SSP2;ECEMF_HighEl_LifestCha;below GDP cutoff;Liquids;Ship;Domestic Ship_tmp_subsectorL2;Domestic Ship;FV;1;2050;10
-SSP2;ECEMF_HighEl_LifestCha;below GDP cutoff;Electric;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;6;2040;15
-SSP2;ECEMF_HighEl_LifestCha;below GDP cutoff;Liquids;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SSP2;ECEMF_HighEl_LifestCha;below GDP cutoff;Electric;Rail;HSR_tmp_subsectorL2;HSR;FV;6;2040;15
-SSP2;ECEMF_HighEl_LifestCha;below GDP cutoff;Liquids;Aviation;International Aviation_tmp_subsectorL2;International Aviation;FV;1;2050;10
-SSP2;ECEMF_HighEl_LifestCha;below GDP cutoff;Liquids;Ship;International Ship_tmp_subsectorL2;International Ship;FV;1;2050;10
-SSP2;ECEMF_HighEl_LifestCha;below GDP cutoff;BEV;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;7;2030;15
-SSP2;ECEMF_HighEl_LifestCha;below GDP cutoff;Liquids;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SSP2;ECEMF_HighEl_LifestCha;below GDP cutoff;Electric;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;6;2040;15
-SSP2;ECEMF_HighEl_LifestCha;below GDP cutoff;Liquids;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SSP2;ECEMF_HighEl_LifestCha;below GDP cutoff;BEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;10;2040;3
-SSP2;ECEMF_HighEl_LifestCha;below GDP cutoff;FCEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;10;2040;3
-SSP2;ECEMF_HighEl_LifestCha;below GDP cutoff;Liquids;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;3
-SSP2;ECEMF_HighEl_LifestCha;below GDP cutoff;BEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;5;2035;5
-SSP2;ECEMF_HighEl_LifestCha;below GDP cutoff;FCEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;7;2035;3
-SSP2;ECEMF_HighEl_LifestCha;below GDP cutoff;Liquids;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;3
-SSP2;ECEMF_HighEl_ModEff;above GDP cutoff;;;;Cycle;S1S;1;2050;10
-SSP2;ECEMF_HighEl_ModEff;above GDP cutoff;;;;Domestic Aviation;S1S;0.75;2035;10
-SSP2;ECEMF_HighEl_ModEff;above GDP cutoff;;;;Domestic Ship;S1S;1;2050;10
-SSP2;ECEMF_HighEl_ModEff;above GDP cutoff;;;;Freight Rail;S1S;1;2050;10
-SSP2;ECEMF_HighEl_ModEff;above GDP cutoff;;;;HSR;S1S;1;2050;10
-SSP2;ECEMF_HighEl_ModEff;above GDP cutoff;;;;Passenger Rail;S1S;1;2050;10
-SSP2;ECEMF_HighEl_ModEff;above GDP cutoff;;;;trn_freight_road;S1S;0.9;2035;10
-SSP2;ECEMF_HighEl_ModEff;above GDP cutoff;;;;trn_pass_road;S1S;0.9;2035;10
-SSP2;ECEMF_HighEl_ModEff;above GDP cutoff;;;;Walk;S1S;1;2050;10
-SSP2;ECEMF_HighEl_ModEff;below GDP cutoff;;;;Cycle;S1S;1;2050;10
-SSP2;ECEMF_HighEl_ModEff;below GDP cutoff;;;;Domestic Aviation;S1S;0.75;2035;10
-SSP2;ECEMF_HighEl_ModEff;below GDP cutoff;;;;Domestic Ship;S1S;1;2050;10
-SSP2;ECEMF_HighEl_ModEff;below GDP cutoff;;;;Freight Rail;S1S;1;2050;10
-SSP2;ECEMF_HighEl_ModEff;below GDP cutoff;;;;HSR;S1S;1;2050;10
-SSP2;ECEMF_HighEl_ModEff;below GDP cutoff;;;;Passenger Rail;S1S;1;2050;10
-SSP2;ECEMF_HighEl_ModEff;below GDP cutoff;;;;trn_freight_road;S1S;0.9;2035;10
-SSP2;ECEMF_HighEl_ModEff;below GDP cutoff;;;;trn_pass_road;S1S;0.9;2035;10
-SSP2;ECEMF_HighEl_ModEff;below GDP cutoff;;;;Walk;S1S;1;2050;10
-SSP2;ECEMF_HighEl_ModEff;above GDP cutoff;;;Bus;trn_pass_road;S2S1;1;2050;10
-SSP2;ECEMF_HighEl_ModEff;above GDP cutoff;;;trn_pass_road_LDV;trn_pass_road;S2S1;0.9;2035;10
-SSP2;ECEMF_HighEl_ModEff;below GDP cutoff;;;Bus;trn_pass_road;S2S1;1;2050;10
-SSP2;ECEMF_HighEl_ModEff;below GDP cutoff;;;trn_pass_road_LDV;trn_pass_road;S2S1;0.9;2035;10
-SSP2;ECEMF_HighEl_ModEff;above GDP cutoff;BEV;Bus;Bus;trn_pass_road;FV;6;2035;15
-SSP2;ECEMF_HighEl_ModEff;above GDP cutoff;FCEV;Bus;Bus;trn_pass_road;FV;1.1;2035;5
-SSP2;ECEMF_HighEl_ModEff;above GDP cutoff;Liquids;Bus;Bus;trn_pass_road;FV;1;2050;10
-SSP2;ECEMF_HighEl_ModEff;above GDP cutoff;Hydrogen;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1.1;2050;5
-SSP2;ECEMF_HighEl_ModEff;above GDP cutoff;Liquids;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SSP2;ECEMF_HighEl_ModEff;above GDP cutoff;Liquids;Ship;Domestic Ship_tmp_subsectorL2;Domestic Ship;FV;1;2050;10
-SSP2;ECEMF_HighEl_ModEff;above GDP cutoff;Electric;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;3;2050;15
-SSP2;ECEMF_HighEl_ModEff;above GDP cutoff;Liquids;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SSP2;ECEMF_HighEl_ModEff;above GDP cutoff;Electric;Rail;HSR_tmp_subsectorL2;HSR;FV;3;2050;15
-SSP2;ECEMF_HighEl_ModEff;above GDP cutoff;Liquids;Aviation;International Aviation_tmp_subsectorL2;International Aviation;FV;1;2050;10
-SSP2;ECEMF_HighEl_ModEff;above GDP cutoff;Liquids;Ship;International Ship_tmp_subsectorL2;International Ship;FV;1;2050;10
-SSP2;ECEMF_HighEl_ModEff;above GDP cutoff;BEV;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;3;2050;15
-SSP2;ECEMF_HighEl_ModEff;above GDP cutoff;Liquids;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SSP2;ECEMF_HighEl_ModEff;above GDP cutoff;Electric;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;3;2050;15
-SSP2;ECEMF_HighEl_ModEff;above GDP cutoff;Liquids;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SSP2;ECEMF_HighEl_ModEff;above GDP cutoff;BEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;40;2040;3
-SSP2;ECEMF_HighEl_ModEff;above GDP cutoff;FCEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;10;2040;3
-SSP2;ECEMF_HighEl_ModEff;above GDP cutoff;Liquids;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;3
-SSP2;ECEMF_HighEl_ModEff;above GDP cutoff;BEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;50;2040;5
-SSP2;ECEMF_HighEl_ModEff;above GDP cutoff;FCEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;60;2040;3
-SSP2;ECEMF_HighEl_ModEff;above GDP cutoff;Liquids;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;3
-SSP2;ECEMF_HighEl_ModEff;below GDP cutoff;BEV;Bus;Bus;trn_pass_road;FV;10;2030;15
-SSP2;ECEMF_HighEl_ModEff;below GDP cutoff;FCEV;Bus;Bus;trn_pass_road;FV;1.1;2035;5
-SSP2;ECEMF_HighEl_ModEff;below GDP cutoff;Liquids;Bus;Bus;trn_pass_road;FV;1;2050;10
-SSP2;ECEMF_HighEl_ModEff;below GDP cutoff;Hydrogen;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;2;2050;5
-SSP2;ECEMF_HighEl_ModEff;below GDP cutoff;Liquids;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SSP2;ECEMF_HighEl_ModEff;below GDP cutoff;Liquids;Ship;Domestic Ship_tmp_subsectorL2;Domestic Ship;FV;1;2050;10
-SSP2;ECEMF_HighEl_ModEff;below GDP cutoff;Electric;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;4;2040;15
-SSP2;ECEMF_HighEl_ModEff;below GDP cutoff;Liquids;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SSP2;ECEMF_HighEl_ModEff;below GDP cutoff;Electric;Rail;HSR_tmp_subsectorL2;HSR;FV;4;2040;15
-SSP2;ECEMF_HighEl_ModEff;below GDP cutoff;Liquids;Aviation;International Aviation_tmp_subsectorL2;International Aviation;FV;1;2050;10
-SSP2;ECEMF_HighEl_ModEff;below GDP cutoff;Liquids;Ship;International Ship_tmp_subsectorL2;International Ship;FV;1;2050;10
-SSP2;ECEMF_HighEl_ModEff;below GDP cutoff;BEV;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;5;2030;15
-SSP2;ECEMF_HighEl_ModEff;below GDP cutoff;Liquids;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SSP2;ECEMF_HighEl_ModEff;below GDP cutoff;Electric;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;4;2040;15
-SSP2;ECEMF_HighEl_ModEff;below GDP cutoff;Liquids;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SSP2;ECEMF_HighEl_ModEff;below GDP cutoff;BEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;10;2040;3
-SSP2;ECEMF_HighEl_ModEff;below GDP cutoff;FCEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;10;2040;3
-SSP2;ECEMF_HighEl_ModEff;below GDP cutoff;Liquids;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;3
-SSP2;ECEMF_HighEl_ModEff;below GDP cutoff;BEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;5;2035;5
-SSP2;ECEMF_HighEl_ModEff;below GDP cutoff;FCEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;7;2035;3
-SSP2;ECEMF_HighEl_ModEff;below GDP cutoff;Liquids;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;3
-SSP2;ECEMF_HighH2_HighEff;above GDP cutoff;;;;Cycle;S1S;1.5;2050;10
-SSP2;ECEMF_HighH2_HighEff;above GDP cutoff;;;;Domestic Aviation;S1S;0.5;2035;10
-SSP2;ECEMF_HighH2_HighEff;above GDP cutoff;;;;Domestic Ship;S1S;1.5;2050;10
-SSP2;ECEMF_HighH2_HighEff;above GDP cutoff;;;;Freight Rail;S1S;1.5;2050;10
-SSP2;ECEMF_HighH2_HighEff;above GDP cutoff;;;;HSR;S1S;1;2050;10
-SSP2;ECEMF_HighH2_HighEff;above GDP cutoff;;;;Passenger Rail;S1S;1.5;2050;10
-SSP2;ECEMF_HighH2_HighEff;above GDP cutoff;;;;trn_freight_road;S1S;0.7;2035;10
-SSP2;ECEMF_HighH2_HighEff;above GDP cutoff;;;;trn_pass_road;S1S;0.7;2035;10
-SSP2;ECEMF_HighH2_HighEff;above GDP cutoff;;;;Walk;S1S;1.5;2050;10
-SSP2;ECEMF_HighH2_HighEff;below GDP cutoff;;;;Cycle;S1S;1.5;2050;10
-SSP2;ECEMF_HighH2_HighEff;below GDP cutoff;;;;Domestic Aviation;S1S;0.5;2035;10
-SSP2;ECEMF_HighH2_HighEff;below GDP cutoff;;;;Domestic Ship;S1S;1.5;2050;10
-SSP2;ECEMF_HighH2_HighEff;below GDP cutoff;;;;Freight Rail;S1S;1.5;2050;10
-SSP2;ECEMF_HighH2_HighEff;below GDP cutoff;;;;HSR;S1S;1;2050;10
-SSP2;ECEMF_HighH2_HighEff;below GDP cutoff;;;;Passenger Rail;S1S;1.5;2050;10
-SSP2;ECEMF_HighH2_HighEff;below GDP cutoff;;;;trn_freight_road;S1S;0.7;2035;10
-SSP2;ECEMF_HighH2_HighEff;below GDP cutoff;;;;trn_pass_road;S1S;0.7;2035;10
-SSP2;ECEMF_HighH2_HighEff;below GDP cutoff;;;;Walk;S1S;1.5;2050;10
-SSP2;ECEMF_HighH2_HighEff;above GDP cutoff;;;Bus;trn_pass_road;S2S1;1.5;2050;10
-SSP2;ECEMF_HighH2_HighEff;above GDP cutoff;;;trn_pass_road_LDV;trn_pass_road;S2S1;0.7;2035;10
-SSP2;ECEMF_HighH2_HighEff;below GDP cutoff;;;Bus;trn_pass_road;S2S1;1.5;2050;10
-SSP2;ECEMF_HighH2_HighEff;below GDP cutoff;;;trn_pass_road_LDV;trn_pass_road;S2S1;0.7;2035;10
-SSP2;ECEMF_HighH2_HighEff;above GDP cutoff;BEV;Bus;Bus;trn_pass_road;FV;3;2060;15
-SSP2;ECEMF_HighH2_HighEff;above GDP cutoff;FCEV;Bus;Bus;trn_pass_road;FV;220;2035;5
-SSP2;ECEMF_HighH2_HighEff;above GDP cutoff;Liquids;Bus;Bus;trn_pass_road;FV;1;2050;10
-SSP2;ECEMF_HighH2_HighEff;above GDP cutoff;Hydrogen;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;3;2055;5
-SSP2;ECEMF_HighH2_HighEff;above GDP cutoff;Liquids;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SSP2;ECEMF_HighH2_HighEff;above GDP cutoff;Liquids;Ship;Domestic Ship_tmp_subsectorL2;Domestic Ship;FV;1;2050;10
-SSP2;ECEMF_HighH2_HighEff;above GDP cutoff;Electric;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;2.5;2050;10
-SSP2;ECEMF_HighH2_HighEff;above GDP cutoff;Liquids;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SSP2;ECEMF_HighH2_HighEff;above GDP cutoff;Electric;Rail;HSR_tmp_subsectorL2;HSR;FV;2.5;2050;10
-SSP2;ECEMF_HighH2_HighEff;above GDP cutoff;Liquids;Aviation;International Aviation_tmp_subsectorL2;International Aviation;FV;1;2050;10
-SSP2;ECEMF_HighH2_HighEff;above GDP cutoff;Liquids;Ship;International Ship_tmp_subsectorL2;International Ship;FV;1;2050;10
-SSP2;ECEMF_HighH2_HighEff;above GDP cutoff;BEV;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;3;2050;10
-SSP2;ECEMF_HighH2_HighEff;above GDP cutoff;Liquids;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SSP2;ECEMF_HighH2_HighEff;above GDP cutoff;Electric;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;2.5;2050;10
-SSP2;ECEMF_HighH2_HighEff;above GDP cutoff;Liquids;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SSP2;ECEMF_HighH2_HighEff;above GDP cutoff;BEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;40;2040;3
-SSP2;ECEMF_HighH2_HighEff;above GDP cutoff;FCEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;50;2040;3
-SSP2;ECEMF_HighH2_HighEff;above GDP cutoff;Liquids;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;3
-SSP2;ECEMF_HighH2_HighEff;above GDP cutoff;BEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;40;2040;5
-SSP2;ECEMF_HighH2_HighEff;above GDP cutoff;FCEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;250;2040;3
-SSP2;ECEMF_HighH2_HighEff;above GDP cutoff;Liquids;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;3
-SSP2;ECEMF_HighH2_HighEff;below GDP cutoff;BEV;Bus;Bus;trn_pass_road;FV;3;2060;15
-SSP2;ECEMF_HighH2_HighEff;below GDP cutoff;FCEV;Bus;Bus;trn_pass_road;FV;160;2040;5
-SSP2;ECEMF_HighH2_HighEff;below GDP cutoff;Liquids;Bus;Bus;trn_pass_road;FV;1;2050;10
-SSP2;ECEMF_HighH2_HighEff;below GDP cutoff;Hydrogen;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;5;2055;10
-SSP2;ECEMF_HighH2_HighEff;below GDP cutoff;Liquids;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SSP2;ECEMF_HighH2_HighEff;below GDP cutoff;Liquids;Ship;Domestic Ship_tmp_subsectorL2;Domestic Ship;FV;1;2050;10
-SSP2;ECEMF_HighH2_HighEff;below GDP cutoff;Electric;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;2;2050;10
-SSP2;ECEMF_HighH2_HighEff;below GDP cutoff;Liquids;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SSP2;ECEMF_HighH2_HighEff;below GDP cutoff;Electric;Rail;HSR_tmp_subsectorL2;HSR;FV;2;2050;10
-SSP2;ECEMF_HighH2_HighEff;below GDP cutoff;Liquids;Aviation;International Aviation_tmp_subsectorL2;International Aviation;FV;1;2050;10
-SSP2;ECEMF_HighH2_HighEff;below GDP cutoff;Liquids;Ship;International Ship_tmp_subsectorL2;International Ship;FV;1;2050;10
-SSP2;ECEMF_HighH2_HighEff;below GDP cutoff;BEV;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;3;2050;10
-SSP2;ECEMF_HighH2_HighEff;below GDP cutoff;Liquids;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SSP2;ECEMF_HighH2_HighEff;below GDP cutoff;Electric;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;2;2050;10
-SSP2;ECEMF_HighH2_HighEff;below GDP cutoff;Liquids;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SSP2;ECEMF_HighH2_HighEff;below GDP cutoff;BEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;10;2040;3
-SSP2;ECEMF_HighH2_HighEff;below GDP cutoff;FCEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;10;2040;3
-SSP2;ECEMF_HighH2_HighEff;below GDP cutoff;Liquids;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;3
-SSP2;ECEMF_HighH2_HighEff;below GDP cutoff;BEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;5;2035;5
-SSP2;ECEMF_HighH2_HighEff;below GDP cutoff;FCEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;30;2035;3
-SSP2;ECEMF_HighH2_HighEff;below GDP cutoff;Liquids;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;3
-SSP2;ECEMF_HighH2_LifestCha;above GDP cutoff;;;;Cycle;S1S;2;2050;10
-SSP2;ECEMF_HighH2_LifestCha;above GDP cutoff;;;;Domestic Aviation;S1S;0.25;2035;10
-SSP2;ECEMF_HighH2_LifestCha;above GDP cutoff;;;;Domestic Ship;S1S;1.5;2050;10
-SSP2;ECEMF_HighH2_LifestCha;above GDP cutoff;;;;Freight Rail;S1S;1.5;2050;10
-SSP2;ECEMF_HighH2_LifestCha;above GDP cutoff;;;;HSR;S1S;1;2050;10
-SSP2;ECEMF_HighH2_LifestCha;above GDP cutoff;;;;Passenger Rail;S1S;2;2050;10
-SSP2;ECEMF_HighH2_LifestCha;above GDP cutoff;;;;trn_freight_road;S1S;0.7;2035;10
-SSP2;ECEMF_HighH2_LifestCha;above GDP cutoff;;;;trn_pass_road;S1S;0.5;2035;10
-SSP2;ECEMF_HighH2_LifestCha;above GDP cutoff;;;;Walk;S1S;2;2050;10
-SSP2;ECEMF_HighH2_LifestCha;below GDP cutoff;;;;Cycle;S1S;2;2050;10
-SSP2;ECEMF_HighH2_LifestCha;below GDP cutoff;;;;Domestic Aviation;S1S;0.25;2035;10
-SSP2;ECEMF_HighH2_LifestCha;below GDP cutoff;;;;Domestic Ship;S1S;1.5;2050;10
-SSP2;ECEMF_HighH2_LifestCha;below GDP cutoff;;;;Freight Rail;S1S;1.5;2050;10
-SSP2;ECEMF_HighH2_LifestCha;below GDP cutoff;;;;HSR;S1S;1;2050;10
-SSP2;ECEMF_HighH2_LifestCha;below GDP cutoff;;;;Passenger Rail;S1S;2;2050;10
-SSP2;ECEMF_HighH2_LifestCha;below GDP cutoff;;;;trn_freight_road;S1S;0.7;2035;10
-SSP2;ECEMF_HighH2_LifestCha;below GDP cutoff;;;;trn_pass_road;S1S;0.5;2035;10
-SSP2;ECEMF_HighH2_LifestCha;below GDP cutoff;;;;Walk;S1S;2;2050;10
-SSP2;ECEMF_HighH2_LifestCha;above GDP cutoff;;;Bus;trn_pass_road;S2S1;2;2050;10
-SSP2;ECEMF_HighH2_LifestCha;above GDP cutoff;;;trn_pass_road_LDV;trn_pass_road;S2S1;0.5;2035;10
-SSP2;ECEMF_HighH2_LifestCha;below GDP cutoff;;;Bus;trn_pass_road;S2S1;2;2050;10
-SSP2;ECEMF_HighH2_LifestCha;below GDP cutoff;;;trn_pass_road_LDV;trn_pass_road;S2S1;0.5;2035;10
-SSP2;ECEMF_HighH2_LifestCha;above GDP cutoff;BEV;Bus;Bus;trn_pass_road;FV;3;2060;15
-SSP2;ECEMF_HighH2_LifestCha;above GDP cutoff;FCEV;Bus;Bus;trn_pass_road;FV;220;2035;5
-SSP2;ECEMF_HighH2_LifestCha;above GDP cutoff;Liquids;Bus;Bus;trn_pass_road;FV;1;2050;10
-SSP2;ECEMF_HighH2_LifestCha;above GDP cutoff;Hydrogen;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;3;2055;5
-SSP2;ECEMF_HighH2_LifestCha;above GDP cutoff;Liquids;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SSP2;ECEMF_HighH2_LifestCha;above GDP cutoff;Liquids;Ship;Domestic Ship_tmp_subsectorL2;Domestic Ship;FV;1;2050;10
-SSP2;ECEMF_HighH2_LifestCha;above GDP cutoff;Electric;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;2.5;2050;10
-SSP2;ECEMF_HighH2_LifestCha;above GDP cutoff;Liquids;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SSP2;ECEMF_HighH2_LifestCha;above GDP cutoff;Electric;Rail;HSR_tmp_subsectorL2;HSR;FV;2.5;2050;10
-SSP2;ECEMF_HighH2_LifestCha;above GDP cutoff;Liquids;Aviation;International Aviation_tmp_subsectorL2;International Aviation;FV;1;2050;10
-SSP2;ECEMF_HighH2_LifestCha;above GDP cutoff;Liquids;Ship;International Ship_tmp_subsectorL2;International Ship;FV;1;2050;10
-SSP2;ECEMF_HighH2_LifestCha;above GDP cutoff;BEV;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;3;2050;10
-SSP2;ECEMF_HighH2_LifestCha;above GDP cutoff;Liquids;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SSP2;ECEMF_HighH2_LifestCha;above GDP cutoff;Electric;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;2.5;2050;10
-SSP2;ECEMF_HighH2_LifestCha;above GDP cutoff;Liquids;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SSP2;ECEMF_HighH2_LifestCha;above GDP cutoff;BEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;40;2040;3
-SSP2;ECEMF_HighH2_LifestCha;above GDP cutoff;FCEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;50;2040;3
-SSP2;ECEMF_HighH2_LifestCha;above GDP cutoff;Liquids;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;3
-SSP2;ECEMF_HighH2_LifestCha;above GDP cutoff;BEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;40;2040;5
-SSP2;ECEMF_HighH2_LifestCha;above GDP cutoff;FCEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;250;2040;3
-SSP2;ECEMF_HighH2_LifestCha;above GDP cutoff;Liquids;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;3
-SSP2;ECEMF_HighH2_LifestCha;below GDP cutoff;BEV;Bus;Bus;trn_pass_road;FV;3;2060;15
-SSP2;ECEMF_HighH2_LifestCha;below GDP cutoff;FCEV;Bus;Bus;trn_pass_road;FV;160;2040;5
-SSP2;ECEMF_HighH2_LifestCha;below GDP cutoff;Liquids;Bus;Bus;trn_pass_road;FV;1;2050;10
-SSP2;ECEMF_HighH2_LifestCha;below GDP cutoff;Hydrogen;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;5;2055;10
-SSP2;ECEMF_HighH2_LifestCha;below GDP cutoff;Liquids;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SSP2;ECEMF_HighH2_LifestCha;below GDP cutoff;Liquids;Ship;Domestic Ship_tmp_subsectorL2;Domestic Ship;FV;1;2050;10
-SSP2;ECEMF_HighH2_LifestCha;below GDP cutoff;Electric;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;2;2050;10
-SSP2;ECEMF_HighH2_LifestCha;below GDP cutoff;Liquids;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SSP2;ECEMF_HighH2_LifestCha;below GDP cutoff;Electric;Rail;HSR_tmp_subsectorL2;HSR;FV;2;2050;10
-SSP2;ECEMF_HighH2_LifestCha;below GDP cutoff;Liquids;Aviation;International Aviation_tmp_subsectorL2;International Aviation;FV;1;2050;10
-SSP2;ECEMF_HighH2_LifestCha;below GDP cutoff;Liquids;Ship;International Ship_tmp_subsectorL2;International Ship;FV;1;2050;10
-SSP2;ECEMF_HighH2_LifestCha;below GDP cutoff;BEV;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;3;2050;10
-SSP2;ECEMF_HighH2_LifestCha;below GDP cutoff;Liquids;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SSP2;ECEMF_HighH2_LifestCha;below GDP cutoff;Electric;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;2;2050;10
-SSP2;ECEMF_HighH2_LifestCha;below GDP cutoff;Liquids;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SSP2;ECEMF_HighH2_LifestCha;below GDP cutoff;BEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;10;2040;3
-SSP2;ECEMF_HighH2_LifestCha;below GDP cutoff;FCEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;10;2040;3
-SSP2;ECEMF_HighH2_LifestCha;below GDP cutoff;Liquids;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;3
-SSP2;ECEMF_HighH2_LifestCha;below GDP cutoff;BEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;5;2035;5
-SSP2;ECEMF_HighH2_LifestCha;below GDP cutoff;FCEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;30;2035;3
-SSP2;ECEMF_HighH2_LifestCha;below GDP cutoff;Liquids;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;3
-SSP2;ECEMF_HighH2_ModEff;above GDP cutoff;;;;Cycle;S1S;1;2050;10
-SSP2;ECEMF_HighH2_ModEff;above GDP cutoff;;;;Domestic Aviation;S1S;0.75;2035;10
-SSP2;ECEMF_HighH2_ModEff;above GDP cutoff;;;;Domestic Ship;S1S;1;2050;10
-SSP2;ECEMF_HighH2_ModEff;above GDP cutoff;;;;Freight Rail;S1S;1;2050;10
-SSP2;ECEMF_HighH2_ModEff;above GDP cutoff;;;;HSR;S1S;1;2050;10
-SSP2;ECEMF_HighH2_ModEff;above GDP cutoff;;;;Passenger Rail;S1S;1;2050;10
-SSP2;ECEMF_HighH2_ModEff;above GDP cutoff;;;;trn_freight_road;S1S;0.9;2035;10
-SSP2;ECEMF_HighH2_ModEff;above GDP cutoff;;;;trn_pass_road;S1S;0.9;2035;10
-SSP2;ECEMF_HighH2_ModEff;above GDP cutoff;;;;Walk;S1S;1;2050;10
-SSP2;ECEMF_HighH2_ModEff;below GDP cutoff;;;;Cycle;S1S;1;2050;10
-SSP2;ECEMF_HighH2_ModEff;below GDP cutoff;;;;Domestic Aviation;S1S;0.75;2035;10
-SSP2;ECEMF_HighH2_ModEff;below GDP cutoff;;;;Domestic Ship;S1S;1;2050;10
-SSP2;ECEMF_HighH2_ModEff;below GDP cutoff;;;;Freight Rail;S1S;1;2050;10
-SSP2;ECEMF_HighH2_ModEff;below GDP cutoff;;;;HSR;S1S;1;2050;10
-SSP2;ECEMF_HighH2_ModEff;below GDP cutoff;;;;Passenger Rail;S1S;1;2050;10
-SSP2;ECEMF_HighH2_ModEff;below GDP cutoff;;;;trn_freight_road;S1S;0.9;2035;10
-SSP2;ECEMF_HighH2_ModEff;below GDP cutoff;;;;trn_pass_road;S1S;0.9;2035;10
-SSP2;ECEMF_HighH2_ModEff;below GDP cutoff;;;;Walk;S1S;1;2050;10
-SSP2;ECEMF_HighH2_ModEff;above GDP cutoff;;;Bus;trn_pass_road;S2S1;1;2050;10
-SSP2;ECEMF_HighH2_ModEff;above GDP cutoff;;;trn_pass_road_LDV;trn_pass_road;S2S1;0.9;2035;10
-SSP2;ECEMF_HighH2_ModEff;below GDP cutoff;;;Bus;trn_pass_road;S2S1;1;2050;10
-SSP2;ECEMF_HighH2_ModEff;below GDP cutoff;;;trn_pass_road_LDV;trn_pass_road;S2S1;0.9;2035;10
-SSP2;ECEMF_HighH2_ModEff;above GDP cutoff;BEV;Bus;Bus;trn_pass_road;FV;3;2060;15
-SSP2;ECEMF_HighH2_ModEff;above GDP cutoff;FCEV;Bus;Bus;trn_pass_road;FV;200;2035;5
-SSP2;ECEMF_HighH2_ModEff;above GDP cutoff;Liquids;Bus;Bus;trn_pass_road;FV;1;2050;10
-SSP2;ECEMF_HighH2_ModEff;above GDP cutoff;Hydrogen;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;3;2055;5
-SSP2;ECEMF_HighH2_ModEff;above GDP cutoff;Liquids;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SSP2;ECEMF_HighH2_ModEff;above GDP cutoff;Liquids;Ship;Domestic Ship_tmp_subsectorL2;Domestic Ship;FV;1;2050;10
-SSP2;ECEMF_HighH2_ModEff;above GDP cutoff;Electric;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1.5;2050;10
-SSP2;ECEMF_HighH2_ModEff;above GDP cutoff;Liquids;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SSP2;ECEMF_HighH2_ModEff;above GDP cutoff;Electric;Rail;HSR_tmp_subsectorL2;HSR;FV;1.5;2050;10
-SSP2;ECEMF_HighH2_ModEff;above GDP cutoff;Liquids;Aviation;International Aviation_tmp_subsectorL2;International Aviation;FV;1;2050;10
-SSP2;ECEMF_HighH2_ModEff;above GDP cutoff;Liquids;Ship;International Ship_tmp_subsectorL2;International Ship;FV;1;2050;10
-SSP2;ECEMF_HighH2_ModEff;above GDP cutoff;BEV;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;3;2050;10
-SSP2;ECEMF_HighH2_ModEff;above GDP cutoff;Liquids;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SSP2;ECEMF_HighH2_ModEff;above GDP cutoff;Electric;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1.5;2050;10
-SSP2;ECEMF_HighH2_ModEff;above GDP cutoff;Liquids;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SSP2;ECEMF_HighH2_ModEff;above GDP cutoff;BEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;40;2040;3
-SSP2;ECEMF_HighH2_ModEff;above GDP cutoff;FCEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;50;2040;3
-SSP2;ECEMF_HighH2_ModEff;above GDP cutoff;Liquids;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;3
-SSP2;ECEMF_HighH2_ModEff;above GDP cutoff;BEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;40;2040;5
-SSP2;ECEMF_HighH2_ModEff;above GDP cutoff;FCEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;250;2040;3
-SSP2;ECEMF_HighH2_ModEff;above GDP cutoff;Liquids;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;3
-SSP2;ECEMF_HighH2_ModEff;below GDP cutoff;BEV;Bus;Bus;trn_pass_road;FV;3;2060;15
-SSP2;ECEMF_HighH2_ModEff;below GDP cutoff;FCEV;Bus;Bus;trn_pass_road;FV;150;2040;5
-SSP2;ECEMF_HighH2_ModEff;below GDP cutoff;Liquids;Bus;Bus;trn_pass_road;FV;1;2050;10
-SSP2;ECEMF_HighH2_ModEff;below GDP cutoff;Hydrogen;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;2.5;2055;10
-SSP2;ECEMF_HighH2_ModEff;below GDP cutoff;Liquids;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SSP2;ECEMF_HighH2_ModEff;below GDP cutoff;Liquids;Ship;Domestic Ship_tmp_subsectorL2;Domestic Ship;FV;1;2050;10
-SSP2;ECEMF_HighH2_ModEff;below GDP cutoff;Electric;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;2.5;2050;10
-SSP2;ECEMF_HighH2_ModEff;below GDP cutoff;Liquids;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SSP2;ECEMF_HighH2_ModEff;below GDP cutoff;Electric;Rail;HSR_tmp_subsectorL2;HSR;FV;2.5;2050;10
-SSP2;ECEMF_HighH2_ModEff;below GDP cutoff;Liquids;Aviation;International Aviation_tmp_subsectorL2;International Aviation;FV;1;2050;10
-SSP2;ECEMF_HighH2_ModEff;below GDP cutoff;Liquids;Ship;International Ship_tmp_subsectorL2;International Ship;FV;1;2050;10
-SSP2;ECEMF_HighH2_ModEff;below GDP cutoff;BEV;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;2.5;2050;10
-SSP2;ECEMF_HighH2_ModEff;below GDP cutoff;Liquids;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SSP2;ECEMF_HighH2_ModEff;below GDP cutoff;Electric;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;2.5;2050;10
-SSP2;ECEMF_HighH2_ModEff;below GDP cutoff;Liquids;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SSP2;ECEMF_HighH2_ModEff;below GDP cutoff;BEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;10;2040;3
-SSP2;ECEMF_HighH2_ModEff;below GDP cutoff;FCEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;10;2040;3
-SSP2;ECEMF_HighH2_ModEff;below GDP cutoff;Liquids;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;3
-SSP2;ECEMF_HighH2_ModEff;below GDP cutoff;BEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;5;2035;5
-SSP2;ECEMF_HighH2_ModEff;below GDP cutoff;FCEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;30;2035;3
-SSP2;ECEMF_HighH2_ModEff;below GDP cutoff;Liquids;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;3
-SSP2;HydrHype4;above GDP cutoff;;;;Cycle;S1S;1;2050;10
-SSP2;HydrHype4;above GDP cutoff;;;;Domestic Aviation;S1S;0.25;2035;10
-SSP2;HydrHype4;above GDP cutoff;;;;Domestic Ship;S1S;1;2050;10
-SSP2;HydrHype4;above GDP cutoff;;;;Freight Rail;S1S;1;2050;10
-SSP2;HydrHype4;above GDP cutoff;;;;HSR;S1S;1;2050;10
-SSP2;HydrHype4;above GDP cutoff;;;;Passenger Rail;S1S;1;2050;10
-SSP2;HydrHype4;above GDP cutoff;;;;trn_freight_road;S1S;0.5;2035;10
-SSP2;HydrHype4;above GDP cutoff;;;;trn_pass_road;S1S;0.7;2035;10
-SSP2;HydrHype4;above GDP cutoff;;;;Walk;S1S;1;2050;10
-SSP2;HydrHype4;below GDP cutoff;;;;Cycle;S1S;1;2050;10
-SSP2;HydrHype4;below GDP cutoff;;;;Domestic Aviation;S1S;0.25;2035;10
-SSP2;HydrHype4;below GDP cutoff;;;;Domestic Ship;S1S;1;2050;10
-SSP2;HydrHype4;below GDP cutoff;;;;Freight Rail;S1S;1;2050;10
-SSP2;HydrHype4;below GDP cutoff;;;;HSR;S1S;1;2050;10
-SSP2;HydrHype4;below GDP cutoff;;;;Passenger Rail;S1S;1;2050;10
-SSP2;HydrHype4;below GDP cutoff;;;;trn_freight_road;S1S;0.5;2035;10
-SSP2;HydrHype4;below GDP cutoff;;;;trn_pass_road;S1S;0.7;2035;10
-SSP2;HydrHype4;below GDP cutoff;;;;Walk;S1S;1;2050;10
-SSP2;HydrHype4;above GDP cutoff;;;Bus;trn_pass_road;S2S1;1;2050;10
-SSP2;HydrHype4;above GDP cutoff;;;trn_pass_road_LDV;trn_pass_road;S2S1;0.7;2035;10
-SSP2;HydrHype4;below GDP cutoff;;;Bus;trn_pass_road;S2S1;1;2050;10
-SSP2;HydrHype4;below GDP cutoff;;;trn_pass_road_LDV;trn_pass_road;S2S1;0.7;2035;10
-SSP2;HydrHype4;above GDP cutoff;BEV;Bus;Bus;trn_pass_road;FV;3;2060;15
-SSP2;HydrHype4;above GDP cutoff;FCEV;Bus;Bus;trn_pass_road;FV;200;2035;5
-SSP2;HydrHype4;above GDP cutoff;Liquids;Bus;Bus;trn_pass_road;FV;1;2050;10
-SSP2;HydrHype4;above GDP cutoff;Hydrogen;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;3;2055;5
-SSP2;HydrHype4;above GDP cutoff;Liquids;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SSP2;HydrHype4;above GDP cutoff;Liquids;Ship;Domestic Ship_tmp_subsectorL2;Domestic Ship;FV;1;2050;10
-SSP2;HydrHype4;above GDP cutoff;Electric;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SSP2;HydrHype4;above GDP cutoff;Liquids;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SSP2;HydrHype4;above GDP cutoff;Electric;Rail;HSR_tmp_subsectorL2;HSR;FV;1;2050;10
-SSP2;HydrHype4;above GDP cutoff;Liquids;Aviation;International Aviation_tmp_subsectorL2;International Aviation;FV;1;2050;10
-SSP2;HydrHype4;above GDP cutoff;Liquids;Ship;International Ship_tmp_subsectorL2;International Ship;FV;1;2050;10
-SSP2;HydrHype4;above GDP cutoff;BEV;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SSP2;HydrHype4;above GDP cutoff;Liquids;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SSP2;HydrHype4;above GDP cutoff;Electric;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SSP2;HydrHype4;above GDP cutoff;Liquids;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SSP2;HydrHype4;above GDP cutoff;BEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;40;2040;3
-SSP2;HydrHype4;above GDP cutoff;FCEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;50;2040;3
-SSP2;HydrHype4;above GDP cutoff;Liquids;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;3
-SSP2;HydrHype4;above GDP cutoff;BEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;40;2040;5
-SSP2;HydrHype4;above GDP cutoff;FCEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;250;2040;3
-SSP2;HydrHype4;above GDP cutoff;Liquids;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;3
-SSP2;HydrHype4;below GDP cutoff;BEV;Bus;Bus;trn_pass_road;FV;3;2060;15
-SSP2;HydrHype4;below GDP cutoff;FCEV;Bus;Bus;trn_pass_road;FV;150;2040;5
-SSP2;HydrHype4;below GDP cutoff;Liquids;Bus;Bus;trn_pass_road;FV;1;2050;10
-SSP2;HydrHype4;below GDP cutoff;Hydrogen;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;2.5;2055;10
-SSP2;HydrHype4;below GDP cutoff;Liquids;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SSP2;HydrHype4;below GDP cutoff;Liquids;Ship;Domestic Ship_tmp_subsectorL2;Domestic Ship;FV;1;2050;10
-SSP2;HydrHype4;below GDP cutoff;Electric;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SSP2;HydrHype4;below GDP cutoff;Liquids;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SSP2;HydrHype4;below GDP cutoff;Electric;Rail;HSR_tmp_subsectorL2;HSR;FV;1;2050;10
-SSP2;HydrHype4;below GDP cutoff;Liquids;Aviation;International Aviation_tmp_subsectorL2;International Aviation;FV;1;2050;10
-SSP2;HydrHype4;below GDP cutoff;Liquids;Ship;International Ship_tmp_subsectorL2;International Ship;FV;1;2050;10
-SSP2;HydrHype4;below GDP cutoff;BEV;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SSP2;HydrHype4;below GDP cutoff;Liquids;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SSP2;HydrHype4;below GDP cutoff;Electric;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SSP2;HydrHype4;below GDP cutoff;Liquids;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SSP2;HydrHype4;below GDP cutoff;BEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;10;2040;3
-SSP2;HydrHype4;below GDP cutoff;FCEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;10;2040;3
-SSP2;HydrHype4;below GDP cutoff;Liquids;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;3
-SSP2;HydrHype4;below GDP cutoff;BEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;5;2035;5
-SSP2;HydrHype4;below GDP cutoff;FCEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;30;2035;3
-SSP2;HydrHype4;below GDP cutoff;Liquids;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;3
-SSP2;Mix2;above GDP cutoff;;;;Cycle;S1S;1;2050;10
-SSP2;Mix2;above GDP cutoff;;;;Domestic Aviation;S1S;0.75;2035;10
-SSP2;Mix2;above GDP cutoff;;;;Domestic Ship;S1S;1;2050;10
-SSP2;Mix2;above GDP cutoff;;;;Freight Rail;S1S;1;2050;10
-SSP2;Mix2;above GDP cutoff;;;;HSR;S1S;1;2050;10
-SSP2;Mix2;above GDP cutoff;;;;Passenger Rail;S1S;1;2050;10
-SSP2;Mix2;above GDP cutoff;;;;trn_freight_road;S1S;0.9;2035;10
-SSP2;Mix2;above GDP cutoff;;;;trn_pass_road;S1S;0.9;2035;10
-SSP2;Mix2;above GDP cutoff;;;;Walk;S1S;1;2050;10
-SSP2;Mix2;below GDP cutoff;;;;Cycle;S1S;1;2050;10
-SSP2;Mix2;below GDP cutoff;;;;Domestic Aviation;S1S;0.75;2035;10
-SSP2;Mix2;below GDP cutoff;;;;Domestic Ship;S1S;1;2050;10
-SSP2;Mix2;below GDP cutoff;;;;Freight Rail;S1S;1;2050;10
-SSP2;Mix2;below GDP cutoff;;;;HSR;S1S;1;2050;10
-SSP2;Mix2;below GDP cutoff;;;;Passenger Rail;S1S;1;2050;10
-SSP2;Mix2;below GDP cutoff;;;;trn_freight_road;S1S;0.9;2035;10
-SSP2;Mix2;below GDP cutoff;;;;trn_pass_road;S1S;0.9;2035;10
-SSP2;Mix2;below GDP cutoff;;;;Walk;S1S;1;2050;10
-SSP2;Mix2;above GDP cutoff;;;Bus;trn_pass_road;S2S1;1;2050;10
-SSP2;Mix2;above GDP cutoff;;;trn_pass_road_LDV;trn_pass_road;S2S1;0.9;2035;10
-SSP2;Mix2;below GDP cutoff;;;Bus;trn_pass_road;S2S1;1;2050;10
-SSP2;Mix2;below GDP cutoff;;;trn_pass_road_LDV;trn_pass_road;S2S1;0.9;2035;10
-SSP2;Mix2;above GDP cutoff;BEV;Bus;Bus;trn_pass_road;FV;2;2035;10
-SSP2;Mix2;above GDP cutoff;FCEV;Bus;Bus;trn_pass_road;FV;2;2035;10
-SSP2;Mix2;above GDP cutoff;Liquids;Bus;Bus;trn_pass_road;FV;1;2050;10
-SSP2;Mix2;above GDP cutoff;Hydrogen;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SSP2;Mix2;above GDP cutoff;Liquids;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SSP2;Mix2;above GDP cutoff;Liquids;Ship;Domestic Ship_tmp_subsectorL2;Domestic Ship;FV;1;2050;10
-SSP2;Mix2;above GDP cutoff;Electric;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SSP2;Mix2;above GDP cutoff;Liquids;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SSP2;Mix2;above GDP cutoff;Electric;Rail;HSR_tmp_subsectorL2;HSR;FV;1;2050;10
-SSP2;Mix2;above GDP cutoff;Liquids;Aviation;International Aviation_tmp_subsectorL2;International Aviation;FV;1;2050;10
-SSP2;Mix2;above GDP cutoff;Liquids;Ship;International Ship_tmp_subsectorL2;International Ship;FV;1;2050;10
-SSP2;Mix2;above GDP cutoff;BEV;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SSP2;Mix2;above GDP cutoff;Liquids;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SSP2;Mix2;above GDP cutoff;Electric;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SSP2;Mix2;above GDP cutoff;Liquids;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SSP2;Mix2;above GDP cutoff;BEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;2;2035;10
-SSP2;Mix2;above GDP cutoff;FCEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;2;2035;10
-SSP2;Mix2;above GDP cutoff;Liquids;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;10
-SSP2;Mix2;above GDP cutoff;BEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;2;2035;10
-SSP2;Mix2;above GDP cutoff;FCEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;2;2035;10
-SSP2;Mix2;above GDP cutoff;Liquids;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;10
-SSP2;Mix2;below GDP cutoff;BEV;Bus;Bus;trn_pass_road;FV;1.5;2035;10
-SSP2;Mix2;below GDP cutoff;FCEV;Bus;Bus;trn_pass_road;FV;1.5;2035;10
-SSP2;Mix2;below GDP cutoff;Liquids;Bus;Bus;trn_pass_road;FV;1;2050;10
-SSP2;Mix2;below GDP cutoff;Hydrogen;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SSP2;Mix2;below GDP cutoff;Liquids;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SSP2;Mix2;below GDP cutoff;Liquids;Ship;Domestic Ship_tmp_subsectorL2;Domestic Ship;FV;1;2050;10
-SSP2;Mix2;below GDP cutoff;Electric;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SSP2;Mix2;below GDP cutoff;Liquids;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SSP2;Mix2;below GDP cutoff;Electric;Rail;HSR_tmp_subsectorL2;HSR;FV;1;2050;10
-SSP2;Mix2;below GDP cutoff;Liquids;Aviation;International Aviation_tmp_subsectorL2;International Aviation;FV;1;2050;10
-SSP2;Mix2;below GDP cutoff;Liquids;Ship;International Ship_tmp_subsectorL2;International Ship;FV;1;2050;10
-SSP2;Mix2;below GDP cutoff;BEV;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SSP2;Mix2;below GDP cutoff;Liquids;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SSP2;Mix2;below GDP cutoff;Electric;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SSP2;Mix2;below GDP cutoff;Liquids;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SSP2;Mix2;below GDP cutoff;BEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1.5;2035;10
-SSP2;Mix2;below GDP cutoff;FCEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1.5;2035;10
-SSP2;Mix2;below GDP cutoff;Liquids;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;10
-SSP2;Mix2;below GDP cutoff;BEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1.5;2035;10
-SSP2;Mix2;below GDP cutoff;FCEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1.5;2035;10
-SSP2;Mix2;below GDP cutoff;Liquids;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;10
-SSP2;Mix3;above GDP cutoff;;;;Cycle;S1S;1;2050;10
-SSP2;Mix3;above GDP cutoff;;;;Domestic Aviation;S1S;0.5;2035;10
-SSP2;Mix3;above GDP cutoff;;;;Domestic Ship;S1S;1;2050;10
-SSP2;Mix3;above GDP cutoff;;;;Freight Rail;S1S;1;2050;10
-SSP2;Mix3;above GDP cutoff;;;;HSR;S1S;1;2050;10
-SSP2;Mix3;above GDP cutoff;;;;Passenger Rail;S1S;1;2050;10
-SSP2;Mix3;above GDP cutoff;;;;trn_freight_road;S1S;0.7;2035;10
-SSP2;Mix3;above GDP cutoff;;;;trn_pass_road;S1S;0.8;2035;10
-SSP2;Mix3;above GDP cutoff;;;;Walk;S1S;1;2050;10
-SSP2;Mix3;below GDP cutoff;;;;Cycle;S1S;1;2050;10
-SSP2;Mix3;below GDP cutoff;;;;Domestic Aviation;S1S;0.5;2035;10
-SSP2;Mix3;below GDP cutoff;;;;Domestic Ship;S1S;1;2050;10
-SSP2;Mix3;below GDP cutoff;;;;Freight Rail;S1S;1;2050;10
-SSP2;Mix3;below GDP cutoff;;;;HSR;S1S;1;2050;10
-SSP2;Mix3;below GDP cutoff;;;;Passenger Rail;S1S;1;2050;10
-SSP2;Mix3;below GDP cutoff;;;;trn_freight_road;S1S;0.7;2035;10
-SSP2;Mix3;below GDP cutoff;;;;trn_pass_road;S1S;0.8;2035;10
-SSP2;Mix3;below GDP cutoff;;;;Walk;S1S;1;2050;10
-SSP2;Mix3;above GDP cutoff;;;Bus;trn_pass_road;S2S1;1;2050;10
-SSP2;Mix3;above GDP cutoff;;;trn_pass_road_LDV;trn_pass_road;S2S1;0.8;2035;10
-SSP2;Mix3;below GDP cutoff;;;Bus;trn_pass_road;S2S1;1;2050;10
-SSP2;Mix3;below GDP cutoff;;;trn_pass_road_LDV;trn_pass_road;S2S1;0.8;2035;10
-SSP2;Mix3;above GDP cutoff;BEV;Bus;Bus;trn_pass_road;FV;4;2035;10
-SSP2;Mix3;above GDP cutoff;FCEV;Bus;Bus;trn_pass_road;FV;4;2035;10
-SSP2;Mix3;above GDP cutoff;Liquids;Bus;Bus;trn_pass_road;FV;1;2050;10
-SSP2;Mix3;above GDP cutoff;Hydrogen;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SSP2;Mix3;above GDP cutoff;Liquids;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SSP2;Mix3;above GDP cutoff;Liquids;Ship;Domestic Ship_tmp_subsectorL2;Domestic Ship;FV;1;2050;10
-SSP2;Mix3;above GDP cutoff;Electric;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1.5;2050;10
-SSP2;Mix3;above GDP cutoff;Liquids;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SSP2;Mix3;above GDP cutoff;Electric;Rail;HSR_tmp_subsectorL2;HSR;FV;1.5;2050;10
-SSP2;Mix3;above GDP cutoff;Liquids;Aviation;International Aviation_tmp_subsectorL2;International Aviation;FV;1;2050;10
-SSP2;Mix3;above GDP cutoff;Liquids;Ship;International Ship_tmp_subsectorL2;International Ship;FV;1;2050;10
-SSP2;Mix3;above GDP cutoff;BEV;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SSP2;Mix3;above GDP cutoff;Liquids;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SSP2;Mix3;above GDP cutoff;Electric;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1.5;2050;10
-SSP2;Mix3;above GDP cutoff;Liquids;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SSP2;Mix3;above GDP cutoff;BEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;3;2035;10
-SSP2;Mix3;above GDP cutoff;FCEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;3;2035;10
-SSP2;Mix3;above GDP cutoff;Liquids;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;10
-SSP2;Mix3;above GDP cutoff;BEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;5;2035;10
-SSP2;Mix3;above GDP cutoff;FCEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;7;2035;10
-SSP2;Mix3;above GDP cutoff;Liquids;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;10
-SSP2;Mix3;below GDP cutoff;BEV;Bus;Bus;trn_pass_road;FV;3.5;2035;10
-SSP2;Mix3;below GDP cutoff;FCEV;Bus;Bus;trn_pass_road;FV;3.5;2035;10
-SSP2;Mix3;below GDP cutoff;Liquids;Bus;Bus;trn_pass_road;FV;1;2050;10
-SSP2;Mix3;below GDP cutoff;Hydrogen;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SSP2;Mix3;below GDP cutoff;Liquids;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SSP2;Mix3;below GDP cutoff;Liquids;Ship;Domestic Ship_tmp_subsectorL2;Domestic Ship;FV;1;2050;10
-SSP2;Mix3;below GDP cutoff;Electric;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1.5;2050;10
-SSP2;Mix3;below GDP cutoff;Liquids;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SSP2;Mix3;below GDP cutoff;Electric;Rail;HSR_tmp_subsectorL2;HSR;FV;1.5;2050;10
-SSP2;Mix3;below GDP cutoff;Liquids;Aviation;International Aviation_tmp_subsectorL2;International Aviation;FV;1;2050;10
-SSP2;Mix3;below GDP cutoff;Liquids;Ship;International Ship_tmp_subsectorL2;International Ship;FV;1;2050;10
-SSP2;Mix3;below GDP cutoff;BEV;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SSP2;Mix3;below GDP cutoff;Liquids;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SSP2;Mix3;below GDP cutoff;Electric;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1.5;2050;10
-SSP2;Mix3;below GDP cutoff;Liquids;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SSP2;Mix3;below GDP cutoff;BEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;3;2035;10
-SSP2;Mix3;below GDP cutoff;FCEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;3;2035;10
-SSP2;Mix3;below GDP cutoff;Liquids;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;10
-SSP2;Mix3;below GDP cutoff;BEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;4;2035;10
-SSP2;Mix3;below GDP cutoff;FCEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;7;2035;10
-SSP2;Mix3;below GDP cutoff;Liquids;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;10
-SSP2;Mix4;above GDP cutoff;;;;Cycle;S1S;1;2050;10
-SSP2;Mix4;above GDP cutoff;;;;Domestic Aviation;S1S;0.25;2035;10
-SSP2;Mix4;above GDP cutoff;;;;Domestic Ship;S1S;1;2050;10
-SSP2;Mix4;above GDP cutoff;;;;Freight Rail;S1S;1;2050;10
-SSP2;Mix4;above GDP cutoff;;;;HSR;S1S;1;2050;10
-SSP2;Mix4;above GDP cutoff;;;;Passenger Rail;S1S;1;2050;10
-SSP2;Mix4;above GDP cutoff;;;;trn_freight_road;S1S;0.5;2035;10
-SSP2;Mix4;above GDP cutoff;;;;trn_pass_road;S1S;0.7;2035;10
-SSP2;Mix4;above GDP cutoff;;;;Walk;S1S;1;2050;10
-SSP2;Mix4;below GDP cutoff;;;;Cycle;S1S;1;2050;10
-SSP2;Mix4;below GDP cutoff;;;;Domestic Aviation;S1S;0.25;2035;10
-SSP2;Mix4;below GDP cutoff;;;;Domestic Ship;S1S;1;2050;10
-SSP2;Mix4;below GDP cutoff;;;;Freight Rail;S1S;1;2050;10
-SSP2;Mix4;below GDP cutoff;;;;HSR;S1S;1;2050;10
-SSP2;Mix4;below GDP cutoff;;;;Passenger Rail;S1S;1;2050;10
-SSP2;Mix4;below GDP cutoff;;;;trn_freight_road;S1S;0.5;2035;10
-SSP2;Mix4;below GDP cutoff;;;;trn_pass_road;S1S;0.7;2035;10
-SSP2;Mix4;below GDP cutoff;;;;Walk;S1S;1;2050;10
-SSP2;Mix4;above GDP cutoff;;;Bus;trn_pass_road;S2S1;1;2050;10
-SSP2;Mix4;above GDP cutoff;;;trn_pass_road_LDV;trn_pass_road;S2S1;0.7;2035;10
-SSP2;Mix4;below GDP cutoff;;;Bus;trn_pass_road;S2S1;1;2050;10
-SSP2;Mix4;below GDP cutoff;;;trn_pass_road_LDV;trn_pass_road;S2S1;0.7;2035;10
-SSP2;Mix4;above GDP cutoff;BEV;Bus;Bus;trn_pass_road;FV;6;2035;10
-SSP2;Mix4;above GDP cutoff;FCEV;Bus;Bus;trn_pass_road;FV;6;2035;10
-SSP2;Mix4;above GDP cutoff;Liquids;Bus;Bus;trn_pass_road;FV;1;2050;10
-SSP2;Mix4;above GDP cutoff;Hydrogen;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SSP2;Mix4;above GDP cutoff;Liquids;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SSP2;Mix4;above GDP cutoff;Liquids;Ship;Domestic Ship_tmp_subsectorL2;Domestic Ship;FV;1;2050;10
-SSP2;Mix4;above GDP cutoff;Electric;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;2;2050;10
-SSP2;Mix4;above GDP cutoff;Liquids;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SSP2;Mix4;above GDP cutoff;Electric;Rail;HSR_tmp_subsectorL2;HSR;FV;2;2050;10
-SSP2;Mix4;above GDP cutoff;Liquids;Aviation;International Aviation_tmp_subsectorL2;International Aviation;FV;1;2050;10
-SSP2;Mix4;above GDP cutoff;Liquids;Ship;International Ship_tmp_subsectorL2;International Ship;FV;1;2050;10
-SSP2;Mix4;above GDP cutoff;BEV;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SSP2;Mix4;above GDP cutoff;Liquids;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SSP2;Mix4;above GDP cutoff;Electric;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;2;2050;10
-SSP2;Mix4;above GDP cutoff;Liquids;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SSP2;Mix4;above GDP cutoff;BEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;40;2040;3
-SSP2;Mix4;above GDP cutoff;FCEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;10;2040;3
-SSP2;Mix4;above GDP cutoff;Liquids;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;3
-SSP2;Mix4;above GDP cutoff;BEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;50;2040;5
-SSP2;Mix4;above GDP cutoff;FCEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;60;2040;3
-SSP2;Mix4;above GDP cutoff;Liquids;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;3
-SSP2;Mix4;below GDP cutoff;BEV;Bus;Bus;trn_pass_road;FV;5;2035;10
-SSP2;Mix4;below GDP cutoff;FCEV;Bus;Bus;trn_pass_road;FV;5;2035;10
-SSP2;Mix4;below GDP cutoff;Liquids;Bus;Bus;trn_pass_road;FV;1;2050;10
-SSP2;Mix4;below GDP cutoff;Hydrogen;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SSP2;Mix4;below GDP cutoff;Liquids;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SSP2;Mix4;below GDP cutoff;Liquids;Ship;Domestic Ship_tmp_subsectorL2;Domestic Ship;FV;1;2050;10
-SSP2;Mix4;below GDP cutoff;Electric;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;2;2050;10
-SSP2;Mix4;below GDP cutoff;Liquids;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SSP2;Mix4;below GDP cutoff;Electric;Rail;HSR_tmp_subsectorL2;HSR;FV;2;2050;10
-SSP2;Mix4;below GDP cutoff;Liquids;Aviation;International Aviation_tmp_subsectorL2;International Aviation;FV;1;2050;10
-SSP2;Mix4;below GDP cutoff;Liquids;Ship;International Ship_tmp_subsectorL2;International Ship;FV;1;2050;10
-SSP2;Mix4;below GDP cutoff;BEV;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SSP2;Mix4;below GDP cutoff;Liquids;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SSP2;Mix4;below GDP cutoff;Electric;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;2;2050;10
-SSP2;Mix4;below GDP cutoff;Liquids;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SSP2;Mix4;below GDP cutoff;BEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;10;2040;3
-SSP2;Mix4;below GDP cutoff;FCEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;10;2040;3
-SSP2;Mix4;below GDP cutoff;Liquids;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;3
-SSP2;Mix4;below GDP cutoff;BEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;5;2035;5
-SSP2;Mix4;below GDP cutoff;FCEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;7;2035;3
-SSP2;Mix4;below GDP cutoff;Liquids;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;3
-SSP2;NAV_act;CAZ;;;;Cycle;S1S;2.5;2040;10
-SSP2;NAV_act;CAZ;;;;Domestic Aviation;S1S;0.3;2040;10
-SSP2;NAV_act;CAZ;;;;Domestic Ship;S1S;1;2040;10
-SSP2;NAV_act;CAZ;;;;Freight Rail;S1S;1;2040;10
-SSP2;NAV_act;CAZ;;;;HSR;S1S;1.7;2040;10
-SSP2;NAV_act;CAZ;;;;Passenger Rail;S1S;4;2040;10
-SSP2;NAV_act;CAZ;;;;trn_freight_road;S1S;0.9;2040;10
-SSP2;NAV_act;CAZ;;;;trn_pass_road;S1S;0.6;2040;10
-SSP2;NAV_act;CAZ;;;;Walk;S1S;2.5;2040;10
-SSP2;NAV_act;USA;;;;Cycle;S1S;2.5;2040;10
-SSP2;NAV_act;USA;;;;Domestic Aviation;S1S;0.3;2040;10
-SSP2;NAV_act;USA;;;;Domestic Ship;S1S;1;2040;10
-SSP2;NAV_act;USA;;;;Freight Rail;S1S;1;2040;10
-SSP2;NAV_act;USA;;;;HSR;S1S;1.7;2040;10
-SSP2;NAV_act;USA;;;;Passenger Rail;S1S;4;2040;10
-SSP2;NAV_act;USA;;;;trn_freight_road;S1S;0.9;2040;10
-SSP2;NAV_act;USA;;;;trn_pass_road;S1S;0.6;2040;10
-SSP2;NAV_act;USA;;;;Walk;S1S;2.5;2040;10
-SSP2;NAV_act;above GDP cutoff;;;;Cycle;S1S;1.8;2040;10
-SSP2;NAV_act;above GDP cutoff;;;;Domestic Aviation;S1S;0.3;2040;10
-SSP2;NAV_act;above GDP cutoff;;;;Domestic Ship;S1S;1;2040;10
-SSP2;NAV_act;above GDP cutoff;;;;Freight Rail;S1S;1;2040;10
-SSP2;NAV_act;above GDP cutoff;;;;HSR;S1S;1.7;2040;10
-SSP2;NAV_act;above GDP cutoff;;;;Passenger Rail;S1S;1.6;2040;10
-SSP2;NAV_act;above GDP cutoff;;;;trn_freight_road;S1S;0.9;2040;10
-SSP2;NAV_act;above GDP cutoff;;;;trn_pass_road;S1S;0.7;2040;10
-SSP2;NAV_act;above GDP cutoff;;;;Walk;S1S;1.7;2040;10
-SSP2;NAV_act;below GDP cutoff;;;;Cycle;S1S;2.5;2040;10
-SSP2;NAV_act;below GDP cutoff;;;;Domestic Aviation;S1S;0.3;2040;10
-SSP2;NAV_act;below GDP cutoff;;;;Domestic Ship;S1S;1;2040;10
-SSP2;NAV_act;below GDP cutoff;;;;Freight Rail;S1S;1;2040;10
-SSP2;NAV_act;below GDP cutoff;;;;HSR;S1S;2.8;2040;10
-SSP2;NAV_act;below GDP cutoff;;;;Passenger Rail;S1S;1.5;2040;10
-SSP2;NAV_act;below GDP cutoff;;;;trn_freight_road;S1S;0.9;2040;10
-SSP2;NAV_act;below GDP cutoff;;;;trn_pass_road;S1S;0.7;2040;10
-SSP2;NAV_act;below GDP cutoff;;;;Walk;S1S;2.5;2040;10
-SSP2;NAV_act;CAZ;;;Bus;trn_pass_road;S2S1;3;2040;10
-SSP2;NAV_act;CAZ;;;trn_pass_road_LDV;trn_pass_road;S2S1;0.7;2040;10
-SSP2;NAV_act;USA;;;Bus;trn_pass_road;S2S1;2;2040;10
-SSP2;NAV_act;USA;;;trn_pass_road_LDV;trn_pass_road;S2S1;0.7;2040;10
-SSP2;NAV_act;above GDP cutoff;;;Bus;trn_pass_road;S2S1;2;2040;10
-SSP2;NAV_act;above GDP cutoff;;;trn_pass_road_LDV;trn_pass_road;S2S1;1;2040;10
-SSP2;NAV_act;below GDP cutoff;;;Bus;trn_pass_road;S2S1;2;2040;10
-SSP2;NAV_act;below GDP cutoff;;;trn_pass_road_LDV;trn_pass_road;S2S1;1;2040;10
-SSP2;NAV_act;CAZ;BEV;Bus;Bus;trn_pass_road;FV;1;2040;10
-SSP2;NAV_act;CAZ;FCEV;Bus;Bus;trn_pass_road;FV;1;2040;10
-SSP2;NAV_act;CAZ;Liquids;Bus;Bus;trn_pass_road;FV;1;2050;10
-SSP2;NAV_act;CAZ;Hydrogen;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SSP2;NAV_act;CAZ;Liquids;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SSP2;NAV_act;CAZ;Liquids;Ship;Domestic Ship_tmp_subsectorL2;Domestic Ship;FV;1;2050;10
-SSP2;NAV_act;CAZ;Electric;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SSP2;NAV_act;CAZ;Liquids;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SSP2;NAV_act;CAZ;Electric;Rail;HSR_tmp_subsectorL2;HSR;FV;1;2050;10
-SSP2;NAV_act;CAZ;Liquids;Aviation;International Aviation_tmp_subsectorL2;International Aviation;FV;1;2050;10
-SSP2;NAV_act;CAZ;Liquids;Ship;International Ship_tmp_subsectorL2;International Ship;FV;1;2050;10
-SSP2;NAV_act;CAZ;BEV;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SSP2;NAV_act;CAZ;Liquids;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SSP2;NAV_act;CAZ;Electric;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SSP2;NAV_act;CAZ;Liquids;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SSP2;NAV_act;CAZ;BEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2040;10
-SSP2;NAV_act;CAZ;FCEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2040;10
-SSP2;NAV_act;CAZ;Liquids;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;10
-SSP2;NAV_act;CAZ;BEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2040;10
-SSP2;NAV_act;CAZ;FCEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2040;10
-SSP2;NAV_act;CAZ;Liquids;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;10
-SSP2;NAV_act;USA;BEV;Bus;Bus;trn_pass_road;FV;1;2035;10
-SSP2;NAV_act;USA;FCEV;Bus;Bus;trn_pass_road;FV;1;2035;10
-SSP2;NAV_act;USA;Liquids;Bus;Bus;trn_pass_road;FV;1;2050;10
-SSP2;NAV_act;USA;Hydrogen;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SSP2;NAV_act;USA;Liquids;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SSP2;NAV_act;USA;Liquids;Ship;Domestic Ship_tmp_subsectorL2;Domestic Ship;FV;1;2050;10
-SSP2;NAV_act;USA;Electric;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SSP2;NAV_act;USA;Liquids;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SSP2;NAV_act;USA;Electric;Rail;HSR_tmp_subsectorL2;HSR;FV;1;2050;10
-SSP2;NAV_act;USA;Liquids;Aviation;International Aviation_tmp_subsectorL2;International Aviation;FV;1;2050;10
-SSP2;NAV_act;USA;Liquids;Ship;International Ship_tmp_subsectorL2;International Ship;FV;1;2050;10
-SSP2;NAV_act;USA;BEV;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SSP2;NAV_act;USA;Liquids;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SSP2;NAV_act;USA;Electric;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SSP2;NAV_act;USA;Liquids;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SSP2;NAV_act;USA;BEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2035;10
-SSP2;NAV_act;USA;FCEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2035;10
-SSP2;NAV_act;USA;Liquids;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;10
-SSP2;NAV_act;USA;BEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2035;10
-SSP2;NAV_act;USA;FCEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2035;10
-SSP2;NAV_act;USA;Liquids;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;10
-SSP2;NAV_act;above GDP cutoff;BEV;Bus;Bus;trn_pass_road;FV;1;2040;10
-SSP2;NAV_act;above GDP cutoff;FCEV;Bus;Bus;trn_pass_road;FV;1;2040;10
-SSP2;NAV_act;above GDP cutoff;Liquids;Bus;Bus;trn_pass_road;FV;1;2050;10
-SSP2;NAV_act;above GDP cutoff;Hydrogen;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SSP2;NAV_act;above GDP cutoff;Liquids;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SSP2;NAV_act;above GDP cutoff;Liquids;Ship;Domestic Ship_tmp_subsectorL2;Domestic Ship;FV;1;2050;10
-SSP2;NAV_act;above GDP cutoff;Electric;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SSP2;NAV_act;above GDP cutoff;Liquids;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SSP2;NAV_act;above GDP cutoff;Electric;Rail;HSR_tmp_subsectorL2;HSR;FV;1;2050;10
-SSP2;NAV_act;above GDP cutoff;Liquids;Aviation;International Aviation_tmp_subsectorL2;International Aviation;FV;1;2050;10
-SSP2;NAV_act;above GDP cutoff;Liquids;Ship;International Ship_tmp_subsectorL2;International Ship;FV;1;2050;10
-SSP2;NAV_act;above GDP cutoff;BEV;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SSP2;NAV_act;above GDP cutoff;Liquids;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SSP2;NAV_act;above GDP cutoff;Electric;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SSP2;NAV_act;above GDP cutoff;Liquids;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SSP2;NAV_act;above GDP cutoff;BEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2040;10
-SSP2;NAV_act;above GDP cutoff;FCEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2040;10
-SSP2;NAV_act;above GDP cutoff;Liquids;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;10
-SSP2;NAV_act;above GDP cutoff;BEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2040;10
-SSP2;NAV_act;above GDP cutoff;FCEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2040;10
-SSP2;NAV_act;above GDP cutoff;Liquids;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;10
-SSP2;NAV_act;below GDP cutoff;BEV;Bus;Bus;trn_pass_road;FV;1;2040;10
-SSP2;NAV_act;below GDP cutoff;FCEV;Bus;Bus;trn_pass_road;FV;1;2040;10
-SSP2;NAV_act;below GDP cutoff;Liquids;Bus;Bus;trn_pass_road;FV;1;2050;10
-SSP2;NAV_act;below GDP cutoff;Hydrogen;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SSP2;NAV_act;below GDP cutoff;Liquids;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SSP2;NAV_act;below GDP cutoff;Liquids;Ship;Domestic Ship_tmp_subsectorL2;Domestic Ship;FV;1;2050;10
-SSP2;NAV_act;below GDP cutoff;Electric;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SSP2;NAV_act;below GDP cutoff;Liquids;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SSP2;NAV_act;below GDP cutoff;Electric;Rail;HSR_tmp_subsectorL2;HSR;FV;1;2050;10
-SSP2;NAV_act;below GDP cutoff;Liquids;Aviation;International Aviation_tmp_subsectorL2;International Aviation;FV;1;2050;10
-SSP2;NAV_act;below GDP cutoff;Liquids;Ship;International Ship_tmp_subsectorL2;International Ship;FV;1;2050;10
-SSP2;NAV_act;below GDP cutoff;BEV;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SSP2;NAV_act;below GDP cutoff;Liquids;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SSP2;NAV_act;below GDP cutoff;Electric;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SSP2;NAV_act;below GDP cutoff;Liquids;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SSP2;NAV_act;below GDP cutoff;BEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2040;10
-SSP2;NAV_act;below GDP cutoff;FCEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2040;10
-SSP2;NAV_act;below GDP cutoff;Liquids;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;10
-SSP2;NAV_act;below GDP cutoff;BEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2040;10
-SSP2;NAV_act;below GDP cutoff;FCEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2040;10
-SSP2;NAV_act;below GDP cutoff;Liquids;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;10
-SSP2;NAV_all;CAZ;;;;Cycle;S1S;2.5;2040;10
-SSP2;NAV_all;CAZ;;;;Domestic Aviation;S1S;0.3;2040;10
-SSP2;NAV_all;CAZ;;;;Domestic Ship;S1S;1;2040;10
-SSP2;NAV_all;CAZ;;;;Freight Rail;S1S;1;2040;10
-SSP2;NAV_all;CAZ;;;;HSR;S1S;1.7;2040;10
-SSP2;NAV_all;CAZ;;;;Passenger Rail;S1S;4;2040;10
-SSP2;NAV_all;CAZ;;;;trn_freight_road;S1S;0.9;2040;10
-SSP2;NAV_all;CAZ;;;;trn_pass_road;S1S;0.6;2040;10
-SSP2;NAV_all;CAZ;;;;Walk;S1S;2.5;2040;10
-SSP2;NAV_all;USA;;;;Cycle;S1S;2.5;2040;10
-SSP2;NAV_all;USA;;;;Domestic Aviation;S1S;0.3;2040;10
-SSP2;NAV_all;USA;;;;Domestic Ship;S1S;1;2040;10
-SSP2;NAV_all;USA;;;;Freight Rail;S1S;1;2040;10
-SSP2;NAV_all;USA;;;;HSR;S1S;1.7;2040;10
-SSP2;NAV_all;USA;;;;Passenger Rail;S1S;4;2040;10
-SSP2;NAV_all;USA;;;;trn_freight_road;S1S;0.9;2040;10
-SSP2;NAV_all;USA;;;;trn_pass_road;S1S;0.6;2040;10
-SSP2;NAV_all;USA;;;;Walk;S1S;2.5;2040;10
-SSP2;NAV_all;above GDP cutoff;;;;Cycle;S1S;1.8;2040;10
-SSP2;NAV_all;above GDP cutoff;;;;Domestic Aviation;S1S;0.3;2040;10
-SSP2;NAV_all;above GDP cutoff;;;;Domestic Ship;S1S;1;2040;10
-SSP2;NAV_all;above GDP cutoff;;;;Freight Rail;S1S;1;2040;10
-SSP2;NAV_all;above GDP cutoff;;;;HSR;S1S;1.7;2040;10
-SSP2;NAV_all;above GDP cutoff;;;;Passenger Rail;S1S;1.6;2040;10
-SSP2;NAV_all;above GDP cutoff;;;;trn_freight_road;S1S;0.9;2040;10
-SSP2;NAV_all;above GDP cutoff;;;;trn_pass_road;S1S;0.7;2040;10
-SSP2;NAV_all;above GDP cutoff;;;;Walk;S1S;1.7;2040;10
-SSP2;NAV_all;below GDP cutoff;;;;Cycle;S1S;2.5;2040;10
-SSP2;NAV_all;below GDP cutoff;;;;Domestic Aviation;S1S;0.3;2040;10
-SSP2;NAV_all;below GDP cutoff;;;;Domestic Ship;S1S;1;2040;10
-SSP2;NAV_all;below GDP cutoff;;;;Freight Rail;S1S;1;2040;10
-SSP2;NAV_all;below GDP cutoff;;;;HSR;S1S;2.8;2040;10
-SSP2;NAV_all;below GDP cutoff;;;;Passenger Rail;S1S;1.5;2040;10
-SSP2;NAV_all;below GDP cutoff;;;;trn_freight_road;S1S;0.9;2040;10
-SSP2;NAV_all;below GDP cutoff;;;;trn_pass_road;S1S;0.7;2040;10
-SSP2;NAV_all;below GDP cutoff;;;;Walk;S1S;2.5;2040;10
-SSP2;NAV_all;CAZ;;;Bus;trn_pass_road;S2S1;3;2040;10
-SSP2;NAV_all;CAZ;;;trn_pass_road_LDV;trn_pass_road;S2S1;0.7;2040;10
-SSP2;NAV_all;USA;;;Bus;trn_pass_road;S2S1;2;2040;10
-SSP2;NAV_all;USA;;;trn_pass_road_LDV;trn_pass_road;S2S1;0.7;2040;10
-SSP2;NAV_all;above GDP cutoff;;;Bus;trn_pass_road;S2S1;2;2040;10
-SSP2;NAV_all;above GDP cutoff;;;trn_pass_road_LDV;trn_pass_road;S2S1;1;2040;10
-SSP2;NAV_all;below GDP cutoff;;;Bus;trn_pass_road;S2S1;2;2040;10
-SSP2;NAV_all;below GDP cutoff;;;trn_pass_road_LDV;trn_pass_road;S2S1;1;2040;10
-SSP2;NAV_all;above GDP cutoff;BEV;Bus;Bus;trn_pass_road;FV;9;2025;10
-SSP2;NAV_all;above GDP cutoff;FCEV;Bus;Bus;trn_pass_road;FV;6;2025;10
-SSP2;NAV_all;above GDP cutoff;Liquids;Bus;Bus;trn_pass_road;FV;0.01;2025;10
-SSP2;NAV_all;above GDP cutoff;Hydrogen;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;10;2045;10
-SSP2;NAV_all;above GDP cutoff;Liquids;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;0.1;2045;10
-SSP2;NAV_all;above GDP cutoff;Liquids;Ship;Domestic Ship_tmp_subsectorL2;Domestic Ship;FV;0.1;2050;10
-SSP2;NAV_all;above GDP cutoff;Electric;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;2;2040;10
-SSP2;NAV_all;above GDP cutoff;Liquids;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;0.1;2040;10
-SSP2;NAV_all;above GDP cutoff;Electric;Rail;HSR_tmp_subsectorL2;HSR;FV;2;2040;10
-SSP2;NAV_all;above GDP cutoff;Liquids;Aviation;International Aviation_tmp_subsectorL2;International Aviation;FV;0.1;2045;10
-SSP2;NAV_all;above GDP cutoff;Liquids;Ship;International Ship_tmp_subsectorL2;International Ship;FV;0.1;2050;10
-SSP2;NAV_all;above GDP cutoff;BEV;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;4;2030;10
-SSP2;NAV_all;above GDP cutoff;Liquids;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;0.05;2030;10
-SSP2;NAV_all;above GDP cutoff;Electric;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;2;2040;10
-SSP2;NAV_all;above GDP cutoff;Liquids;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;0.1;2040;10
-SSP2;NAV_all;above GDP cutoff;BEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;4;2025;10
-SSP2;NAV_all;above GDP cutoff;FCEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;4;2025;10
-SSP2;NAV_all;above GDP cutoff;Liquids;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;0.01;2025;10
-SSP2;NAV_all;above GDP cutoff;BEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;4;2025;10
-SSP2;NAV_all;above GDP cutoff;FCEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;9;2025;10
-SSP2;NAV_all;above GDP cutoff;Liquids;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;0.01;2025;10
-SSP2;NAV_all;below GDP cutoff;BEV;Bus;Bus;trn_pass_road;FV;7;2025;10
-SSP2;NAV_all;below GDP cutoff;FCEV;Bus;Bus;trn_pass_road;FV;5;2025;10
-SSP2;NAV_all;below GDP cutoff;Liquids;Bus;Bus;trn_pass_road;FV;0.01;2025;10
-SSP2;NAV_all;below GDP cutoff;Hydrogen;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;10;2045;10
-SSP2;NAV_all;below GDP cutoff;Liquids;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;0.1;2045;10
-SSP2;NAV_all;below GDP cutoff;Liquids;Ship;Domestic Ship_tmp_subsectorL2;Domestic Ship;FV;0.1;2050;10
-SSP2;NAV_all;below GDP cutoff;Electric;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;2;2040;10
-SSP2;NAV_all;below GDP cutoff;Liquids;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;0.1;2040;10
-SSP2;NAV_all;below GDP cutoff;Electric;Rail;HSR_tmp_subsectorL2;HSR;FV;2;2040;10
-SSP2;NAV_all;below GDP cutoff;Liquids;Aviation;International Aviation_tmp_subsectorL2;International Aviation;FV;0.1;2045;10
-SSP2;NAV_all;below GDP cutoff;Liquids;Ship;International Ship_tmp_subsectorL2;International Ship;FV;0.1;2050;10
-SSP2;NAV_all;below GDP cutoff;BEV;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;4;2030;10
-SSP2;NAV_all;below GDP cutoff;Liquids;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;0.05;2030;10
-SSP2;NAV_all;below GDP cutoff;Electric;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;2;2040;10
-SSP2;NAV_all;below GDP cutoff;Liquids;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;0.1;2040;10
-SSP2;NAV_all;below GDP cutoff;BEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;4;2025;10
-SSP2;NAV_all;below GDP cutoff;FCEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;4;2025;10
-SSP2;NAV_all;below GDP cutoff;Liquids;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;0.01;2025;10
-SSP2;NAV_all;below GDP cutoff;BEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1.5;2025;10
-SSP2;NAV_all;below GDP cutoff;FCEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;9;2025;10
-SSP2;NAV_all;below GDP cutoff;Liquids;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;0.01;2025;10
-SSP2;NAV_ele;above GDP cutoff;;;;Cycle;S1S;1;2040;10
-SSP2;NAV_ele;above GDP cutoff;;;;Domestic Aviation;S1S;1;2040;10
-SSP2;NAV_ele;above GDP cutoff;;;;Domestic Ship;S1S;1;2040;10
-SSP2;NAV_ele;above GDP cutoff;;;;Freight Rail;S1S;1;2040;10
-SSP2;NAV_ele;above GDP cutoff;;;;HSR;S1S;1;2040;10
-SSP2;NAV_ele;above GDP cutoff;;;;Passenger Rail;S1S;1;2040;10
-SSP2;NAV_ele;above GDP cutoff;;;;trn_freight_road;S1S;1;2040;10
-SSP2;NAV_ele;above GDP cutoff;;;;trn_pass_road;S1S;1;2040;10
-SSP2;NAV_ele;above GDP cutoff;;;;Walk;S1S;1;2040;10
-SSP2;NAV_ele;below GDP cutoff;;;;Cycle;S1S;1;2040;10
-SSP2;NAV_ele;below GDP cutoff;;;;Domestic Aviation;S1S;1;2040;10
-SSP2;NAV_ele;below GDP cutoff;;;;Domestic Ship;S1S;1;2040;10
-SSP2;NAV_ele;below GDP cutoff;;;;Freight Rail;S1S;1;2040;10
-SSP2;NAV_ele;below GDP cutoff;;;;HSR;S1S;1;2040;10
-SSP2;NAV_ele;below GDP cutoff;;;;Passenger Rail;S1S;1;2040;10
-SSP2;NAV_ele;below GDP cutoff;;;;trn_freight_road;S1S;1;2040;10
-SSP2;NAV_ele;below GDP cutoff;;;;trn_pass_road;S1S;1;2040;10
-SSP2;NAV_ele;below GDP cutoff;;;;Walk;S1S;1;2040;10
-SSP2;NAV_ele;above GDP cutoff;;;Bus;trn_pass_road;S2S1;1;2040;10
-SSP2;NAV_ele;above GDP cutoff;;;trn_pass_road_LDV;trn_pass_road;S2S1;1;2040;10
-SSP2;NAV_ele;below GDP cutoff;;;Bus;trn_pass_road;S2S1;1;2040;10
-SSP2;NAV_ele;below GDP cutoff;;;trn_pass_road_LDV;trn_pass_road;S2S1;1;2040;10
-SSP2;NAV_ele;above GDP cutoff;BEV;Bus;Bus;trn_pass_road;FV;9;2025;10
-SSP2;NAV_ele;above GDP cutoff;FCEV;Bus;Bus;trn_pass_road;FV;6;2025;10
-SSP2;NAV_ele;above GDP cutoff;Liquids;Bus;Bus;trn_pass_road;FV;0.01;2025;10
-SSP2;NAV_ele;above GDP cutoff;Hydrogen;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;10;2045;10
-SSP2;NAV_ele;above GDP cutoff;Liquids;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;0.1;2045;10
-SSP2;NAV_ele;above GDP cutoff;Liquids;Ship;Domestic Ship_tmp_subsectorL2;Domestic Ship;FV;0.1;2050;10
-SSP2;NAV_ele;above GDP cutoff;Electric;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;2;2040;10
-SSP2;NAV_ele;above GDP cutoff;Liquids;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;0.1;2040;10
-SSP2;NAV_ele;above GDP cutoff;Electric;Rail;HSR_tmp_subsectorL2;HSR;FV;2;2040;10
-SSP2;NAV_ele;above GDP cutoff;Liquids;Aviation;International Aviation_tmp_subsectorL2;International Aviation;FV;0.1;2045;10
-SSP2;NAV_ele;above GDP cutoff;Liquids;Ship;International Ship_tmp_subsectorL2;International Ship;FV;0.1;2050;10
-SSP2;NAV_ele;above GDP cutoff;BEV;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;4;2030;10
-SSP2;NAV_ele;above GDP cutoff;Liquids;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;0.05;2030;10
-SSP2;NAV_ele;above GDP cutoff;Electric;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;2;2040;10
-SSP2;NAV_ele;above GDP cutoff;Liquids;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;0.1;2040;10
-SSP2;NAV_ele;above GDP cutoff;BEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;4;2025;10
-SSP2;NAV_ele;above GDP cutoff;FCEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;4;2025;10
-SSP2;NAV_ele;above GDP cutoff;Liquids;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;0.01;2025;10
-SSP2;NAV_ele;above GDP cutoff;BEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;4;2025;10
-SSP2;NAV_ele;above GDP cutoff;FCEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;9;2025;10
-SSP2;NAV_ele;above GDP cutoff;Liquids;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;0.01;2025;10
-SSP2;NAV_ele;below GDP cutoff;BEV;Bus;Bus;trn_pass_road;FV;7;2025;10
-SSP2;NAV_ele;below GDP cutoff;FCEV;Bus;Bus;trn_pass_road;FV;5;2025;10
-SSP2;NAV_ele;below GDP cutoff;Liquids;Bus;Bus;trn_pass_road;FV;0.01;2025;10
-SSP2;NAV_ele;below GDP cutoff;Hydrogen;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;10;2045;10
-SSP2;NAV_ele;below GDP cutoff;Liquids;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;0.1;2045;10
-SSP2;NAV_ele;below GDP cutoff;Liquids;Ship;Domestic Ship_tmp_subsectorL2;Domestic Ship;FV;0.1;2050;10
-SSP2;NAV_ele;below GDP cutoff;Electric;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;2;2040;10
-SSP2;NAV_ele;below GDP cutoff;Liquids;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;0.1;2040;10
-SSP2;NAV_ele;below GDP cutoff;Electric;Rail;HSR_tmp_subsectorL2;HSR;FV;2;2040;10
-SSP2;NAV_ele;below GDP cutoff;Liquids;Aviation;International Aviation_tmp_subsectorL2;International Aviation;FV;0.1;2045;10
-SSP2;NAV_ele;below GDP cutoff;Liquids;Ship;International Ship_tmp_subsectorL2;International Ship;FV;0.1;2050;10
-SSP2;NAV_ele;below GDP cutoff;BEV;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;4;2030;10
-SSP2;NAV_ele;below GDP cutoff;Liquids;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;0.05;2030;10
-SSP2;NAV_ele;below GDP cutoff;Electric;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;2;2040;10
-SSP2;NAV_ele;below GDP cutoff;Liquids;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;0.1;2040;10
-SSP2;NAV_ele;below GDP cutoff;BEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;4;2025;10
-SSP2;NAV_ele;below GDP cutoff;FCEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;4;2025;10
-SSP2;NAV_ele;below GDP cutoff;Liquids;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;0.01;2025;10
-SSP2;NAV_ele;below GDP cutoff;BEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1.5;2025;10
-SSP2;NAV_ele;below GDP cutoff;FCEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;9;2025;10
-SSP2;NAV_ele;below GDP cutoff;Liquids;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;0.01;2025;10
-SSP2;NAV_lce;CAZ;;;;Cycle;S1S;2.5;2040;10
-SSP2;NAV_lce;CAZ;;;;Domestic Aviation;S1S;0.3;2040;10
-SSP2;NAV_lce;CAZ;;;;Domestic Ship;S1S;1;2040;10
-SSP2;NAV_lce;CAZ;;;;Freight Rail;S1S;1;2040;10
-SSP2;NAV_lce;CAZ;;;;HSR;S1S;1.7;2040;10
-SSP2;NAV_lce;CAZ;;;;Passenger Rail;S1S;4;2040;10
-SSP2;NAV_lce;CAZ;;;;trn_freight_road;S1S;0.9;2040;10
-SSP2;NAV_lce;CAZ;;;;trn_pass_road;S1S;0.6;2040;10
-SSP2;NAV_lce;CAZ;;;;Walk;S1S;2.5;2040;10
-SSP2;NAV_lce;USA;;;;Cycle;S1S;2.5;2040;10
-SSP2;NAV_lce;USA;;;;Domestic Aviation;S1S;0.3;2040;10
-SSP2;NAV_lce;USA;;;;Domestic Ship;S1S;1;2040;10
-SSP2;NAV_lce;USA;;;;Freight Rail;S1S;1;2040;10
-SSP2;NAV_lce;USA;;;;HSR;S1S;1.7;2040;10
-SSP2;NAV_lce;USA;;;;Passenger Rail;S1S;4;2040;10
-SSP2;NAV_lce;USA;;;;trn_freight_road;S1S;0.9;2040;10
-SSP2;NAV_lce;USA;;;;trn_pass_road;S1S;0.6;2040;10
-SSP2;NAV_lce;USA;;;;Walk;S1S;2.5;2040;10
-SSP2;NAV_lce;above GDP cutoff;;;;Cycle;S1S;1.8;2040;10
-SSP2;NAV_lce;above GDP cutoff;;;;Domestic Aviation;S1S;0.3;2040;10
-SSP2;NAV_lce;above GDP cutoff;;;;Domestic Ship;S1S;1;2040;10
-SSP2;NAV_lce;above GDP cutoff;;;;Freight Rail;S1S;1;2040;10
-SSP2;NAV_lce;above GDP cutoff;;;;HSR;S1S;1.7;2040;10
-SSP2;NAV_lce;above GDP cutoff;;;;Passenger Rail;S1S;1.6;2040;10
-SSP2;NAV_lce;above GDP cutoff;;;;trn_freight_road;S1S;0.9;2040;10
-SSP2;NAV_lce;above GDP cutoff;;;;trn_pass_road;S1S;0.7;2040;10
-SSP2;NAV_lce;above GDP cutoff;;;;Walk;S1S;1.7;2040;10
-SSP2;NAV_lce;below GDP cutoff;;;;Cycle;S1S;2.5;2040;10
-SSP2;NAV_lce;below GDP cutoff;;;;Domestic Aviation;S1S;0.3;2040;10
-SSP2;NAV_lce;below GDP cutoff;;;;Domestic Ship;S1S;1;2040;10
-SSP2;NAV_lce;below GDP cutoff;;;;Freight Rail;S1S;1;2040;10
-SSP2;NAV_lce;below GDP cutoff;;;;HSR;S1S;2.8;2040;10
-SSP2;NAV_lce;below GDP cutoff;;;;Passenger Rail;S1S;1.5;2040;10
-SSP2;NAV_lce;below GDP cutoff;;;;trn_freight_road;S1S;0.9;2040;10
-SSP2;NAV_lce;below GDP cutoff;;;;trn_pass_road;S1S;0.7;2040;10
-SSP2;NAV_lce;below GDP cutoff;;;;Walk;S1S;2.5;2040;10
-SSP2;NAV_lce;CAZ;;;Bus;trn_pass_road;S2S1;3;2040;10
-SSP2;NAV_lce;CAZ;;;trn_pass_road_LDV;trn_pass_road;S2S1;0.7;2040;10
-SSP2;NAV_lce;USA;;;Bus;trn_pass_road;S2S1;2;2040;10
-SSP2;NAV_lce;USA;;;trn_pass_road_LDV;trn_pass_road;S2S1;0.7;2040;10
-SSP2;NAV_lce;above GDP cutoff;;;Bus;trn_pass_road;S2S1;2;2040;10
-SSP2;NAV_lce;above GDP cutoff;;;trn_pass_road_LDV;trn_pass_road;S2S1;1;2040;10
-SSP2;NAV_lce;below GDP cutoff;;;Bus;trn_pass_road;S2S1;2;2040;10
-SSP2;NAV_lce;below GDP cutoff;;;trn_pass_road_LDV;trn_pass_road;S2S1;1;2040;10
-SSP2;NAV_lce;CAZ;BEV;Bus;Bus;trn_pass_road;FV;1;2040;10
-SSP2;NAV_lce;CAZ;FCEV;Bus;Bus;trn_pass_road;FV;1;2040;10
-SSP2;NAV_lce;CAZ;Liquids;Bus;Bus;trn_pass_road;FV;1;2050;10
-SSP2;NAV_lce;CAZ;Hydrogen;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SSP2;NAV_lce;CAZ;Liquids;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SSP2;NAV_lce;CAZ;Liquids;Ship;Domestic Ship_tmp_subsectorL2;Domestic Ship;FV;1;2050;10
-SSP2;NAV_lce;CAZ;Electric;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SSP2;NAV_lce;CAZ;Liquids;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SSP2;NAV_lce;CAZ;Electric;Rail;HSR_tmp_subsectorL2;HSR;FV;1;2050;10
-SSP2;NAV_lce;CAZ;Liquids;Aviation;International Aviation_tmp_subsectorL2;International Aviation;FV;1;2050;10
-SSP2;NAV_lce;CAZ;Liquids;Ship;International Ship_tmp_subsectorL2;International Ship;FV;1;2050;10
-SSP2;NAV_lce;CAZ;BEV;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SSP2;NAV_lce;CAZ;Liquids;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SSP2;NAV_lce;CAZ;Electric;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SSP2;NAV_lce;CAZ;Liquids;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SSP2;NAV_lce;CAZ;BEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2040;10
-SSP2;NAV_lce;CAZ;FCEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2040;10
-SSP2;NAV_lce;CAZ;Liquids;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;10
-SSP2;NAV_lce;CAZ;BEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2040;10
-SSP2;NAV_lce;CAZ;FCEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2040;10
-SSP2;NAV_lce;CAZ;Liquids;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;10
-SSP2;NAV_lce;USA;BEV;Bus;Bus;trn_pass_road;FV;1;2035;10
-SSP2;NAV_lce;USA;FCEV;Bus;Bus;trn_pass_road;FV;1;2035;10
-SSP2;NAV_lce;USA;Liquids;Bus;Bus;trn_pass_road;FV;1;2050;10
-SSP2;NAV_lce;USA;Hydrogen;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SSP2;NAV_lce;USA;Liquids;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SSP2;NAV_lce;USA;Liquids;Ship;Domestic Ship_tmp_subsectorL2;Domestic Ship;FV;1;2050;10
-SSP2;NAV_lce;USA;Electric;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SSP2;NAV_lce;USA;Liquids;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SSP2;NAV_lce;USA;Electric;Rail;HSR_tmp_subsectorL2;HSR;FV;1;2050;10
-SSP2;NAV_lce;USA;Liquids;Aviation;International Aviation_tmp_subsectorL2;International Aviation;FV;1;2050;10
-SSP2;NAV_lce;USA;Liquids;Ship;International Ship_tmp_subsectorL2;International Ship;FV;1;2050;10
-SSP2;NAV_lce;USA;BEV;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SSP2;NAV_lce;USA;Liquids;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SSP2;NAV_lce;USA;Electric;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SSP2;NAV_lce;USA;Liquids;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SSP2;NAV_lce;USA;BEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2035;10
-SSP2;NAV_lce;USA;FCEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2035;10
-SSP2;NAV_lce;USA;Liquids;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;10
-SSP2;NAV_lce;USA;BEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2035;10
-SSP2;NAV_lce;USA;FCEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2035;10
-SSP2;NAV_lce;USA;Liquids;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;10
-SSP2;NAV_lce;above GDP cutoff;BEV;Bus;Bus;trn_pass_road;FV;1;2040;10
-SSP2;NAV_lce;above GDP cutoff;FCEV;Bus;Bus;trn_pass_road;FV;1;2040;10
-SSP2;NAV_lce;above GDP cutoff;Liquids;Bus;Bus;trn_pass_road;FV;1;2050;10
-SSP2;NAV_lce;above GDP cutoff;Hydrogen;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SSP2;NAV_lce;above GDP cutoff;Liquids;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SSP2;NAV_lce;above GDP cutoff;Liquids;Ship;Domestic Ship_tmp_subsectorL2;Domestic Ship;FV;1;2050;10
-SSP2;NAV_lce;above GDP cutoff;Electric;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SSP2;NAV_lce;above GDP cutoff;Liquids;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SSP2;NAV_lce;above GDP cutoff;Electric;Rail;HSR_tmp_subsectorL2;HSR;FV;1;2050;10
-SSP2;NAV_lce;above GDP cutoff;Liquids;Aviation;International Aviation_tmp_subsectorL2;International Aviation;FV;1;2050;10
-SSP2;NAV_lce;above GDP cutoff;Liquids;Ship;International Ship_tmp_subsectorL2;International Ship;FV;1;2050;10
-SSP2;NAV_lce;above GDP cutoff;BEV;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SSP2;NAV_lce;above GDP cutoff;Liquids;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SSP2;NAV_lce;above GDP cutoff;Electric;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SSP2;NAV_lce;above GDP cutoff;Liquids;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SSP2;NAV_lce;above GDP cutoff;BEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2040;10
-SSP2;NAV_lce;above GDP cutoff;FCEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2040;10
-SSP2;NAV_lce;above GDP cutoff;Liquids;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;10
-SSP2;NAV_lce;above GDP cutoff;BEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2040;10
-SSP2;NAV_lce;above GDP cutoff;FCEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2040;10
-SSP2;NAV_lce;above GDP cutoff;Liquids;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;10
-SSP2;NAV_lce;below GDP cutoff;BEV;Bus;Bus;trn_pass_road;FV;1;2040;10
-SSP2;NAV_lce;below GDP cutoff;FCEV;Bus;Bus;trn_pass_road;FV;1;2040;10
-SSP2;NAV_lce;below GDP cutoff;Liquids;Bus;Bus;trn_pass_road;FV;1;2050;10
-SSP2;NAV_lce;below GDP cutoff;Hydrogen;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SSP2;NAV_lce;below GDP cutoff;Liquids;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SSP2;NAV_lce;below GDP cutoff;Liquids;Ship;Domestic Ship_tmp_subsectorL2;Domestic Ship;FV;1;2050;10
-SSP2;NAV_lce;below GDP cutoff;Electric;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SSP2;NAV_lce;below GDP cutoff;Liquids;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SSP2;NAV_lce;below GDP cutoff;Electric;Rail;HSR_tmp_subsectorL2;HSR;FV;1;2050;10
-SSP2;NAV_lce;below GDP cutoff;Liquids;Aviation;International Aviation_tmp_subsectorL2;International Aviation;FV;1;2050;10
-SSP2;NAV_lce;below GDP cutoff;Liquids;Ship;International Ship_tmp_subsectorL2;International Ship;FV;1;2050;10
-SSP2;NAV_lce;below GDP cutoff;BEV;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SSP2;NAV_lce;below GDP cutoff;Liquids;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SSP2;NAV_lce;below GDP cutoff;Electric;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SSP2;NAV_lce;below GDP cutoff;Liquids;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SSP2;NAV_lce;below GDP cutoff;BEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2040;10
-SSP2;NAV_lce;below GDP cutoff;FCEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2040;10
-SSP2;NAV_lce;below GDP cutoff;Liquids;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;10
-SSP2;NAV_lce;below GDP cutoff;BEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2040;10
-SSP2;NAV_lce;below GDP cutoff;FCEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2040;10
-SSP2;NAV_lce;below GDP cutoff;Liquids;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;10
-SSP5;Mix2;above GDP cutoff;;;;Cycle;S1S;1;2050;10
-SSP5;Mix2;above GDP cutoff;;;;Domestic Aviation;S1S;0.75;2035;10
-SSP5;Mix2;above GDP cutoff;;;;Domestic Ship;S1S;1;2050;10
-SSP5;Mix2;above GDP cutoff;;;;Freight Rail;S1S;1;2050;10
-SSP5;Mix2;above GDP cutoff;;;;HSR;S1S;1;2050;10
-SSP5;Mix2;above GDP cutoff;;;;Passenger Rail;S1S;1;2050;10
-SSP5;Mix2;above GDP cutoff;;;;trn_freight_road;S1S;0.9;2035;10
-SSP5;Mix2;above GDP cutoff;;;;trn_pass_road;S1S;0.9;2035;10
-SSP5;Mix2;above GDP cutoff;;;;Walk;S1S;1;2050;10
-SSP5;Mix2;below GDP cutoff;;;;Cycle;S1S;1;2050;10
-SSP5;Mix2;below GDP cutoff;;;;Domestic Aviation;S1S;0.75;2035;10
-SSP5;Mix2;below GDP cutoff;;;;Domestic Ship;S1S;1;2050;10
-SSP5;Mix2;below GDP cutoff;;;;Freight Rail;S1S;1;2050;10
-SSP5;Mix2;below GDP cutoff;;;;HSR;S1S;1;2050;10
-SSP5;Mix2;below GDP cutoff;;;;Passenger Rail;S1S;1;2050;10
-SSP5;Mix2;below GDP cutoff;;;;trn_freight_road;S1S;0.9;2035;10
-SSP5;Mix2;below GDP cutoff;;;;trn_pass_road;S1S;0.9;2035;10
-SSP5;Mix2;below GDP cutoff;;;;Walk;S1S;1;2050;10
-SSP5;Mix2;above GDP cutoff;;;Bus;trn_pass_road;S2S1;1;2050;10
-SSP5;Mix2;above GDP cutoff;;;trn_pass_road_LDV;trn_pass_road;S2S1;0.9;2035;10
-SSP5;Mix2;below GDP cutoff;;;Bus;trn_pass_road;S2S1;1;2050;10
-SSP5;Mix2;below GDP cutoff;;;trn_pass_road_LDV;trn_pass_road;S2S1;0.9;2035;10
-SSP5;Mix2;above GDP cutoff;BEV;Bus;Bus;trn_pass_road;FV;2;2035;10
-SSP5;Mix2;above GDP cutoff;FCEV;Bus;Bus;trn_pass_road;FV;2;2035;10
-SSP5;Mix2;above GDP cutoff;Liquids;Bus;Bus;trn_pass_road;FV;1;2050;10
-SSP5;Mix2;above GDP cutoff;Hydrogen;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SSP5;Mix2;above GDP cutoff;Liquids;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SSP5;Mix2;above GDP cutoff;Liquids;Ship;Domestic Ship_tmp_subsectorL2;Domestic Ship;FV;1;2050;10
-SSP5;Mix2;above GDP cutoff;Electric;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SSP5;Mix2;above GDP cutoff;Liquids;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SSP5;Mix2;above GDP cutoff;Electric;Rail;HSR_tmp_subsectorL2;HSR;FV;1;2050;10
-SSP5;Mix2;above GDP cutoff;Liquids;Aviation;International Aviation_tmp_subsectorL2;International Aviation;FV;1;2050;10
-SSP5;Mix2;above GDP cutoff;Liquids;Ship;International Ship_tmp_subsectorL2;International Ship;FV;1;2050;10
-SSP5;Mix2;above GDP cutoff;BEV;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SSP5;Mix2;above GDP cutoff;Liquids;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SSP5;Mix2;above GDP cutoff;Electric;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SSP5;Mix2;above GDP cutoff;Liquids;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SSP5;Mix2;above GDP cutoff;BEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;2;2035;10
-SSP5;Mix2;above GDP cutoff;FCEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;2;2035;10
-SSP5;Mix2;above GDP cutoff;Liquids;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;10
-SSP5;Mix2;above GDP cutoff;BEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;2;2035;10
-SSP5;Mix2;above GDP cutoff;FCEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;2;2035;10
-SSP5;Mix2;above GDP cutoff;Liquids;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;10
-SSP5;Mix2;below GDP cutoff;BEV;Bus;Bus;trn_pass_road;FV;1.5;2035;10
-SSP5;Mix2;below GDP cutoff;FCEV;Bus;Bus;trn_pass_road;FV;1.5;2035;10
-SSP5;Mix2;below GDP cutoff;Liquids;Bus;Bus;trn_pass_road;FV;1;2050;10
-SSP5;Mix2;below GDP cutoff;Hydrogen;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SSP5;Mix2;below GDP cutoff;Liquids;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SSP5;Mix2;below GDP cutoff;Liquids;Ship;Domestic Ship_tmp_subsectorL2;Domestic Ship;FV;1;2050;10
-SSP5;Mix2;below GDP cutoff;Electric;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SSP5;Mix2;below GDP cutoff;Liquids;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SSP5;Mix2;below GDP cutoff;Electric;Rail;HSR_tmp_subsectorL2;HSR;FV;1;2050;10
-SSP5;Mix2;below GDP cutoff;Liquids;Aviation;International Aviation_tmp_subsectorL2;International Aviation;FV;1;2050;10
-SSP5;Mix2;below GDP cutoff;Liquids;Ship;International Ship_tmp_subsectorL2;International Ship;FV;1;2050;10
-SSP5;Mix2;below GDP cutoff;BEV;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SSP5;Mix2;below GDP cutoff;Liquids;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SSP5;Mix2;below GDP cutoff;Electric;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SSP5;Mix2;below GDP cutoff;Liquids;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SSP5;Mix2;below GDP cutoff;BEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1.5;2035;10
-SSP5;Mix2;below GDP cutoff;FCEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1.5;2035;10
-SSP5;Mix2;below GDP cutoff;Liquids;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;10
-SSP5;Mix2;below GDP cutoff;BEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1.5;2035;10
-SSP5;Mix2;below GDP cutoff;FCEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1.5;2035;10
-SSP5;Mix2;below GDP cutoff;Liquids;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;10
-SSP5;Mix3;above GDP cutoff;;;;Cycle;S1S;1;2050;10
-SSP5;Mix3;above GDP cutoff;;;;Domestic Aviation;S1S;0.5;2035;10
-SSP5;Mix3;above GDP cutoff;;;;Domestic Ship;S1S;1;2050;10
-SSP5;Mix3;above GDP cutoff;;;;Freight Rail;S1S;1;2050;10
-SSP5;Mix3;above GDP cutoff;;;;HSR;S1S;1;2050;10
-SSP5;Mix3;above GDP cutoff;;;;Passenger Rail;S1S;1;2050;10
-SSP5;Mix3;above GDP cutoff;;;;trn_freight_road;S1S;0.7;2035;10
-SSP5;Mix3;above GDP cutoff;;;;trn_pass_road;S1S;0.7;2035;10
-SSP5;Mix3;above GDP cutoff;;;;Walk;S1S;1;2050;10
-SSP5;Mix3;below GDP cutoff;;;;Cycle;S1S;1;2050;10
-SSP5;Mix3;below GDP cutoff;;;;Domestic Aviation;S1S;0.5;2035;10
-SSP5;Mix3;below GDP cutoff;;;;Domestic Ship;S1S;1;2050;10
-SSP5;Mix3;below GDP cutoff;;;;Freight Rail;S1S;1;2050;10
-SSP5;Mix3;below GDP cutoff;;;;HSR;S1S;1;2050;10
-SSP5;Mix3;below GDP cutoff;;;;Passenger Rail;S1S;1;2050;10
-SSP5;Mix3;below GDP cutoff;;;;trn_freight_road;S1S;0.7;2035;10
-SSP5;Mix3;below GDP cutoff;;;;trn_pass_road;S1S;0.7;2035;10
-SSP5;Mix3;below GDP cutoff;;;;Walk;S1S;1;2050;10
-SSP5;Mix3;above GDP cutoff;;;Bus;trn_pass_road;S2S1;1;2050;10
-SSP5;Mix3;above GDP cutoff;;;trn_pass_road_LDV;trn_pass_road;S2S1;0.7;2035;10
-SSP5;Mix3;below GDP cutoff;;;Bus;trn_pass_road;S2S1;1;2050;10
-SSP5;Mix3;below GDP cutoff;;;trn_pass_road_LDV;trn_pass_road;S2S1;0.7;2035;10
-SSP5;Mix3;above GDP cutoff;BEV;Bus;Bus;trn_pass_road;FV;4;2035;10
-SSP5;Mix3;above GDP cutoff;FCEV;Bus;Bus;trn_pass_road;FV;4;2035;10
-SSP5;Mix3;above GDP cutoff;Liquids;Bus;Bus;trn_pass_road;FV;1;2050;10
-SSP5;Mix3;above GDP cutoff;Hydrogen;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SSP5;Mix3;above GDP cutoff;Liquids;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SSP5;Mix3;above GDP cutoff;Liquids;Ship;Domestic Ship_tmp_subsectorL2;Domestic Ship;FV;1;2050;10
-SSP5;Mix3;above GDP cutoff;Electric;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SSP5;Mix3;above GDP cutoff;Liquids;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SSP5;Mix3;above GDP cutoff;Electric;Rail;HSR_tmp_subsectorL2;HSR;FV;1;2050;10
-SSP5;Mix3;above GDP cutoff;Liquids;Aviation;International Aviation_tmp_subsectorL2;International Aviation;FV;1;2050;10
-SSP5;Mix3;above GDP cutoff;Liquids;Ship;International Ship_tmp_subsectorL2;International Ship;FV;1;2050;10
-SSP5;Mix3;above GDP cutoff;BEV;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SSP5;Mix3;above GDP cutoff;Liquids;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SSP5;Mix3;above GDP cutoff;Electric;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SSP5;Mix3;above GDP cutoff;Liquids;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SSP5;Mix3;above GDP cutoff;BEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;4;2035;10
-SSP5;Mix3;above GDP cutoff;FCEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;4;2035;10
-SSP5;Mix3;above GDP cutoff;Liquids;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;10
-SSP5;Mix3;above GDP cutoff;BEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;7;2035;10
-SSP5;Mix3;above GDP cutoff;FCEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;20;2035;10
-SSP5;Mix3;above GDP cutoff;Liquids;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;10
-SSP5;Mix3;below GDP cutoff;BEV;Bus;Bus;trn_pass_road;FV;3.5;2035;10
-SSP5;Mix3;below GDP cutoff;FCEV;Bus;Bus;trn_pass_road;FV;3.5;2035;10
-SSP5;Mix3;below GDP cutoff;Liquids;Bus;Bus;trn_pass_road;FV;1;2050;10
-SSP5;Mix3;below GDP cutoff;Hydrogen;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SSP5;Mix3;below GDP cutoff;Liquids;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SSP5;Mix3;below GDP cutoff;Liquids;Ship;Domestic Ship_tmp_subsectorL2;Domestic Ship;FV;1;2050;10
-SSP5;Mix3;below GDP cutoff;Electric;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SSP5;Mix3;below GDP cutoff;Liquids;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SSP5;Mix3;below GDP cutoff;Electric;Rail;HSR_tmp_subsectorL2;HSR;FV;1;2050;10
-SSP5;Mix3;below GDP cutoff;Liquids;Aviation;International Aviation_tmp_subsectorL2;International Aviation;FV;1;2050;10
-SSP5;Mix3;below GDP cutoff;Liquids;Ship;International Ship_tmp_subsectorL2;International Ship;FV;1;2050;10
-SSP5;Mix3;below GDP cutoff;BEV;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SSP5;Mix3;below GDP cutoff;Liquids;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SSP5;Mix3;below GDP cutoff;Electric;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SSP5;Mix3;below GDP cutoff;Liquids;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SSP5;Mix3;below GDP cutoff;BEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;3.5;2035;10
-SSP5;Mix3;below GDP cutoff;FCEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;3.5;2035;10
-SSP5;Mix3;below GDP cutoff;Liquids;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;10
-SSP5;Mix3;below GDP cutoff;BEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;5;2035;10
-SSP5;Mix3;below GDP cutoff;FCEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;17;2035;10
-SSP5;Mix3;below GDP cutoff;Liquids;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;10
-SSP5;Mix4;above GDP cutoff;;;;Cycle;S1S;1;2050;10
-SSP5;Mix4;above GDP cutoff;;;;Domestic Aviation;S1S;0.25;2035;10
-SSP5;Mix4;above GDP cutoff;;;;Domestic Ship;S1S;1;2050;10
-SSP5;Mix4;above GDP cutoff;;;;Freight Rail;S1S;1;2050;10
-SSP5;Mix4;above GDP cutoff;;;;HSR;S1S;1;2050;10
-SSP5;Mix4;above GDP cutoff;;;;Passenger Rail;S1S;1;2050;10
-SSP5;Mix4;above GDP cutoff;;;;trn_freight_road;S1S;0.5;2035;10
-SSP5;Mix4;above GDP cutoff;;;;trn_pass_road;S1S;0.5;2035;10
-SSP5;Mix4;above GDP cutoff;;;;Walk;S1S;1;2050;10
-SSP5;Mix4;below GDP cutoff;;;;Cycle;S1S;1;2050;10
-SSP5;Mix4;below GDP cutoff;;;;Domestic Aviation;S1S;0.25;2035;10
-SSP5;Mix4;below GDP cutoff;;;;Domestic Ship;S1S;1;2050;10
-SSP5;Mix4;below GDP cutoff;;;;Freight Rail;S1S;1;2050;10
-SSP5;Mix4;below GDP cutoff;;;;HSR;S1S;1;2050;10
-SSP5;Mix4;below GDP cutoff;;;;Passenger Rail;S1S;1;2050;10
-SSP5;Mix4;below GDP cutoff;;;;trn_freight_road;S1S;0.5;2035;10
-SSP5;Mix4;below GDP cutoff;;;;trn_pass_road;S1S;0.5;2035;10
-SSP5;Mix4;below GDP cutoff;;;;Walk;S1S;1;2050;10
-SSP5;Mix4;above GDP cutoff;;;Bus;trn_pass_road;S2S1;1;2050;10
-SSP5;Mix4;above GDP cutoff;;;trn_pass_road_LDV;trn_pass_road;S2S1;0.5;2035;10
-SSP5;Mix4;below GDP cutoff;;;Bus;trn_pass_road;S2S1;1;2050;10
-SSP5;Mix4;below GDP cutoff;;;trn_pass_road_LDV;trn_pass_road;S2S1;0.5;2035;10
-SSP5;Mix4;above GDP cutoff;BEV;Bus;Bus;trn_pass_road;FV;6;2035;10
-SSP5;Mix4;above GDP cutoff;FCEV;Bus;Bus;trn_pass_road;FV;6;2035;10
-SSP5;Mix4;above GDP cutoff;Liquids;Bus;Bus;trn_pass_road;FV;1;2050;10
-SSP5;Mix4;above GDP cutoff;Hydrogen;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SSP5;Mix4;above GDP cutoff;Liquids;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SSP5;Mix4;above GDP cutoff;Liquids;Ship;Domestic Ship_tmp_subsectorL2;Domestic Ship;FV;1;2050;10
-SSP5;Mix4;above GDP cutoff;Electric;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SSP5;Mix4;above GDP cutoff;Liquids;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SSP5;Mix4;above GDP cutoff;Electric;Rail;HSR_tmp_subsectorL2;HSR;FV;1;2050;10
-SSP5;Mix4;above GDP cutoff;Liquids;Aviation;International Aviation_tmp_subsectorL2;International Aviation;FV;1;2050;10
-SSP5;Mix4;above GDP cutoff;Liquids;Ship;International Ship_tmp_subsectorL2;International Ship;FV;1;2050;10
-SSP5;Mix4;above GDP cutoff;BEV;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SSP5;Mix4;above GDP cutoff;Liquids;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SSP5;Mix4;above GDP cutoff;Electric;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SSP5;Mix4;above GDP cutoff;Liquids;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SSP5;Mix4;above GDP cutoff;BEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;6;2035;10
-SSP5;Mix4;above GDP cutoff;FCEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;6;2035;10
-SSP5;Mix4;above GDP cutoff;Liquids;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;10
-SSP5;Mix4;above GDP cutoff;BEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;20;2035;10
-SSP5;Mix4;above GDP cutoff;FCEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;100;2035;10
-SSP5;Mix4;above GDP cutoff;Liquids;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;10
-SSP5;Mix4;below GDP cutoff;BEV;Bus;Bus;trn_pass_road;FV;5;2035;10
-SSP5;Mix4;below GDP cutoff;FCEV;Bus;Bus;trn_pass_road;FV;5;2035;10
-SSP5;Mix4;below GDP cutoff;Liquids;Bus;Bus;trn_pass_road;FV;1;2050;10
-SSP5;Mix4;below GDP cutoff;Hydrogen;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SSP5;Mix4;below GDP cutoff;Liquids;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SSP5;Mix4;below GDP cutoff;Liquids;Ship;Domestic Ship_tmp_subsectorL2;Domestic Ship;FV;1;2050;10
-SSP5;Mix4;below GDP cutoff;Electric;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SSP5;Mix4;below GDP cutoff;Liquids;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SSP5;Mix4;below GDP cutoff;Electric;Rail;HSR_tmp_subsectorL2;HSR;FV;1;2050;10
-SSP5;Mix4;below GDP cutoff;Liquids;Aviation;International Aviation_tmp_subsectorL2;International Aviation;FV;1;2050;10
-SSP5;Mix4;below GDP cutoff;Liquids;Ship;International Ship_tmp_subsectorL2;International Ship;FV;1;2050;10
-SSP5;Mix4;below GDP cutoff;BEV;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SSP5;Mix4;below GDP cutoff;Liquids;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SSP5;Mix4;below GDP cutoff;Electric;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SSP5;Mix4;below GDP cutoff;Liquids;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SSP5;Mix4;below GDP cutoff;BEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;5;2035;10
-SSP5;Mix4;below GDP cutoff;FCEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;5;2035;10
-SSP5;Mix4;below GDP cutoff;Liquids;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;10
-SSP5;Mix4;below GDP cutoff;BEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;17;2035;10
-SSP5;Mix4;below GDP cutoff;FCEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;85;2035;10
-SSP5;Mix4;below GDP cutoff;Liquids;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;10
-SSP3;CAMP_lscStrong;CAZ;;;;Cycle;S1S;2.5;2040;10
-SSP3;CAMP_lscStrong;CAZ;;;;Domestic Aviation;S1S;0.3;2040;10
-SSP3;CAMP_lscStrong;CAZ;;;;Domestic Ship;S1S;1;2040;10
-SSP3;CAMP_lscStrong;CAZ;;;;Freight Rail;S1S;1;2040;10
-SSP3;CAMP_lscStrong;CAZ;;;;HSR;S1S;1.7;2040;10
-SSP3;CAMP_lscStrong;CAZ;;;;Passenger Rail;S1S;4;2040;10
-SSP3;CAMP_lscStrong;CAZ;;;;trn_freight_road;S1S;0.9;2040;10
-SSP3;CAMP_lscStrong;CAZ;;;;trn_pass_road;S1S;0.6;2040;10
-SSP3;CAMP_lscStrong;CAZ;;;;Walk;S1S;2.5;2040;10
-SSP3;CAMP_lscStrong;USA;;;;Cycle;S1S;2.5;2040;10
-SSP3;CAMP_lscStrong;USA;;;;Domestic Aviation;S1S;0.3;2040;10
-SSP3;CAMP_lscStrong;USA;;;;Domestic Ship;S1S;1;2040;10
-SSP3;CAMP_lscStrong;USA;;;;Freight Rail;S1S;1;2040;10
-SSP3;CAMP_lscStrong;USA;;;;HSR;S1S;1.7;2040;10
-SSP3;CAMP_lscStrong;USA;;;;Passenger Rail;S1S;4;2040;10
-SSP3;CAMP_lscStrong;USA;;;;trn_freight_road;S1S;0.9;2040;10
-SSP3;CAMP_lscStrong;USA;;;;trn_pass_road;S1S;0.6;2040;10
-SSP3;CAMP_lscStrong;USA;;;;Walk;S1S;2.5;2040;10
-SSP3;CAMP_lscStrong;above GDP cutoff;;;;Cycle;S1S;3;2040;10
-SSP3;CAMP_lscStrong;above GDP cutoff;;;;Domestic Aviation;S1S;0.3;2040;10
-SSP3;CAMP_lscStrong;above GDP cutoff;;;;Domestic Ship;S1S;1;2040;10
-SSP3;CAMP_lscStrong;above GDP cutoff;;;;Freight Rail;S1S;1;2040;10
-SSP3;CAMP_lscStrong;above GDP cutoff;;;;HSR;S1S;2;2040;10
-SSP3;CAMP_lscStrong;above GDP cutoff;;;;Passenger Rail;S1S;2;2040;10
-SSP3;CAMP_lscStrong;above GDP cutoff;;;;trn_freight_road;S1S;0.7;2040;10
-SSP3;CAMP_lscStrong;above GDP cutoff;;;;trn_pass_road;S1S;0.75;2040;10
-SSP3;CAMP_lscStrong;above GDP cutoff;;;;Walk;S1S;3;2040;10
-SSP3;CAMP_lscStrong;below GDP cutoff;;;;Cycle;S1S;2.5;2040;10
-SSP3;CAMP_lscStrong;below GDP cutoff;;;;Domestic Aviation;S1S;0.3;2040;10
-SSP3;CAMP_lscStrong;below GDP cutoff;;;;Domestic Ship;S1S;1;2040;10
-SSP3;CAMP_lscStrong;below GDP cutoff;;;;Freight Rail;S1S;1;2040;10
-SSP3;CAMP_lscStrong;below GDP cutoff;;;;HSR;S1S;2.8;2040;10
-SSP3;CAMP_lscStrong;below GDP cutoff;;;;Passenger Rail;S1S;1.5;2040;10
-SSP3;CAMP_lscStrong;below GDP cutoff;;;;trn_freight_road;S1S;0.9;2040;10
-SSP3;CAMP_lscStrong;below GDP cutoff;;;;trn_pass_road;S1S;0.7;2040;10
-SSP3;CAMP_lscStrong;below GDP cutoff;;;;Walk;S1S;2.5;2040;10
-SSP3;CAMP_lscStrong;CAZ;;;Bus;trn_pass_road;S2S1;3;2040;10
-SSP3;CAMP_lscStrong;CAZ;;;trn_pass_road_LDV;trn_pass_road;S2S1;0.7;2040;10
-SSP3;CAMP_lscStrong;USA;;;Bus;trn_pass_road;S2S1;2;2040;10
-SSP3;CAMP_lscStrong;USA;;;trn_pass_road_LDV;trn_pass_road;S2S1;0.7;2040;10
-SSP3;CAMP_lscStrong;above GDP cutoff;;;Bus;trn_pass_road;S2S1;2.5;2040;10
-SSP3;CAMP_lscStrong;above GDP cutoff;;;trn_pass_road_LDV;trn_pass_road;S2S1;0.75;2035;10
-SSP3;CAMP_lscStrong;below GDP cutoff;;;Bus;trn_pass_road;S2S1;2;2040;10
-SSP3;CAMP_lscStrong;below GDP cutoff;;;trn_pass_road_LDV;trn_pass_road;S2S1;1;2040;10
-SSP3;CAMP_lscStrong;CAZ;BEV;Bus;Bus;trn_pass_road;FV;2;2040;10
-SSP3;CAMP_lscStrong;CAZ;FCEV;Bus;Bus;trn_pass_road;FV;1.5;2040;10
-SSP3;CAMP_lscStrong;CAZ;Liquids;Bus;Bus;trn_pass_road;FV;1;2050;10
-SSP3;CAMP_lscStrong;CAZ;Hydrogen;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SSP3;CAMP_lscStrong;CAZ;Liquids;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SSP3;CAMP_lscStrong;CAZ;Liquids;Ship;Domestic Ship_tmp_subsectorL2;Domestic Ship;FV;1;2050;10
-SSP3;CAMP_lscStrong;CAZ;Electric;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SSP3;CAMP_lscStrong;CAZ;Liquids;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SSP3;CAMP_lscStrong;CAZ;Electric;Rail;HSR_tmp_subsectorL2;HSR;FV;1;2050;10
-SSP3;CAMP_lscStrong;CAZ;Liquids;Aviation;International Aviation_tmp_subsectorL2;International Aviation;FV;1;2050;10
-SSP3;CAMP_lscStrong;CAZ;Liquids;Ship;International Ship_tmp_subsectorL2;International Ship;FV;1;2050;10
-SSP3;CAMP_lscStrong;CAZ;BEV;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SSP3;CAMP_lscStrong;CAZ;Liquids;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SSP3;CAMP_lscStrong;CAZ;Electric;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SSP3;CAMP_lscStrong;CAZ;Liquids;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SSP3;CAMP_lscStrong;CAZ;BEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;3;2040;10
-SSP3;CAMP_lscStrong;CAZ;FCEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;2;2040;10
-SSP3;CAMP_lscStrong;CAZ;Liquids;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;10
-SSP3;CAMP_lscStrong;CAZ;BEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;3;2040;10
-SSP3;CAMP_lscStrong;CAZ;FCEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;2;2040;10
-SSP3;CAMP_lscStrong;CAZ;Liquids;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;10
-SSP3;CAMP_lscStrong;USA;BEV;Bus;Bus;trn_pass_road;FV;4;2035;10
-SSP3;CAMP_lscStrong;USA;FCEV;Bus;Bus;trn_pass_road;FV;2;2035;10
-SSP3;CAMP_lscStrong;USA;Liquids;Bus;Bus;trn_pass_road;FV;1;2050;10
-SSP3;CAMP_lscStrong;USA;Hydrogen;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SSP3;CAMP_lscStrong;USA;Liquids;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SSP3;CAMP_lscStrong;USA;Liquids;Ship;Domestic Ship_tmp_subsectorL2;Domestic Ship;FV;1;2050;10
-SSP3;CAMP_lscStrong;USA;Electric;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SSP3;CAMP_lscStrong;USA;Liquids;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SSP3;CAMP_lscStrong;USA;Electric;Rail;HSR_tmp_subsectorL2;HSR;FV;1;2050;10
-SSP3;CAMP_lscStrong;USA;Liquids;Aviation;International Aviation_tmp_subsectorL2;International Aviation;FV;1;2050;10
-SSP3;CAMP_lscStrong;USA;Liquids;Ship;International Ship_tmp_subsectorL2;International Ship;FV;1;2050;10
-SSP3;CAMP_lscStrong;USA;BEV;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SSP3;CAMP_lscStrong;USA;Liquids;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SSP3;CAMP_lscStrong;USA;Electric;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SSP3;CAMP_lscStrong;USA;Liquids;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SSP3;CAMP_lscStrong;USA;BEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;3;2035;10
-SSP3;CAMP_lscStrong;USA;FCEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;2;2035;10
-SSP3;CAMP_lscStrong;USA;Liquids;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;10
-SSP3;CAMP_lscStrong;USA;BEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;3;2035;10
-SSP3;CAMP_lscStrong;USA;FCEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;2;2035;10
-SSP3;CAMP_lscStrong;USA;Liquids;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;10
-SSP3;CAMP_lscStrong;above GDP cutoff;BEV;Bus;Bus;trn_pass_road;FV;2;2040;10
-SSP3;CAMP_lscStrong;above GDP cutoff;FCEV;Bus;Bus;trn_pass_road;FV;2;2040;10
-SSP3;CAMP_lscStrong;above GDP cutoff;Liquids;Bus;Bus;trn_pass_road;FV;1;2050;10
-SSP3;CAMP_lscStrong;above GDP cutoff;Hydrogen;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SSP3;CAMP_lscStrong;above GDP cutoff;Liquids;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SSP3;CAMP_lscStrong;above GDP cutoff;Liquids;Ship;Domestic Ship_tmp_subsectorL2;Domestic Ship;FV;1;2050;10
-SSP3;CAMP_lscStrong;above GDP cutoff;Electric;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;2;2050;10
-SSP3;CAMP_lscStrong;above GDP cutoff;Liquids;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;2;2050;10
-SSP3;CAMP_lscStrong;above GDP cutoff;Electric;Rail;HSR_tmp_subsectorL2;HSR;FV;2;2050;10
-SSP3;CAMP_lscStrong;above GDP cutoff;Liquids;Aviation;International Aviation_tmp_subsectorL2;International Aviation;FV;1;2050;10
-SSP3;CAMP_lscStrong;above GDP cutoff;Liquids;Ship;International Ship_tmp_subsectorL2;International Ship;FV;1;2050;10
-SSP3;CAMP_lscStrong;above GDP cutoff;BEV;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SSP3;CAMP_lscStrong;above GDP cutoff;Liquids;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SSP3;CAMP_lscStrong;above GDP cutoff;Electric;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;2;2050;10
-SSP3;CAMP_lscStrong;above GDP cutoff;Liquids;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;2;2050;10
-SSP3;CAMP_lscStrong;above GDP cutoff;BEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2040;10
-SSP3;CAMP_lscStrong;above GDP cutoff;FCEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2040;10
-SSP3;CAMP_lscStrong;above GDP cutoff;Liquids;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;10
-SSP3;CAMP_lscStrong;above GDP cutoff;BEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2040;10
-SSP3;CAMP_lscStrong;above GDP cutoff;FCEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2040;10
-SSP3;CAMP_lscStrong;above GDP cutoff;Liquids;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;10
-SSP3;CAMP_lscStrong;below GDP cutoff;BEV;Bus;Bus;trn_pass_road;FV;3;2040;10
-SSP3;CAMP_lscStrong;below GDP cutoff;FCEV;Bus;Bus;trn_pass_road;FV;1.5;2040;10
-SSP3;CAMP_lscStrong;below GDP cutoff;Liquids;Bus;Bus;trn_pass_road;FV;1;2050;10
-SSP3;CAMP_lscStrong;below GDP cutoff;Hydrogen;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SSP3;CAMP_lscStrong;below GDP cutoff;Liquids;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SSP3;CAMP_lscStrong;below GDP cutoff;Liquids;Ship;Domestic Ship_tmp_subsectorL2;Domestic Ship;FV;1;2050;10
-SSP3;CAMP_lscStrong;below GDP cutoff;Electric;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SSP3;CAMP_lscStrong;below GDP cutoff;Liquids;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SSP3;CAMP_lscStrong;below GDP cutoff;Electric;Rail;HSR_tmp_subsectorL2;HSR;FV;1;2050;10
-SSP3;CAMP_lscStrong;below GDP cutoff;Liquids;Aviation;International Aviation_tmp_subsectorL2;International Aviation;FV;1;2050;10
-SSP3;CAMP_lscStrong;below GDP cutoff;Liquids;Ship;International Ship_tmp_subsectorL2;International Ship;FV;1;2050;10
-SSP3;CAMP_lscStrong;below GDP cutoff;BEV;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SSP3;CAMP_lscStrong;below GDP cutoff;Liquids;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SSP3;CAMP_lscStrong;below GDP cutoff;Electric;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SSP3;CAMP_lscStrong;below GDP cutoff;Liquids;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SSP3;CAMP_lscStrong;below GDP cutoff;BEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;2;2040;10
-SSP3;CAMP_lscStrong;below GDP cutoff;FCEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1.5;2040;10
-SSP3;CAMP_lscStrong;below GDP cutoff;Liquids;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;10
-SSP3;CAMP_lscStrong;below GDP cutoff;BEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;2;2040;10
-SSP3;CAMP_lscStrong;below GDP cutoff;FCEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1.5;2040;10
-SSP3;CAMP_lscStrong;below GDP cutoff;Liquids;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;10
-SSP3;CAMP_lscWeak;CAZ;;;;Cycle;S1S;1.75;2040;10
-SSP3;CAMP_lscWeak;CAZ;;;;Domestic Aviation;S1S;0.53;2040;10
-SSP3;CAMP_lscWeak;CAZ;;;;Domestic Ship;S1S;1;2040;10
-SSP3;CAMP_lscWeak;CAZ;;;;Freight Rail;S1S;1;2040;10
-SSP3;CAMP_lscWeak;CAZ;;;;HSR;S1S;1.35;2040;10
-SSP3;CAMP_lscWeak;CAZ;;;;Passenger Rail;S1S;2;2040;10
-SSP3;CAMP_lscWeak;CAZ;;;;trn_freight_road;S1S;0.9;2040;10
-SSP3;CAMP_lscWeak;CAZ;;;;trn_pass_road;S1S;0.65;2040;10
-SSP3;CAMP_lscWeak;CAZ;;;;Walk;S1S;1.75;2040;10
-SSP3;CAMP_lscWeak;USA;;;;Cycle;S1S;1.75;2040;10
-SSP3;CAMP_lscWeak;USA;;;;Domestic Aviation;S1S;0.53;2040;10
-SSP3;CAMP_lscWeak;USA;;;;Domestic Ship;S1S;1;2040;10
-SSP3;CAMP_lscWeak;USA;;;;Freight Rail;S1S;1;2040;10
-SSP3;CAMP_lscWeak;USA;;;;HSR;S1S;1.35;2040;10
-SSP3;CAMP_lscWeak;USA;;;;Passenger Rail;S1S;2;2040;10
-SSP3;CAMP_lscWeak;USA;;;;trn_freight_road;S1S;0.9;2040;10
-SSP3;CAMP_lscWeak;USA;;;;trn_pass_road;S1S;0.65;2040;10
-SSP3;CAMP_lscWeak;USA;;;;Walk;S1S;1.75;2040;10
-SSP3;CAMP_lscWeak;above GDP cutoff;;;;Cycle;S1S;2.25;2040;10
-SSP3;CAMP_lscWeak;above GDP cutoff;;;;Domestic Aviation;S1S;0.4;2040;10
-SSP3;CAMP_lscWeak;above GDP cutoff;;;;Domestic Ship;S1S;1;2040;10
-SSP3;CAMP_lscWeak;above GDP cutoff;;;;Freight Rail;S1S;1;2040;10
-SSP3;CAMP_lscWeak;above GDP cutoff;;;;HSR;S1S;1.6;2040;10
-SSP3;CAMP_lscWeak;above GDP cutoff;;;;Passenger Rail;S1S;1.6;2040;10
-SSP3;CAMP_lscWeak;above GDP cutoff;;;;trn_freight_road;S1S;0.75;2040;10
-SSP3;CAMP_lscWeak;above GDP cutoff;;;;trn_pass_road;S1S;0.8;2040;10
-SSP3;CAMP_lscWeak;above GDP cutoff;;;;Walk;S1S;2.25;2040;10
-SSP3;CAMP_lscWeak;below GDP cutoff;;;;Cycle;S1S;1.75;2040;10
-SSP3;CAMP_lscWeak;below GDP cutoff;;;;Domestic Aviation;S1S;0.53;2040;10
-SSP3;CAMP_lscWeak;below GDP cutoff;;;;Domestic Ship;S1S;1;2040;10
-SSP3;CAMP_lscWeak;below GDP cutoff;;;;Freight Rail;S1S;1;2040;10
-SSP3;CAMP_lscWeak;below GDP cutoff;;;;HSR;S1S;1.9;2040;10
-SSP3;CAMP_lscWeak;below GDP cutoff;;;;Passenger Rail;S1S;1.25;2040;10
-SSP3;CAMP_lscWeak;below GDP cutoff;;;;trn_freight_road;S1S;0.9;2040;10
-SSP3;CAMP_lscWeak;below GDP cutoff;;;;trn_pass_road;S1S;0.8;2040;10
-SSP3;CAMP_lscWeak;below GDP cutoff;;;;Walk;S1S;1.75;2040;10
-SSP3;CAMP_lscWeak;CAZ;;;Bus;trn_pass_road;S2S1;2;2040;10
-SSP3;CAMP_lscWeak;CAZ;;;trn_pass_road_LDV;trn_pass_road;S2S1;0.7;2040;10
-SSP3;CAMP_lscWeak;USA;;;Bus;trn_pass_road;S2S1;1.5;2040;10
-SSP3;CAMP_lscWeak;USA;;;trn_pass_road_LDV;trn_pass_road;S2S1;0.7;2040;10
-SSP3;CAMP_lscWeak;above GDP cutoff;;;Bus;trn_pass_road;S2S1;2;2040;10
-SSP3;CAMP_lscWeak;above GDP cutoff;;;trn_pass_road_LDV;trn_pass_road;S2S1;0.8;2035;10
-SSP3;CAMP_lscWeak;below GDP cutoff;;;Bus;trn_pass_road;S2S1;1.5;2040;10
-SSP3;CAMP_lscWeak;below GDP cutoff;;;trn_pass_road_LDV;trn_pass_road;S2S1;0.95;2040;10
-SSP3;CAMP_lscWeak;CAZ;BEV;Bus;Bus;trn_pass_road;FV;2;2040;10
-SSP3;CAMP_lscWeak;CAZ;FCEV;Bus;Bus;trn_pass_road;FV;1.5;2040;10
-SSP3;CAMP_lscWeak;CAZ;Liquids;Bus;Bus;trn_pass_road;FV;1;2050;10
-SSP3;CAMP_lscWeak;CAZ;Hydrogen;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SSP3;CAMP_lscWeak;CAZ;Liquids;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SSP3;CAMP_lscWeak;CAZ;Liquids;Ship;Domestic Ship_tmp_subsectorL2;Domestic Ship;FV;1;2050;10
-SSP3;CAMP_lscWeak;CAZ;Electric;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SSP3;CAMP_lscWeak;CAZ;Liquids;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SSP3;CAMP_lscWeak;CAZ;Electric;Rail;HSR_tmp_subsectorL2;HSR;FV;1;2050;10
-SSP3;CAMP_lscWeak;CAZ;Liquids;Aviation;International Aviation_tmp_subsectorL2;International Aviation;FV;1;2050;10
-SSP3;CAMP_lscWeak;CAZ;Liquids;Ship;International Ship_tmp_subsectorL2;International Ship;FV;1;2050;10
-SSP3;CAMP_lscWeak;CAZ;BEV;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SSP3;CAMP_lscWeak;CAZ;Liquids;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SSP3;CAMP_lscWeak;CAZ;Electric;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SSP3;CAMP_lscWeak;CAZ;Liquids;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SSP3;CAMP_lscWeak;CAZ;BEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;3;2040;10
-SSP3;CAMP_lscWeak;CAZ;FCEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;2;2040;10
-SSP3;CAMP_lscWeak;CAZ;Liquids;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;10
-SSP3;CAMP_lscWeak;CAZ;BEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;3;2040;10
-SSP3;CAMP_lscWeak;CAZ;FCEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;2;2040;10
-SSP3;CAMP_lscWeak;CAZ;Liquids;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;10
-SSP3;CAMP_lscWeak;USA;BEV;Bus;Bus;trn_pass_road;FV;2;2035;10
-SSP3;CAMP_lscWeak;USA;FCEV;Bus;Bus;trn_pass_road;FV;2;2035;10
-SSP3;CAMP_lscWeak;USA;Liquids;Bus;Bus;trn_pass_road;FV;1;2050;10
-SSP3;CAMP_lscWeak;USA;Hydrogen;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SSP3;CAMP_lscWeak;USA;Liquids;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SSP3;CAMP_lscWeak;USA;Liquids;Ship;Domestic Ship_tmp_subsectorL2;Domestic Ship;FV;1;2050;10
-SSP3;CAMP_lscWeak;USA;Electric;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SSP3;CAMP_lscWeak;USA;Liquids;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SSP3;CAMP_lscWeak;USA;Electric;Rail;HSR_tmp_subsectorL2;HSR;FV;1;2050;10
-SSP3;CAMP_lscWeak;USA;Liquids;Aviation;International Aviation_tmp_subsectorL2;International Aviation;FV;1;2050;10
-SSP3;CAMP_lscWeak;USA;Liquids;Ship;International Ship_tmp_subsectorL2;International Ship;FV;1;2050;10
-SSP3;CAMP_lscWeak;USA;BEV;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SSP3;CAMP_lscWeak;USA;Liquids;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SSP3;CAMP_lscWeak;USA;Electric;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SSP3;CAMP_lscWeak;USA;Liquids;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SSP3;CAMP_lscWeak;USA;BEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;3;2035;10
-SSP3;CAMP_lscWeak;USA;FCEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;2;2035;10
-SSP3;CAMP_lscWeak;USA;Liquids;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;10
-SSP3;CAMP_lscWeak;USA;BEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;3;2035;10
-SSP3;CAMP_lscWeak;USA;FCEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;2;2035;10
-SSP3;CAMP_lscWeak;USA;Liquids;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;10
-SSP3;CAMP_lscWeak;above GDP cutoff;BEV;Bus;Bus;trn_pass_road;FV;2;2040;10
-SSP3;CAMP_lscWeak;above GDP cutoff;FCEV;Bus;Bus;trn_pass_road;FV;2;2040;10
-SSP3;CAMP_lscWeak;above GDP cutoff;Liquids;Bus;Bus;trn_pass_road;FV;1;2050;10
-SSP3;CAMP_lscWeak;above GDP cutoff;Hydrogen;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SSP3;CAMP_lscWeak;above GDP cutoff;Liquids;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SSP3;CAMP_lscWeak;above GDP cutoff;Liquids;Ship;Domestic Ship_tmp_subsectorL2;Domestic Ship;FV;1;2050;10
-SSP3;CAMP_lscWeak;above GDP cutoff;Electric;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1.5;2050;10
-SSP3;CAMP_lscWeak;above GDP cutoff;Liquids;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1.5;2050;10
-SSP3;CAMP_lscWeak;above GDP cutoff;Electric;Rail;HSR_tmp_subsectorL2;HSR;FV;1.5;2050;10
-SSP3;CAMP_lscWeak;above GDP cutoff;Liquids;Aviation;International Aviation_tmp_subsectorL2;International Aviation;FV;1;2050;10
-SSP3;CAMP_lscWeak;above GDP cutoff;Liquids;Ship;International Ship_tmp_subsectorL2;International Ship;FV;1;2050;10
-SSP3;CAMP_lscWeak;above GDP cutoff;BEV;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SSP3;CAMP_lscWeak;above GDP cutoff;Liquids;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SSP3;CAMP_lscWeak;above GDP cutoff;Electric;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1.5;2050;10
-SSP3;CAMP_lscWeak;above GDP cutoff;Liquids;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1.5;2050;10
-SSP3;CAMP_lscWeak;above GDP cutoff;BEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2040;10
-SSP3;CAMP_lscWeak;above GDP cutoff;FCEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2040;10
-SSP3;CAMP_lscWeak;above GDP cutoff;Liquids;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;10
-SSP3;CAMP_lscWeak;above GDP cutoff;BEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2040;10
-SSP3;CAMP_lscWeak;above GDP cutoff;FCEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2040;10
-SSP3;CAMP_lscWeak;above GDP cutoff;Liquids;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;10
-SSP3;CAMP_lscWeak;below GDP cutoff;BEV;Bus;Bus;trn_pass_road;FV;1.5;2040;10
-SSP3;CAMP_lscWeak;below GDP cutoff;FCEV;Bus;Bus;trn_pass_road;FV;1.5;2040;10
-SSP3;CAMP_lscWeak;below GDP cutoff;Liquids;Bus;Bus;trn_pass_road;FV;1;2050;10
-SSP3;CAMP_lscWeak;below GDP cutoff;Hydrogen;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SSP3;CAMP_lscWeak;below GDP cutoff;Liquids;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SSP3;CAMP_lscWeak;below GDP cutoff;Liquids;Ship;Domestic Ship_tmp_subsectorL2;Domestic Ship;FV;1;2050;10
-SSP3;CAMP_lscWeak;below GDP cutoff;Electric;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SSP3;CAMP_lscWeak;below GDP cutoff;Liquids;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SSP3;CAMP_lscWeak;below GDP cutoff;Electric;Rail;HSR_tmp_subsectorL2;HSR;FV;1;2050;10
-SSP3;CAMP_lscWeak;below GDP cutoff;Liquids;Aviation;International Aviation_tmp_subsectorL2;International Aviation;FV;1;2050;10
-SSP3;CAMP_lscWeak;below GDP cutoff;Liquids;Ship;International Ship_tmp_subsectorL2;International Ship;FV;1;2050;10
-SSP3;CAMP_lscWeak;below GDP cutoff;BEV;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SSP3;CAMP_lscWeak;below GDP cutoff;Liquids;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SSP3;CAMP_lscWeak;below GDP cutoff;Electric;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SSP3;CAMP_lscWeak;below GDP cutoff;Liquids;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SSP3;CAMP_lscWeak;below GDP cutoff;BEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;2;2040;10
-SSP3;CAMP_lscWeak;below GDP cutoff;FCEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1.5;2040;10
-SSP3;CAMP_lscWeak;below GDP cutoff;Liquids;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;10
-SSP3;CAMP_lscWeak;below GDP cutoff;BEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;2;2040;10
-SSP3;CAMP_lscWeak;below GDP cutoff;FCEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1.5;2040;10
-SSP3;CAMP_lscWeak;below GDP cutoff;Liquids;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;10
-SSP3;ECEMF_HighEl_HighEff;above GDP cutoff;;;;Cycle;S1S;1.5;2050;10
-SSP3;ECEMF_HighEl_HighEff;above GDP cutoff;;;;Domestic Aviation;S1S;0.5;2035;10
-SSP3;ECEMF_HighEl_HighEff;above GDP cutoff;;;;Domestic Ship;S1S;1.5;2050;10
-SSP3;ECEMF_HighEl_HighEff;above GDP cutoff;;;;Freight Rail;S1S;1.5;2050;10
-SSP3;ECEMF_HighEl_HighEff;above GDP cutoff;;;;HSR;S1S;1;2050;10
-SSP3;ECEMF_HighEl_HighEff;above GDP cutoff;;;;Passenger Rail;S1S;1.5;2050;10
-SSP3;ECEMF_HighEl_HighEff;above GDP cutoff;;;;trn_freight_road;S1S;0.7;2035;10
-SSP3;ECEMF_HighEl_HighEff;above GDP cutoff;;;;trn_pass_road;S1S;0.7;2035;10
-SSP3;ECEMF_HighEl_HighEff;above GDP cutoff;;;;Walk;S1S;1.5;2050;10
-SSP3;ECEMF_HighEl_HighEff;below GDP cutoff;;;;Cycle;S1S;1.5;2050;10
-SSP3;ECEMF_HighEl_HighEff;below GDP cutoff;;;;Domestic Aviation;S1S;0.5;2035;10
-SSP3;ECEMF_HighEl_HighEff;below GDP cutoff;;;;Domestic Ship;S1S;1.5;2050;10
-SSP3;ECEMF_HighEl_HighEff;below GDP cutoff;;;;Freight Rail;S1S;1.5;2050;10
-SSP3;ECEMF_HighEl_HighEff;below GDP cutoff;;;;HSR;S1S;1;2050;10
-SSP3;ECEMF_HighEl_HighEff;below GDP cutoff;;;;Passenger Rail;S1S;1.5;2050;10
-SSP3;ECEMF_HighEl_HighEff;below GDP cutoff;;;;trn_freight_road;S1S;0.7;2035;10
-SSP3;ECEMF_HighEl_HighEff;below GDP cutoff;;;;trn_pass_road;S1S;0.7;2035;10
-SSP3;ECEMF_HighEl_HighEff;below GDP cutoff;;;;Walk;S1S;1.5;2050;10
-SSP3;ECEMF_HighEl_HighEff;above GDP cutoff;;;Bus;trn_pass_road;S2S1;1.5;2050;10
-SSP3;ECEMF_HighEl_HighEff;above GDP cutoff;;;trn_pass_road_LDV;trn_pass_road;S2S1;0.7;2035;10
-SSP3;ECEMF_HighEl_HighEff;below GDP cutoff;;;Bus;trn_pass_road;S2S1;1.5;2050;10
-SSP3;ECEMF_HighEl_HighEff;below GDP cutoff;;;trn_pass_road_LDV;trn_pass_road;S2S1;0.7;2035;10
-SSP3;ECEMF_HighEl_HighEff;above GDP cutoff;BEV;Bus;Bus;trn_pass_road;FV;10;2035;15
-SSP3;ECEMF_HighEl_HighEff;above GDP cutoff;FCEV;Bus;Bus;trn_pass_road;FV;1.1;2035;5
-SSP3;ECEMF_HighEl_HighEff;above GDP cutoff;Liquids;Bus;Bus;trn_pass_road;FV;1;2050;10
-SSP3;ECEMF_HighEl_HighEff;above GDP cutoff;Hydrogen;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1.1;2050;5
-SSP3;ECEMF_HighEl_HighEff;above GDP cutoff;Liquids;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SSP3;ECEMF_HighEl_HighEff;above GDP cutoff;Liquids;Ship;Domestic Ship_tmp_subsectorL2;Domestic Ship;FV;1;2050;10
-SSP3;ECEMF_HighEl_HighEff;above GDP cutoff;Electric;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;5;2050;15
-SSP3;ECEMF_HighEl_HighEff;above GDP cutoff;Liquids;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SSP3;ECEMF_HighEl_HighEff;above GDP cutoff;Electric;Rail;HSR_tmp_subsectorL2;HSR;FV;5;2050;15
-SSP3;ECEMF_HighEl_HighEff;above GDP cutoff;Liquids;Aviation;International Aviation_tmp_subsectorL2;International Aviation;FV;1;2050;10
-SSP3;ECEMF_HighEl_HighEff;above GDP cutoff;Liquids;Ship;International Ship_tmp_subsectorL2;International Ship;FV;1;2050;10
-SSP3;ECEMF_HighEl_HighEff;above GDP cutoff;BEV;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;7;2050;15
-SSP3;ECEMF_HighEl_HighEff;above GDP cutoff;Liquids;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SSP3;ECEMF_HighEl_HighEff;above GDP cutoff;Electric;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;5;2050;15
-SSP3;ECEMF_HighEl_HighEff;above GDP cutoff;Liquids;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SSP3;ECEMF_HighEl_HighEff;above GDP cutoff;BEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;40;2040;3
-SSP3;ECEMF_HighEl_HighEff;above GDP cutoff;FCEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;10;2040;3
-SSP3;ECEMF_HighEl_HighEff;above GDP cutoff;Liquids;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;3
-SSP3;ECEMF_HighEl_HighEff;above GDP cutoff;BEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;50;2040;5
-SSP3;ECEMF_HighEl_HighEff;above GDP cutoff;FCEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;60;2040;3
-SSP3;ECEMF_HighEl_HighEff;above GDP cutoff;Liquids;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;3
-SSP3;ECEMF_HighEl_HighEff;below GDP cutoff;BEV;Bus;Bus;trn_pass_road;FV;13;2030;15
-SSP3;ECEMF_HighEl_HighEff;below GDP cutoff;FCEV;Bus;Bus;trn_pass_road;FV;1.1;2035;5
-SSP3;ECEMF_HighEl_HighEff;below GDP cutoff;Liquids;Bus;Bus;trn_pass_road;FV;1;2050;10
-SSP3;ECEMF_HighEl_HighEff;below GDP cutoff;Hydrogen;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;2;2050;5
-SSP3;ECEMF_HighEl_HighEff;below GDP cutoff;Liquids;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SSP3;ECEMF_HighEl_HighEff;below GDP cutoff;Liquids;Ship;Domestic Ship_tmp_subsectorL2;Domestic Ship;FV;1;2050;10
-SSP3;ECEMF_HighEl_HighEff;below GDP cutoff;Electric;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;6;2040;15
-SSP3;ECEMF_HighEl_HighEff;below GDP cutoff;Liquids;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SSP3;ECEMF_HighEl_HighEff;below GDP cutoff;Electric;Rail;HSR_tmp_subsectorL2;HSR;FV;6;2040;15
-SSP3;ECEMF_HighEl_HighEff;below GDP cutoff;Liquids;Aviation;International Aviation_tmp_subsectorL2;International Aviation;FV;1;2050;10
-SSP3;ECEMF_HighEl_HighEff;below GDP cutoff;Liquids;Ship;International Ship_tmp_subsectorL2;International Ship;FV;1;2050;10
-SSP3;ECEMF_HighEl_HighEff;below GDP cutoff;BEV;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;7;2030;15
-SSP3;ECEMF_HighEl_HighEff;below GDP cutoff;Liquids;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SSP3;ECEMF_HighEl_HighEff;below GDP cutoff;Electric;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;6;2040;15
-SSP3;ECEMF_HighEl_HighEff;below GDP cutoff;Liquids;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SSP3;ECEMF_HighEl_HighEff;below GDP cutoff;BEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;10;2040;3
-SSP3;ECEMF_HighEl_HighEff;below GDP cutoff;FCEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;10;2040;3
-SSP3;ECEMF_HighEl_HighEff;below GDP cutoff;Liquids;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;3
-SSP3;ECEMF_HighEl_HighEff;below GDP cutoff;BEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;5;2035;5
-SSP3;ECEMF_HighEl_HighEff;below GDP cutoff;FCEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;7;2035;3
-SSP3;ECEMF_HighEl_HighEff;below GDP cutoff;Liquids;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;3
-SSP3;ECEMF_HighEl_LifestCha;above GDP cutoff;;;;Cycle;S1S;2;2050;10
-SSP3;ECEMF_HighEl_LifestCha;above GDP cutoff;;;;Domestic Aviation;S1S;0.25;2035;10
-SSP3;ECEMF_HighEl_LifestCha;above GDP cutoff;;;;Domestic Ship;S1S;1.5;2050;10
-SSP3;ECEMF_HighEl_LifestCha;above GDP cutoff;;;;Freight Rail;S1S;1.5;2050;10
-SSP3;ECEMF_HighEl_LifestCha;above GDP cutoff;;;;HSR;S1S;1;2050;10
-SSP3;ECEMF_HighEl_LifestCha;above GDP cutoff;;;;Passenger Rail;S1S;2;2050;10
-SSP3;ECEMF_HighEl_LifestCha;above GDP cutoff;;;;trn_freight_road;S1S;0.7;2035;10
-SSP3;ECEMF_HighEl_LifestCha;above GDP cutoff;;;;trn_pass_road;S1S;0.5;2035;10
-SSP3;ECEMF_HighEl_LifestCha;above GDP cutoff;;;;Walk;S1S;2;2050;10
-SSP3;ECEMF_HighEl_LifestCha;below GDP cutoff;;;;Cycle;S1S;2;2050;10
-SSP3;ECEMF_HighEl_LifestCha;below GDP cutoff;;;;Domestic Aviation;S1S;0.25;2035;10
-SSP3;ECEMF_HighEl_LifestCha;below GDP cutoff;;;;Domestic Ship;S1S;1.5;2050;10
-SSP3;ECEMF_HighEl_LifestCha;below GDP cutoff;;;;Freight Rail;S1S;1.5;2050;10
-SSP3;ECEMF_HighEl_LifestCha;below GDP cutoff;;;;HSR;S1S;1;2050;10
-SSP3;ECEMF_HighEl_LifestCha;below GDP cutoff;;;;Passenger Rail;S1S;2;2050;10
-SSP3;ECEMF_HighEl_LifestCha;below GDP cutoff;;;;trn_freight_road;S1S;0.7;2035;10
-SSP3;ECEMF_HighEl_LifestCha;below GDP cutoff;;;;trn_pass_road;S1S;0.5;2035;10
-SSP3;ECEMF_HighEl_LifestCha;below GDP cutoff;;;;Walk;S1S;2;2050;10
-SSP3;ECEMF_HighEl_LifestCha;above GDP cutoff;;;Bus;trn_pass_road;S2S1;2;2050;10
-SSP3;ECEMF_HighEl_LifestCha;above GDP cutoff;;;trn_pass_road_LDV;trn_pass_road;S2S1;0.5;2035;10
-SSP3;ECEMF_HighEl_LifestCha;below GDP cutoff;;;Bus;trn_pass_road;S2S1;2;2050;10
-SSP3;ECEMF_HighEl_LifestCha;below GDP cutoff;;;trn_pass_road_LDV;trn_pass_road;S2S1;0.5;2035;10
-SSP3;ECEMF_HighEl_LifestCha;above GDP cutoff;BEV;Bus;Bus;trn_pass_road;FV;10;2035;15
-SSP3;ECEMF_HighEl_LifestCha;above GDP cutoff;FCEV;Bus;Bus;trn_pass_road;FV;1.1;2035;5
-SSP3;ECEMF_HighEl_LifestCha;above GDP cutoff;Liquids;Bus;Bus;trn_pass_road;FV;1;2050;10
-SSP3;ECEMF_HighEl_LifestCha;above GDP cutoff;Hydrogen;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1.1;2050;5
-SSP3;ECEMF_HighEl_LifestCha;above GDP cutoff;Liquids;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SSP3;ECEMF_HighEl_LifestCha;above GDP cutoff;Liquids;Ship;Domestic Ship_tmp_subsectorL2;Domestic Ship;FV;1;2050;10
-SSP3;ECEMF_HighEl_LifestCha;above GDP cutoff;Electric;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;5;2050;15
-SSP3;ECEMF_HighEl_LifestCha;above GDP cutoff;Liquids;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SSP3;ECEMF_HighEl_LifestCha;above GDP cutoff;Electric;Rail;HSR_tmp_subsectorL2;HSR;FV;5;2050;15
-SSP3;ECEMF_HighEl_LifestCha;above GDP cutoff;Liquids;Aviation;International Aviation_tmp_subsectorL2;International Aviation;FV;1;2050;10
-SSP3;ECEMF_HighEl_LifestCha;above GDP cutoff;Liquids;Ship;International Ship_tmp_subsectorL2;International Ship;FV;1;2050;10
-SSP3;ECEMF_HighEl_LifestCha;above GDP cutoff;BEV;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;7;2050;15
-SSP3;ECEMF_HighEl_LifestCha;above GDP cutoff;Liquids;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SSP3;ECEMF_HighEl_LifestCha;above GDP cutoff;Electric;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;5;2050;15
-SSP3;ECEMF_HighEl_LifestCha;above GDP cutoff;Liquids;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SSP3;ECEMF_HighEl_LifestCha;above GDP cutoff;BEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;40;2040;3
-SSP3;ECEMF_HighEl_LifestCha;above GDP cutoff;FCEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;10;2040;3
-SSP3;ECEMF_HighEl_LifestCha;above GDP cutoff;Liquids;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;3
-SSP3;ECEMF_HighEl_LifestCha;above GDP cutoff;BEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;50;2040;5
-SSP3;ECEMF_HighEl_LifestCha;above GDP cutoff;FCEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;60;2040;3
-SSP3;ECEMF_HighEl_LifestCha;above GDP cutoff;Liquids;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;3
-SSP3;ECEMF_HighEl_LifestCha;below GDP cutoff;BEV;Bus;Bus;trn_pass_road;FV;13;2030;15
-SSP3;ECEMF_HighEl_LifestCha;below GDP cutoff;FCEV;Bus;Bus;trn_pass_road;FV;1.1;2035;5
-SSP3;ECEMF_HighEl_LifestCha;below GDP cutoff;Liquids;Bus;Bus;trn_pass_road;FV;1;2050;10
-SSP3;ECEMF_HighEl_LifestCha;below GDP cutoff;Hydrogen;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;2;2050;5
-SSP3;ECEMF_HighEl_LifestCha;below GDP cutoff;Liquids;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SSP3;ECEMF_HighEl_LifestCha;below GDP cutoff;Liquids;Ship;Domestic Ship_tmp_subsectorL2;Domestic Ship;FV;1;2050;10
-SSP3;ECEMF_HighEl_LifestCha;below GDP cutoff;Electric;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;6;2040;15
-SSP3;ECEMF_HighEl_LifestCha;below GDP cutoff;Liquids;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SSP3;ECEMF_HighEl_LifestCha;below GDP cutoff;Electric;Rail;HSR_tmp_subsectorL2;HSR;FV;6;2040;15
-SSP3;ECEMF_HighEl_LifestCha;below GDP cutoff;Liquids;Aviation;International Aviation_tmp_subsectorL2;International Aviation;FV;1;2050;10
-SSP3;ECEMF_HighEl_LifestCha;below GDP cutoff;Liquids;Ship;International Ship_tmp_subsectorL2;International Ship;FV;1;2050;10
-SSP3;ECEMF_HighEl_LifestCha;below GDP cutoff;BEV;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;7;2030;15
-SSP3;ECEMF_HighEl_LifestCha;below GDP cutoff;Liquids;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SSP3;ECEMF_HighEl_LifestCha;below GDP cutoff;Electric;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;6;2040;15
-SSP3;ECEMF_HighEl_LifestCha;below GDP cutoff;Liquids;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SSP3;ECEMF_HighEl_LifestCha;below GDP cutoff;BEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;10;2040;3
-SSP3;ECEMF_HighEl_LifestCha;below GDP cutoff;FCEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;10;2040;3
-SSP3;ECEMF_HighEl_LifestCha;below GDP cutoff;Liquids;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;3
-SSP3;ECEMF_HighEl_LifestCha;below GDP cutoff;BEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;5;2035;5
-SSP3;ECEMF_HighEl_LifestCha;below GDP cutoff;FCEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;7;2035;3
-SSP3;ECEMF_HighEl_LifestCha;below GDP cutoff;Liquids;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;3
-SSP3;ECEMF_HighEl_ModEff;above GDP cutoff;;;;Cycle;S1S;1;2050;10
-SSP3;ECEMF_HighEl_ModEff;above GDP cutoff;;;;Domestic Aviation;S1S;0.75;2035;10
-SSP3;ECEMF_HighEl_ModEff;above GDP cutoff;;;;Domestic Ship;S1S;1;2050;10
-SSP3;ECEMF_HighEl_ModEff;above GDP cutoff;;;;Freight Rail;S1S;1;2050;10
-SSP3;ECEMF_HighEl_ModEff;above GDP cutoff;;;;HSR;S1S;1;2050;10
-SSP3;ECEMF_HighEl_ModEff;above GDP cutoff;;;;Passenger Rail;S1S;1;2050;10
-SSP3;ECEMF_HighEl_ModEff;above GDP cutoff;;;;trn_freight_road;S1S;0.9;2035;10
-SSP3;ECEMF_HighEl_ModEff;above GDP cutoff;;;;trn_pass_road;S1S;0.9;2035;10
-SSP3;ECEMF_HighEl_ModEff;above GDP cutoff;;;;Walk;S1S;1;2050;10
-SSP3;ECEMF_HighEl_ModEff;below GDP cutoff;;;;Cycle;S1S;1;2050;10
-SSP3;ECEMF_HighEl_ModEff;below GDP cutoff;;;;Domestic Aviation;S1S;0.75;2035;10
-SSP3;ECEMF_HighEl_ModEff;below GDP cutoff;;;;Domestic Ship;S1S;1;2050;10
-SSP3;ECEMF_HighEl_ModEff;below GDP cutoff;;;;Freight Rail;S1S;1;2050;10
-SSP3;ECEMF_HighEl_ModEff;below GDP cutoff;;;;HSR;S1S;1;2050;10
-SSP3;ECEMF_HighEl_ModEff;below GDP cutoff;;;;Passenger Rail;S1S;1;2050;10
-SSP3;ECEMF_HighEl_ModEff;below GDP cutoff;;;;trn_freight_road;S1S;0.9;2035;10
-SSP3;ECEMF_HighEl_ModEff;below GDP cutoff;;;;trn_pass_road;S1S;0.9;2035;10
-SSP3;ECEMF_HighEl_ModEff;below GDP cutoff;;;;Walk;S1S;1;2050;10
-SSP3;ECEMF_HighEl_ModEff;above GDP cutoff;;;Bus;trn_pass_road;S2S1;1;2050;10
-SSP3;ECEMF_HighEl_ModEff;above GDP cutoff;;;trn_pass_road_LDV;trn_pass_road;S2S1;0.9;2035;10
-SSP3;ECEMF_HighEl_ModEff;below GDP cutoff;;;Bus;trn_pass_road;S2S1;1;2050;10
-SSP3;ECEMF_HighEl_ModEff;below GDP cutoff;;;trn_pass_road_LDV;trn_pass_road;S2S1;0.9;2035;10
-SSP3;ECEMF_HighEl_ModEff;above GDP cutoff;BEV;Bus;Bus;trn_pass_road;FV;6;2035;15
-SSP3;ECEMF_HighEl_ModEff;above GDP cutoff;FCEV;Bus;Bus;trn_pass_road;FV;1.1;2035;5
-SSP3;ECEMF_HighEl_ModEff;above GDP cutoff;Liquids;Bus;Bus;trn_pass_road;FV;1;2050;10
-SSP3;ECEMF_HighEl_ModEff;above GDP cutoff;Hydrogen;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1.1;2050;5
-SSP3;ECEMF_HighEl_ModEff;above GDP cutoff;Liquids;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SSP3;ECEMF_HighEl_ModEff;above GDP cutoff;Liquids;Ship;Domestic Ship_tmp_subsectorL2;Domestic Ship;FV;1;2050;10
-SSP3;ECEMF_HighEl_ModEff;above GDP cutoff;Electric;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;3;2050;15
-SSP3;ECEMF_HighEl_ModEff;above GDP cutoff;Liquids;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SSP3;ECEMF_HighEl_ModEff;above GDP cutoff;Electric;Rail;HSR_tmp_subsectorL2;HSR;FV;3;2050;15
-SSP3;ECEMF_HighEl_ModEff;above GDP cutoff;Liquids;Aviation;International Aviation_tmp_subsectorL2;International Aviation;FV;1;2050;10
-SSP3;ECEMF_HighEl_ModEff;above GDP cutoff;Liquids;Ship;International Ship_tmp_subsectorL2;International Ship;FV;1;2050;10
-SSP3;ECEMF_HighEl_ModEff;above GDP cutoff;BEV;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;3;2050;15
-SSP3;ECEMF_HighEl_ModEff;above GDP cutoff;Liquids;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SSP3;ECEMF_HighEl_ModEff;above GDP cutoff;Electric;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;3;2050;15
-SSP3;ECEMF_HighEl_ModEff;above GDP cutoff;Liquids;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SSP3;ECEMF_HighEl_ModEff;above GDP cutoff;BEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;40;2040;3
-SSP3;ECEMF_HighEl_ModEff;above GDP cutoff;FCEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;10;2040;3
-SSP3;ECEMF_HighEl_ModEff;above GDP cutoff;Liquids;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;3
-SSP3;ECEMF_HighEl_ModEff;above GDP cutoff;BEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;50;2040;5
-SSP3;ECEMF_HighEl_ModEff;above GDP cutoff;FCEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;60;2040;3
-SSP3;ECEMF_HighEl_ModEff;above GDP cutoff;Liquids;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;3
-SSP3;ECEMF_HighEl_ModEff;below GDP cutoff;BEV;Bus;Bus;trn_pass_road;FV;10;2030;15
-SSP3;ECEMF_HighEl_ModEff;below GDP cutoff;FCEV;Bus;Bus;trn_pass_road;FV;1.1;2035;5
-SSP3;ECEMF_HighEl_ModEff;below GDP cutoff;Liquids;Bus;Bus;trn_pass_road;FV;1;2050;10
-SSP3;ECEMF_HighEl_ModEff;below GDP cutoff;Hydrogen;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;2;2050;5
-SSP3;ECEMF_HighEl_ModEff;below GDP cutoff;Liquids;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SSP3;ECEMF_HighEl_ModEff;below GDP cutoff;Liquids;Ship;Domestic Ship_tmp_subsectorL2;Domestic Ship;FV;1;2050;10
-SSP3;ECEMF_HighEl_ModEff;below GDP cutoff;Electric;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;4;2040;15
-SSP3;ECEMF_HighEl_ModEff;below GDP cutoff;Liquids;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SSP3;ECEMF_HighEl_ModEff;below GDP cutoff;Electric;Rail;HSR_tmp_subsectorL2;HSR;FV;4;2040;15
-SSP3;ECEMF_HighEl_ModEff;below GDP cutoff;Liquids;Aviation;International Aviation_tmp_subsectorL2;International Aviation;FV;1;2050;10
-SSP3;ECEMF_HighEl_ModEff;below GDP cutoff;Liquids;Ship;International Ship_tmp_subsectorL2;International Ship;FV;1;2050;10
-SSP3;ECEMF_HighEl_ModEff;below GDP cutoff;BEV;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;5;2030;15
-SSP3;ECEMF_HighEl_ModEff;below GDP cutoff;Liquids;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SSP3;ECEMF_HighEl_ModEff;below GDP cutoff;Electric;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;4;2040;15
-SSP3;ECEMF_HighEl_ModEff;below GDP cutoff;Liquids;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SSP3;ECEMF_HighEl_ModEff;below GDP cutoff;BEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;10;2040;3
-SSP3;ECEMF_HighEl_ModEff;below GDP cutoff;FCEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;10;2040;3
-SSP3;ECEMF_HighEl_ModEff;below GDP cutoff;Liquids;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;3
-SSP3;ECEMF_HighEl_ModEff;below GDP cutoff;BEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;5;2035;5
-SSP3;ECEMF_HighEl_ModEff;below GDP cutoff;FCEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;7;2035;3
-SSP3;ECEMF_HighEl_ModEff;below GDP cutoff;Liquids;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;3
-SSP3;ECEMF_HighH2_HighEff;above GDP cutoff;;;;Cycle;S1S;1.5;2050;10
-SSP3;ECEMF_HighH2_HighEff;above GDP cutoff;;;;Domestic Aviation;S1S;0.5;2035;10
-SSP3;ECEMF_HighH2_HighEff;above GDP cutoff;;;;Domestic Ship;S1S;1.5;2050;10
-SSP3;ECEMF_HighH2_HighEff;above GDP cutoff;;;;Freight Rail;S1S;1.5;2050;10
-SSP3;ECEMF_HighH2_HighEff;above GDP cutoff;;;;HSR;S1S;1;2050;10
-SSP3;ECEMF_HighH2_HighEff;above GDP cutoff;;;;Passenger Rail;S1S;1.5;2050;10
-SSP3;ECEMF_HighH2_HighEff;above GDP cutoff;;;;trn_freight_road;S1S;0.7;2035;10
-SSP3;ECEMF_HighH2_HighEff;above GDP cutoff;;;;trn_pass_road;S1S;0.7;2035;10
-SSP3;ECEMF_HighH2_HighEff;above GDP cutoff;;;;Walk;S1S;1.5;2050;10
-SSP3;ECEMF_HighH2_HighEff;below GDP cutoff;;;;Cycle;S1S;1.5;2050;10
-SSP3;ECEMF_HighH2_HighEff;below GDP cutoff;;;;Domestic Aviation;S1S;0.5;2035;10
-SSP3;ECEMF_HighH2_HighEff;below GDP cutoff;;;;Domestic Ship;S1S;1.5;2050;10
-SSP3;ECEMF_HighH2_HighEff;below GDP cutoff;;;;Freight Rail;S1S;1.5;2050;10
-SSP3;ECEMF_HighH2_HighEff;below GDP cutoff;;;;HSR;S1S;1;2050;10
-SSP3;ECEMF_HighH2_HighEff;below GDP cutoff;;;;Passenger Rail;S1S;1.5;2050;10
-SSP3;ECEMF_HighH2_HighEff;below GDP cutoff;;;;trn_freight_road;S1S;0.7;2035;10
-SSP3;ECEMF_HighH2_HighEff;below GDP cutoff;;;;trn_pass_road;S1S;0.7;2035;10
-SSP3;ECEMF_HighH2_HighEff;below GDP cutoff;;;;Walk;S1S;1.5;2050;10
-SSP3;ECEMF_HighH2_HighEff;above GDP cutoff;;;Bus;trn_pass_road;S2S1;1.5;2050;10
-SSP3;ECEMF_HighH2_HighEff;above GDP cutoff;;;trn_pass_road_LDV;trn_pass_road;S2S1;0.7;2035;10
-SSP3;ECEMF_HighH2_HighEff;below GDP cutoff;;;Bus;trn_pass_road;S2S1;1.5;2050;10
-SSP3;ECEMF_HighH2_HighEff;below GDP cutoff;;;trn_pass_road_LDV;trn_pass_road;S2S1;0.7;2035;10
-SSP3;ECEMF_HighH2_HighEff;above GDP cutoff;BEV;Bus;Bus;trn_pass_road;FV;3;2060;15
-SSP3;ECEMF_HighH2_HighEff;above GDP cutoff;FCEV;Bus;Bus;trn_pass_road;FV;220;2035;5
-SSP3;ECEMF_HighH2_HighEff;above GDP cutoff;Liquids;Bus;Bus;trn_pass_road;FV;1;2050;10
-SSP3;ECEMF_HighH2_HighEff;above GDP cutoff;Hydrogen;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;3;2055;5
-SSP3;ECEMF_HighH2_HighEff;above GDP cutoff;Liquids;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SSP3;ECEMF_HighH2_HighEff;above GDP cutoff;Liquids;Ship;Domestic Ship_tmp_subsectorL2;Domestic Ship;FV;1;2050;10
-SSP3;ECEMF_HighH2_HighEff;above GDP cutoff;Electric;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;2.5;2050;10
-SSP3;ECEMF_HighH2_HighEff;above GDP cutoff;Liquids;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SSP3;ECEMF_HighH2_HighEff;above GDP cutoff;Electric;Rail;HSR_tmp_subsectorL2;HSR;FV;2.5;2050;10
-SSP3;ECEMF_HighH2_HighEff;above GDP cutoff;Liquids;Aviation;International Aviation_tmp_subsectorL2;International Aviation;FV;1;2050;10
-SSP3;ECEMF_HighH2_HighEff;above GDP cutoff;Liquids;Ship;International Ship_tmp_subsectorL2;International Ship;FV;1;2050;10
-SSP3;ECEMF_HighH2_HighEff;above GDP cutoff;BEV;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;3;2050;10
-SSP3;ECEMF_HighH2_HighEff;above GDP cutoff;Liquids;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SSP3;ECEMF_HighH2_HighEff;above GDP cutoff;Electric;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;2.5;2050;10
-SSP3;ECEMF_HighH2_HighEff;above GDP cutoff;Liquids;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SSP3;ECEMF_HighH2_HighEff;above GDP cutoff;BEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;40;2040;3
-SSP3;ECEMF_HighH2_HighEff;above GDP cutoff;FCEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;50;2040;3
-SSP3;ECEMF_HighH2_HighEff;above GDP cutoff;Liquids;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;3
-SSP3;ECEMF_HighH2_HighEff;above GDP cutoff;BEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;40;2040;5
-SSP3;ECEMF_HighH2_HighEff;above GDP cutoff;FCEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;250;2040;3
-SSP3;ECEMF_HighH2_HighEff;above GDP cutoff;Liquids;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;3
-SSP3;ECEMF_HighH2_HighEff;below GDP cutoff;BEV;Bus;Bus;trn_pass_road;FV;3;2060;15
-SSP3;ECEMF_HighH2_HighEff;below GDP cutoff;FCEV;Bus;Bus;trn_pass_road;FV;160;2040;5
-SSP3;ECEMF_HighH2_HighEff;below GDP cutoff;Liquids;Bus;Bus;trn_pass_road;FV;1;2050;10
-SSP3;ECEMF_HighH2_HighEff;below GDP cutoff;Hydrogen;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;5;2055;10
-SSP3;ECEMF_HighH2_HighEff;below GDP cutoff;Liquids;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SSP3;ECEMF_HighH2_HighEff;below GDP cutoff;Liquids;Ship;Domestic Ship_tmp_subsectorL2;Domestic Ship;FV;1;2050;10
-SSP3;ECEMF_HighH2_HighEff;below GDP cutoff;Electric;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;2;2050;10
-SSP3;ECEMF_HighH2_HighEff;below GDP cutoff;Liquids;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SSP3;ECEMF_HighH2_HighEff;below GDP cutoff;Electric;Rail;HSR_tmp_subsectorL2;HSR;FV;2;2050;10
-SSP3;ECEMF_HighH2_HighEff;below GDP cutoff;Liquids;Aviation;International Aviation_tmp_subsectorL2;International Aviation;FV;1;2050;10
-SSP3;ECEMF_HighH2_HighEff;below GDP cutoff;Liquids;Ship;International Ship_tmp_subsectorL2;International Ship;FV;1;2050;10
-SSP3;ECEMF_HighH2_HighEff;below GDP cutoff;BEV;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;3;2050;10
-SSP3;ECEMF_HighH2_HighEff;below GDP cutoff;Liquids;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SSP3;ECEMF_HighH2_HighEff;below GDP cutoff;Electric;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;2;2050;10
-SSP3;ECEMF_HighH2_HighEff;below GDP cutoff;Liquids;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SSP3;ECEMF_HighH2_HighEff;below GDP cutoff;BEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;10;2040;3
-SSP3;ECEMF_HighH2_HighEff;below GDP cutoff;FCEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;10;2040;3
-SSP3;ECEMF_HighH2_HighEff;below GDP cutoff;Liquids;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;3
-SSP3;ECEMF_HighH2_HighEff;below GDP cutoff;BEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;5;2035;5
-SSP3;ECEMF_HighH2_HighEff;below GDP cutoff;FCEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;30;2035;3
-SSP3;ECEMF_HighH2_HighEff;below GDP cutoff;Liquids;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;3
-SSP3;ECEMF_HighH2_LifestCha;above GDP cutoff;;;;Cycle;S1S;2;2050;10
-SSP3;ECEMF_HighH2_LifestCha;above GDP cutoff;;;;Domestic Aviation;S1S;0.25;2035;10
-SSP3;ECEMF_HighH2_LifestCha;above GDP cutoff;;;;Domestic Ship;S1S;1.5;2050;10
-SSP3;ECEMF_HighH2_LifestCha;above GDP cutoff;;;;Freight Rail;S1S;1.5;2050;10
-SSP3;ECEMF_HighH2_LifestCha;above GDP cutoff;;;;HSR;S1S;1;2050;10
-SSP3;ECEMF_HighH2_LifestCha;above GDP cutoff;;;;Passenger Rail;S1S;2;2050;10
-SSP3;ECEMF_HighH2_LifestCha;above GDP cutoff;;;;trn_freight_road;S1S;0.7;2035;10
-SSP3;ECEMF_HighH2_LifestCha;above GDP cutoff;;;;trn_pass_road;S1S;0.5;2035;10
-SSP3;ECEMF_HighH2_LifestCha;above GDP cutoff;;;;Walk;S1S;2;2050;10
-SSP3;ECEMF_HighH2_LifestCha;below GDP cutoff;;;;Cycle;S1S;2;2050;10
-SSP3;ECEMF_HighH2_LifestCha;below GDP cutoff;;;;Domestic Aviation;S1S;0.25;2035;10
-SSP3;ECEMF_HighH2_LifestCha;below GDP cutoff;;;;Domestic Ship;S1S;1.5;2050;10
-SSP3;ECEMF_HighH2_LifestCha;below GDP cutoff;;;;Freight Rail;S1S;1.5;2050;10
-SSP3;ECEMF_HighH2_LifestCha;below GDP cutoff;;;;HSR;S1S;1;2050;10
-SSP3;ECEMF_HighH2_LifestCha;below GDP cutoff;;;;Passenger Rail;S1S;2;2050;10
-SSP3;ECEMF_HighH2_LifestCha;below GDP cutoff;;;;trn_freight_road;S1S;0.7;2035;10
-SSP3;ECEMF_HighH2_LifestCha;below GDP cutoff;;;;trn_pass_road;S1S;0.5;2035;10
-SSP3;ECEMF_HighH2_LifestCha;below GDP cutoff;;;;Walk;S1S;2;2050;10
-SSP3;ECEMF_HighH2_LifestCha;above GDP cutoff;;;Bus;trn_pass_road;S2S1;2;2050;10
-SSP3;ECEMF_HighH2_LifestCha;above GDP cutoff;;;trn_pass_road_LDV;trn_pass_road;S2S1;0.5;2035;10
-SSP3;ECEMF_HighH2_LifestCha;below GDP cutoff;;;Bus;trn_pass_road;S2S1;2;2050;10
-SSP3;ECEMF_HighH2_LifestCha;below GDP cutoff;;;trn_pass_road_LDV;trn_pass_road;S2S1;0.5;2035;10
-SSP3;ECEMF_HighH2_LifestCha;above GDP cutoff;BEV;Bus;Bus;trn_pass_road;FV;3;2060;15
-SSP3;ECEMF_HighH2_LifestCha;above GDP cutoff;FCEV;Bus;Bus;trn_pass_road;FV;220;2035;5
-SSP3;ECEMF_HighH2_LifestCha;above GDP cutoff;Liquids;Bus;Bus;trn_pass_road;FV;1;2050;10
-SSP3;ECEMF_HighH2_LifestCha;above GDP cutoff;Hydrogen;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;3;2055;5
-SSP3;ECEMF_HighH2_LifestCha;above GDP cutoff;Liquids;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SSP3;ECEMF_HighH2_LifestCha;above GDP cutoff;Liquids;Ship;Domestic Ship_tmp_subsectorL2;Domestic Ship;FV;1;2050;10
-SSP3;ECEMF_HighH2_LifestCha;above GDP cutoff;Electric;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;2.5;2050;10
-SSP3;ECEMF_HighH2_LifestCha;above GDP cutoff;Liquids;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SSP3;ECEMF_HighH2_LifestCha;above GDP cutoff;Electric;Rail;HSR_tmp_subsectorL2;HSR;FV;2.5;2050;10
-SSP3;ECEMF_HighH2_LifestCha;above GDP cutoff;Liquids;Aviation;International Aviation_tmp_subsectorL2;International Aviation;FV;1;2050;10
-SSP3;ECEMF_HighH2_LifestCha;above GDP cutoff;Liquids;Ship;International Ship_tmp_subsectorL2;International Ship;FV;1;2050;10
-SSP3;ECEMF_HighH2_LifestCha;above GDP cutoff;BEV;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;3;2050;10
-SSP3;ECEMF_HighH2_LifestCha;above GDP cutoff;Liquids;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SSP3;ECEMF_HighH2_LifestCha;above GDP cutoff;Electric;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;2.5;2050;10
-SSP3;ECEMF_HighH2_LifestCha;above GDP cutoff;Liquids;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SSP3;ECEMF_HighH2_LifestCha;above GDP cutoff;BEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;40;2040;3
-SSP3;ECEMF_HighH2_LifestCha;above GDP cutoff;FCEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;50;2040;3
-SSP3;ECEMF_HighH2_LifestCha;above GDP cutoff;Liquids;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;3
-SSP3;ECEMF_HighH2_LifestCha;above GDP cutoff;BEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;40;2040;5
-SSP3;ECEMF_HighH2_LifestCha;above GDP cutoff;FCEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;250;2040;3
-SSP3;ECEMF_HighH2_LifestCha;above GDP cutoff;Liquids;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;3
-SSP3;ECEMF_HighH2_LifestCha;below GDP cutoff;BEV;Bus;Bus;trn_pass_road;FV;3;2060;15
-SSP3;ECEMF_HighH2_LifestCha;below GDP cutoff;FCEV;Bus;Bus;trn_pass_road;FV;160;2040;5
-SSP3;ECEMF_HighH2_LifestCha;below GDP cutoff;Liquids;Bus;Bus;trn_pass_road;FV;1;2050;10
-SSP3;ECEMF_HighH2_LifestCha;below GDP cutoff;Hydrogen;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;5;2055;10
-SSP3;ECEMF_HighH2_LifestCha;below GDP cutoff;Liquids;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SSP3;ECEMF_HighH2_LifestCha;below GDP cutoff;Liquids;Ship;Domestic Ship_tmp_subsectorL2;Domestic Ship;FV;1;2050;10
-SSP3;ECEMF_HighH2_LifestCha;below GDP cutoff;Electric;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;2;2050;10
-SSP3;ECEMF_HighH2_LifestCha;below GDP cutoff;Liquids;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SSP3;ECEMF_HighH2_LifestCha;below GDP cutoff;Electric;Rail;HSR_tmp_subsectorL2;HSR;FV;2;2050;10
-SSP3;ECEMF_HighH2_LifestCha;below GDP cutoff;Liquids;Aviation;International Aviation_tmp_subsectorL2;International Aviation;FV;1;2050;10
-SSP3;ECEMF_HighH2_LifestCha;below GDP cutoff;Liquids;Ship;International Ship_tmp_subsectorL2;International Ship;FV;1;2050;10
-SSP3;ECEMF_HighH2_LifestCha;below GDP cutoff;BEV;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;3;2050;10
-SSP3;ECEMF_HighH2_LifestCha;below GDP cutoff;Liquids;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SSP3;ECEMF_HighH2_LifestCha;below GDP cutoff;Electric;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;2;2050;10
-SSP3;ECEMF_HighH2_LifestCha;below GDP cutoff;Liquids;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SSP3;ECEMF_HighH2_LifestCha;below GDP cutoff;BEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;10;2040;3
-SSP3;ECEMF_HighH2_LifestCha;below GDP cutoff;FCEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;10;2040;3
-SSP3;ECEMF_HighH2_LifestCha;below GDP cutoff;Liquids;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;3
-SSP3;ECEMF_HighH2_LifestCha;below GDP cutoff;BEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;5;2035;5
-SSP3;ECEMF_HighH2_LifestCha;below GDP cutoff;FCEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;30;2035;3
-SSP3;ECEMF_HighH2_LifestCha;below GDP cutoff;Liquids;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;3
-SSP3;ECEMF_HighH2_ModEff;above GDP cutoff;;;;Cycle;S1S;1;2050;10
-SSP3;ECEMF_HighH2_ModEff;above GDP cutoff;;;;Domestic Aviation;S1S;0.75;2035;10
-SSP3;ECEMF_HighH2_ModEff;above GDP cutoff;;;;Domestic Ship;S1S;1;2050;10
-SSP3;ECEMF_HighH2_ModEff;above GDP cutoff;;;;Freight Rail;S1S;1;2050;10
-SSP3;ECEMF_HighH2_ModEff;above GDP cutoff;;;;HSR;S1S;1;2050;10
-SSP3;ECEMF_HighH2_ModEff;above GDP cutoff;;;;Passenger Rail;S1S;1;2050;10
-SSP3;ECEMF_HighH2_ModEff;above GDP cutoff;;;;trn_freight_road;S1S;0.9;2035;10
-SSP3;ECEMF_HighH2_ModEff;above GDP cutoff;;;;trn_pass_road;S1S;0.9;2035;10
-SSP3;ECEMF_HighH2_ModEff;above GDP cutoff;;;;Walk;S1S;1;2050;10
-SSP3;ECEMF_HighH2_ModEff;below GDP cutoff;;;;Cycle;S1S;1;2050;10
-SSP3;ECEMF_HighH2_ModEff;below GDP cutoff;;;;Domestic Aviation;S1S;0.75;2035;10
-SSP3;ECEMF_HighH2_ModEff;below GDP cutoff;;;;Domestic Ship;S1S;1;2050;10
-SSP3;ECEMF_HighH2_ModEff;below GDP cutoff;;;;Freight Rail;S1S;1;2050;10
-SSP3;ECEMF_HighH2_ModEff;below GDP cutoff;;;;HSR;S1S;1;2050;10
-SSP3;ECEMF_HighH2_ModEff;below GDP cutoff;;;;Passenger Rail;S1S;1;2050;10
-SSP3;ECEMF_HighH2_ModEff;below GDP cutoff;;;;trn_freight_road;S1S;0.9;2035;10
-SSP3;ECEMF_HighH2_ModEff;below GDP cutoff;;;;trn_pass_road;S1S;0.9;2035;10
-SSP3;ECEMF_HighH2_ModEff;below GDP cutoff;;;;Walk;S1S;1;2050;10
-SSP3;ECEMF_HighH2_ModEff;above GDP cutoff;;;Bus;trn_pass_road;S2S1;1;2050;10
-SSP3;ECEMF_HighH2_ModEff;above GDP cutoff;;;trn_pass_road_LDV;trn_pass_road;S2S1;0.9;2035;10
-SSP3;ECEMF_HighH2_ModEff;below GDP cutoff;;;Bus;trn_pass_road;S2S1;1;2050;10
-SSP3;ECEMF_HighH2_ModEff;below GDP cutoff;;;trn_pass_road_LDV;trn_pass_road;S2S1;0.9;2035;10
-SSP3;ECEMF_HighH2_ModEff;above GDP cutoff;BEV;Bus;Bus;trn_pass_road;FV;3;2060;15
-SSP3;ECEMF_HighH2_ModEff;above GDP cutoff;FCEV;Bus;Bus;trn_pass_road;FV;200;2035;5
-SSP3;ECEMF_HighH2_ModEff;above GDP cutoff;Liquids;Bus;Bus;trn_pass_road;FV;1;2050;10
-SSP3;ECEMF_HighH2_ModEff;above GDP cutoff;Hydrogen;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;3;2055;5
-SSP3;ECEMF_HighH2_ModEff;above GDP cutoff;Liquids;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SSP3;ECEMF_HighH2_ModEff;above GDP cutoff;Liquids;Ship;Domestic Ship_tmp_subsectorL2;Domestic Ship;FV;1;2050;10
-SSP3;ECEMF_HighH2_ModEff;above GDP cutoff;Electric;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1.5;2050;10
-SSP3;ECEMF_HighH2_ModEff;above GDP cutoff;Liquids;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SSP3;ECEMF_HighH2_ModEff;above GDP cutoff;Electric;Rail;HSR_tmp_subsectorL2;HSR;FV;1.5;2050;10
-SSP3;ECEMF_HighH2_ModEff;above GDP cutoff;Liquids;Aviation;International Aviation_tmp_subsectorL2;International Aviation;FV;1;2050;10
-SSP3;ECEMF_HighH2_ModEff;above GDP cutoff;Liquids;Ship;International Ship_tmp_subsectorL2;International Ship;FV;1;2050;10
-SSP3;ECEMF_HighH2_ModEff;above GDP cutoff;BEV;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;3;2050;10
-SSP3;ECEMF_HighH2_ModEff;above GDP cutoff;Liquids;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SSP3;ECEMF_HighH2_ModEff;above GDP cutoff;Electric;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1.5;2050;10
-SSP3;ECEMF_HighH2_ModEff;above GDP cutoff;Liquids;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SSP3;ECEMF_HighH2_ModEff;above GDP cutoff;BEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;40;2040;3
-SSP3;ECEMF_HighH2_ModEff;above GDP cutoff;FCEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;50;2040;3
-SSP3;ECEMF_HighH2_ModEff;above GDP cutoff;Liquids;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;3
-SSP3;ECEMF_HighH2_ModEff;above GDP cutoff;BEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;40;2040;5
-SSP3;ECEMF_HighH2_ModEff;above GDP cutoff;FCEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;250;2040;3
-SSP3;ECEMF_HighH2_ModEff;above GDP cutoff;Liquids;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;3
-SSP3;ECEMF_HighH2_ModEff;below GDP cutoff;BEV;Bus;Bus;trn_pass_road;FV;3;2060;15
-SSP3;ECEMF_HighH2_ModEff;below GDP cutoff;FCEV;Bus;Bus;trn_pass_road;FV;150;2040;5
-SSP3;ECEMF_HighH2_ModEff;below GDP cutoff;Liquids;Bus;Bus;trn_pass_road;FV;1;2050;10
-SSP3;ECEMF_HighH2_ModEff;below GDP cutoff;Hydrogen;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;2.5;2055;10
-SSP3;ECEMF_HighH2_ModEff;below GDP cutoff;Liquids;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SSP3;ECEMF_HighH2_ModEff;below GDP cutoff;Liquids;Ship;Domestic Ship_tmp_subsectorL2;Domestic Ship;FV;1;2050;10
-SSP3;ECEMF_HighH2_ModEff;below GDP cutoff;Electric;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;2.5;2050;10
-SSP3;ECEMF_HighH2_ModEff;below GDP cutoff;Liquids;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SSP3;ECEMF_HighH2_ModEff;below GDP cutoff;Electric;Rail;HSR_tmp_subsectorL2;HSR;FV;2.5;2050;10
-SSP3;ECEMF_HighH2_ModEff;below GDP cutoff;Liquids;Aviation;International Aviation_tmp_subsectorL2;International Aviation;FV;1;2050;10
-SSP3;ECEMF_HighH2_ModEff;below GDP cutoff;Liquids;Ship;International Ship_tmp_subsectorL2;International Ship;FV;1;2050;10
-SSP3;ECEMF_HighH2_ModEff;below GDP cutoff;BEV;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;2.5;2050;10
-SSP3;ECEMF_HighH2_ModEff;below GDP cutoff;Liquids;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SSP3;ECEMF_HighH2_ModEff;below GDP cutoff;Electric;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;2.5;2050;10
-SSP3;ECEMF_HighH2_ModEff;below GDP cutoff;Liquids;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SSP3;ECEMF_HighH2_ModEff;below GDP cutoff;BEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;10;2040;3
-SSP3;ECEMF_HighH2_ModEff;below GDP cutoff;FCEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;10;2040;3
-SSP3;ECEMF_HighH2_ModEff;below GDP cutoff;Liquids;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;3
-SSP3;ECEMF_HighH2_ModEff;below GDP cutoff;BEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;5;2035;5
-SSP3;ECEMF_HighH2_ModEff;below GDP cutoff;FCEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;30;2035;3
-SSP3;ECEMF_HighH2_ModEff;below GDP cutoff;Liquids;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;3
-SSP3;HydrHype4;above GDP cutoff;;;;Cycle;S1S;1;2050;10
-SSP3;HydrHype4;above GDP cutoff;;;;Domestic Aviation;S1S;0.25;2035;10
-SSP3;HydrHype4;above GDP cutoff;;;;Domestic Ship;S1S;1;2050;10
-SSP3;HydrHype4;above GDP cutoff;;;;Freight Rail;S1S;1;2050;10
-SSP3;HydrHype4;above GDP cutoff;;;;HSR;S1S;1;2050;10
-SSP3;HydrHype4;above GDP cutoff;;;;Passenger Rail;S1S;1;2050;10
-SSP3;HydrHype4;above GDP cutoff;;;;trn_freight_road;S1S;0.5;2035;10
-SSP3;HydrHype4;above GDP cutoff;;;;trn_pass_road;S1S;0.7;2035;10
-SSP3;HydrHype4;above GDP cutoff;;;;Walk;S1S;1;2050;10
-SSP3;HydrHype4;below GDP cutoff;;;;Cycle;S1S;1;2050;10
-SSP3;HydrHype4;below GDP cutoff;;;;Domestic Aviation;S1S;0.25;2035;10
-SSP3;HydrHype4;below GDP cutoff;;;;Domestic Ship;S1S;1;2050;10
-SSP3;HydrHype4;below GDP cutoff;;;;Freight Rail;S1S;1;2050;10
-SSP3;HydrHype4;below GDP cutoff;;;;HSR;S1S;1;2050;10
-SSP3;HydrHype4;below GDP cutoff;;;;Passenger Rail;S1S;1;2050;10
-SSP3;HydrHype4;below GDP cutoff;;;;trn_freight_road;S1S;0.5;2035;10
-SSP3;HydrHype4;below GDP cutoff;;;;trn_pass_road;S1S;0.7;2035;10
-SSP3;HydrHype4;below GDP cutoff;;;;Walk;S1S;1;2050;10
-SSP3;HydrHype4;above GDP cutoff;;;Bus;trn_pass_road;S2S1;1;2050;10
-SSP3;HydrHype4;above GDP cutoff;;;trn_pass_road_LDV;trn_pass_road;S2S1;0.7;2035;10
-SSP3;HydrHype4;below GDP cutoff;;;Bus;trn_pass_road;S2S1;1;2050;10
-SSP3;HydrHype4;below GDP cutoff;;;trn_pass_road_LDV;trn_pass_road;S2S1;0.7;2035;10
-SSP3;HydrHype4;above GDP cutoff;BEV;Bus;Bus;trn_pass_road;FV;3;2060;15
-SSP3;HydrHype4;above GDP cutoff;FCEV;Bus;Bus;trn_pass_road;FV;200;2035;5
-SSP3;HydrHype4;above GDP cutoff;Liquids;Bus;Bus;trn_pass_road;FV;1;2050;10
-SSP3;HydrHype4;above GDP cutoff;Hydrogen;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;3;2055;5
-SSP3;HydrHype4;above GDP cutoff;Liquids;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SSP3;HydrHype4;above GDP cutoff;Liquids;Ship;Domestic Ship_tmp_subsectorL2;Domestic Ship;FV;1;2050;10
-SSP3;HydrHype4;above GDP cutoff;Electric;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SSP3;HydrHype4;above GDP cutoff;Liquids;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SSP3;HydrHype4;above GDP cutoff;Electric;Rail;HSR_tmp_subsectorL2;HSR;FV;1;2050;10
-SSP3;HydrHype4;above GDP cutoff;Liquids;Aviation;International Aviation_tmp_subsectorL2;International Aviation;FV;1;2050;10
-SSP3;HydrHype4;above GDP cutoff;Liquids;Ship;International Ship_tmp_subsectorL2;International Ship;FV;1;2050;10
-SSP3;HydrHype4;above GDP cutoff;BEV;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SSP3;HydrHype4;above GDP cutoff;Liquids;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SSP3;HydrHype4;above GDP cutoff;Electric;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SSP3;HydrHype4;above GDP cutoff;Liquids;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SSP3;HydrHype4;above GDP cutoff;BEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;40;2040;3
-SSP3;HydrHype4;above GDP cutoff;FCEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;50;2040;3
-SSP3;HydrHype4;above GDP cutoff;Liquids;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;3
-SSP3;HydrHype4;above GDP cutoff;BEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;40;2040;5
-SSP3;HydrHype4;above GDP cutoff;FCEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;250;2040;3
-SSP3;HydrHype4;above GDP cutoff;Liquids;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;3
-SSP3;HydrHype4;below GDP cutoff;BEV;Bus;Bus;trn_pass_road;FV;3;2060;15
-SSP3;HydrHype4;below GDP cutoff;FCEV;Bus;Bus;trn_pass_road;FV;150;2040;5
-SSP3;HydrHype4;below GDP cutoff;Liquids;Bus;Bus;trn_pass_road;FV;1;2050;10
-SSP3;HydrHype4;below GDP cutoff;Hydrogen;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;2.5;2055;10
-SSP3;HydrHype4;below GDP cutoff;Liquids;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SSP3;HydrHype4;below GDP cutoff;Liquids;Ship;Domestic Ship_tmp_subsectorL2;Domestic Ship;FV;1;2050;10
-SSP3;HydrHype4;below GDP cutoff;Electric;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SSP3;HydrHype4;below GDP cutoff;Liquids;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SSP3;HydrHype4;below GDP cutoff;Electric;Rail;HSR_tmp_subsectorL2;HSR;FV;1;2050;10
-SSP3;HydrHype4;below GDP cutoff;Liquids;Aviation;International Aviation_tmp_subsectorL2;International Aviation;FV;1;2050;10
-SSP3;HydrHype4;below GDP cutoff;Liquids;Ship;International Ship_tmp_subsectorL2;International Ship;FV;1;2050;10
-SSP3;HydrHype4;below GDP cutoff;BEV;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SSP3;HydrHype4;below GDP cutoff;Liquids;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SSP3;HydrHype4;below GDP cutoff;Electric;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SSP3;HydrHype4;below GDP cutoff;Liquids;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SSP3;HydrHype4;below GDP cutoff;BEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;10;2040;3
-SSP3;HydrHype4;below GDP cutoff;FCEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;10;2040;3
-SSP3;HydrHype4;below GDP cutoff;Liquids;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;3
-SSP3;HydrHype4;below GDP cutoff;BEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;5;2035;5
-SSP3;HydrHype4;below GDP cutoff;FCEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;30;2035;3
-SSP3;HydrHype4;below GDP cutoff;Liquids;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;3
-SSP3;Mix2;above GDP cutoff;;;;Cycle;S1S;1;2050;10
-SSP3;Mix2;above GDP cutoff;;;;Domestic Aviation;S1S;0.75;2035;10
-SSP3;Mix2;above GDP cutoff;;;;Domestic Ship;S1S;1;2050;10
-SSP3;Mix2;above GDP cutoff;;;;Freight Rail;S1S;1;2050;10
-SSP3;Mix2;above GDP cutoff;;;;HSR;S1S;1;2050;10
-SSP3;Mix2;above GDP cutoff;;;;Passenger Rail;S1S;1;2050;10
-SSP3;Mix2;above GDP cutoff;;;;trn_freight_road;S1S;0.9;2035;10
-SSP3;Mix2;above GDP cutoff;;;;trn_pass_road;S1S;0.9;2035;10
-SSP3;Mix2;above GDP cutoff;;;;Walk;S1S;1;2050;10
-SSP3;Mix2;below GDP cutoff;;;;Cycle;S1S;1;2050;10
-SSP3;Mix2;below GDP cutoff;;;;Domestic Aviation;S1S;0.75;2035;10
-SSP3;Mix2;below GDP cutoff;;;;Domestic Ship;S1S;1;2050;10
-SSP3;Mix2;below GDP cutoff;;;;Freight Rail;S1S;1;2050;10
-SSP3;Mix2;below GDP cutoff;;;;HSR;S1S;1;2050;10
-SSP3;Mix2;below GDP cutoff;;;;Passenger Rail;S1S;1;2050;10
-SSP3;Mix2;below GDP cutoff;;;;trn_freight_road;S1S;0.9;2035;10
-SSP3;Mix2;below GDP cutoff;;;;trn_pass_road;S1S;0.9;2035;10
-SSP3;Mix2;below GDP cutoff;;;;Walk;S1S;1;2050;10
-SSP3;Mix2;above GDP cutoff;;;Bus;trn_pass_road;S2S1;1;2050;10
-SSP3;Mix2;above GDP cutoff;;;trn_pass_road_LDV;trn_pass_road;S2S1;0.9;2035;10
-SSP3;Mix2;below GDP cutoff;;;Bus;trn_pass_road;S2S1;1;2050;10
-SSP3;Mix2;below GDP cutoff;;;trn_pass_road_LDV;trn_pass_road;S2S1;0.9;2035;10
-SSP3;Mix2;above GDP cutoff;BEV;Bus;Bus;trn_pass_road;FV;2;2035;10
-SSP3;Mix2;above GDP cutoff;FCEV;Bus;Bus;trn_pass_road;FV;2;2035;10
-SSP3;Mix2;above GDP cutoff;Liquids;Bus;Bus;trn_pass_road;FV;1;2050;10
-SSP3;Mix2;above GDP cutoff;Hydrogen;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SSP3;Mix2;above GDP cutoff;Liquids;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SSP3;Mix2;above GDP cutoff;Liquids;Ship;Domestic Ship_tmp_subsectorL2;Domestic Ship;FV;1;2050;10
-SSP3;Mix2;above GDP cutoff;Electric;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SSP3;Mix2;above GDP cutoff;Liquids;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SSP3;Mix2;above GDP cutoff;Electric;Rail;HSR_tmp_subsectorL2;HSR;FV;1;2050;10
-SSP3;Mix2;above GDP cutoff;Liquids;Aviation;International Aviation_tmp_subsectorL2;International Aviation;FV;1;2050;10
-SSP3;Mix2;above GDP cutoff;Liquids;Ship;International Ship_tmp_subsectorL2;International Ship;FV;1;2050;10
-SSP3;Mix2;above GDP cutoff;BEV;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SSP3;Mix2;above GDP cutoff;Liquids;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SSP3;Mix2;above GDP cutoff;Electric;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SSP3;Mix2;above GDP cutoff;Liquids;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SSP3;Mix2;above GDP cutoff;BEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;2;2035;10
-SSP3;Mix2;above GDP cutoff;FCEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;2;2035;10
-SSP3;Mix2;above GDP cutoff;Liquids;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;10
-SSP3;Mix2;above GDP cutoff;BEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;2;2035;10
-SSP3;Mix2;above GDP cutoff;FCEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;2;2035;10
-SSP3;Mix2;above GDP cutoff;Liquids;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;10
-SSP3;Mix2;below GDP cutoff;BEV;Bus;Bus;trn_pass_road;FV;1.5;2035;10
-SSP3;Mix2;below GDP cutoff;FCEV;Bus;Bus;trn_pass_road;FV;1.5;2035;10
-SSP3;Mix2;below GDP cutoff;Liquids;Bus;Bus;trn_pass_road;FV;1;2050;10
-SSP3;Mix2;below GDP cutoff;Hydrogen;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SSP3;Mix2;below GDP cutoff;Liquids;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SSP3;Mix2;below GDP cutoff;Liquids;Ship;Domestic Ship_tmp_subsectorL2;Domestic Ship;FV;1;2050;10
-SSP3;Mix2;below GDP cutoff;Electric;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SSP3;Mix2;below GDP cutoff;Liquids;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SSP3;Mix2;below GDP cutoff;Electric;Rail;HSR_tmp_subsectorL2;HSR;FV;1;2050;10
-SSP3;Mix2;below GDP cutoff;Liquids;Aviation;International Aviation_tmp_subsectorL2;International Aviation;FV;1;2050;10
-SSP3;Mix2;below GDP cutoff;Liquids;Ship;International Ship_tmp_subsectorL2;International Ship;FV;1;2050;10
-SSP3;Mix2;below GDP cutoff;BEV;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SSP3;Mix2;below GDP cutoff;Liquids;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SSP3;Mix2;below GDP cutoff;Electric;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SSP3;Mix2;below GDP cutoff;Liquids;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SSP3;Mix2;below GDP cutoff;BEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1.5;2035;10
-SSP3;Mix2;below GDP cutoff;FCEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1.5;2035;10
-SSP3;Mix2;below GDP cutoff;Liquids;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;10
-SSP3;Mix2;below GDP cutoff;BEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1.5;2035;10
-SSP3;Mix2;below GDP cutoff;FCEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1.5;2035;10
-SSP3;Mix2;below GDP cutoff;Liquids;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;10
-SSP3;Mix3;above GDP cutoff;;;;Cycle;S1S;1;2050;10
-SSP3;Mix3;above GDP cutoff;;;;Domestic Aviation;S1S;0.5;2035;10
-SSP3;Mix3;above GDP cutoff;;;;Domestic Ship;S1S;1;2050;10
-SSP3;Mix3;above GDP cutoff;;;;Freight Rail;S1S;1;2050;10
-SSP3;Mix3;above GDP cutoff;;;;HSR;S1S;1;2050;10
-SSP3;Mix3;above GDP cutoff;;;;Passenger Rail;S1S;1;2050;10
-SSP3;Mix3;above GDP cutoff;;;;trn_freight_road;S1S;0.7;2035;10
-SSP3;Mix3;above GDP cutoff;;;;trn_pass_road;S1S;0.8;2035;10
-SSP3;Mix3;above GDP cutoff;;;;Walk;S1S;1;2050;10
-SSP3;Mix3;below GDP cutoff;;;;Cycle;S1S;1;2050;10
-SSP3;Mix3;below GDP cutoff;;;;Domestic Aviation;S1S;0.5;2035;10
-SSP3;Mix3;below GDP cutoff;;;;Domestic Ship;S1S;1;2050;10
-SSP3;Mix3;below GDP cutoff;;;;Freight Rail;S1S;1;2050;10
-SSP3;Mix3;below GDP cutoff;;;;HSR;S1S;1;2050;10
-SSP3;Mix3;below GDP cutoff;;;;Passenger Rail;S1S;1;2050;10
-SSP3;Mix3;below GDP cutoff;;;;trn_freight_road;S1S;0.7;2035;10
-SSP3;Mix3;below GDP cutoff;;;;trn_pass_road;S1S;0.8;2035;10
-SSP3;Mix3;below GDP cutoff;;;;Walk;S1S;1;2050;10
-SSP3;Mix3;above GDP cutoff;;;Bus;trn_pass_road;S2S1;1;2050;10
-SSP3;Mix3;above GDP cutoff;;;trn_pass_road_LDV;trn_pass_road;S2S1;0.8;2035;10
-SSP3;Mix3;below GDP cutoff;;;Bus;trn_pass_road;S2S1;1;2050;10
-SSP3;Mix3;below GDP cutoff;;;trn_pass_road_LDV;trn_pass_road;S2S1;0.8;2035;10
-SSP3;Mix3;above GDP cutoff;BEV;Bus;Bus;trn_pass_road;FV;4;2035;10
-SSP3;Mix3;above GDP cutoff;FCEV;Bus;Bus;trn_pass_road;FV;4;2035;10
-SSP3;Mix3;above GDP cutoff;Liquids;Bus;Bus;trn_pass_road;FV;1;2050;10
-SSP3;Mix3;above GDP cutoff;Hydrogen;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SSP3;Mix3;above GDP cutoff;Liquids;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SSP3;Mix3;above GDP cutoff;Liquids;Ship;Domestic Ship_tmp_subsectorL2;Domestic Ship;FV;1;2050;10
-SSP3;Mix3;above GDP cutoff;Electric;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1.5;2050;10
-SSP3;Mix3;above GDP cutoff;Liquids;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SSP3;Mix3;above GDP cutoff;Electric;Rail;HSR_tmp_subsectorL2;HSR;FV;1.5;2050;10
-SSP3;Mix3;above GDP cutoff;Liquids;Aviation;International Aviation_tmp_subsectorL2;International Aviation;FV;1;2050;10
-SSP3;Mix3;above GDP cutoff;Liquids;Ship;International Ship_tmp_subsectorL2;International Ship;FV;1;2050;10
-SSP3;Mix3;above GDP cutoff;BEV;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SSP3;Mix3;above GDP cutoff;Liquids;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SSP3;Mix3;above GDP cutoff;Electric;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1.5;2050;10
-SSP3;Mix3;above GDP cutoff;Liquids;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SSP3;Mix3;above GDP cutoff;BEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;3;2035;10
-SSP3;Mix3;above GDP cutoff;FCEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;3;2035;10
-SSP3;Mix3;above GDP cutoff;Liquids;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;10
-SSP3;Mix3;above GDP cutoff;BEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;5;2035;10
-SSP3;Mix3;above GDP cutoff;FCEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;7;2035;10
-SSP3;Mix3;above GDP cutoff;Liquids;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;10
-SSP3;Mix3;below GDP cutoff;BEV;Bus;Bus;trn_pass_road;FV;3.5;2035;10
-SSP3;Mix3;below GDP cutoff;FCEV;Bus;Bus;trn_pass_road;FV;3.5;2035;10
-SSP3;Mix3;below GDP cutoff;Liquids;Bus;Bus;trn_pass_road;FV;1;2050;10
-SSP3;Mix3;below GDP cutoff;Hydrogen;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SSP3;Mix3;below GDP cutoff;Liquids;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SSP3;Mix3;below GDP cutoff;Liquids;Ship;Domestic Ship_tmp_subsectorL2;Domestic Ship;FV;1;2050;10
-SSP3;Mix3;below GDP cutoff;Electric;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1.5;2050;10
-SSP3;Mix3;below GDP cutoff;Liquids;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SSP3;Mix3;below GDP cutoff;Electric;Rail;HSR_tmp_subsectorL2;HSR;FV;1.5;2050;10
-SSP3;Mix3;below GDP cutoff;Liquids;Aviation;International Aviation_tmp_subsectorL2;International Aviation;FV;1;2050;10
-SSP3;Mix3;below GDP cutoff;Liquids;Ship;International Ship_tmp_subsectorL2;International Ship;FV;1;2050;10
-SSP3;Mix3;below GDP cutoff;BEV;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SSP3;Mix3;below GDP cutoff;Liquids;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SSP3;Mix3;below GDP cutoff;Electric;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1.5;2050;10
-SSP3;Mix3;below GDP cutoff;Liquids;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SSP3;Mix3;below GDP cutoff;BEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;3;2035;10
-SSP3;Mix3;below GDP cutoff;FCEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;3;2035;10
-SSP3;Mix3;below GDP cutoff;Liquids;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;10
-SSP3;Mix3;below GDP cutoff;BEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;4;2035;10
-SSP3;Mix3;below GDP cutoff;FCEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;7;2035;10
-SSP3;Mix3;below GDP cutoff;Liquids;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;10
-SSP3;Mix4;above GDP cutoff;;;;Cycle;S1S;1;2050;10
-SSP3;Mix4;above GDP cutoff;;;;Domestic Aviation;S1S;0.25;2035;10
-SSP3;Mix4;above GDP cutoff;;;;Domestic Ship;S1S;1;2050;10
-SSP3;Mix4;above GDP cutoff;;;;Freight Rail;S1S;1;2050;10
-SSP3;Mix4;above GDP cutoff;;;;HSR;S1S;1;2050;10
-SSP3;Mix4;above GDP cutoff;;;;Passenger Rail;S1S;1;2050;10
-SSP3;Mix4;above GDP cutoff;;;;trn_freight_road;S1S;0.5;2035;10
-SSP3;Mix4;above GDP cutoff;;;;trn_pass_road;S1S;0.7;2035;10
-SSP3;Mix4;above GDP cutoff;;;;Walk;S1S;1;2050;10
-SSP3;Mix4;below GDP cutoff;;;;Cycle;S1S;1;2050;10
-SSP3;Mix4;below GDP cutoff;;;;Domestic Aviation;S1S;0.25;2035;10
-SSP3;Mix4;below GDP cutoff;;;;Domestic Ship;S1S;1;2050;10
-SSP3;Mix4;below GDP cutoff;;;;Freight Rail;S1S;1;2050;10
-SSP3;Mix4;below GDP cutoff;;;;HSR;S1S;1;2050;10
-SSP3;Mix4;below GDP cutoff;;;;Passenger Rail;S1S;1;2050;10
-SSP3;Mix4;below GDP cutoff;;;;trn_freight_road;S1S;0.5;2035;10
-SSP3;Mix4;below GDP cutoff;;;;trn_pass_road;S1S;0.7;2035;10
-SSP3;Mix4;below GDP cutoff;;;;Walk;S1S;1;2050;10
-SSP3;Mix4;above GDP cutoff;;;Bus;trn_pass_road;S2S1;1;2050;10
-SSP3;Mix4;above GDP cutoff;;;trn_pass_road_LDV;trn_pass_road;S2S1;0.7;2035;10
-SSP3;Mix4;below GDP cutoff;;;Bus;trn_pass_road;S2S1;1;2050;10
-SSP3;Mix4;below GDP cutoff;;;trn_pass_road_LDV;trn_pass_road;S2S1;0.7;2035;10
-SSP3;Mix4;above GDP cutoff;BEV;Bus;Bus;trn_pass_road;FV;6;2035;10
-SSP3;Mix4;above GDP cutoff;FCEV;Bus;Bus;trn_pass_road;FV;6;2035;10
-SSP3;Mix4;above GDP cutoff;Liquids;Bus;Bus;trn_pass_road;FV;1;2050;10
-SSP3;Mix4;above GDP cutoff;Hydrogen;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SSP3;Mix4;above GDP cutoff;Liquids;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SSP3;Mix4;above GDP cutoff;Liquids;Ship;Domestic Ship_tmp_subsectorL2;Domestic Ship;FV;1;2050;10
-SSP3;Mix4;above GDP cutoff;Electric;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;2;2050;10
-SSP3;Mix4;above GDP cutoff;Liquids;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SSP3;Mix4;above GDP cutoff;Electric;Rail;HSR_tmp_subsectorL2;HSR;FV;2;2050;10
-SSP3;Mix4;above GDP cutoff;Liquids;Aviation;International Aviation_tmp_subsectorL2;International Aviation;FV;1;2050;10
-SSP3;Mix4;above GDP cutoff;Liquids;Ship;International Ship_tmp_subsectorL2;International Ship;FV;1;2050;10
-SSP3;Mix4;above GDP cutoff;BEV;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SSP3;Mix4;above GDP cutoff;Liquids;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SSP3;Mix4;above GDP cutoff;Electric;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;2;2050;10
-SSP3;Mix4;above GDP cutoff;Liquids;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SSP3;Mix4;above GDP cutoff;BEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;40;2040;3
-SSP3;Mix4;above GDP cutoff;FCEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;10;2040;3
-SSP3;Mix4;above GDP cutoff;Liquids;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;3
-SSP3;Mix4;above GDP cutoff;BEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;50;2040;5
-SSP3;Mix4;above GDP cutoff;FCEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;60;2040;3
-SSP3;Mix4;above GDP cutoff;Liquids;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;3
-SSP3;Mix4;below GDP cutoff;BEV;Bus;Bus;trn_pass_road;FV;5;2035;10
-SSP3;Mix4;below GDP cutoff;FCEV;Bus;Bus;trn_pass_road;FV;5;2035;10
-SSP3;Mix4;below GDP cutoff;Liquids;Bus;Bus;trn_pass_road;FV;1;2050;10
-SSP3;Mix4;below GDP cutoff;Hydrogen;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SSP3;Mix4;below GDP cutoff;Liquids;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SSP3;Mix4;below GDP cutoff;Liquids;Ship;Domestic Ship_tmp_subsectorL2;Domestic Ship;FV;1;2050;10
-SSP3;Mix4;below GDP cutoff;Electric;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;2;2050;10
-SSP3;Mix4;below GDP cutoff;Liquids;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SSP3;Mix4;below GDP cutoff;Electric;Rail;HSR_tmp_subsectorL2;HSR;FV;2;2050;10
-SSP3;Mix4;below GDP cutoff;Liquids;Aviation;International Aviation_tmp_subsectorL2;International Aviation;FV;1;2050;10
-SSP3;Mix4;below GDP cutoff;Liquids;Ship;International Ship_tmp_subsectorL2;International Ship;FV;1;2050;10
-SSP3;Mix4;below GDP cutoff;BEV;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SSP3;Mix4;below GDP cutoff;Liquids;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SSP3;Mix4;below GDP cutoff;Electric;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;2;2050;10
-SSP3;Mix4;below GDP cutoff;Liquids;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SSP3;Mix4;below GDP cutoff;BEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;10;2040;3
-SSP3;Mix4;below GDP cutoff;FCEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;10;2040;3
-SSP3;Mix4;below GDP cutoff;Liquids;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;3
-SSP3;Mix4;below GDP cutoff;BEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;5;2035;5
-SSP3;Mix4;below GDP cutoff;FCEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;7;2035;3
-SSP3;Mix4;below GDP cutoff;Liquids;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;3
-SSP3;NAV_act;CAZ;;;;Cycle;S1S;2.5;2040;10
-SSP3;NAV_act;CAZ;;;;Domestic Aviation;S1S;0.3;2040;10
-SSP3;NAV_act;CAZ;;;;Domestic Ship;S1S;1;2040;10
-SSP3;NAV_act;CAZ;;;;Freight Rail;S1S;1;2040;10
-SSP3;NAV_act;CAZ;;;;HSR;S1S;1.7;2040;10
-SSP3;NAV_act;CAZ;;;;Passenger Rail;S1S;4;2040;10
-SSP3;NAV_act;CAZ;;;;trn_freight_road;S1S;0.9;2040;10
-SSP3;NAV_act;CAZ;;;;trn_pass_road;S1S;0.6;2040;10
-SSP3;NAV_act;CAZ;;;;Walk;S1S;2.5;2040;10
-SSP3;NAV_act;USA;;;;Cycle;S1S;2.5;2040;10
-SSP3;NAV_act;USA;;;;Domestic Aviation;S1S;0.3;2040;10
-SSP3;NAV_act;USA;;;;Domestic Ship;S1S;1;2040;10
-SSP3;NAV_act;USA;;;;Freight Rail;S1S;1;2040;10
-SSP3;NAV_act;USA;;;;HSR;S1S;1.7;2040;10
-SSP3;NAV_act;USA;;;;Passenger Rail;S1S;4;2040;10
-SSP3;NAV_act;USA;;;;trn_freight_road;S1S;0.9;2040;10
-SSP3;NAV_act;USA;;;;trn_pass_road;S1S;0.6;2040;10
-SSP3;NAV_act;USA;;;;Walk;S1S;2.5;2040;10
-SSP3;NAV_act;above GDP cutoff;;;;Cycle;S1S;1.8;2040;10
-SSP3;NAV_act;above GDP cutoff;;;;Domestic Aviation;S1S;0.3;2040;10
-SSP3;NAV_act;above GDP cutoff;;;;Domestic Ship;S1S;1;2040;10
-SSP3;NAV_act;above GDP cutoff;;;;Freight Rail;S1S;1;2040;10
-SSP3;NAV_act;above GDP cutoff;;;;HSR;S1S;1.7;2040;10
-SSP3;NAV_act;above GDP cutoff;;;;Passenger Rail;S1S;1.6;2040;10
-SSP3;NAV_act;above GDP cutoff;;;;trn_freight_road;S1S;0.9;2040;10
-SSP3;NAV_act;above GDP cutoff;;;;trn_pass_road;S1S;0.7;2040;10
-SSP3;NAV_act;above GDP cutoff;;;;Walk;S1S;1.7;2040;10
-SSP3;NAV_act;below GDP cutoff;;;;Cycle;S1S;2.5;2040;10
-SSP3;NAV_act;below GDP cutoff;;;;Domestic Aviation;S1S;0.3;2040;10
-SSP3;NAV_act;below GDP cutoff;;;;Domestic Ship;S1S;1;2040;10
-SSP3;NAV_act;below GDP cutoff;;;;Freight Rail;S1S;1;2040;10
-SSP3;NAV_act;below GDP cutoff;;;;HSR;S1S;2.8;2040;10
-SSP3;NAV_act;below GDP cutoff;;;;Passenger Rail;S1S;1.5;2040;10
-SSP3;NAV_act;below GDP cutoff;;;;trn_freight_road;S1S;0.9;2040;10
-SSP3;NAV_act;below GDP cutoff;;;;trn_pass_road;S1S;0.7;2040;10
-SSP3;NAV_act;below GDP cutoff;;;;Walk;S1S;2.5;2040;10
-SSP3;NAV_act;CAZ;;;Bus;trn_pass_road;S2S1;3;2040;10
-SSP3;NAV_act;CAZ;;;trn_pass_road_LDV;trn_pass_road;S2S1;0.7;2040;10
-SSP3;NAV_act;USA;;;Bus;trn_pass_road;S2S1;2;2040;10
-SSP3;NAV_act;USA;;;trn_pass_road_LDV;trn_pass_road;S2S1;0.7;2040;10
-SSP3;NAV_act;above GDP cutoff;;;Bus;trn_pass_road;S2S1;2;2040;10
-SSP3;NAV_act;above GDP cutoff;;;trn_pass_road_LDV;trn_pass_road;S2S1;1;2040;10
-SSP3;NAV_act;below GDP cutoff;;;Bus;trn_pass_road;S2S1;2;2040;10
-SSP3;NAV_act;below GDP cutoff;;;trn_pass_road_LDV;trn_pass_road;S2S1;1;2040;10
-SSP3;NAV_act;CAZ;BEV;Bus;Bus;trn_pass_road;FV;1;2040;10
-SSP3;NAV_act;CAZ;FCEV;Bus;Bus;trn_pass_road;FV;1;2040;10
-SSP3;NAV_act;CAZ;Liquids;Bus;Bus;trn_pass_road;FV;1;2050;10
-SSP3;NAV_act;CAZ;Hydrogen;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SSP3;NAV_act;CAZ;Liquids;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SSP3;NAV_act;CAZ;Liquids;Ship;Domestic Ship_tmp_subsectorL2;Domestic Ship;FV;1;2050;10
-SSP3;NAV_act;CAZ;Electric;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SSP3;NAV_act;CAZ;Liquids;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SSP3;NAV_act;CAZ;Electric;Rail;HSR_tmp_subsectorL2;HSR;FV;1;2050;10
-SSP3;NAV_act;CAZ;Liquids;Aviation;International Aviation_tmp_subsectorL2;International Aviation;FV;1;2050;10
-SSP3;NAV_act;CAZ;Liquids;Ship;International Ship_tmp_subsectorL2;International Ship;FV;1;2050;10
-SSP3;NAV_act;CAZ;BEV;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SSP3;NAV_act;CAZ;Liquids;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SSP3;NAV_act;CAZ;Electric;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SSP3;NAV_act;CAZ;Liquids;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SSP3;NAV_act;CAZ;BEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2040;10
-SSP3;NAV_act;CAZ;FCEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2040;10
-SSP3;NAV_act;CAZ;Liquids;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;10
-SSP3;NAV_act;CAZ;BEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2040;10
-SSP3;NAV_act;CAZ;FCEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2040;10
-SSP3;NAV_act;CAZ;Liquids;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;10
-SSP3;NAV_act;USA;BEV;Bus;Bus;trn_pass_road;FV;1;2035;10
-SSP3;NAV_act;USA;FCEV;Bus;Bus;trn_pass_road;FV;1;2035;10
-SSP3;NAV_act;USA;Liquids;Bus;Bus;trn_pass_road;FV;1;2050;10
-SSP3;NAV_act;USA;Hydrogen;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SSP3;NAV_act;USA;Liquids;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SSP3;NAV_act;USA;Liquids;Ship;Domestic Ship_tmp_subsectorL2;Domestic Ship;FV;1;2050;10
-SSP3;NAV_act;USA;Electric;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SSP3;NAV_act;USA;Liquids;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SSP3;NAV_act;USA;Electric;Rail;HSR_tmp_subsectorL2;HSR;FV;1;2050;10
-SSP3;NAV_act;USA;Liquids;Aviation;International Aviation_tmp_subsectorL2;International Aviation;FV;1;2050;10
-SSP3;NAV_act;USA;Liquids;Ship;International Ship_tmp_subsectorL2;International Ship;FV;1;2050;10
-SSP3;NAV_act;USA;BEV;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SSP3;NAV_act;USA;Liquids;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SSP3;NAV_act;USA;Electric;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SSP3;NAV_act;USA;Liquids;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SSP3;NAV_act;USA;BEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2035;10
-SSP3;NAV_act;USA;FCEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2035;10
-SSP3;NAV_act;USA;Liquids;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;10
-SSP3;NAV_act;USA;BEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2035;10
-SSP3;NAV_act;USA;FCEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2035;10
-SSP3;NAV_act;USA;Liquids;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;10
-SSP3;NAV_act;above GDP cutoff;BEV;Bus;Bus;trn_pass_road;FV;1;2040;10
-SSP3;NAV_act;above GDP cutoff;FCEV;Bus;Bus;trn_pass_road;FV;1;2040;10
-SSP3;NAV_act;above GDP cutoff;Liquids;Bus;Bus;trn_pass_road;FV;1;2050;10
-SSP3;NAV_act;above GDP cutoff;Hydrogen;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SSP3;NAV_act;above GDP cutoff;Liquids;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SSP3;NAV_act;above GDP cutoff;Liquids;Ship;Domestic Ship_tmp_subsectorL2;Domestic Ship;FV;1;2050;10
-SSP3;NAV_act;above GDP cutoff;Electric;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SSP3;NAV_act;above GDP cutoff;Liquids;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SSP3;NAV_act;above GDP cutoff;Electric;Rail;HSR_tmp_subsectorL2;HSR;FV;1;2050;10
-SSP3;NAV_act;above GDP cutoff;Liquids;Aviation;International Aviation_tmp_subsectorL2;International Aviation;FV;1;2050;10
-SSP3;NAV_act;above GDP cutoff;Liquids;Ship;International Ship_tmp_subsectorL2;International Ship;FV;1;2050;10
-SSP3;NAV_act;above GDP cutoff;BEV;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SSP3;NAV_act;above GDP cutoff;Liquids;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SSP3;NAV_act;above GDP cutoff;Electric;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SSP3;NAV_act;above GDP cutoff;Liquids;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SSP3;NAV_act;above GDP cutoff;BEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2040;10
-SSP3;NAV_act;above GDP cutoff;FCEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2040;10
-SSP3;NAV_act;above GDP cutoff;Liquids;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;10
-SSP3;NAV_act;above GDP cutoff;BEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2040;10
-SSP3;NAV_act;above GDP cutoff;FCEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2040;10
-SSP3;NAV_act;above GDP cutoff;Liquids;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;10
-SSP3;NAV_act;below GDP cutoff;BEV;Bus;Bus;trn_pass_road;FV;1;2040;10
-SSP3;NAV_act;below GDP cutoff;FCEV;Bus;Bus;trn_pass_road;FV;1;2040;10
-SSP3;NAV_act;below GDP cutoff;Liquids;Bus;Bus;trn_pass_road;FV;1;2050;10
-SSP3;NAV_act;below GDP cutoff;Hydrogen;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SSP3;NAV_act;below GDP cutoff;Liquids;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SSP3;NAV_act;below GDP cutoff;Liquids;Ship;Domestic Ship_tmp_subsectorL2;Domestic Ship;FV;1;2050;10
-SSP3;NAV_act;below GDP cutoff;Electric;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SSP3;NAV_act;below GDP cutoff;Liquids;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SSP3;NAV_act;below GDP cutoff;Electric;Rail;HSR_tmp_subsectorL2;HSR;FV;1;2050;10
-SSP3;NAV_act;below GDP cutoff;Liquids;Aviation;International Aviation_tmp_subsectorL2;International Aviation;FV;1;2050;10
-SSP3;NAV_act;below GDP cutoff;Liquids;Ship;International Ship_tmp_subsectorL2;International Ship;FV;1;2050;10
-SSP3;NAV_act;below GDP cutoff;BEV;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SSP3;NAV_act;below GDP cutoff;Liquids;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SSP3;NAV_act;below GDP cutoff;Electric;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SSP3;NAV_act;below GDP cutoff;Liquids;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SSP3;NAV_act;below GDP cutoff;BEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2040;10
-SSP3;NAV_act;below GDP cutoff;FCEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2040;10
-SSP3;NAV_act;below GDP cutoff;Liquids;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;10
-SSP3;NAV_act;below GDP cutoff;BEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2040;10
-SSP3;NAV_act;below GDP cutoff;FCEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2040;10
-SSP3;NAV_act;below GDP cutoff;Liquids;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;10
-SSP3;NAV_all;CAZ;;;;Cycle;S1S;2.5;2040;10
-SSP3;NAV_all;CAZ;;;;Domestic Aviation;S1S;0.3;2040;10
-SSP3;NAV_all;CAZ;;;;Domestic Ship;S1S;1;2040;10
-SSP3;NAV_all;CAZ;;;;Freight Rail;S1S;1;2040;10
-SSP3;NAV_all;CAZ;;;;HSR;S1S;1.7;2040;10
-SSP3;NAV_all;CAZ;;;;Passenger Rail;S1S;4;2040;10
-SSP3;NAV_all;CAZ;;;;trn_freight_road;S1S;0.9;2040;10
-SSP3;NAV_all;CAZ;;;;trn_pass_road;S1S;0.6;2040;10
-SSP3;NAV_all;CAZ;;;;Walk;S1S;2.5;2040;10
-SSP3;NAV_all;USA;;;;Cycle;S1S;2.5;2040;10
-SSP3;NAV_all;USA;;;;Domestic Aviation;S1S;0.3;2040;10
-SSP3;NAV_all;USA;;;;Domestic Ship;S1S;1;2040;10
-SSP3;NAV_all;USA;;;;Freight Rail;S1S;1;2040;10
-SSP3;NAV_all;USA;;;;HSR;S1S;1.7;2040;10
-SSP3;NAV_all;USA;;;;Passenger Rail;S1S;4;2040;10
-SSP3;NAV_all;USA;;;;trn_freight_road;S1S;0.9;2040;10
-SSP3;NAV_all;USA;;;;trn_pass_road;S1S;0.6;2040;10
-SSP3;NAV_all;USA;;;;Walk;S1S;2.5;2040;10
-SSP3;NAV_all;above GDP cutoff;;;;Cycle;S1S;1.8;2040;10
-SSP3;NAV_all;above GDP cutoff;;;;Domestic Aviation;S1S;0.3;2040;10
-SSP3;NAV_all;above GDP cutoff;;;;Domestic Ship;S1S;1;2040;10
-SSP3;NAV_all;above GDP cutoff;;;;Freight Rail;S1S;1;2040;10
-SSP3;NAV_all;above GDP cutoff;;;;HSR;S1S;1.7;2040;10
-SSP3;NAV_all;above GDP cutoff;;;;Passenger Rail;S1S;1.6;2040;10
-SSP3;NAV_all;above GDP cutoff;;;;trn_freight_road;S1S;0.9;2040;10
-SSP3;NAV_all;above GDP cutoff;;;;trn_pass_road;S1S;0.7;2040;10
-SSP3;NAV_all;above GDP cutoff;;;;Walk;S1S;1.7;2040;10
-SSP3;NAV_all;below GDP cutoff;;;;Cycle;S1S;2.5;2040;10
-SSP3;NAV_all;below GDP cutoff;;;;Domestic Aviation;S1S;0.3;2040;10
-SSP3;NAV_all;below GDP cutoff;;;;Domestic Ship;S1S;1;2040;10
-SSP3;NAV_all;below GDP cutoff;;;;Freight Rail;S1S;1;2040;10
-SSP3;NAV_all;below GDP cutoff;;;;HSR;S1S;2.8;2040;10
-SSP3;NAV_all;below GDP cutoff;;;;Passenger Rail;S1S;1.5;2040;10
-SSP3;NAV_all;below GDP cutoff;;;;trn_freight_road;S1S;0.9;2040;10
-SSP3;NAV_all;below GDP cutoff;;;;trn_pass_road;S1S;0.7;2040;10
-SSP3;NAV_all;below GDP cutoff;;;;Walk;S1S;2.5;2040;10
-SSP3;NAV_all;CAZ;;;Bus;trn_pass_road;S2S1;3;2040;10
-SSP3;NAV_all;CAZ;;;trn_pass_road_LDV;trn_pass_road;S2S1;0.7;2040;10
-SSP3;NAV_all;USA;;;Bus;trn_pass_road;S2S1;2;2040;10
-SSP3;NAV_all;USA;;;trn_pass_road_LDV;trn_pass_road;S2S1;0.7;2040;10
-SSP3;NAV_all;above GDP cutoff;;;Bus;trn_pass_road;S2S1;2;2040;10
-SSP3;NAV_all;above GDP cutoff;;;trn_pass_road_LDV;trn_pass_road;S2S1;1;2040;10
-SSP3;NAV_all;below GDP cutoff;;;Bus;trn_pass_road;S2S1;2;2040;10
-SSP3;NAV_all;below GDP cutoff;;;trn_pass_road_LDV;trn_pass_road;S2S1;1;2040;10
-SSP3;NAV_all;above GDP cutoff;BEV;Bus;Bus;trn_pass_road;FV;9;2025;10
-SSP3;NAV_all;above GDP cutoff;FCEV;Bus;Bus;trn_pass_road;FV;6;2025;10
-SSP3;NAV_all;above GDP cutoff;Liquids;Bus;Bus;trn_pass_road;FV;0.01;2025;10
-SSP3;NAV_all;above GDP cutoff;Hydrogen;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;10;2045;10
-SSP3;NAV_all;above GDP cutoff;Liquids;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;0.1;2045;10
-SSP3;NAV_all;above GDP cutoff;Liquids;Ship;Domestic Ship_tmp_subsectorL2;Domestic Ship;FV;0.1;2050;10
-SSP3;NAV_all;above GDP cutoff;Electric;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;2;2040;10
-SSP3;NAV_all;above GDP cutoff;Liquids;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;0.1;2040;10
-SSP3;NAV_all;above GDP cutoff;Electric;Rail;HSR_tmp_subsectorL2;HSR;FV;2;2040;10
-SSP3;NAV_all;above GDP cutoff;Liquids;Aviation;International Aviation_tmp_subsectorL2;International Aviation;FV;0.1;2045;10
-SSP3;NAV_all;above GDP cutoff;Liquids;Ship;International Ship_tmp_subsectorL2;International Ship;FV;0.1;2050;10
-SSP3;NAV_all;above GDP cutoff;BEV;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;4;2030;10
-SSP3;NAV_all;above GDP cutoff;Liquids;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;0.05;2030;10
-SSP3;NAV_all;above GDP cutoff;Electric;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;2;2040;10
-SSP3;NAV_all;above GDP cutoff;Liquids;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;0.1;2040;10
-SSP3;NAV_all;above GDP cutoff;BEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;4;2025;10
-SSP3;NAV_all;above GDP cutoff;FCEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;4;2025;10
-SSP3;NAV_all;above GDP cutoff;Liquids;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;0.01;2025;10
-SSP3;NAV_all;above GDP cutoff;BEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;4;2025;10
-SSP3;NAV_all;above GDP cutoff;FCEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;9;2025;10
-SSP3;NAV_all;above GDP cutoff;Liquids;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;0.01;2025;10
-SSP3;NAV_all;below GDP cutoff;BEV;Bus;Bus;trn_pass_road;FV;7;2025;10
-SSP3;NAV_all;below GDP cutoff;FCEV;Bus;Bus;trn_pass_road;FV;5;2025;10
-SSP3;NAV_all;below GDP cutoff;Liquids;Bus;Bus;trn_pass_road;FV;0.01;2025;10
-SSP3;NAV_all;below GDP cutoff;Hydrogen;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;10;2045;10
-SSP3;NAV_all;below GDP cutoff;Liquids;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;0.1;2045;10
-SSP3;NAV_all;below GDP cutoff;Liquids;Ship;Domestic Ship_tmp_subsectorL2;Domestic Ship;FV;0.1;2050;10
-SSP3;NAV_all;below GDP cutoff;Electric;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;2;2040;10
-SSP3;NAV_all;below GDP cutoff;Liquids;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;0.1;2040;10
-SSP3;NAV_all;below GDP cutoff;Electric;Rail;HSR_tmp_subsectorL2;HSR;FV;2;2040;10
-SSP3;NAV_all;below GDP cutoff;Liquids;Aviation;International Aviation_tmp_subsectorL2;International Aviation;FV;0.1;2045;10
-SSP3;NAV_all;below GDP cutoff;Liquids;Ship;International Ship_tmp_subsectorL2;International Ship;FV;0.1;2050;10
-SSP3;NAV_all;below GDP cutoff;BEV;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;4;2030;10
-SSP3;NAV_all;below GDP cutoff;Liquids;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;0.05;2030;10
-SSP3;NAV_all;below GDP cutoff;Electric;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;2;2040;10
-SSP3;NAV_all;below GDP cutoff;Liquids;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;0.1;2040;10
-SSP3;NAV_all;below GDP cutoff;BEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;4;2025;10
-SSP3;NAV_all;below GDP cutoff;FCEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;4;2025;10
-SSP3;NAV_all;below GDP cutoff;Liquids;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;0.01;2025;10
-SSP3;NAV_all;below GDP cutoff;BEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1.5;2025;10
-SSP3;NAV_all;below GDP cutoff;FCEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;9;2025;10
-SSP3;NAV_all;below GDP cutoff;Liquids;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;0.01;2025;10
-SSP3;NAV_ele;above GDP cutoff;;;;Cycle;S1S;1;2040;10
-SSP3;NAV_ele;above GDP cutoff;;;;Domestic Aviation;S1S;1;2040;10
-SSP3;NAV_ele;above GDP cutoff;;;;Domestic Ship;S1S;1;2040;10
-SSP3;NAV_ele;above GDP cutoff;;;;Freight Rail;S1S;1;2040;10
-SSP3;NAV_ele;above GDP cutoff;;;;HSR;S1S;1;2040;10
-SSP3;NAV_ele;above GDP cutoff;;;;Passenger Rail;S1S;1;2040;10
-SSP3;NAV_ele;above GDP cutoff;;;;trn_freight_road;S1S;1;2040;10
-SSP3;NAV_ele;above GDP cutoff;;;;trn_pass_road;S1S;1;2040;10
-SSP3;NAV_ele;above GDP cutoff;;;;Walk;S1S;1;2040;10
-SSP3;NAV_ele;below GDP cutoff;;;;Cycle;S1S;1;2040;10
-SSP3;NAV_ele;below GDP cutoff;;;;Domestic Aviation;S1S;1;2040;10
-SSP3;NAV_ele;below GDP cutoff;;;;Domestic Ship;S1S;1;2040;10
-SSP3;NAV_ele;below GDP cutoff;;;;Freight Rail;S1S;1;2040;10
-SSP3;NAV_ele;below GDP cutoff;;;;HSR;S1S;1;2040;10
-SSP3;NAV_ele;below GDP cutoff;;;;Passenger Rail;S1S;1;2040;10
-SSP3;NAV_ele;below GDP cutoff;;;;trn_freight_road;S1S;1;2040;10
-SSP3;NAV_ele;below GDP cutoff;;;;trn_pass_road;S1S;1;2040;10
-SSP3;NAV_ele;below GDP cutoff;;;;Walk;S1S;1;2040;10
-SSP3;NAV_ele;above GDP cutoff;;;Bus;trn_pass_road;S2S1;1;2040;10
-SSP3;NAV_ele;above GDP cutoff;;;trn_pass_road_LDV;trn_pass_road;S2S1;1;2040;10
-SSP3;NAV_ele;below GDP cutoff;;;Bus;trn_pass_road;S2S1;1;2040;10
-SSP3;NAV_ele;below GDP cutoff;;;trn_pass_road_LDV;trn_pass_road;S2S1;1;2040;10
-SSP3;NAV_ele;above GDP cutoff;BEV;Bus;Bus;trn_pass_road;FV;9;2025;10
-SSP3;NAV_ele;above GDP cutoff;FCEV;Bus;Bus;trn_pass_road;FV;6;2025;10
-SSP3;NAV_ele;above GDP cutoff;Liquids;Bus;Bus;trn_pass_road;FV;0.01;2025;10
-SSP3;NAV_ele;above GDP cutoff;Hydrogen;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;10;2045;10
-SSP3;NAV_ele;above GDP cutoff;Liquids;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;0.1;2045;10
-SSP3;NAV_ele;above GDP cutoff;Liquids;Ship;Domestic Ship_tmp_subsectorL2;Domestic Ship;FV;0.1;2050;10
-SSP3;NAV_ele;above GDP cutoff;Electric;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;2;2040;10
-SSP3;NAV_ele;above GDP cutoff;Liquids;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;0.1;2040;10
-SSP3;NAV_ele;above GDP cutoff;Electric;Rail;HSR_tmp_subsectorL2;HSR;FV;2;2040;10
-SSP3;NAV_ele;above GDP cutoff;Liquids;Aviation;International Aviation_tmp_subsectorL2;International Aviation;FV;0.1;2045;10
-SSP3;NAV_ele;above GDP cutoff;Liquids;Ship;International Ship_tmp_subsectorL2;International Ship;FV;0.1;2050;10
-SSP3;NAV_ele;above GDP cutoff;BEV;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;4;2030;10
-SSP3;NAV_ele;above GDP cutoff;Liquids;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;0.05;2030;10
-SSP3;NAV_ele;above GDP cutoff;Electric;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;2;2040;10
-SSP3;NAV_ele;above GDP cutoff;Liquids;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;0.1;2040;10
-SSP3;NAV_ele;above GDP cutoff;BEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;4;2025;10
-SSP3;NAV_ele;above GDP cutoff;FCEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;4;2025;10
-SSP3;NAV_ele;above GDP cutoff;Liquids;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;0.01;2025;10
-SSP3;NAV_ele;above GDP cutoff;BEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;4;2025;10
-SSP3;NAV_ele;above GDP cutoff;FCEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;9;2025;10
-SSP3;NAV_ele;above GDP cutoff;Liquids;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;0.01;2025;10
-SSP3;NAV_ele;below GDP cutoff;BEV;Bus;Bus;trn_pass_road;FV;7;2025;10
-SSP3;NAV_ele;below GDP cutoff;FCEV;Bus;Bus;trn_pass_road;FV;5;2025;10
-SSP3;NAV_ele;below GDP cutoff;Liquids;Bus;Bus;trn_pass_road;FV;0.01;2025;10
-SSP3;NAV_ele;below GDP cutoff;Hydrogen;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;10;2045;10
-SSP3;NAV_ele;below GDP cutoff;Liquids;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;0.1;2045;10
-SSP3;NAV_ele;below GDP cutoff;Liquids;Ship;Domestic Ship_tmp_subsectorL2;Domestic Ship;FV;0.1;2050;10
-SSP3;NAV_ele;below GDP cutoff;Electric;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;2;2040;10
-SSP3;NAV_ele;below GDP cutoff;Liquids;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;0.1;2040;10
-SSP3;NAV_ele;below GDP cutoff;Electric;Rail;HSR_tmp_subsectorL2;HSR;FV;2;2040;10
-SSP3;NAV_ele;below GDP cutoff;Liquids;Aviation;International Aviation_tmp_subsectorL2;International Aviation;FV;0.1;2045;10
-SSP3;NAV_ele;below GDP cutoff;Liquids;Ship;International Ship_tmp_subsectorL2;International Ship;FV;0.1;2050;10
-SSP3;NAV_ele;below GDP cutoff;BEV;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;4;2030;10
-SSP3;NAV_ele;below GDP cutoff;Liquids;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;0.05;2030;10
-SSP3;NAV_ele;below GDP cutoff;Electric;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;2;2040;10
-SSP3;NAV_ele;below GDP cutoff;Liquids;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;0.1;2040;10
-SSP3;NAV_ele;below GDP cutoff;BEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;4;2025;10
-SSP3;NAV_ele;below GDP cutoff;FCEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;4;2025;10
-SSP3;NAV_ele;below GDP cutoff;Liquids;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;0.01;2025;10
-SSP3;NAV_ele;below GDP cutoff;BEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1.5;2025;10
-SSP3;NAV_ele;below GDP cutoff;FCEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;9;2025;10
-SSP3;NAV_ele;below GDP cutoff;Liquids;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;0.01;2025;10
-SSP3;NAV_lce;CAZ;;;;Cycle;S1S;2.5;2040;10
-SSP3;NAV_lce;CAZ;;;;Domestic Aviation;S1S;0.3;2040;10
-SSP3;NAV_lce;CAZ;;;;Domestic Ship;S1S;1;2040;10
-SSP3;NAV_lce;CAZ;;;;Freight Rail;S1S;1;2040;10
-SSP3;NAV_lce;CAZ;;;;HSR;S1S;1.7;2040;10
-SSP3;NAV_lce;CAZ;;;;Passenger Rail;S1S;4;2040;10
-SSP3;NAV_lce;CAZ;;;;trn_freight_road;S1S;0.9;2040;10
-SSP3;NAV_lce;CAZ;;;;trn_pass_road;S1S;0.6;2040;10
-SSP3;NAV_lce;CAZ;;;;Walk;S1S;2.5;2040;10
-SSP3;NAV_lce;USA;;;;Cycle;S1S;2.5;2040;10
-SSP3;NAV_lce;USA;;;;Domestic Aviation;S1S;0.3;2040;10
-SSP3;NAV_lce;USA;;;;Domestic Ship;S1S;1;2040;10
-SSP3;NAV_lce;USA;;;;Freight Rail;S1S;1;2040;10
-SSP3;NAV_lce;USA;;;;HSR;S1S;1.7;2040;10
-SSP3;NAV_lce;USA;;;;Passenger Rail;S1S;4;2040;10
-SSP3;NAV_lce;USA;;;;trn_freight_road;S1S;0.9;2040;10
-SSP3;NAV_lce;USA;;;;trn_pass_road;S1S;0.6;2040;10
-SSP3;NAV_lce;USA;;;;Walk;S1S;2.5;2040;10
-SSP3;NAV_lce;above GDP cutoff;;;;Cycle;S1S;1.8;2040;10
-SSP3;NAV_lce;above GDP cutoff;;;;Domestic Aviation;S1S;0.3;2040;10
-SSP3;NAV_lce;above GDP cutoff;;;;Domestic Ship;S1S;1;2040;10
-SSP3;NAV_lce;above GDP cutoff;;;;Freight Rail;S1S;1;2040;10
-SSP3;NAV_lce;above GDP cutoff;;;;HSR;S1S;1.7;2040;10
-SSP3;NAV_lce;above GDP cutoff;;;;Passenger Rail;S1S;1.6;2040;10
-SSP3;NAV_lce;above GDP cutoff;;;;trn_freight_road;S1S;0.9;2040;10
-SSP3;NAV_lce;above GDP cutoff;;;;trn_pass_road;S1S;0.7;2040;10
-SSP3;NAV_lce;above GDP cutoff;;;;Walk;S1S;1.7;2040;10
-SSP3;NAV_lce;below GDP cutoff;;;;Cycle;S1S;2.5;2040;10
-SSP3;NAV_lce;below GDP cutoff;;;;Domestic Aviation;S1S;0.3;2040;10
-SSP3;NAV_lce;below GDP cutoff;;;;Domestic Ship;S1S;1;2040;10
-SSP3;NAV_lce;below GDP cutoff;;;;Freight Rail;S1S;1;2040;10
-SSP3;NAV_lce;below GDP cutoff;;;;HSR;S1S;2.8;2040;10
-SSP3;NAV_lce;below GDP cutoff;;;;Passenger Rail;S1S;1.5;2040;10
-SSP3;NAV_lce;below GDP cutoff;;;;trn_freight_road;S1S;0.9;2040;10
-SSP3;NAV_lce;below GDP cutoff;;;;trn_pass_road;S1S;0.7;2040;10
-SSP3;NAV_lce;below GDP cutoff;;;;Walk;S1S;2.5;2040;10
-SSP3;NAV_lce;CAZ;;;Bus;trn_pass_road;S2S1;3;2040;10
-SSP3;NAV_lce;CAZ;;;trn_pass_road_LDV;trn_pass_road;S2S1;0.7;2040;10
-SSP3;NAV_lce;USA;;;Bus;trn_pass_road;S2S1;2;2040;10
-SSP3;NAV_lce;USA;;;trn_pass_road_LDV;trn_pass_road;S2S1;0.7;2040;10
-SSP3;NAV_lce;above GDP cutoff;;;Bus;trn_pass_road;S2S1;2;2040;10
-SSP3;NAV_lce;above GDP cutoff;;;trn_pass_road_LDV;trn_pass_road;S2S1;1;2040;10
-SSP3;NAV_lce;below GDP cutoff;;;Bus;trn_pass_road;S2S1;2;2040;10
-SSP3;NAV_lce;below GDP cutoff;;;trn_pass_road_LDV;trn_pass_road;S2S1;1;2040;10
-SSP3;NAV_lce;CAZ;BEV;Bus;Bus;trn_pass_road;FV;1;2040;10
-SSP3;NAV_lce;CAZ;FCEV;Bus;Bus;trn_pass_road;FV;1;2040;10
-SSP3;NAV_lce;CAZ;Liquids;Bus;Bus;trn_pass_road;FV;1;2050;10
-SSP3;NAV_lce;CAZ;Hydrogen;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SSP3;NAV_lce;CAZ;Liquids;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SSP3;NAV_lce;CAZ;Liquids;Ship;Domestic Ship_tmp_subsectorL2;Domestic Ship;FV;1;2050;10
-SSP3;NAV_lce;CAZ;Electric;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SSP3;NAV_lce;CAZ;Liquids;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SSP3;NAV_lce;CAZ;Electric;Rail;HSR_tmp_subsectorL2;HSR;FV;1;2050;10
-SSP3;NAV_lce;CAZ;Liquids;Aviation;International Aviation_tmp_subsectorL2;International Aviation;FV;1;2050;10
-SSP3;NAV_lce;CAZ;Liquids;Ship;International Ship_tmp_subsectorL2;International Ship;FV;1;2050;10
-SSP3;NAV_lce;CAZ;BEV;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SSP3;NAV_lce;CAZ;Liquids;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SSP3;NAV_lce;CAZ;Electric;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SSP3;NAV_lce;CAZ;Liquids;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SSP3;NAV_lce;CAZ;BEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2040;10
-SSP3;NAV_lce;CAZ;FCEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2040;10
-SSP3;NAV_lce;CAZ;Liquids;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;10
-SSP3;NAV_lce;CAZ;BEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2040;10
-SSP3;NAV_lce;CAZ;FCEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2040;10
-SSP3;NAV_lce;CAZ;Liquids;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;10
-SSP3;NAV_lce;USA;BEV;Bus;Bus;trn_pass_road;FV;1;2035;10
-SSP3;NAV_lce;USA;FCEV;Bus;Bus;trn_pass_road;FV;1;2035;10
-SSP3;NAV_lce;USA;Liquids;Bus;Bus;trn_pass_road;FV;1;2050;10
-SSP3;NAV_lce;USA;Hydrogen;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SSP3;NAV_lce;USA;Liquids;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SSP3;NAV_lce;USA;Liquids;Ship;Domestic Ship_tmp_subsectorL2;Domestic Ship;FV;1;2050;10
-SSP3;NAV_lce;USA;Electric;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SSP3;NAV_lce;USA;Liquids;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SSP3;NAV_lce;USA;Electric;Rail;HSR_tmp_subsectorL2;HSR;FV;1;2050;10
-SSP3;NAV_lce;USA;Liquids;Aviation;International Aviation_tmp_subsectorL2;International Aviation;FV;1;2050;10
-SSP3;NAV_lce;USA;Liquids;Ship;International Ship_tmp_subsectorL2;International Ship;FV;1;2050;10
-SSP3;NAV_lce;USA;BEV;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SSP3;NAV_lce;USA;Liquids;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SSP3;NAV_lce;USA;Electric;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SSP3;NAV_lce;USA;Liquids;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SSP3;NAV_lce;USA;BEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2035;10
-SSP3;NAV_lce;USA;FCEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2035;10
-SSP3;NAV_lce;USA;Liquids;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;10
-SSP3;NAV_lce;USA;BEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2035;10
-SSP3;NAV_lce;USA;FCEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2035;10
-SSP3;NAV_lce;USA;Liquids;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;10
-SSP3;NAV_lce;above GDP cutoff;BEV;Bus;Bus;trn_pass_road;FV;1;2040;10
-SSP3;NAV_lce;above GDP cutoff;FCEV;Bus;Bus;trn_pass_road;FV;1;2040;10
-SSP3;NAV_lce;above GDP cutoff;Liquids;Bus;Bus;trn_pass_road;FV;1;2050;10
-SSP3;NAV_lce;above GDP cutoff;Hydrogen;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SSP3;NAV_lce;above GDP cutoff;Liquids;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SSP3;NAV_lce;above GDP cutoff;Liquids;Ship;Domestic Ship_tmp_subsectorL2;Domestic Ship;FV;1;2050;10
-SSP3;NAV_lce;above GDP cutoff;Electric;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SSP3;NAV_lce;above GDP cutoff;Liquids;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SSP3;NAV_lce;above GDP cutoff;Electric;Rail;HSR_tmp_subsectorL2;HSR;FV;1;2050;10
-SSP3;NAV_lce;above GDP cutoff;Liquids;Aviation;International Aviation_tmp_subsectorL2;International Aviation;FV;1;2050;10
-SSP3;NAV_lce;above GDP cutoff;Liquids;Ship;International Ship_tmp_subsectorL2;International Ship;FV;1;2050;10
-SSP3;NAV_lce;above GDP cutoff;BEV;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SSP3;NAV_lce;above GDP cutoff;Liquids;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SSP3;NAV_lce;above GDP cutoff;Electric;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SSP3;NAV_lce;above GDP cutoff;Liquids;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SSP3;NAV_lce;above GDP cutoff;BEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2040;10
-SSP3;NAV_lce;above GDP cutoff;FCEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2040;10
-SSP3;NAV_lce;above GDP cutoff;Liquids;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;10
-SSP3;NAV_lce;above GDP cutoff;BEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2040;10
-SSP3;NAV_lce;above GDP cutoff;FCEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2040;10
-SSP3;NAV_lce;above GDP cutoff;Liquids;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;10
-SSP3;NAV_lce;below GDP cutoff;BEV;Bus;Bus;trn_pass_road;FV;1;2040;10
-SSP3;NAV_lce;below GDP cutoff;FCEV;Bus;Bus;trn_pass_road;FV;1;2040;10
-SSP3;NAV_lce;below GDP cutoff;Liquids;Bus;Bus;trn_pass_road;FV;1;2050;10
-SSP3;NAV_lce;below GDP cutoff;Hydrogen;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SSP3;NAV_lce;below GDP cutoff;Liquids;Aviation;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;FV;1;2050;10
-SSP3;NAV_lce;below GDP cutoff;Liquids;Ship;Domestic Ship_tmp_subsectorL2;Domestic Ship;FV;1;2050;10
-SSP3;NAV_lce;below GDP cutoff;Electric;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SSP3;NAV_lce;below GDP cutoff;Liquids;Rail;Freight Rail_tmp_subsectorL2;Freight Rail;FV;1;2050;10
-SSP3;NAV_lce;below GDP cutoff;Electric;Rail;HSR_tmp_subsectorL2;HSR;FV;1;2050;10
-SSP3;NAV_lce;below GDP cutoff;Liquids;Aviation;International Aviation_tmp_subsectorL2;International Aviation;FV;1;2050;10
-SSP3;NAV_lce;below GDP cutoff;Liquids;Ship;International Ship_tmp_subsectorL2;International Ship;FV;1;2050;10
-SSP3;NAV_lce;below GDP cutoff;BEV;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SSP3;NAV_lce;below GDP cutoff;Liquids;LDV|2W;trn_pass_road_LDV;trn_pass_road;FV;1;2050;10
-SSP3;NAV_lce;below GDP cutoff;Electric;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SSP3;NAV_lce;below GDP cutoff;Liquids;Rail;Passenger Rail_tmp_subsectorL2;Passenger Rail;FV;1;2050;10
-SSP3;NAV_lce;below GDP cutoff;BEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2040;10
-SSP3;NAV_lce;below GDP cutoff;FCEV;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2040;10
-SSP3;NAV_lce;below GDP cutoff;Liquids;Truck|light;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;10
-SSP3;NAV_lce;below GDP cutoff;BEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2040;10
-SSP3;NAV_lce;below GDP cutoff;FCEV;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2040;10
-SSP3;NAV_lce;below GDP cutoff;Liquids;Truck|heavy;trn_freight_road_tmp_subsectorL2;trn_freight_road;FV;1;2050;10
+SSPscen,transportPolScen,regionCat,technology,FVvehvar,subsectorL2,subsectorL1,level,target,symmyr,speed
+SDP,Mix2,above GDP cutoff,,,,Cycle,S1S,1,2050,10
+SDP,Mix2,above GDP cutoff,,,,Domestic Aviation,S1S,0.75,2035,10
+SDP,Mix2,above GDP cutoff,,,,Domestic Ship,S1S,1,2050,10
+SDP,Mix2,above GDP cutoff,,,,Freight Rail,S1S,1,2050,10
+SDP,Mix2,above GDP cutoff,,,,HSR,S1S,1,2050,10
+SDP,Mix2,above GDP cutoff,,,,Passenger Rail,S1S,1,2050,10
+SDP,Mix2,above GDP cutoff,,,,trn_freight_road,S1S,0.9,2035,10
+SDP,Mix2,above GDP cutoff,,,,trn_pass_road,S1S,0.9,2035,10
+SDP,Mix2,above GDP cutoff,,,,Walk,S1S,1,2050,10
+SDP,Mix2,below GDP cutoff,,,,Cycle,S1S,1,2050,10
+SDP,Mix2,below GDP cutoff,,,,Domestic Aviation,S1S,0.75,2035,10
+SDP,Mix2,below GDP cutoff,,,,Domestic Ship,S1S,1,2050,10
+SDP,Mix2,below GDP cutoff,,,,Freight Rail,S1S,1,2050,10
+SDP,Mix2,below GDP cutoff,,,,HSR,S1S,1,2050,10
+SDP,Mix2,below GDP cutoff,,,,Passenger Rail,S1S,1,2050,10
+SDP,Mix2,below GDP cutoff,,,,trn_freight_road,S1S,0.9,2035,10
+SDP,Mix2,below GDP cutoff,,,,trn_pass_road,S1S,0.9,2035,10
+SDP,Mix2,below GDP cutoff,,,,Walk,S1S,1,2050,10
+SDP,Mix2,above GDP cutoff,,,Bus,trn_pass_road,S2S1,1,2050,10
+SDP,Mix2,above GDP cutoff,,,trn_pass_road_LDV,trn_pass_road,S2S1,0.9,2035,10
+SDP,Mix2,below GDP cutoff,,,Bus,trn_pass_road,S2S1,1,2050,10
+SDP,Mix2,below GDP cutoff,,,trn_pass_road_LDV,trn_pass_road,S2S1,0.9,2035,10
+SDP,Mix2,above GDP cutoff,BEV,Bus,Bus,trn_pass_road,FV,2,2035,10
+SDP,Mix2,above GDP cutoff,FCEV,Bus,Bus,trn_pass_road,FV,2,2035,10
+SDP,Mix2,above GDP cutoff,Liquids,Bus,Bus,trn_pass_road,FV,1,2050,10
+SDP,Mix2,above GDP cutoff,Hydrogen,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SDP,Mix2,above GDP cutoff,Liquids,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SDP,Mix2,above GDP cutoff,Liquids,Ship,Domestic Ship_tmp_subsectorL2,Domestic Ship,FV,1,2050,10
+SDP,Mix2,above GDP cutoff,Electric,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SDP,Mix2,above GDP cutoff,Liquids,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SDP,Mix2,above GDP cutoff,Electric,Rail,HSR_tmp_subsectorL2,HSR,FV,1,2050,10
+SDP,Mix2,above GDP cutoff,Liquids,Aviation,International Aviation_tmp_subsectorL2,International Aviation,FV,1,2050,10
+SDP,Mix2,above GDP cutoff,Liquids,Ship,International Ship_tmp_subsectorL2,International Ship,FV,1,2050,10
+SDP,Mix2,above GDP cutoff,BEV,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SDP,Mix2,above GDP cutoff,Liquids,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SDP,Mix2,above GDP cutoff,Electric,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SDP,Mix2,above GDP cutoff,Liquids,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SDP,Mix2,above GDP cutoff,BEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,2,2035,10
+SDP,Mix2,above GDP cutoff,FCEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,2,2035,10
+SDP,Mix2,above GDP cutoff,Liquids,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,10
+SDP,Mix2,above GDP cutoff,BEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,2,2035,10
+SDP,Mix2,above GDP cutoff,FCEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,2,2035,10
+SDP,Mix2,above GDP cutoff,Liquids,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,10
+SDP,Mix2,below GDP cutoff,BEV,Bus,Bus,trn_pass_road,FV,1.5,2035,10
+SDP,Mix2,below GDP cutoff,FCEV,Bus,Bus,trn_pass_road,FV,1.5,2035,10
+SDP,Mix2,below GDP cutoff,Liquids,Bus,Bus,trn_pass_road,FV,1,2050,10
+SDP,Mix2,below GDP cutoff,Hydrogen,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SDP,Mix2,below GDP cutoff,Liquids,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SDP,Mix2,below GDP cutoff,Liquids,Ship,Domestic Ship_tmp_subsectorL2,Domestic Ship,FV,1,2050,10
+SDP,Mix2,below GDP cutoff,Electric,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SDP,Mix2,below GDP cutoff,Liquids,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SDP,Mix2,below GDP cutoff,Electric,Rail,HSR_tmp_subsectorL2,HSR,FV,1,2050,10
+SDP,Mix2,below GDP cutoff,Liquids,Aviation,International Aviation_tmp_subsectorL2,International Aviation,FV,1,2050,10
+SDP,Mix2,below GDP cutoff,Liquids,Ship,International Ship_tmp_subsectorL2,International Ship,FV,1,2050,10
+SDP,Mix2,below GDP cutoff,BEV,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SDP,Mix2,below GDP cutoff,Liquids,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SDP,Mix2,below GDP cutoff,Electric,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SDP,Mix2,below GDP cutoff,Liquids,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SDP,Mix2,below GDP cutoff,BEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1.5,2035,10
+SDP,Mix2,below GDP cutoff,FCEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1.5,2035,10
+SDP,Mix2,below GDP cutoff,Liquids,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,10
+SDP,Mix2,below GDP cutoff,BEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1.5,2035,10
+SDP,Mix2,below GDP cutoff,FCEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1.5,2035,10
+SDP,Mix2,below GDP cutoff,Liquids,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,10
+SDP,Mix3,above GDP cutoff,,,,Cycle,S1S,1,2050,10
+SDP,Mix3,above GDP cutoff,,,,Domestic Aviation,S1S,0.5,2035,10
+SDP,Mix3,above GDP cutoff,,,,Domestic Ship,S1S,1,2050,10
+SDP,Mix3,above GDP cutoff,,,,Freight Rail,S1S,1,2050,10
+SDP,Mix3,above GDP cutoff,,,,HSR,S1S,1,2050,10
+SDP,Mix3,above GDP cutoff,,,,Passenger Rail,S1S,1,2050,10
+SDP,Mix3,above GDP cutoff,,,,trn_freight_road,S1S,0.7,2035,10
+SDP,Mix3,above GDP cutoff,,,,trn_pass_road,S1S,0.7,2035,10
+SDP,Mix3,above GDP cutoff,,,,Walk,S1S,1,2050,10
+SDP,Mix3,below GDP cutoff,,,,Cycle,S1S,1,2050,10
+SDP,Mix3,below GDP cutoff,,,,Domestic Aviation,S1S,0.5,2035,10
+SDP,Mix3,below GDP cutoff,,,,Domestic Ship,S1S,1,2050,10
+SDP,Mix3,below GDP cutoff,,,,Freight Rail,S1S,1,2050,10
+SDP,Mix3,below GDP cutoff,,,,HSR,S1S,1,2050,10
+SDP,Mix3,below GDP cutoff,,,,Passenger Rail,S1S,1,2050,10
+SDP,Mix3,below GDP cutoff,,,,trn_freight_road,S1S,0.7,2035,10
+SDP,Mix3,below GDP cutoff,,,,trn_pass_road,S1S,0.7,2035,10
+SDP,Mix3,below GDP cutoff,,,,Walk,S1S,1,2050,10
+SDP,Mix3,above GDP cutoff,,,Bus,trn_pass_road,S2S1,1,2050,10
+SDP,Mix3,above GDP cutoff,,,trn_pass_road_LDV,trn_pass_road,S2S1,0.7,2035,10
+SDP,Mix3,below GDP cutoff,,,Bus,trn_pass_road,S2S1,1,2050,10
+SDP,Mix3,below GDP cutoff,,,trn_pass_road_LDV,trn_pass_road,S2S1,0.7,2035,10
+SDP,Mix3,above GDP cutoff,BEV,Bus,Bus,trn_pass_road,FV,4,2035,10
+SDP,Mix3,above GDP cutoff,FCEV,Bus,Bus,trn_pass_road,FV,4,2035,10
+SDP,Mix3,above GDP cutoff,Liquids,Bus,Bus,trn_pass_road,FV,1,2050,10
+SDP,Mix3,above GDP cutoff,Hydrogen,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SDP,Mix3,above GDP cutoff,Liquids,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SDP,Mix3,above GDP cutoff,Liquids,Ship,Domestic Ship_tmp_subsectorL2,Domestic Ship,FV,1,2050,10
+SDP,Mix3,above GDP cutoff,Electric,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SDP,Mix3,above GDP cutoff,Liquids,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SDP,Mix3,above GDP cutoff,Electric,Rail,HSR_tmp_subsectorL2,HSR,FV,1,2050,10
+SDP,Mix3,above GDP cutoff,Liquids,Aviation,International Aviation_tmp_subsectorL2,International Aviation,FV,1,2050,10
+SDP,Mix3,above GDP cutoff,Liquids,Ship,International Ship_tmp_subsectorL2,International Ship,FV,1,2050,10
+SDP,Mix3,above GDP cutoff,BEV,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SDP,Mix3,above GDP cutoff,Liquids,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SDP,Mix3,above GDP cutoff,Electric,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SDP,Mix3,above GDP cutoff,Liquids,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SDP,Mix3,above GDP cutoff,BEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,4,2035,10
+SDP,Mix3,above GDP cutoff,FCEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,4,2035,10
+SDP,Mix3,above GDP cutoff,Liquids,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,10
+SDP,Mix3,above GDP cutoff,BEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,7,2035,10
+SDP,Mix3,above GDP cutoff,FCEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,20,2035,10
+SDP,Mix3,above GDP cutoff,Liquids,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,10
+SDP,Mix3,below GDP cutoff,BEV,Bus,Bus,trn_pass_road,FV,3.5,2035,10
+SDP,Mix3,below GDP cutoff,FCEV,Bus,Bus,trn_pass_road,FV,3.5,2035,10
+SDP,Mix3,below GDP cutoff,Liquids,Bus,Bus,trn_pass_road,FV,1,2050,10
+SDP,Mix3,below GDP cutoff,Hydrogen,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SDP,Mix3,below GDP cutoff,Liquids,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SDP,Mix3,below GDP cutoff,Liquids,Ship,Domestic Ship_tmp_subsectorL2,Domestic Ship,FV,1,2050,10
+SDP,Mix3,below GDP cutoff,Electric,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SDP,Mix3,below GDP cutoff,Liquids,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SDP,Mix3,below GDP cutoff,Electric,Rail,HSR_tmp_subsectorL2,HSR,FV,1,2050,10
+SDP,Mix3,below GDP cutoff,Liquids,Aviation,International Aviation_tmp_subsectorL2,International Aviation,FV,1,2050,10
+SDP,Mix3,below GDP cutoff,Liquids,Ship,International Ship_tmp_subsectorL2,International Ship,FV,1,2050,10
+SDP,Mix3,below GDP cutoff,BEV,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SDP,Mix3,below GDP cutoff,Liquids,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SDP,Mix3,below GDP cutoff,Electric,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SDP,Mix3,below GDP cutoff,Liquids,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SDP,Mix3,below GDP cutoff,BEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,3.5,2035,10
+SDP,Mix3,below GDP cutoff,FCEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,3.5,2035,10
+SDP,Mix3,below GDP cutoff,Liquids,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,10
+SDP,Mix3,below GDP cutoff,BEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,5,2035,10
+SDP,Mix3,below GDP cutoff,FCEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,17,2035,10
+SDP,Mix3,below GDP cutoff,Liquids,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,10
+SDP,Mix4,above GDP cutoff,,,,Cycle,S1S,1,2050,10
+SDP,Mix4,above GDP cutoff,,,,Domestic Aviation,S1S,0.25,2035,10
+SDP,Mix4,above GDP cutoff,,,,Domestic Ship,S1S,1,2050,10
+SDP,Mix4,above GDP cutoff,,,,Freight Rail,S1S,1,2050,10
+SDP,Mix4,above GDP cutoff,,,,HSR,S1S,1,2050,10
+SDP,Mix4,above GDP cutoff,,,,Passenger Rail,S1S,1,2050,10
+SDP,Mix4,above GDP cutoff,,,,trn_freight_road,S1S,0.5,2035,10
+SDP,Mix4,above GDP cutoff,,,,trn_pass_road,S1S,0.5,2035,10
+SDP,Mix4,above GDP cutoff,,,,Walk,S1S,1,2050,10
+SDP,Mix4,below GDP cutoff,,,,Cycle,S1S,1,2050,10
+SDP,Mix4,below GDP cutoff,,,,Domestic Aviation,S1S,0.25,2035,10
+SDP,Mix4,below GDP cutoff,,,,Domestic Ship,S1S,1,2050,10
+SDP,Mix4,below GDP cutoff,,,,Freight Rail,S1S,1,2050,10
+SDP,Mix4,below GDP cutoff,,,,HSR,S1S,1,2050,10
+SDP,Mix4,below GDP cutoff,,,,Passenger Rail,S1S,1,2050,10
+SDP,Mix4,below GDP cutoff,,,,trn_freight_road,S1S,0.5,2035,10
+SDP,Mix4,below GDP cutoff,,,,trn_pass_road,S1S,0.5,2035,10
+SDP,Mix4,below GDP cutoff,,,,Walk,S1S,1,2050,10
+SDP,Mix4,above GDP cutoff,,,Bus,trn_pass_road,S2S1,1,2050,10
+SDP,Mix4,above GDP cutoff,,,trn_pass_road_LDV,trn_pass_road,S2S1,0.5,2035,10
+SDP,Mix4,below GDP cutoff,,,Bus,trn_pass_road,S2S1,1,2050,10
+SDP,Mix4,below GDP cutoff,,,trn_pass_road_LDV,trn_pass_road,S2S1,0.5,2035,10
+SDP,Mix4,above GDP cutoff,BEV,Bus,Bus,trn_pass_road,FV,6,2035,10
+SDP,Mix4,above GDP cutoff,FCEV,Bus,Bus,trn_pass_road,FV,6,2035,10
+SDP,Mix4,above GDP cutoff,Liquids,Bus,Bus,trn_pass_road,FV,1,2050,10
+SDP,Mix4,above GDP cutoff,Hydrogen,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SDP,Mix4,above GDP cutoff,Liquids,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SDP,Mix4,above GDP cutoff,Liquids,Ship,Domestic Ship_tmp_subsectorL2,Domestic Ship,FV,1,2050,10
+SDP,Mix4,above GDP cutoff,Electric,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SDP,Mix4,above GDP cutoff,Liquids,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SDP,Mix4,above GDP cutoff,Electric,Rail,HSR_tmp_subsectorL2,HSR,FV,1,2050,10
+SDP,Mix4,above GDP cutoff,Liquids,Aviation,International Aviation_tmp_subsectorL2,International Aviation,FV,1,2050,10
+SDP,Mix4,above GDP cutoff,Liquids,Ship,International Ship_tmp_subsectorL2,International Ship,FV,1,2050,10
+SDP,Mix4,above GDP cutoff,BEV,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SDP,Mix4,above GDP cutoff,Liquids,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SDP,Mix4,above GDP cutoff,Electric,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SDP,Mix4,above GDP cutoff,Liquids,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SDP,Mix4,above GDP cutoff,BEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,6,2035,10
+SDP,Mix4,above GDP cutoff,FCEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,6,2035,10
+SDP,Mix4,above GDP cutoff,Liquids,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,10
+SDP,Mix4,above GDP cutoff,BEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,20,2035,10
+SDP,Mix4,above GDP cutoff,FCEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,100,2035,10
+SDP,Mix4,above GDP cutoff,Liquids,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,10
+SDP,Mix4,below GDP cutoff,BEV,Bus,Bus,trn_pass_road,FV,5,2035,10
+SDP,Mix4,below GDP cutoff,FCEV,Bus,Bus,trn_pass_road,FV,5,2035,10
+SDP,Mix4,below GDP cutoff,Liquids,Bus,Bus,trn_pass_road,FV,1,2050,10
+SDP,Mix4,below GDP cutoff,Hydrogen,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SDP,Mix4,below GDP cutoff,Liquids,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SDP,Mix4,below GDP cutoff,Liquids,Ship,Domestic Ship_tmp_subsectorL2,Domestic Ship,FV,1,2050,10
+SDP,Mix4,below GDP cutoff,Electric,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SDP,Mix4,below GDP cutoff,Liquids,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SDP,Mix4,below GDP cutoff,Electric,Rail,HSR_tmp_subsectorL2,HSR,FV,1,2050,10
+SDP,Mix4,below GDP cutoff,Liquids,Aviation,International Aviation_tmp_subsectorL2,International Aviation,FV,1,2050,10
+SDP,Mix4,below GDP cutoff,Liquids,Ship,International Ship_tmp_subsectorL2,International Ship,FV,1,2050,10
+SDP,Mix4,below GDP cutoff,BEV,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SDP,Mix4,below GDP cutoff,Liquids,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SDP,Mix4,below GDP cutoff,Electric,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SDP,Mix4,below GDP cutoff,Liquids,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SDP,Mix4,below GDP cutoff,BEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,5,2035,10
+SDP,Mix4,below GDP cutoff,FCEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,5,2035,10
+SDP,Mix4,below GDP cutoff,Liquids,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,10
+SDP,Mix4,below GDP cutoff,BEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,17,2035,10
+SDP,Mix4,below GDP cutoff,FCEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,85,2035,10
+SDP,Mix4,below GDP cutoff,Liquids,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,10
+SDP_EI,Mix2,above GDP cutoff,,,,Cycle,S1S,1,2050,10
+SDP_EI,Mix2,above GDP cutoff,,,,Domestic Aviation,S1S,0.75,2035,10
+SDP_EI,Mix2,above GDP cutoff,,,,Domestic Ship,S1S,1,2050,10
+SDP_EI,Mix2,above GDP cutoff,,,,Freight Rail,S1S,1,2050,10
+SDP_EI,Mix2,above GDP cutoff,,,,HSR,S1S,1,2050,10
+SDP_EI,Mix2,above GDP cutoff,,,,Passenger Rail,S1S,1,2050,10
+SDP_EI,Mix2,above GDP cutoff,,,,trn_freight_road,S1S,0.9,2035,10
+SDP_EI,Mix2,above GDP cutoff,,,,trn_pass_road,S1S,0.9,2035,10
+SDP_EI,Mix2,above GDP cutoff,,,,Walk,S1S,1,2050,10
+SDP_EI,Mix2,below GDP cutoff,,,,Cycle,S1S,1,2050,10
+SDP_EI,Mix2,below GDP cutoff,,,,Domestic Aviation,S1S,0.75,2035,10
+SDP_EI,Mix2,below GDP cutoff,,,,Domestic Ship,S1S,1,2050,10
+SDP_EI,Mix2,below GDP cutoff,,,,Freight Rail,S1S,1,2050,10
+SDP_EI,Mix2,below GDP cutoff,,,,HSR,S1S,1,2050,10
+SDP_EI,Mix2,below GDP cutoff,,,,Passenger Rail,S1S,1,2050,10
+SDP_EI,Mix2,below GDP cutoff,,,,trn_freight_road,S1S,0.9,2035,10
+SDP_EI,Mix2,below GDP cutoff,,,,trn_pass_road,S1S,0.9,2035,10
+SDP_EI,Mix2,below GDP cutoff,,,,Walk,S1S,1,2050,10
+SDP_EI,Mix2,above GDP cutoff,,,Bus,trn_pass_road,S2S1,1,2050,10
+SDP_EI,Mix2,above GDP cutoff,,,trn_pass_road_LDV,trn_pass_road,S2S1,0.9,2035,10
+SDP_EI,Mix2,below GDP cutoff,,,Bus,trn_pass_road,S2S1,1,2050,10
+SDP_EI,Mix2,below GDP cutoff,,,trn_pass_road_LDV,trn_pass_road,S2S1,0.9,2035,10
+SDP_EI,Mix2,above GDP cutoff,BEV,Bus,Bus,trn_pass_road,FV,2,2035,10
+SDP_EI,Mix2,above GDP cutoff,FCEV,Bus,Bus,trn_pass_road,FV,2,2035,10
+SDP_EI,Mix2,above GDP cutoff,Liquids,Bus,Bus,trn_pass_road,FV,1,2050,10
+SDP_EI,Mix2,above GDP cutoff,Hydrogen,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SDP_EI,Mix2,above GDP cutoff,Liquids,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SDP_EI,Mix2,above GDP cutoff,Liquids,Ship,Domestic Ship_tmp_subsectorL2,Domestic Ship,FV,1,2050,10
+SDP_EI,Mix2,above GDP cutoff,Electric,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SDP_EI,Mix2,above GDP cutoff,Liquids,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SDP_EI,Mix2,above GDP cutoff,Electric,Rail,HSR_tmp_subsectorL2,HSR,FV,1,2050,10
+SDP_EI,Mix2,above GDP cutoff,Liquids,Aviation,International Aviation_tmp_subsectorL2,International Aviation,FV,1,2050,10
+SDP_EI,Mix2,above GDP cutoff,Liquids,Ship,International Ship_tmp_subsectorL2,International Ship,FV,1,2050,10
+SDP_EI,Mix2,above GDP cutoff,BEV,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SDP_EI,Mix2,above GDP cutoff,Liquids,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SDP_EI,Mix2,above GDP cutoff,Electric,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SDP_EI,Mix2,above GDP cutoff,Liquids,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SDP_EI,Mix2,above GDP cutoff,BEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,2,2035,10
+SDP_EI,Mix2,above GDP cutoff,FCEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,2,2035,10
+SDP_EI,Mix2,above GDP cutoff,Liquids,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,10
+SDP_EI,Mix2,above GDP cutoff,BEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,2,2035,10
+SDP_EI,Mix2,above GDP cutoff,FCEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,2,2035,10
+SDP_EI,Mix2,above GDP cutoff,Liquids,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,10
+SDP_EI,Mix2,below GDP cutoff,BEV,Bus,Bus,trn_pass_road,FV,1.5,2035,10
+SDP_EI,Mix2,below GDP cutoff,FCEV,Bus,Bus,trn_pass_road,FV,1.5,2035,10
+SDP_EI,Mix2,below GDP cutoff,Liquids,Bus,Bus,trn_pass_road,FV,1,2050,10
+SDP_EI,Mix2,below GDP cutoff,Hydrogen,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SDP_EI,Mix2,below GDP cutoff,Liquids,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SDP_EI,Mix2,below GDP cutoff,Liquids,Ship,Domestic Ship_tmp_subsectorL2,Domestic Ship,FV,1,2050,10
+SDP_EI,Mix2,below GDP cutoff,Electric,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SDP_EI,Mix2,below GDP cutoff,Liquids,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SDP_EI,Mix2,below GDP cutoff,Electric,Rail,HSR_tmp_subsectorL2,HSR,FV,1,2050,10
+SDP_EI,Mix2,below GDP cutoff,Liquids,Aviation,International Aviation_tmp_subsectorL2,International Aviation,FV,1,2050,10
+SDP_EI,Mix2,below GDP cutoff,Liquids,Ship,International Ship_tmp_subsectorL2,International Ship,FV,1,2050,10
+SDP_EI,Mix2,below GDP cutoff,BEV,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SDP_EI,Mix2,below GDP cutoff,Liquids,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SDP_EI,Mix2,below GDP cutoff,Electric,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SDP_EI,Mix2,below GDP cutoff,Liquids,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SDP_EI,Mix2,below GDP cutoff,BEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1.5,2035,10
+SDP_EI,Mix2,below GDP cutoff,FCEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1.5,2035,10
+SDP_EI,Mix2,below GDP cutoff,Liquids,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,10
+SDP_EI,Mix2,below GDP cutoff,BEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1.5,2035,10
+SDP_EI,Mix2,below GDP cutoff,FCEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1.5,2035,10
+SDP_EI,Mix2,below GDP cutoff,Liquids,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,10
+SDP_EI,Mix3,above GDP cutoff,,,,Cycle,S1S,1,2050,10
+SDP_EI,Mix3,above GDP cutoff,,,,Domestic Aviation,S1S,0.5,2035,10
+SDP_EI,Mix3,above GDP cutoff,,,,Domestic Ship,S1S,1,2050,10
+SDP_EI,Mix3,above GDP cutoff,,,,Freight Rail,S1S,1,2050,10
+SDP_EI,Mix3,above GDP cutoff,,,,HSR,S1S,1,2050,10
+SDP_EI,Mix3,above GDP cutoff,,,,Passenger Rail,S1S,1,2050,10
+SDP_EI,Mix3,above GDP cutoff,,,,trn_freight_road,S1S,0.7,2035,10
+SDP_EI,Mix3,above GDP cutoff,,,,trn_pass_road,S1S,0.7,2035,10
+SDP_EI,Mix3,above GDP cutoff,,,,Walk,S1S,1,2050,10
+SDP_EI,Mix3,below GDP cutoff,,,,Cycle,S1S,1,2050,10
+SDP_EI,Mix3,below GDP cutoff,,,,Domestic Aviation,S1S,0.5,2035,10
+SDP_EI,Mix3,below GDP cutoff,,,,Domestic Ship,S1S,1,2050,10
+SDP_EI,Mix3,below GDP cutoff,,,,Freight Rail,S1S,1,2050,10
+SDP_EI,Mix3,below GDP cutoff,,,,HSR,S1S,1,2050,10
+SDP_EI,Mix3,below GDP cutoff,,,,Passenger Rail,S1S,1,2050,10
+SDP_EI,Mix3,below GDP cutoff,,,,trn_freight_road,S1S,0.7,2035,10
+SDP_EI,Mix3,below GDP cutoff,,,,trn_pass_road,S1S,0.7,2035,10
+SDP_EI,Mix3,below GDP cutoff,,,,Walk,S1S,1,2050,10
+SDP_EI,Mix3,above GDP cutoff,,,Bus,trn_pass_road,S2S1,1,2050,10
+SDP_EI,Mix3,above GDP cutoff,,,trn_pass_road_LDV,trn_pass_road,S2S1,0.7,2035,10
+SDP_EI,Mix3,below GDP cutoff,,,Bus,trn_pass_road,S2S1,1,2050,10
+SDP_EI,Mix3,below GDP cutoff,,,trn_pass_road_LDV,trn_pass_road,S2S1,0.7,2035,10
+SDP_EI,Mix3,above GDP cutoff,BEV,Bus,Bus,trn_pass_road,FV,4,2035,10
+SDP_EI,Mix3,above GDP cutoff,FCEV,Bus,Bus,trn_pass_road,FV,4,2035,10
+SDP_EI,Mix3,above GDP cutoff,Liquids,Bus,Bus,trn_pass_road,FV,1,2050,10
+SDP_EI,Mix3,above GDP cutoff,Hydrogen,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SDP_EI,Mix3,above GDP cutoff,Liquids,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SDP_EI,Mix3,above GDP cutoff,Liquids,Ship,Domestic Ship_tmp_subsectorL2,Domestic Ship,FV,1,2050,10
+SDP_EI,Mix3,above GDP cutoff,Electric,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SDP_EI,Mix3,above GDP cutoff,Liquids,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SDP_EI,Mix3,above GDP cutoff,Electric,Rail,HSR_tmp_subsectorL2,HSR,FV,1,2050,10
+SDP_EI,Mix3,above GDP cutoff,Liquids,Aviation,International Aviation_tmp_subsectorL2,International Aviation,FV,1,2050,10
+SDP_EI,Mix3,above GDP cutoff,Liquids,Ship,International Ship_tmp_subsectorL2,International Ship,FV,1,2050,10
+SDP_EI,Mix3,above GDP cutoff,BEV,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SDP_EI,Mix3,above GDP cutoff,Liquids,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SDP_EI,Mix3,above GDP cutoff,Electric,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SDP_EI,Mix3,above GDP cutoff,Liquids,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SDP_EI,Mix3,above GDP cutoff,BEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,4,2035,10
+SDP_EI,Mix3,above GDP cutoff,FCEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,4,2035,10
+SDP_EI,Mix3,above GDP cutoff,Liquids,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,10
+SDP_EI,Mix3,above GDP cutoff,BEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,7,2035,10
+SDP_EI,Mix3,above GDP cutoff,FCEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,20,2035,10
+SDP_EI,Mix3,above GDP cutoff,Liquids,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,10
+SDP_EI,Mix3,below GDP cutoff,BEV,Bus,Bus,trn_pass_road,FV,3.5,2035,10
+SDP_EI,Mix3,below GDP cutoff,FCEV,Bus,Bus,trn_pass_road,FV,3.5,2035,10
+SDP_EI,Mix3,below GDP cutoff,Liquids,Bus,Bus,trn_pass_road,FV,1,2050,10
+SDP_EI,Mix3,below GDP cutoff,Hydrogen,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SDP_EI,Mix3,below GDP cutoff,Liquids,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SDP_EI,Mix3,below GDP cutoff,Liquids,Ship,Domestic Ship_tmp_subsectorL2,Domestic Ship,FV,1,2050,10
+SDP_EI,Mix3,below GDP cutoff,Electric,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SDP_EI,Mix3,below GDP cutoff,Liquids,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SDP_EI,Mix3,below GDP cutoff,Electric,Rail,HSR_tmp_subsectorL2,HSR,FV,1,2050,10
+SDP_EI,Mix3,below GDP cutoff,Liquids,Aviation,International Aviation_tmp_subsectorL2,International Aviation,FV,1,2050,10
+SDP_EI,Mix3,below GDP cutoff,Liquids,Ship,International Ship_tmp_subsectorL2,International Ship,FV,1,2050,10
+SDP_EI,Mix3,below GDP cutoff,BEV,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SDP_EI,Mix3,below GDP cutoff,Liquids,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SDP_EI,Mix3,below GDP cutoff,Electric,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SDP_EI,Mix3,below GDP cutoff,Liquids,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SDP_EI,Mix3,below GDP cutoff,BEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,3.5,2035,10
+SDP_EI,Mix3,below GDP cutoff,FCEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,3.5,2035,10
+SDP_EI,Mix3,below GDP cutoff,Liquids,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,10
+SDP_EI,Mix3,below GDP cutoff,BEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,5,2035,10
+SDP_EI,Mix3,below GDP cutoff,FCEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,17,2035,10
+SDP_EI,Mix3,below GDP cutoff,Liquids,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,10
+SDP_EI,Mix4,above GDP cutoff,,,,Cycle,S1S,1,2050,10
+SDP_EI,Mix4,above GDP cutoff,,,,Domestic Aviation,S1S,0.25,2035,10
+SDP_EI,Mix4,above GDP cutoff,,,,Domestic Ship,S1S,1,2050,10
+SDP_EI,Mix4,above GDP cutoff,,,,Freight Rail,S1S,1,2050,10
+SDP_EI,Mix4,above GDP cutoff,,,,HSR,S1S,1,2050,10
+SDP_EI,Mix4,above GDP cutoff,,,,Passenger Rail,S1S,1,2050,10
+SDP_EI,Mix4,above GDP cutoff,,,,trn_freight_road,S1S,0.5,2035,10
+SDP_EI,Mix4,above GDP cutoff,,,,trn_pass_road,S1S,0.5,2035,10
+SDP_EI,Mix4,above GDP cutoff,,,,Walk,S1S,1,2050,10
+SDP_EI,Mix4,below GDP cutoff,,,,Cycle,S1S,1,2050,10
+SDP_EI,Mix4,below GDP cutoff,,,,Domestic Aviation,S1S,0.25,2035,10
+SDP_EI,Mix4,below GDP cutoff,,,,Domestic Ship,S1S,1,2050,10
+SDP_EI,Mix4,below GDP cutoff,,,,Freight Rail,S1S,1,2050,10
+SDP_EI,Mix4,below GDP cutoff,,,,HSR,S1S,1,2050,10
+SDP_EI,Mix4,below GDP cutoff,,,,Passenger Rail,S1S,1,2050,10
+SDP_EI,Mix4,below GDP cutoff,,,,trn_freight_road,S1S,0.5,2035,10
+SDP_EI,Mix4,below GDP cutoff,,,,trn_pass_road,S1S,0.5,2035,10
+SDP_EI,Mix4,below GDP cutoff,,,,Walk,S1S,1,2050,10
+SDP_EI,Mix4,above GDP cutoff,,,Bus,trn_pass_road,S2S1,1,2050,10
+SDP_EI,Mix4,above GDP cutoff,,,trn_pass_road_LDV,trn_pass_road,S2S1,0.5,2035,10
+SDP_EI,Mix4,below GDP cutoff,,,Bus,trn_pass_road,S2S1,1,2050,10
+SDP_EI,Mix4,below GDP cutoff,,,trn_pass_road_LDV,trn_pass_road,S2S1,0.5,2035,10
+SDP_EI,Mix4,above GDP cutoff,BEV,Bus,Bus,trn_pass_road,FV,6,2035,10
+SDP_EI,Mix4,above GDP cutoff,FCEV,Bus,Bus,trn_pass_road,FV,6,2035,10
+SDP_EI,Mix4,above GDP cutoff,Liquids,Bus,Bus,trn_pass_road,FV,1,2050,10
+SDP_EI,Mix4,above GDP cutoff,Hydrogen,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SDP_EI,Mix4,above GDP cutoff,Liquids,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SDP_EI,Mix4,above GDP cutoff,Liquids,Ship,Domestic Ship_tmp_subsectorL2,Domestic Ship,FV,1,2050,10
+SDP_EI,Mix4,above GDP cutoff,Electric,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SDP_EI,Mix4,above GDP cutoff,Liquids,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SDP_EI,Mix4,above GDP cutoff,Electric,Rail,HSR_tmp_subsectorL2,HSR,FV,1,2050,10
+SDP_EI,Mix4,above GDP cutoff,Liquids,Aviation,International Aviation_tmp_subsectorL2,International Aviation,FV,1,2050,10
+SDP_EI,Mix4,above GDP cutoff,Liquids,Ship,International Ship_tmp_subsectorL2,International Ship,FV,1,2050,10
+SDP_EI,Mix4,above GDP cutoff,BEV,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SDP_EI,Mix4,above GDP cutoff,Liquids,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SDP_EI,Mix4,above GDP cutoff,Electric,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SDP_EI,Mix4,above GDP cutoff,Liquids,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SDP_EI,Mix4,above GDP cutoff,BEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,6,2035,10
+SDP_EI,Mix4,above GDP cutoff,FCEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,6,2035,10
+SDP_EI,Mix4,above GDP cutoff,Liquids,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,10
+SDP_EI,Mix4,above GDP cutoff,BEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,20,2035,10
+SDP_EI,Mix4,above GDP cutoff,FCEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,100,2035,10
+SDP_EI,Mix4,above GDP cutoff,Liquids,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,10
+SDP_EI,Mix4,below GDP cutoff,BEV,Bus,Bus,trn_pass_road,FV,5,2035,10
+SDP_EI,Mix4,below GDP cutoff,FCEV,Bus,Bus,trn_pass_road,FV,5,2035,10
+SDP_EI,Mix4,below GDP cutoff,Liquids,Bus,Bus,trn_pass_road,FV,1,2050,10
+SDP_EI,Mix4,below GDP cutoff,Hydrogen,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SDP_EI,Mix4,below GDP cutoff,Liquids,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SDP_EI,Mix4,below GDP cutoff,Liquids,Ship,Domestic Ship_tmp_subsectorL2,Domestic Ship,FV,1,2050,10
+SDP_EI,Mix4,below GDP cutoff,Electric,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SDP_EI,Mix4,below GDP cutoff,Liquids,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SDP_EI,Mix4,below GDP cutoff,Electric,Rail,HSR_tmp_subsectorL2,HSR,FV,1,2050,10
+SDP_EI,Mix4,below GDP cutoff,Liquids,Aviation,International Aviation_tmp_subsectorL2,International Aviation,FV,1,2050,10
+SDP_EI,Mix4,below GDP cutoff,Liquids,Ship,International Ship_tmp_subsectorL2,International Ship,FV,1,2050,10
+SDP_EI,Mix4,below GDP cutoff,BEV,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SDP_EI,Mix4,below GDP cutoff,Liquids,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SDP_EI,Mix4,below GDP cutoff,Electric,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SDP_EI,Mix4,below GDP cutoff,Liquids,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SDP_EI,Mix4,below GDP cutoff,BEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,5,2035,10
+SDP_EI,Mix4,below GDP cutoff,FCEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,5,2035,10
+SDP_EI,Mix4,below GDP cutoff,Liquids,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,10
+SDP_EI,Mix4,below GDP cutoff,BEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,17,2035,10
+SDP_EI,Mix4,below GDP cutoff,FCEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,85,2035,10
+SDP_EI,Mix4,below GDP cutoff,Liquids,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,10
+SDP_MC,Mix2,above GDP cutoff,,,,Cycle,S1S,1,2050,10
+SDP_MC,Mix2,above GDP cutoff,,,,Domestic Aviation,S1S,0.75,2035,10
+SDP_MC,Mix2,above GDP cutoff,,,,Domestic Ship,S1S,1,2050,10
+SDP_MC,Mix2,above GDP cutoff,,,,Freight Rail,S1S,1,2050,10
+SDP_MC,Mix2,above GDP cutoff,,,,HSR,S1S,1,2050,10
+SDP_MC,Mix2,above GDP cutoff,,,,Passenger Rail,S1S,1,2050,10
+SDP_MC,Mix2,above GDP cutoff,,,,trn_freight_road,S1S,0.9,2035,10
+SDP_MC,Mix2,above GDP cutoff,,,,trn_pass_road,S1S,0.9,2035,10
+SDP_MC,Mix2,above GDP cutoff,,,,Walk,S1S,1,2050,10
+SDP_MC,Mix2,below GDP cutoff,,,,Cycle,S1S,1,2050,10
+SDP_MC,Mix2,below GDP cutoff,,,,Domestic Aviation,S1S,0.75,2035,10
+SDP_MC,Mix2,below GDP cutoff,,,,Domestic Ship,S1S,1,2050,10
+SDP_MC,Mix2,below GDP cutoff,,,,Freight Rail,S1S,1,2050,10
+SDP_MC,Mix2,below GDP cutoff,,,,HSR,S1S,1,2050,10
+SDP_MC,Mix2,below GDP cutoff,,,,Passenger Rail,S1S,1,2050,10
+SDP_MC,Mix2,below GDP cutoff,,,,trn_freight_road,S1S,0.9,2035,10
+SDP_MC,Mix2,below GDP cutoff,,,,trn_pass_road,S1S,0.9,2035,10
+SDP_MC,Mix2,below GDP cutoff,,,,Walk,S1S,1,2050,10
+SDP_MC,Mix2,above GDP cutoff,,,Bus,trn_pass_road,S2S1,1,2050,10
+SDP_MC,Mix2,above GDP cutoff,,,trn_pass_road_LDV,trn_pass_road,S2S1,0.9,2035,10
+SDP_MC,Mix2,below GDP cutoff,,,Bus,trn_pass_road,S2S1,1,2050,10
+SDP_MC,Mix2,below GDP cutoff,,,trn_pass_road_LDV,trn_pass_road,S2S1,0.9,2035,10
+SDP_MC,Mix2,above GDP cutoff,BEV,Bus,Bus,trn_pass_road,FV,2,2035,10
+SDP_MC,Mix2,above GDP cutoff,FCEV,Bus,Bus,trn_pass_road,FV,2,2035,10
+SDP_MC,Mix2,above GDP cutoff,Liquids,Bus,Bus,trn_pass_road,FV,1,2050,10
+SDP_MC,Mix2,above GDP cutoff,Hydrogen,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SDP_MC,Mix2,above GDP cutoff,Liquids,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SDP_MC,Mix2,above GDP cutoff,Liquids,Ship,Domestic Ship_tmp_subsectorL2,Domestic Ship,FV,1,2050,10
+SDP_MC,Mix2,above GDP cutoff,Electric,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SDP_MC,Mix2,above GDP cutoff,Liquids,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SDP_MC,Mix2,above GDP cutoff,Electric,Rail,HSR_tmp_subsectorL2,HSR,FV,1,2050,10
+SDP_MC,Mix2,above GDP cutoff,Liquids,Aviation,International Aviation_tmp_subsectorL2,International Aviation,FV,1,2050,10
+SDP_MC,Mix2,above GDP cutoff,Liquids,Ship,International Ship_tmp_subsectorL2,International Ship,FV,1,2050,10
+SDP_MC,Mix2,above GDP cutoff,BEV,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SDP_MC,Mix2,above GDP cutoff,Liquids,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SDP_MC,Mix2,above GDP cutoff,Electric,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SDP_MC,Mix2,above GDP cutoff,Liquids,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SDP_MC,Mix2,above GDP cutoff,BEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,2,2035,10
+SDP_MC,Mix2,above GDP cutoff,FCEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,2,2035,10
+SDP_MC,Mix2,above GDP cutoff,Liquids,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,10
+SDP_MC,Mix2,above GDP cutoff,BEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,2,2035,10
+SDP_MC,Mix2,above GDP cutoff,FCEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,2,2035,10
+SDP_MC,Mix2,above GDP cutoff,Liquids,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,10
+SDP_MC,Mix2,below GDP cutoff,BEV,Bus,Bus,trn_pass_road,FV,1.5,2035,10
+SDP_MC,Mix2,below GDP cutoff,FCEV,Bus,Bus,trn_pass_road,FV,1.5,2035,10
+SDP_MC,Mix2,below GDP cutoff,Liquids,Bus,Bus,trn_pass_road,FV,1,2050,10
+SDP_MC,Mix2,below GDP cutoff,Hydrogen,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SDP_MC,Mix2,below GDP cutoff,Liquids,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SDP_MC,Mix2,below GDP cutoff,Liquids,Ship,Domestic Ship_tmp_subsectorL2,Domestic Ship,FV,1,2050,10
+SDP_MC,Mix2,below GDP cutoff,Electric,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SDP_MC,Mix2,below GDP cutoff,Liquids,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SDP_MC,Mix2,below GDP cutoff,Electric,Rail,HSR_tmp_subsectorL2,HSR,FV,1,2050,10
+SDP_MC,Mix2,below GDP cutoff,Liquids,Aviation,International Aviation_tmp_subsectorL2,International Aviation,FV,1,2050,10
+SDP_MC,Mix2,below GDP cutoff,Liquids,Ship,International Ship_tmp_subsectorL2,International Ship,FV,1,2050,10
+SDP_MC,Mix2,below GDP cutoff,BEV,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SDP_MC,Mix2,below GDP cutoff,Liquids,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SDP_MC,Mix2,below GDP cutoff,Electric,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SDP_MC,Mix2,below GDP cutoff,Liquids,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SDP_MC,Mix2,below GDP cutoff,BEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1.5,2035,10
+SDP_MC,Mix2,below GDP cutoff,FCEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1.5,2035,10
+SDP_MC,Mix2,below GDP cutoff,Liquids,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,10
+SDP_MC,Mix2,below GDP cutoff,BEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1.5,2035,10
+SDP_MC,Mix2,below GDP cutoff,FCEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1.5,2035,10
+SDP_MC,Mix2,below GDP cutoff,Liquids,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,10
+SDP_MC,Mix3,above GDP cutoff,,,,Cycle,S1S,1,2050,10
+SDP_MC,Mix3,above GDP cutoff,,,,Domestic Aviation,S1S,0.5,2035,10
+SDP_MC,Mix3,above GDP cutoff,,,,Domestic Ship,S1S,1,2050,10
+SDP_MC,Mix3,above GDP cutoff,,,,Freight Rail,S1S,1,2050,10
+SDP_MC,Mix3,above GDP cutoff,,,,HSR,S1S,1,2050,10
+SDP_MC,Mix3,above GDP cutoff,,,,Passenger Rail,S1S,1,2050,10
+SDP_MC,Mix3,above GDP cutoff,,,,trn_freight_road,S1S,0.7,2035,10
+SDP_MC,Mix3,above GDP cutoff,,,,trn_pass_road,S1S,0.7,2035,10
+SDP_MC,Mix3,above GDP cutoff,,,,Walk,S1S,1,2050,10
+SDP_MC,Mix3,below GDP cutoff,,,,Cycle,S1S,1,2050,10
+SDP_MC,Mix3,below GDP cutoff,,,,Domestic Aviation,S1S,0.5,2035,10
+SDP_MC,Mix3,below GDP cutoff,,,,Domestic Ship,S1S,1,2050,10
+SDP_MC,Mix3,below GDP cutoff,,,,Freight Rail,S1S,1,2050,10
+SDP_MC,Mix3,below GDP cutoff,,,,HSR,S1S,1,2050,10
+SDP_MC,Mix3,below GDP cutoff,,,,Passenger Rail,S1S,1,2050,10
+SDP_MC,Mix3,below GDP cutoff,,,,trn_freight_road,S1S,0.7,2035,10
+SDP_MC,Mix3,below GDP cutoff,,,,trn_pass_road,S1S,0.7,2035,10
+SDP_MC,Mix3,below GDP cutoff,,,,Walk,S1S,1,2050,10
+SDP_MC,Mix3,above GDP cutoff,,,Bus,trn_pass_road,S2S1,1,2050,10
+SDP_MC,Mix3,above GDP cutoff,,,trn_pass_road_LDV,trn_pass_road,S2S1,0.7,2035,10
+SDP_MC,Mix3,below GDP cutoff,,,Bus,trn_pass_road,S2S1,1,2050,10
+SDP_MC,Mix3,below GDP cutoff,,,trn_pass_road_LDV,trn_pass_road,S2S1,0.7,2035,10
+SDP_MC,Mix3,above GDP cutoff,BEV,Bus,Bus,trn_pass_road,FV,4,2035,10
+SDP_MC,Mix3,above GDP cutoff,FCEV,Bus,Bus,trn_pass_road,FV,4,2035,10
+SDP_MC,Mix3,above GDP cutoff,Liquids,Bus,Bus,trn_pass_road,FV,1,2050,10
+SDP_MC,Mix3,above GDP cutoff,Hydrogen,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SDP_MC,Mix3,above GDP cutoff,Liquids,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SDP_MC,Mix3,above GDP cutoff,Liquids,Ship,Domestic Ship_tmp_subsectorL2,Domestic Ship,FV,1,2050,10
+SDP_MC,Mix3,above GDP cutoff,Electric,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SDP_MC,Mix3,above GDP cutoff,Liquids,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SDP_MC,Mix3,above GDP cutoff,Electric,Rail,HSR_tmp_subsectorL2,HSR,FV,1,2050,10
+SDP_MC,Mix3,above GDP cutoff,Liquids,Aviation,International Aviation_tmp_subsectorL2,International Aviation,FV,1,2050,10
+SDP_MC,Mix3,above GDP cutoff,Liquids,Ship,International Ship_tmp_subsectorL2,International Ship,FV,1,2050,10
+SDP_MC,Mix3,above GDP cutoff,BEV,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SDP_MC,Mix3,above GDP cutoff,Liquids,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SDP_MC,Mix3,above GDP cutoff,Electric,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SDP_MC,Mix3,above GDP cutoff,Liquids,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SDP_MC,Mix3,above GDP cutoff,BEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,4,2035,10
+SDP_MC,Mix3,above GDP cutoff,FCEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,4,2035,10
+SDP_MC,Mix3,above GDP cutoff,Liquids,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,10
+SDP_MC,Mix3,above GDP cutoff,BEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,7,2035,10
+SDP_MC,Mix3,above GDP cutoff,FCEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,20,2035,10
+SDP_MC,Mix3,above GDP cutoff,Liquids,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,10
+SDP_MC,Mix3,below GDP cutoff,BEV,Bus,Bus,trn_pass_road,FV,3.5,2035,10
+SDP_MC,Mix3,below GDP cutoff,FCEV,Bus,Bus,trn_pass_road,FV,3.5,2035,10
+SDP_MC,Mix3,below GDP cutoff,Liquids,Bus,Bus,trn_pass_road,FV,1,2050,10
+SDP_MC,Mix3,below GDP cutoff,Hydrogen,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SDP_MC,Mix3,below GDP cutoff,Liquids,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SDP_MC,Mix3,below GDP cutoff,Liquids,Ship,Domestic Ship_tmp_subsectorL2,Domestic Ship,FV,1,2050,10
+SDP_MC,Mix3,below GDP cutoff,Electric,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SDP_MC,Mix3,below GDP cutoff,Liquids,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SDP_MC,Mix3,below GDP cutoff,Electric,Rail,HSR_tmp_subsectorL2,HSR,FV,1,2050,10
+SDP_MC,Mix3,below GDP cutoff,Liquids,Aviation,International Aviation_tmp_subsectorL2,International Aviation,FV,1,2050,10
+SDP_MC,Mix3,below GDP cutoff,Liquids,Ship,International Ship_tmp_subsectorL2,International Ship,FV,1,2050,10
+SDP_MC,Mix3,below GDP cutoff,BEV,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SDP_MC,Mix3,below GDP cutoff,Liquids,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SDP_MC,Mix3,below GDP cutoff,Electric,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SDP_MC,Mix3,below GDP cutoff,Liquids,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SDP_MC,Mix3,below GDP cutoff,BEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,3.5,2035,10
+SDP_MC,Mix3,below GDP cutoff,FCEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,3.5,2035,10
+SDP_MC,Mix3,below GDP cutoff,Liquids,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,10
+SDP_MC,Mix3,below GDP cutoff,BEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,5,2035,10
+SDP_MC,Mix3,below GDP cutoff,FCEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,17,2035,10
+SDP_MC,Mix3,below GDP cutoff,Liquids,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,10
+SDP_MC,Mix4,above GDP cutoff,,,,Cycle,S1S,1,2050,10
+SDP_MC,Mix4,above GDP cutoff,,,,Domestic Aviation,S1S,0.25,2035,10
+SDP_MC,Mix4,above GDP cutoff,,,,Domestic Ship,S1S,1,2050,10
+SDP_MC,Mix4,above GDP cutoff,,,,Freight Rail,S1S,1,2050,10
+SDP_MC,Mix4,above GDP cutoff,,,,HSR,S1S,1,2050,10
+SDP_MC,Mix4,above GDP cutoff,,,,Passenger Rail,S1S,1,2050,10
+SDP_MC,Mix4,above GDP cutoff,,,,trn_freight_road,S1S,0.5,2035,10
+SDP_MC,Mix4,above GDP cutoff,,,,trn_pass_road,S1S,0.5,2035,10
+SDP_MC,Mix4,above GDP cutoff,,,,Walk,S1S,1,2050,10
+SDP_MC,Mix4,below GDP cutoff,,,,Cycle,S1S,1,2050,10
+SDP_MC,Mix4,below GDP cutoff,,,,Domestic Aviation,S1S,0.25,2035,10
+SDP_MC,Mix4,below GDP cutoff,,,,Domestic Ship,S1S,1,2050,10
+SDP_MC,Mix4,below GDP cutoff,,,,Freight Rail,S1S,1,2050,10
+SDP_MC,Mix4,below GDP cutoff,,,,HSR,S1S,1,2050,10
+SDP_MC,Mix4,below GDP cutoff,,,,Passenger Rail,S1S,1,2050,10
+SDP_MC,Mix4,below GDP cutoff,,,,trn_freight_road,S1S,0.5,2035,10
+SDP_MC,Mix4,below GDP cutoff,,,,trn_pass_road,S1S,0.5,2035,10
+SDP_MC,Mix4,below GDP cutoff,,,,Walk,S1S,1,2050,10
+SDP_MC,Mix4,above GDP cutoff,,,Bus,trn_pass_road,S2S1,1,2050,10
+SDP_MC,Mix4,above GDP cutoff,,,trn_pass_road_LDV,trn_pass_road,S2S1,0.5,2035,10
+SDP_MC,Mix4,below GDP cutoff,,,Bus,trn_pass_road,S2S1,1,2050,10
+SDP_MC,Mix4,below GDP cutoff,,,trn_pass_road_LDV,trn_pass_road,S2S1,0.5,2035,10
+SDP_MC,Mix4,above GDP cutoff,BEV,Bus,Bus,trn_pass_road,FV,6,2035,10
+SDP_MC,Mix4,above GDP cutoff,FCEV,Bus,Bus,trn_pass_road,FV,6,2035,10
+SDP_MC,Mix4,above GDP cutoff,Liquids,Bus,Bus,trn_pass_road,FV,1,2050,10
+SDP_MC,Mix4,above GDP cutoff,Hydrogen,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SDP_MC,Mix4,above GDP cutoff,Liquids,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SDP_MC,Mix4,above GDP cutoff,Liquids,Ship,Domestic Ship_tmp_subsectorL2,Domestic Ship,FV,1,2050,10
+SDP_MC,Mix4,above GDP cutoff,Electric,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SDP_MC,Mix4,above GDP cutoff,Liquids,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SDP_MC,Mix4,above GDP cutoff,Electric,Rail,HSR_tmp_subsectorL2,HSR,FV,1,2050,10
+SDP_MC,Mix4,above GDP cutoff,Liquids,Aviation,International Aviation_tmp_subsectorL2,International Aviation,FV,1,2050,10
+SDP_MC,Mix4,above GDP cutoff,Liquids,Ship,International Ship_tmp_subsectorL2,International Ship,FV,1,2050,10
+SDP_MC,Mix4,above GDP cutoff,BEV,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SDP_MC,Mix4,above GDP cutoff,Liquids,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SDP_MC,Mix4,above GDP cutoff,Electric,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SDP_MC,Mix4,above GDP cutoff,Liquids,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SDP_MC,Mix4,above GDP cutoff,BEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,6,2035,10
+SDP_MC,Mix4,above GDP cutoff,FCEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,6,2035,10
+SDP_MC,Mix4,above GDP cutoff,Liquids,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,10
+SDP_MC,Mix4,above GDP cutoff,BEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,20,2035,10
+SDP_MC,Mix4,above GDP cutoff,FCEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,100,2035,10
+SDP_MC,Mix4,above GDP cutoff,Liquids,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,10
+SDP_MC,Mix4,below GDP cutoff,BEV,Bus,Bus,trn_pass_road,FV,5,2035,10
+SDP_MC,Mix4,below GDP cutoff,FCEV,Bus,Bus,trn_pass_road,FV,5,2035,10
+SDP_MC,Mix4,below GDP cutoff,Liquids,Bus,Bus,trn_pass_road,FV,1,2050,10
+SDP_MC,Mix4,below GDP cutoff,Hydrogen,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SDP_MC,Mix4,below GDP cutoff,Liquids,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SDP_MC,Mix4,below GDP cutoff,Liquids,Ship,Domestic Ship_tmp_subsectorL2,Domestic Ship,FV,1,2050,10
+SDP_MC,Mix4,below GDP cutoff,Electric,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SDP_MC,Mix4,below GDP cutoff,Liquids,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SDP_MC,Mix4,below GDP cutoff,Electric,Rail,HSR_tmp_subsectorL2,HSR,FV,1,2050,10
+SDP_MC,Mix4,below GDP cutoff,Liquids,Aviation,International Aviation_tmp_subsectorL2,International Aviation,FV,1,2050,10
+SDP_MC,Mix4,below GDP cutoff,Liquids,Ship,International Ship_tmp_subsectorL2,International Ship,FV,1,2050,10
+SDP_MC,Mix4,below GDP cutoff,BEV,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SDP_MC,Mix4,below GDP cutoff,Liquids,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SDP_MC,Mix4,below GDP cutoff,Electric,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SDP_MC,Mix4,below GDP cutoff,Liquids,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SDP_MC,Mix4,below GDP cutoff,BEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,5,2035,10
+SDP_MC,Mix4,below GDP cutoff,FCEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,5,2035,10
+SDP_MC,Mix4,below GDP cutoff,Liquids,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,10
+SDP_MC,Mix4,below GDP cutoff,BEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,17,2035,10
+SDP_MC,Mix4,below GDP cutoff,FCEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,85,2035,10
+SDP_MC,Mix4,below GDP cutoff,Liquids,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,10
+SDP_RC,Mix2,above GDP cutoff,,,,Cycle,S1S,1,2050,10
+SDP_RC,Mix2,above GDP cutoff,,,,Domestic Aviation,S1S,0.75,2035,10
+SDP_RC,Mix2,above GDP cutoff,,,,Domestic Ship,S1S,1,2050,10
+SDP_RC,Mix2,above GDP cutoff,,,,Freight Rail,S1S,1,2050,10
+SDP_RC,Mix2,above GDP cutoff,,,,HSR,S1S,1,2050,10
+SDP_RC,Mix2,above GDP cutoff,,,,Passenger Rail,S1S,1,2050,10
+SDP_RC,Mix2,above GDP cutoff,,,,trn_freight_road,S1S,0.9,2035,10
+SDP_RC,Mix2,above GDP cutoff,,,,trn_pass_road,S1S,0.9,2035,10
+SDP_RC,Mix2,above GDP cutoff,,,,Walk,S1S,1,2050,10
+SDP_RC,Mix2,below GDP cutoff,,,,Cycle,S1S,1,2050,10
+SDP_RC,Mix2,below GDP cutoff,,,,Domestic Aviation,S1S,0.75,2035,10
+SDP_RC,Mix2,below GDP cutoff,,,,Domestic Ship,S1S,1,2050,10
+SDP_RC,Mix2,below GDP cutoff,,,,Freight Rail,S1S,1,2050,10
+SDP_RC,Mix2,below GDP cutoff,,,,HSR,S1S,1,2050,10
+SDP_RC,Mix2,below GDP cutoff,,,,Passenger Rail,S1S,1,2050,10
+SDP_RC,Mix2,below GDP cutoff,,,,trn_freight_road,S1S,0.9,2035,10
+SDP_RC,Mix2,below GDP cutoff,,,,trn_pass_road,S1S,0.9,2035,10
+SDP_RC,Mix2,below GDP cutoff,,,,Walk,S1S,1,2050,10
+SDP_RC,Mix2,above GDP cutoff,,,Bus,trn_pass_road,S2S1,1,2050,10
+SDP_RC,Mix2,above GDP cutoff,,,trn_pass_road_LDV,trn_pass_road,S2S1,0.9,2035,10
+SDP_RC,Mix2,below GDP cutoff,,,Bus,trn_pass_road,S2S1,1,2050,10
+SDP_RC,Mix2,below GDP cutoff,,,trn_pass_road_LDV,trn_pass_road,S2S1,0.9,2035,10
+SDP_RC,Mix2,above GDP cutoff,BEV,Bus,Bus,trn_pass_road,FV,2,2035,10
+SDP_RC,Mix2,above GDP cutoff,FCEV,Bus,Bus,trn_pass_road,FV,2,2035,10
+SDP_RC,Mix2,above GDP cutoff,Liquids,Bus,Bus,trn_pass_road,FV,1,2050,10
+SDP_RC,Mix2,above GDP cutoff,Hydrogen,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SDP_RC,Mix2,above GDP cutoff,Liquids,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SDP_RC,Mix2,above GDP cutoff,Liquids,Ship,Domestic Ship_tmp_subsectorL2,Domestic Ship,FV,1,2050,10
+SDP_RC,Mix2,above GDP cutoff,Electric,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SDP_RC,Mix2,above GDP cutoff,Liquids,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SDP_RC,Mix2,above GDP cutoff,Electric,Rail,HSR_tmp_subsectorL2,HSR,FV,1,2050,10
+SDP_RC,Mix2,above GDP cutoff,Liquids,Aviation,International Aviation_tmp_subsectorL2,International Aviation,FV,1,2050,10
+SDP_RC,Mix2,above GDP cutoff,Liquids,Ship,International Ship_tmp_subsectorL2,International Ship,FV,1,2050,10
+SDP_RC,Mix2,above GDP cutoff,BEV,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SDP_RC,Mix2,above GDP cutoff,Liquids,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SDP_RC,Mix2,above GDP cutoff,Electric,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SDP_RC,Mix2,above GDP cutoff,Liquids,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SDP_RC,Mix2,above GDP cutoff,BEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,2,2035,10
+SDP_RC,Mix2,above GDP cutoff,FCEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,2,2035,10
+SDP_RC,Mix2,above GDP cutoff,Liquids,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,10
+SDP_RC,Mix2,above GDP cutoff,BEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,2,2035,10
+SDP_RC,Mix2,above GDP cutoff,FCEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,2,2035,10
+SDP_RC,Mix2,above GDP cutoff,Liquids,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,10
+SDP_RC,Mix2,below GDP cutoff,BEV,Bus,Bus,trn_pass_road,FV,1.5,2035,10
+SDP_RC,Mix2,below GDP cutoff,FCEV,Bus,Bus,trn_pass_road,FV,1.5,2035,10
+SDP_RC,Mix2,below GDP cutoff,Liquids,Bus,Bus,trn_pass_road,FV,1,2050,10
+SDP_RC,Mix2,below GDP cutoff,Hydrogen,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SDP_RC,Mix2,below GDP cutoff,Liquids,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SDP_RC,Mix2,below GDP cutoff,Liquids,Ship,Domestic Ship_tmp_subsectorL2,Domestic Ship,FV,1,2050,10
+SDP_RC,Mix2,below GDP cutoff,Electric,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SDP_RC,Mix2,below GDP cutoff,Liquids,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SDP_RC,Mix2,below GDP cutoff,Electric,Rail,HSR_tmp_subsectorL2,HSR,FV,1,2050,10
+SDP_RC,Mix2,below GDP cutoff,Liquids,Aviation,International Aviation_tmp_subsectorL2,International Aviation,FV,1,2050,10
+SDP_RC,Mix2,below GDP cutoff,Liquids,Ship,International Ship_tmp_subsectorL2,International Ship,FV,1,2050,10
+SDP_RC,Mix2,below GDP cutoff,BEV,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SDP_RC,Mix2,below GDP cutoff,Liquids,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SDP_RC,Mix2,below GDP cutoff,Electric,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SDP_RC,Mix2,below GDP cutoff,Liquids,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SDP_RC,Mix2,below GDP cutoff,BEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1.5,2035,10
+SDP_RC,Mix2,below GDP cutoff,FCEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1.5,2035,10
+SDP_RC,Mix2,below GDP cutoff,Liquids,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,10
+SDP_RC,Mix2,below GDP cutoff,BEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1.5,2035,10
+SDP_RC,Mix2,below GDP cutoff,FCEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1.5,2035,10
+SDP_RC,Mix2,below GDP cutoff,Liquids,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,10
+SDP_RC,Mix3,above GDP cutoff,,,,Cycle,S1S,1,2050,10
+SDP_RC,Mix3,above GDP cutoff,,,,Domestic Aviation,S1S,0.5,2035,10
+SDP_RC,Mix3,above GDP cutoff,,,,Domestic Ship,S1S,1,2050,10
+SDP_RC,Mix3,above GDP cutoff,,,,Freight Rail,S1S,1,2050,10
+SDP_RC,Mix3,above GDP cutoff,,,,HSR,S1S,1,2050,10
+SDP_RC,Mix3,above GDP cutoff,,,,Passenger Rail,S1S,1,2050,10
+SDP_RC,Mix3,above GDP cutoff,,,,trn_freight_road,S1S,0.7,2035,10
+SDP_RC,Mix3,above GDP cutoff,,,,trn_pass_road,S1S,0.7,2035,10
+SDP_RC,Mix3,above GDP cutoff,,,,Walk,S1S,1,2050,10
+SDP_RC,Mix3,below GDP cutoff,,,,Cycle,S1S,1,2050,10
+SDP_RC,Mix3,below GDP cutoff,,,,Domestic Aviation,S1S,0.5,2035,10
+SDP_RC,Mix3,below GDP cutoff,,,,Domestic Ship,S1S,1,2050,10
+SDP_RC,Mix3,below GDP cutoff,,,,Freight Rail,S1S,1,2050,10
+SDP_RC,Mix3,below GDP cutoff,,,,HSR,S1S,1,2050,10
+SDP_RC,Mix3,below GDP cutoff,,,,Passenger Rail,S1S,1,2050,10
+SDP_RC,Mix3,below GDP cutoff,,,,trn_freight_road,S1S,0.7,2035,10
+SDP_RC,Mix3,below GDP cutoff,,,,trn_pass_road,S1S,0.7,2035,10
+SDP_RC,Mix3,below GDP cutoff,,,,Walk,S1S,1,2050,10
+SDP_RC,Mix3,above GDP cutoff,,,Bus,trn_pass_road,S2S1,1,2050,10
+SDP_RC,Mix3,above GDP cutoff,,,trn_pass_road_LDV,trn_pass_road,S2S1,0.7,2035,10
+SDP_RC,Mix3,below GDP cutoff,,,Bus,trn_pass_road,S2S1,1,2050,10
+SDP_RC,Mix3,below GDP cutoff,,,trn_pass_road_LDV,trn_pass_road,S2S1,0.7,2035,10
+SDP_RC,Mix3,above GDP cutoff,BEV,Bus,Bus,trn_pass_road,FV,4,2035,10
+SDP_RC,Mix3,above GDP cutoff,FCEV,Bus,Bus,trn_pass_road,FV,4,2035,10
+SDP_RC,Mix3,above GDP cutoff,Liquids,Bus,Bus,trn_pass_road,FV,1,2050,10
+SDP_RC,Mix3,above GDP cutoff,Hydrogen,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SDP_RC,Mix3,above GDP cutoff,Liquids,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SDP_RC,Mix3,above GDP cutoff,Liquids,Ship,Domestic Ship_tmp_subsectorL2,Domestic Ship,FV,1,2050,10
+SDP_RC,Mix3,above GDP cutoff,Electric,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SDP_RC,Mix3,above GDP cutoff,Liquids,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SDP_RC,Mix3,above GDP cutoff,Electric,Rail,HSR_tmp_subsectorL2,HSR,FV,1,2050,10
+SDP_RC,Mix3,above GDP cutoff,Liquids,Aviation,International Aviation_tmp_subsectorL2,International Aviation,FV,1,2050,10
+SDP_RC,Mix3,above GDP cutoff,Liquids,Ship,International Ship_tmp_subsectorL2,International Ship,FV,1,2050,10
+SDP_RC,Mix3,above GDP cutoff,BEV,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SDP_RC,Mix3,above GDP cutoff,Liquids,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SDP_RC,Mix3,above GDP cutoff,Electric,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SDP_RC,Mix3,above GDP cutoff,Liquids,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SDP_RC,Mix3,above GDP cutoff,BEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,4,2035,10
+SDP_RC,Mix3,above GDP cutoff,FCEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,4,2035,10
+SDP_RC,Mix3,above GDP cutoff,Liquids,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,10
+SDP_RC,Mix3,above GDP cutoff,BEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,7,2035,10
+SDP_RC,Mix3,above GDP cutoff,FCEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,20,2035,10
+SDP_RC,Mix3,above GDP cutoff,Liquids,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,10
+SDP_RC,Mix3,below GDP cutoff,BEV,Bus,Bus,trn_pass_road,FV,3.5,2035,10
+SDP_RC,Mix3,below GDP cutoff,FCEV,Bus,Bus,trn_pass_road,FV,3.5,2035,10
+SDP_RC,Mix3,below GDP cutoff,Liquids,Bus,Bus,trn_pass_road,FV,1,2050,10
+SDP_RC,Mix3,below GDP cutoff,Hydrogen,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SDP_RC,Mix3,below GDP cutoff,Liquids,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SDP_RC,Mix3,below GDP cutoff,Liquids,Ship,Domestic Ship_tmp_subsectorL2,Domestic Ship,FV,1,2050,10
+SDP_RC,Mix3,below GDP cutoff,Electric,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SDP_RC,Mix3,below GDP cutoff,Liquids,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SDP_RC,Mix3,below GDP cutoff,Electric,Rail,HSR_tmp_subsectorL2,HSR,FV,1,2050,10
+SDP_RC,Mix3,below GDP cutoff,Liquids,Aviation,International Aviation_tmp_subsectorL2,International Aviation,FV,1,2050,10
+SDP_RC,Mix3,below GDP cutoff,Liquids,Ship,International Ship_tmp_subsectorL2,International Ship,FV,1,2050,10
+SDP_RC,Mix3,below GDP cutoff,BEV,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SDP_RC,Mix3,below GDP cutoff,Liquids,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SDP_RC,Mix3,below GDP cutoff,Electric,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SDP_RC,Mix3,below GDP cutoff,Liquids,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SDP_RC,Mix3,below GDP cutoff,BEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,3.5,2035,10
+SDP_RC,Mix3,below GDP cutoff,FCEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,3.5,2035,10
+SDP_RC,Mix3,below GDP cutoff,Liquids,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,10
+SDP_RC,Mix3,below GDP cutoff,BEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,5,2035,10
+SDP_RC,Mix3,below GDP cutoff,FCEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,17,2035,10
+SDP_RC,Mix3,below GDP cutoff,Liquids,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,10
+SDP_RC,Mix4,above GDP cutoff,,,,Cycle,S1S,1,2050,10
+SDP_RC,Mix4,above GDP cutoff,,,,Domestic Aviation,S1S,0.25,2035,10
+SDP_RC,Mix4,above GDP cutoff,,,,Domestic Ship,S1S,1,2050,10
+SDP_RC,Mix4,above GDP cutoff,,,,Freight Rail,S1S,1,2050,10
+SDP_RC,Mix4,above GDP cutoff,,,,HSR,S1S,1,2050,10
+SDP_RC,Mix4,above GDP cutoff,,,,Passenger Rail,S1S,1,2050,10
+SDP_RC,Mix4,above GDP cutoff,,,,trn_freight_road,S1S,0.5,2035,10
+SDP_RC,Mix4,above GDP cutoff,,,,trn_pass_road,S1S,0.5,2035,10
+SDP_RC,Mix4,above GDP cutoff,,,,Walk,S1S,1,2050,10
+SDP_RC,Mix4,below GDP cutoff,,,,Cycle,S1S,1,2050,10
+SDP_RC,Mix4,below GDP cutoff,,,,Domestic Aviation,S1S,0.25,2035,10
+SDP_RC,Mix4,below GDP cutoff,,,,Domestic Ship,S1S,1,2050,10
+SDP_RC,Mix4,below GDP cutoff,,,,Freight Rail,S1S,1,2050,10
+SDP_RC,Mix4,below GDP cutoff,,,,HSR,S1S,1,2050,10
+SDP_RC,Mix4,below GDP cutoff,,,,Passenger Rail,S1S,1,2050,10
+SDP_RC,Mix4,below GDP cutoff,,,,trn_freight_road,S1S,0.5,2035,10
+SDP_RC,Mix4,below GDP cutoff,,,,trn_pass_road,S1S,0.5,2035,10
+SDP_RC,Mix4,below GDP cutoff,,,,Walk,S1S,1,2050,10
+SDP_RC,Mix4,above GDP cutoff,,,Bus,trn_pass_road,S2S1,1,2050,10
+SDP_RC,Mix4,above GDP cutoff,,,trn_pass_road_LDV,trn_pass_road,S2S1,0.5,2035,10
+SDP_RC,Mix4,below GDP cutoff,,,Bus,trn_pass_road,S2S1,1,2050,10
+SDP_RC,Mix4,below GDP cutoff,,,trn_pass_road_LDV,trn_pass_road,S2S1,0.5,2035,10
+SDP_RC,Mix4,above GDP cutoff,BEV,Bus,Bus,trn_pass_road,FV,6,2035,10
+SDP_RC,Mix4,above GDP cutoff,FCEV,Bus,Bus,trn_pass_road,FV,6,2035,10
+SDP_RC,Mix4,above GDP cutoff,Liquids,Bus,Bus,trn_pass_road,FV,1,2050,10
+SDP_RC,Mix4,above GDP cutoff,Hydrogen,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SDP_RC,Mix4,above GDP cutoff,Liquids,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SDP_RC,Mix4,above GDP cutoff,Liquids,Ship,Domestic Ship_tmp_subsectorL2,Domestic Ship,FV,1,2050,10
+SDP_RC,Mix4,above GDP cutoff,Electric,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SDP_RC,Mix4,above GDP cutoff,Liquids,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SDP_RC,Mix4,above GDP cutoff,Electric,Rail,HSR_tmp_subsectorL2,HSR,FV,1,2050,10
+SDP_RC,Mix4,above GDP cutoff,Liquids,Aviation,International Aviation_tmp_subsectorL2,International Aviation,FV,1,2050,10
+SDP_RC,Mix4,above GDP cutoff,Liquids,Ship,International Ship_tmp_subsectorL2,International Ship,FV,1,2050,10
+SDP_RC,Mix4,above GDP cutoff,BEV,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SDP_RC,Mix4,above GDP cutoff,Liquids,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SDP_RC,Mix4,above GDP cutoff,Electric,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SDP_RC,Mix4,above GDP cutoff,Liquids,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SDP_RC,Mix4,above GDP cutoff,BEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,6,2035,10
+SDP_RC,Mix4,above GDP cutoff,FCEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,6,2035,10
+SDP_RC,Mix4,above GDP cutoff,Liquids,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,10
+SDP_RC,Mix4,above GDP cutoff,BEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,20,2035,10
+SDP_RC,Mix4,above GDP cutoff,FCEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,100,2035,10
+SDP_RC,Mix4,above GDP cutoff,Liquids,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,10
+SDP_RC,Mix4,below GDP cutoff,BEV,Bus,Bus,trn_pass_road,FV,5,2035,10
+SDP_RC,Mix4,below GDP cutoff,FCEV,Bus,Bus,trn_pass_road,FV,5,2035,10
+SDP_RC,Mix4,below GDP cutoff,Liquids,Bus,Bus,trn_pass_road,FV,1,2050,10
+SDP_RC,Mix4,below GDP cutoff,Hydrogen,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SDP_RC,Mix4,below GDP cutoff,Liquids,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SDP_RC,Mix4,below GDP cutoff,Liquids,Ship,Domestic Ship_tmp_subsectorL2,Domestic Ship,FV,1,2050,10
+SDP_RC,Mix4,below GDP cutoff,Electric,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SDP_RC,Mix4,below GDP cutoff,Liquids,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SDP_RC,Mix4,below GDP cutoff,Electric,Rail,HSR_tmp_subsectorL2,HSR,FV,1,2050,10
+SDP_RC,Mix4,below GDP cutoff,Liquids,Aviation,International Aviation_tmp_subsectorL2,International Aviation,FV,1,2050,10
+SDP_RC,Mix4,below GDP cutoff,Liquids,Ship,International Ship_tmp_subsectorL2,International Ship,FV,1,2050,10
+SDP_RC,Mix4,below GDP cutoff,BEV,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SDP_RC,Mix4,below GDP cutoff,Liquids,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SDP_RC,Mix4,below GDP cutoff,Electric,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SDP_RC,Mix4,below GDP cutoff,Liquids,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SDP_RC,Mix4,below GDP cutoff,BEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,5,2035,10
+SDP_RC,Mix4,below GDP cutoff,FCEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,5,2035,10
+SDP_RC,Mix4,below GDP cutoff,Liquids,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,10
+SDP_RC,Mix4,below GDP cutoff,BEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,17,2035,10
+SDP_RC,Mix4,below GDP cutoff,FCEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,85,2035,10
+SDP_RC,Mix4,below GDP cutoff,Liquids,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,10
+SSP1,Mix2,above GDP cutoff,,,,Cycle,S1S,1,2050,10
+SSP1,Mix2,above GDP cutoff,,,,Domestic Aviation,S1S,0.75,2035,10
+SSP1,Mix2,above GDP cutoff,,,,Domestic Ship,S1S,1,2050,10
+SSP1,Mix2,above GDP cutoff,,,,Freight Rail,S1S,1,2050,10
+SSP1,Mix2,above GDP cutoff,,,,HSR,S1S,1,2050,10
+SSP1,Mix2,above GDP cutoff,,,,Passenger Rail,S1S,1,2050,10
+SSP1,Mix2,above GDP cutoff,,,,trn_freight_road,S1S,0.9,2035,10
+SSP1,Mix2,above GDP cutoff,,,,trn_pass_road,S1S,0.9,2035,10
+SSP1,Mix2,above GDP cutoff,,,,Walk,S1S,1,2050,10
+SSP1,Mix2,below GDP cutoff,,,,Cycle,S1S,1,2050,10
+SSP1,Mix2,below GDP cutoff,,,,Domestic Aviation,S1S,0.75,2035,10
+SSP1,Mix2,below GDP cutoff,,,,Domestic Ship,S1S,1,2050,10
+SSP1,Mix2,below GDP cutoff,,,,Freight Rail,S1S,1,2050,10
+SSP1,Mix2,below GDP cutoff,,,,HSR,S1S,1,2050,10
+SSP1,Mix2,below GDP cutoff,,,,Passenger Rail,S1S,1,2050,10
+SSP1,Mix2,below GDP cutoff,,,,trn_freight_road,S1S,0.9,2035,10
+SSP1,Mix2,below GDP cutoff,,,,trn_pass_road,S1S,0.9,2035,10
+SSP1,Mix2,below GDP cutoff,,,,Walk,S1S,1,2050,10
+SSP1,Mix2,above GDP cutoff,,,Bus,trn_pass_road,S2S1,1,2050,10
+SSP1,Mix2,above GDP cutoff,,,trn_pass_road_LDV,trn_pass_road,S2S1,0.9,2035,10
+SSP1,Mix2,below GDP cutoff,,,Bus,trn_pass_road,S2S1,1,2050,10
+SSP1,Mix2,below GDP cutoff,,,trn_pass_road_LDV,trn_pass_road,S2S1,0.9,2035,10
+SSP1,Mix2,above GDP cutoff,BEV,Bus,Bus,trn_pass_road,FV,2,2035,10
+SSP1,Mix2,above GDP cutoff,FCEV,Bus,Bus,trn_pass_road,FV,2,2035,10
+SSP1,Mix2,above GDP cutoff,Liquids,Bus,Bus,trn_pass_road,FV,1,2050,10
+SSP1,Mix2,above GDP cutoff,Hydrogen,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SSP1,Mix2,above GDP cutoff,Liquids,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SSP1,Mix2,above GDP cutoff,Liquids,Ship,Domestic Ship_tmp_subsectorL2,Domestic Ship,FV,1,2050,10
+SSP1,Mix2,above GDP cutoff,Electric,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SSP1,Mix2,above GDP cutoff,Liquids,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SSP1,Mix2,above GDP cutoff,Electric,Rail,HSR_tmp_subsectorL2,HSR,FV,1,2050,10
+SSP1,Mix2,above GDP cutoff,Liquids,Aviation,International Aviation_tmp_subsectorL2,International Aviation,FV,1,2050,10
+SSP1,Mix2,above GDP cutoff,Liquids,Ship,International Ship_tmp_subsectorL2,International Ship,FV,1,2050,10
+SSP1,Mix2,above GDP cutoff,BEV,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SSP1,Mix2,above GDP cutoff,Liquids,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SSP1,Mix2,above GDP cutoff,Electric,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SSP1,Mix2,above GDP cutoff,Liquids,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SSP1,Mix2,above GDP cutoff,BEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,2,2035,10
+SSP1,Mix2,above GDP cutoff,FCEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,2,2035,10
+SSP1,Mix2,above GDP cutoff,Liquids,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,10
+SSP1,Mix2,above GDP cutoff,BEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,2,2035,10
+SSP1,Mix2,above GDP cutoff,FCEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,2,2035,10
+SSP1,Mix2,above GDP cutoff,Liquids,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,10
+SSP1,Mix2,below GDP cutoff,BEV,Bus,Bus,trn_pass_road,FV,1.5,2035,10
+SSP1,Mix2,below GDP cutoff,FCEV,Bus,Bus,trn_pass_road,FV,1.5,2035,10
+SSP1,Mix2,below GDP cutoff,Liquids,Bus,Bus,trn_pass_road,FV,1,2050,10
+SSP1,Mix2,below GDP cutoff,Hydrogen,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SSP1,Mix2,below GDP cutoff,Liquids,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SSP1,Mix2,below GDP cutoff,Liquids,Ship,Domestic Ship_tmp_subsectorL2,Domestic Ship,FV,1,2050,10
+SSP1,Mix2,below GDP cutoff,Electric,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SSP1,Mix2,below GDP cutoff,Liquids,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SSP1,Mix2,below GDP cutoff,Electric,Rail,HSR_tmp_subsectorL2,HSR,FV,1,2050,10
+SSP1,Mix2,below GDP cutoff,Liquids,Aviation,International Aviation_tmp_subsectorL2,International Aviation,FV,1,2050,10
+SSP1,Mix2,below GDP cutoff,Liquids,Ship,International Ship_tmp_subsectorL2,International Ship,FV,1,2050,10
+SSP1,Mix2,below GDP cutoff,BEV,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SSP1,Mix2,below GDP cutoff,Liquids,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SSP1,Mix2,below GDP cutoff,Electric,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SSP1,Mix2,below GDP cutoff,Liquids,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SSP1,Mix2,below GDP cutoff,BEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1.5,2035,10
+SSP1,Mix2,below GDP cutoff,FCEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1.5,2035,10
+SSP1,Mix2,below GDP cutoff,Liquids,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,10
+SSP1,Mix2,below GDP cutoff,BEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1.5,2035,10
+SSP1,Mix2,below GDP cutoff,FCEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1.5,2035,10
+SSP1,Mix2,below GDP cutoff,Liquids,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,10
+SSP1,Mix3,above GDP cutoff,,,,Cycle,S1S,1,2050,10
+SSP1,Mix3,above GDP cutoff,,,,Domestic Aviation,S1S,0.5,2035,10
+SSP1,Mix3,above GDP cutoff,,,,Domestic Ship,S1S,1,2050,10
+SSP1,Mix3,above GDP cutoff,,,,Freight Rail,S1S,1,2050,10
+SSP1,Mix3,above GDP cutoff,,,,HSR,S1S,1,2050,10
+SSP1,Mix3,above GDP cutoff,,,,Passenger Rail,S1S,1,2050,10
+SSP1,Mix3,above GDP cutoff,,,,trn_freight_road,S1S,0.7,2035,10
+SSP1,Mix3,above GDP cutoff,,,,trn_pass_road,S1S,0.7,2035,10
+SSP1,Mix3,above GDP cutoff,,,,Walk,S1S,1,2050,10
+SSP1,Mix3,below GDP cutoff,,,,Cycle,S1S,1,2050,10
+SSP1,Mix3,below GDP cutoff,,,,Domestic Aviation,S1S,0.5,2035,10
+SSP1,Mix3,below GDP cutoff,,,,Domestic Ship,S1S,1,2050,10
+SSP1,Mix3,below GDP cutoff,,,,Freight Rail,S1S,1,2050,10
+SSP1,Mix3,below GDP cutoff,,,,HSR,S1S,1,2050,10
+SSP1,Mix3,below GDP cutoff,,,,Passenger Rail,S1S,1,2050,10
+SSP1,Mix3,below GDP cutoff,,,,trn_freight_road,S1S,0.7,2035,10
+SSP1,Mix3,below GDP cutoff,,,,trn_pass_road,S1S,0.7,2035,10
+SSP1,Mix3,below GDP cutoff,,,,Walk,S1S,1,2050,10
+SSP1,Mix3,above GDP cutoff,,,Bus,trn_pass_road,S2S1,1,2050,10
+SSP1,Mix3,above GDP cutoff,,,trn_pass_road_LDV,trn_pass_road,S2S1,0.7,2035,10
+SSP1,Mix3,below GDP cutoff,,,Bus,trn_pass_road,S2S1,1,2050,10
+SSP1,Mix3,below GDP cutoff,,,trn_pass_road_LDV,trn_pass_road,S2S1,0.7,2035,10
+SSP1,Mix3,above GDP cutoff,BEV,Bus,Bus,trn_pass_road,FV,4,2035,10
+SSP1,Mix3,above GDP cutoff,FCEV,Bus,Bus,trn_pass_road,FV,4,2035,10
+SSP1,Mix3,above GDP cutoff,Liquids,Bus,Bus,trn_pass_road,FV,1,2050,10
+SSP1,Mix3,above GDP cutoff,Hydrogen,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SSP1,Mix3,above GDP cutoff,Liquids,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SSP1,Mix3,above GDP cutoff,Liquids,Ship,Domestic Ship_tmp_subsectorL2,Domestic Ship,FV,1,2050,10
+SSP1,Mix3,above GDP cutoff,Electric,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SSP1,Mix3,above GDP cutoff,Liquids,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SSP1,Mix3,above GDP cutoff,Electric,Rail,HSR_tmp_subsectorL2,HSR,FV,1,2050,10
+SSP1,Mix3,above GDP cutoff,Liquids,Aviation,International Aviation_tmp_subsectorL2,International Aviation,FV,1,2050,10
+SSP1,Mix3,above GDP cutoff,Liquids,Ship,International Ship_tmp_subsectorL2,International Ship,FV,1,2050,10
+SSP1,Mix3,above GDP cutoff,BEV,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SSP1,Mix3,above GDP cutoff,Liquids,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SSP1,Mix3,above GDP cutoff,Electric,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SSP1,Mix3,above GDP cutoff,Liquids,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SSP1,Mix3,above GDP cutoff,BEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,4,2035,10
+SSP1,Mix3,above GDP cutoff,FCEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,4,2035,10
+SSP1,Mix3,above GDP cutoff,Liquids,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,10
+SSP1,Mix3,above GDP cutoff,BEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,7,2035,10
+SSP1,Mix3,above GDP cutoff,FCEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,20,2035,10
+SSP1,Mix3,above GDP cutoff,Liquids,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,10
+SSP1,Mix3,below GDP cutoff,BEV,Bus,Bus,trn_pass_road,FV,3.5,2035,10
+SSP1,Mix3,below GDP cutoff,FCEV,Bus,Bus,trn_pass_road,FV,3.5,2035,10
+SSP1,Mix3,below GDP cutoff,Liquids,Bus,Bus,trn_pass_road,FV,1,2050,10
+SSP1,Mix3,below GDP cutoff,Hydrogen,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SSP1,Mix3,below GDP cutoff,Liquids,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SSP1,Mix3,below GDP cutoff,Liquids,Ship,Domestic Ship_tmp_subsectorL2,Domestic Ship,FV,1,2050,10
+SSP1,Mix3,below GDP cutoff,Electric,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SSP1,Mix3,below GDP cutoff,Liquids,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SSP1,Mix3,below GDP cutoff,Electric,Rail,HSR_tmp_subsectorL2,HSR,FV,1,2050,10
+SSP1,Mix3,below GDP cutoff,Liquids,Aviation,International Aviation_tmp_subsectorL2,International Aviation,FV,1,2050,10
+SSP1,Mix3,below GDP cutoff,Liquids,Ship,International Ship_tmp_subsectorL2,International Ship,FV,1,2050,10
+SSP1,Mix3,below GDP cutoff,BEV,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SSP1,Mix3,below GDP cutoff,Liquids,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SSP1,Mix3,below GDP cutoff,Electric,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SSP1,Mix3,below GDP cutoff,Liquids,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SSP1,Mix3,below GDP cutoff,BEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,3.5,2035,10
+SSP1,Mix3,below GDP cutoff,FCEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,3.5,2035,10
+SSP1,Mix3,below GDP cutoff,Liquids,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,10
+SSP1,Mix3,below GDP cutoff,BEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,5,2035,10
+SSP1,Mix3,below GDP cutoff,FCEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,17,2035,10
+SSP1,Mix3,below GDP cutoff,Liquids,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,10
+SSP1,Mix4,above GDP cutoff,,,,Cycle,S1S,1,2050,10
+SSP1,Mix4,above GDP cutoff,,,,Domestic Aviation,S1S,0.25,2035,10
+SSP1,Mix4,above GDP cutoff,,,,Domestic Ship,S1S,1,2050,10
+SSP1,Mix4,above GDP cutoff,,,,Freight Rail,S1S,1,2050,10
+SSP1,Mix4,above GDP cutoff,,,,HSR,S1S,1,2050,10
+SSP1,Mix4,above GDP cutoff,,,,Passenger Rail,S1S,1,2050,10
+SSP1,Mix4,above GDP cutoff,,,,trn_freight_road,S1S,0.5,2035,10
+SSP1,Mix4,above GDP cutoff,,,,trn_pass_road,S1S,0.5,2035,10
+SSP1,Mix4,above GDP cutoff,,,,Walk,S1S,1,2050,10
+SSP1,Mix4,below GDP cutoff,,,,Cycle,S1S,1,2050,10
+SSP1,Mix4,below GDP cutoff,,,,Domestic Aviation,S1S,0.25,2035,10
+SSP1,Mix4,below GDP cutoff,,,,Domestic Ship,S1S,1,2050,10
+SSP1,Mix4,below GDP cutoff,,,,Freight Rail,S1S,1,2050,10
+SSP1,Mix4,below GDP cutoff,,,,HSR,S1S,1,2050,10
+SSP1,Mix4,below GDP cutoff,,,,Passenger Rail,S1S,1,2050,10
+SSP1,Mix4,below GDP cutoff,,,,trn_freight_road,S1S,0.5,2035,10
+SSP1,Mix4,below GDP cutoff,,,,trn_pass_road,S1S,0.5,2035,10
+SSP1,Mix4,below GDP cutoff,,,,Walk,S1S,1,2050,10
+SSP1,Mix4,above GDP cutoff,,,Bus,trn_pass_road,S2S1,1,2050,10
+SSP1,Mix4,above GDP cutoff,,,trn_pass_road_LDV,trn_pass_road,S2S1,0.5,2035,10
+SSP1,Mix4,below GDP cutoff,,,Bus,trn_pass_road,S2S1,1,2050,10
+SSP1,Mix4,below GDP cutoff,,,trn_pass_road_LDV,trn_pass_road,S2S1,0.5,2035,10
+SSP1,Mix4,above GDP cutoff,BEV,Bus,Bus,trn_pass_road,FV,6,2035,10
+SSP1,Mix4,above GDP cutoff,FCEV,Bus,Bus,trn_pass_road,FV,6,2035,10
+SSP1,Mix4,above GDP cutoff,Liquids,Bus,Bus,trn_pass_road,FV,1,2050,10
+SSP1,Mix4,above GDP cutoff,Hydrogen,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SSP1,Mix4,above GDP cutoff,Liquids,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SSP1,Mix4,above GDP cutoff,Liquids,Ship,Domestic Ship_tmp_subsectorL2,Domestic Ship,FV,1,2050,10
+SSP1,Mix4,above GDP cutoff,Electric,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SSP1,Mix4,above GDP cutoff,Liquids,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SSP1,Mix4,above GDP cutoff,Electric,Rail,HSR_tmp_subsectorL2,HSR,FV,1,2050,10
+SSP1,Mix4,above GDP cutoff,Liquids,Aviation,International Aviation_tmp_subsectorL2,International Aviation,FV,1,2050,10
+SSP1,Mix4,above GDP cutoff,Liquids,Ship,International Ship_tmp_subsectorL2,International Ship,FV,1,2050,10
+SSP1,Mix4,above GDP cutoff,BEV,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SSP1,Mix4,above GDP cutoff,Liquids,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SSP1,Mix4,above GDP cutoff,Electric,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SSP1,Mix4,above GDP cutoff,Liquids,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SSP1,Mix4,above GDP cutoff,BEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,6,2035,10
+SSP1,Mix4,above GDP cutoff,FCEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,6,2035,10
+SSP1,Mix4,above GDP cutoff,Liquids,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,10
+SSP1,Mix4,above GDP cutoff,BEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,20,2035,10
+SSP1,Mix4,above GDP cutoff,FCEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,100,2035,10
+SSP1,Mix4,above GDP cutoff,Liquids,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,10
+SSP1,Mix4,below GDP cutoff,BEV,Bus,Bus,trn_pass_road,FV,5,2035,10
+SSP1,Mix4,below GDP cutoff,FCEV,Bus,Bus,trn_pass_road,FV,5,2035,10
+SSP1,Mix4,below GDP cutoff,Liquids,Bus,Bus,trn_pass_road,FV,1,2050,10
+SSP1,Mix4,below GDP cutoff,Hydrogen,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SSP1,Mix4,below GDP cutoff,Liquids,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SSP1,Mix4,below GDP cutoff,Liquids,Ship,Domestic Ship_tmp_subsectorL2,Domestic Ship,FV,1,2050,10
+SSP1,Mix4,below GDP cutoff,Electric,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SSP1,Mix4,below GDP cutoff,Liquids,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SSP1,Mix4,below GDP cutoff,Electric,Rail,HSR_tmp_subsectorL2,HSR,FV,1,2050,10
+SSP1,Mix4,below GDP cutoff,Liquids,Aviation,International Aviation_tmp_subsectorL2,International Aviation,FV,1,2050,10
+SSP1,Mix4,below GDP cutoff,Liquids,Ship,International Ship_tmp_subsectorL2,International Ship,FV,1,2050,10
+SSP1,Mix4,below GDP cutoff,BEV,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SSP1,Mix4,below GDP cutoff,Liquids,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SSP1,Mix4,below GDP cutoff,Electric,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SSP1,Mix4,below GDP cutoff,Liquids,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SSP1,Mix4,below GDP cutoff,BEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,5,2035,10
+SSP1,Mix4,below GDP cutoff,FCEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,5,2035,10
+SSP1,Mix4,below GDP cutoff,Liquids,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,10
+SSP1,Mix4,below GDP cutoff,BEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,17,2035,10
+SSP1,Mix4,below GDP cutoff,FCEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,85,2035,10
+SSP1,Mix4,below GDP cutoff,Liquids,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,10
+SSP2,CAMP_lscStrong,CAZ,,,,Cycle,S1S,2.5,2040,10
+SSP2,CAMP_lscStrong,CAZ,,,,Domestic Aviation,S1S,0.3,2040,10
+SSP2,CAMP_lscStrong,CAZ,,,,Domestic Ship,S1S,1,2040,10
+SSP2,CAMP_lscStrong,CAZ,,,,Freight Rail,S1S,1,2040,10
+SSP2,CAMP_lscStrong,CAZ,,,,HSR,S1S,1.7,2040,10
+SSP2,CAMP_lscStrong,CAZ,,,,Passenger Rail,S1S,4,2040,10
+SSP2,CAMP_lscStrong,CAZ,,,,trn_freight_road,S1S,0.9,2040,10
+SSP2,CAMP_lscStrong,CAZ,,,,trn_pass_road,S1S,0.6,2040,10
+SSP2,CAMP_lscStrong,CAZ,,,,Walk,S1S,2.5,2040,10
+SSP2,CAMP_lscStrong,USA,,,,Cycle,S1S,2.5,2040,10
+SSP2,CAMP_lscStrong,USA,,,,Domestic Aviation,S1S,0.3,2040,10
+SSP2,CAMP_lscStrong,USA,,,,Domestic Ship,S1S,1,2040,10
+SSP2,CAMP_lscStrong,USA,,,,Freight Rail,S1S,1,2040,10
+SSP2,CAMP_lscStrong,USA,,,,HSR,S1S,1.7,2040,10
+SSP2,CAMP_lscStrong,USA,,,,Passenger Rail,S1S,4,2040,10
+SSP2,CAMP_lscStrong,USA,,,,trn_freight_road,S1S,0.9,2040,10
+SSP2,CAMP_lscStrong,USA,,,,trn_pass_road,S1S,0.6,2040,10
+SSP2,CAMP_lscStrong,USA,,,,Walk,S1S,2.5,2040,10
+SSP2,CAMP_lscStrong,above GDP cutoff,,,,Cycle,S1S,3,2040,10
+SSP2,CAMP_lscStrong,above GDP cutoff,,,,Domestic Aviation,S1S,0.3,2040,10
+SSP2,CAMP_lscStrong,above GDP cutoff,,,,Domestic Ship,S1S,1,2040,10
+SSP2,CAMP_lscStrong,above GDP cutoff,,,,Freight Rail,S1S,1,2040,10
+SSP2,CAMP_lscStrong,above GDP cutoff,,,,HSR,S1S,2,2040,10
+SSP2,CAMP_lscStrong,above GDP cutoff,,,,Passenger Rail,S1S,2,2040,10
+SSP2,CAMP_lscStrong,above GDP cutoff,,,,trn_freight_road,S1S,0.7,2040,10
+SSP2,CAMP_lscStrong,above GDP cutoff,,,,trn_pass_road,S1S,0.75,2040,10
+SSP2,CAMP_lscStrong,above GDP cutoff,,,,Walk,S1S,3,2040,10
+SSP2,CAMP_lscStrong,below GDP cutoff,,,,Cycle,S1S,2.5,2040,10
+SSP2,CAMP_lscStrong,below GDP cutoff,,,,Domestic Aviation,S1S,0.3,2040,10
+SSP2,CAMP_lscStrong,below GDP cutoff,,,,Domestic Ship,S1S,1,2040,10
+SSP2,CAMP_lscStrong,below GDP cutoff,,,,Freight Rail,S1S,1,2040,10
+SSP2,CAMP_lscStrong,below GDP cutoff,,,,HSR,S1S,2.8,2040,10
+SSP2,CAMP_lscStrong,below GDP cutoff,,,,Passenger Rail,S1S,1.5,2040,10
+SSP2,CAMP_lscStrong,below GDP cutoff,,,,trn_freight_road,S1S,0.9,2040,10
+SSP2,CAMP_lscStrong,below GDP cutoff,,,,trn_pass_road,S1S,0.7,2040,10
+SSP2,CAMP_lscStrong,below GDP cutoff,,,,Walk,S1S,2.5,2040,10
+SSP2,CAMP_lscStrong,CAZ,,,Bus,trn_pass_road,S2S1,3,2040,10
+SSP2,CAMP_lscStrong,CAZ,,,trn_pass_road_LDV,trn_pass_road,S2S1,0.7,2040,10
+SSP2,CAMP_lscStrong,USA,,,Bus,trn_pass_road,S2S1,2,2040,10
+SSP2,CAMP_lscStrong,USA,,,trn_pass_road_LDV,trn_pass_road,S2S1,0.7,2040,10
+SSP2,CAMP_lscStrong,above GDP cutoff,,,Bus,trn_pass_road,S2S1,2.5,2040,10
+SSP2,CAMP_lscStrong,above GDP cutoff,,,trn_pass_road_LDV,trn_pass_road,S2S1,0.75,2035,10
+SSP2,CAMP_lscStrong,below GDP cutoff,,,Bus,trn_pass_road,S2S1,2,2040,10
+SSP2,CAMP_lscStrong,below GDP cutoff,,,trn_pass_road_LDV,trn_pass_road,S2S1,1,2040,10
+SSP2,CAMP_lscStrong,CAZ,BEV,Bus,Bus,trn_pass_road,FV,2,2040,10
+SSP2,CAMP_lscStrong,CAZ,FCEV,Bus,Bus,trn_pass_road,FV,1.5,2040,10
+SSP2,CAMP_lscStrong,CAZ,Liquids,Bus,Bus,trn_pass_road,FV,1,2050,10
+SSP2,CAMP_lscStrong,CAZ,Hydrogen,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SSP2,CAMP_lscStrong,CAZ,Liquids,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SSP2,CAMP_lscStrong,CAZ,Liquids,Ship,Domestic Ship_tmp_subsectorL2,Domestic Ship,FV,1,2050,10
+SSP2,CAMP_lscStrong,CAZ,Electric,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SSP2,CAMP_lscStrong,CAZ,Liquids,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SSP2,CAMP_lscStrong,CAZ,Electric,Rail,HSR_tmp_subsectorL2,HSR,FV,1,2050,10
+SSP2,CAMP_lscStrong,CAZ,Liquids,Aviation,International Aviation_tmp_subsectorL2,International Aviation,FV,1,2050,10
+SSP2,CAMP_lscStrong,CAZ,Liquids,Ship,International Ship_tmp_subsectorL2,International Ship,FV,1,2050,10
+SSP2,CAMP_lscStrong,CAZ,BEV,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SSP2,CAMP_lscStrong,CAZ,Liquids,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SSP2,CAMP_lscStrong,CAZ,Electric,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SSP2,CAMP_lscStrong,CAZ,Liquids,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SSP2,CAMP_lscStrong,CAZ,BEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,3,2040,10
+SSP2,CAMP_lscStrong,CAZ,FCEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,2,2040,10
+SSP2,CAMP_lscStrong,CAZ,Liquids,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,10
+SSP2,CAMP_lscStrong,CAZ,BEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,3,2040,10
+SSP2,CAMP_lscStrong,CAZ,FCEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,2,2040,10
+SSP2,CAMP_lscStrong,CAZ,Liquids,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,10
+SSP2,CAMP_lscStrong,USA,BEV,Bus,Bus,trn_pass_road,FV,4,2035,10
+SSP2,CAMP_lscStrong,USA,FCEV,Bus,Bus,trn_pass_road,FV,2,2035,10
+SSP2,CAMP_lscStrong,USA,Liquids,Bus,Bus,trn_pass_road,FV,1,2050,10
+SSP2,CAMP_lscStrong,USA,Hydrogen,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SSP2,CAMP_lscStrong,USA,Liquids,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SSP2,CAMP_lscStrong,USA,Liquids,Ship,Domestic Ship_tmp_subsectorL2,Domestic Ship,FV,1,2050,10
+SSP2,CAMP_lscStrong,USA,Electric,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SSP2,CAMP_lscStrong,USA,Liquids,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SSP2,CAMP_lscStrong,USA,Electric,Rail,HSR_tmp_subsectorL2,HSR,FV,1,2050,10
+SSP2,CAMP_lscStrong,USA,Liquids,Aviation,International Aviation_tmp_subsectorL2,International Aviation,FV,1,2050,10
+SSP2,CAMP_lscStrong,USA,Liquids,Ship,International Ship_tmp_subsectorL2,International Ship,FV,1,2050,10
+SSP2,CAMP_lscStrong,USA,BEV,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SSP2,CAMP_lscStrong,USA,Liquids,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SSP2,CAMP_lscStrong,USA,Electric,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SSP2,CAMP_lscStrong,USA,Liquids,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SSP2,CAMP_lscStrong,USA,BEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,3,2035,10
+SSP2,CAMP_lscStrong,USA,FCEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,2,2035,10
+SSP2,CAMP_lscStrong,USA,Liquids,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,10
+SSP2,CAMP_lscStrong,USA,BEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,3,2035,10
+SSP2,CAMP_lscStrong,USA,FCEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,2,2035,10
+SSP2,CAMP_lscStrong,USA,Liquids,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,10
+SSP2,CAMP_lscStrong,above GDP cutoff,BEV,Bus,Bus,trn_pass_road,FV,2,2040,10
+SSP2,CAMP_lscStrong,above GDP cutoff,FCEV,Bus,Bus,trn_pass_road,FV,2,2040,10
+SSP2,CAMP_lscStrong,above GDP cutoff,Liquids,Bus,Bus,trn_pass_road,FV,1,2050,10
+SSP2,CAMP_lscStrong,above GDP cutoff,Hydrogen,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SSP2,CAMP_lscStrong,above GDP cutoff,Liquids,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SSP2,CAMP_lscStrong,above GDP cutoff,Liquids,Ship,Domestic Ship_tmp_subsectorL2,Domestic Ship,FV,1,2050,10
+SSP2,CAMP_lscStrong,above GDP cutoff,Electric,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,2,2050,10
+SSP2,CAMP_lscStrong,above GDP cutoff,Liquids,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,2,2050,10
+SSP2,CAMP_lscStrong,above GDP cutoff,Electric,Rail,HSR_tmp_subsectorL2,HSR,FV,2,2050,10
+SSP2,CAMP_lscStrong,above GDP cutoff,Liquids,Aviation,International Aviation_tmp_subsectorL2,International Aviation,FV,1,2050,10
+SSP2,CAMP_lscStrong,above GDP cutoff,Liquids,Ship,International Ship_tmp_subsectorL2,International Ship,FV,1,2050,10
+SSP2,CAMP_lscStrong,above GDP cutoff,BEV,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SSP2,CAMP_lscStrong,above GDP cutoff,Liquids,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SSP2,CAMP_lscStrong,above GDP cutoff,Electric,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,2,2050,10
+SSP2,CAMP_lscStrong,above GDP cutoff,Liquids,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,2,2050,10
+SSP2,CAMP_lscStrong,above GDP cutoff,BEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2040,10
+SSP2,CAMP_lscStrong,above GDP cutoff,FCEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2040,10
+SSP2,CAMP_lscStrong,above GDP cutoff,Liquids,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,10
+SSP2,CAMP_lscStrong,above GDP cutoff,BEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2040,10
+SSP2,CAMP_lscStrong,above GDP cutoff,FCEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2040,10
+SSP2,CAMP_lscStrong,above GDP cutoff,Liquids,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,10
+SSP2,CAMP_lscStrong,below GDP cutoff,BEV,Bus,Bus,trn_pass_road,FV,3,2040,10
+SSP2,CAMP_lscStrong,below GDP cutoff,FCEV,Bus,Bus,trn_pass_road,FV,1.5,2040,10
+SSP2,CAMP_lscStrong,below GDP cutoff,Liquids,Bus,Bus,trn_pass_road,FV,1,2050,10
+SSP2,CAMP_lscStrong,below GDP cutoff,Hydrogen,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SSP2,CAMP_lscStrong,below GDP cutoff,Liquids,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SSP2,CAMP_lscStrong,below GDP cutoff,Liquids,Ship,Domestic Ship_tmp_subsectorL2,Domestic Ship,FV,1,2050,10
+SSP2,CAMP_lscStrong,below GDP cutoff,Electric,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SSP2,CAMP_lscStrong,below GDP cutoff,Liquids,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SSP2,CAMP_lscStrong,below GDP cutoff,Electric,Rail,HSR_tmp_subsectorL2,HSR,FV,1,2050,10
+SSP2,CAMP_lscStrong,below GDP cutoff,Liquids,Aviation,International Aviation_tmp_subsectorL2,International Aviation,FV,1,2050,10
+SSP2,CAMP_lscStrong,below GDP cutoff,Liquids,Ship,International Ship_tmp_subsectorL2,International Ship,FV,1,2050,10
+SSP2,CAMP_lscStrong,below GDP cutoff,BEV,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SSP2,CAMP_lscStrong,below GDP cutoff,Liquids,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SSP2,CAMP_lscStrong,below GDP cutoff,Electric,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SSP2,CAMP_lscStrong,below GDP cutoff,Liquids,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SSP2,CAMP_lscStrong,below GDP cutoff,BEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,2,2040,10
+SSP2,CAMP_lscStrong,below GDP cutoff,FCEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1.5,2040,10
+SSP2,CAMP_lscStrong,below GDP cutoff,Liquids,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,10
+SSP2,CAMP_lscStrong,below GDP cutoff,BEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,2,2040,10
+SSP2,CAMP_lscStrong,below GDP cutoff,FCEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1.5,2040,10
+SSP2,CAMP_lscStrong,below GDP cutoff,Liquids,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,10
+SSP2,CAMP_lscWeak,CAZ,,,,Cycle,S1S,1.75,2040,10
+SSP2,CAMP_lscWeak,CAZ,,,,Domestic Aviation,S1S,0.53,2040,10
+SSP2,CAMP_lscWeak,CAZ,,,,Domestic Ship,S1S,1,2040,10
+SSP2,CAMP_lscWeak,CAZ,,,,Freight Rail,S1S,1,2040,10
+SSP2,CAMP_lscWeak,CAZ,,,,HSR,S1S,1.35,2040,10
+SSP2,CAMP_lscWeak,CAZ,,,,Passenger Rail,S1S,2,2040,10
+SSP2,CAMP_lscWeak,CAZ,,,,trn_freight_road,S1S,0.9,2040,10
+SSP2,CAMP_lscWeak,CAZ,,,,trn_pass_road,S1S,0.65,2040,10
+SSP2,CAMP_lscWeak,CAZ,,,,Walk,S1S,1.75,2040,10
+SSP2,CAMP_lscWeak,USA,,,,Cycle,S1S,1.75,2040,10
+SSP2,CAMP_lscWeak,USA,,,,Domestic Aviation,S1S,0.53,2040,10
+SSP2,CAMP_lscWeak,USA,,,,Domestic Ship,S1S,1,2040,10
+SSP2,CAMP_lscWeak,USA,,,,Freight Rail,S1S,1,2040,10
+SSP2,CAMP_lscWeak,USA,,,,HSR,S1S,1.35,2040,10
+SSP2,CAMP_lscWeak,USA,,,,Passenger Rail,S1S,2,2040,10
+SSP2,CAMP_lscWeak,USA,,,,trn_freight_road,S1S,0.9,2040,10
+SSP2,CAMP_lscWeak,USA,,,,trn_pass_road,S1S,0.65,2040,10
+SSP2,CAMP_lscWeak,USA,,,,Walk,S1S,1.75,2040,10
+SSP2,CAMP_lscWeak,above GDP cutoff,,,,Cycle,S1S,2.25,2040,10
+SSP2,CAMP_lscWeak,above GDP cutoff,,,,Domestic Aviation,S1S,0.4,2040,10
+SSP2,CAMP_lscWeak,above GDP cutoff,,,,Domestic Ship,S1S,1,2040,10
+SSP2,CAMP_lscWeak,above GDP cutoff,,,,Freight Rail,S1S,1,2040,10
+SSP2,CAMP_lscWeak,above GDP cutoff,,,,HSR,S1S,1.6,2040,10
+SSP2,CAMP_lscWeak,above GDP cutoff,,,,Passenger Rail,S1S,1.6,2040,10
+SSP2,CAMP_lscWeak,above GDP cutoff,,,,trn_freight_road,S1S,0.75,2040,10
+SSP2,CAMP_lscWeak,above GDP cutoff,,,,trn_pass_road,S1S,0.8,2040,10
+SSP2,CAMP_lscWeak,above GDP cutoff,,,,Walk,S1S,2.25,2040,10
+SSP2,CAMP_lscWeak,below GDP cutoff,,,,Cycle,S1S,1.75,2040,10
+SSP2,CAMP_lscWeak,below GDP cutoff,,,,Domestic Aviation,S1S,0.53,2040,10
+SSP2,CAMP_lscWeak,below GDP cutoff,,,,Domestic Ship,S1S,1,2040,10
+SSP2,CAMP_lscWeak,below GDP cutoff,,,,Freight Rail,S1S,1,2040,10
+SSP2,CAMP_lscWeak,below GDP cutoff,,,,HSR,S1S,1.9,2040,10
+SSP2,CAMP_lscWeak,below GDP cutoff,,,,Passenger Rail,S1S,1.25,2040,10
+SSP2,CAMP_lscWeak,below GDP cutoff,,,,trn_freight_road,S1S,0.9,2040,10
+SSP2,CAMP_lscWeak,below GDP cutoff,,,,trn_pass_road,S1S,0.8,2040,10
+SSP2,CAMP_lscWeak,below GDP cutoff,,,,Walk,S1S,1.75,2040,10
+SSP2,CAMP_lscWeak,CAZ,,,Bus,trn_pass_road,S2S1,2,2040,10
+SSP2,CAMP_lscWeak,CAZ,,,trn_pass_road_LDV,trn_pass_road,S2S1,0.7,2040,10
+SSP2,CAMP_lscWeak,USA,,,Bus,trn_pass_road,S2S1,1.5,2040,10
+SSP2,CAMP_lscWeak,USA,,,trn_pass_road_LDV,trn_pass_road,S2S1,0.7,2040,10
+SSP2,CAMP_lscWeak,above GDP cutoff,,,Bus,trn_pass_road,S2S1,2,2040,10
+SSP2,CAMP_lscWeak,above GDP cutoff,,,trn_pass_road_LDV,trn_pass_road,S2S1,0.8,2035,10
+SSP2,CAMP_lscWeak,below GDP cutoff,,,Bus,trn_pass_road,S2S1,1.5,2040,10
+SSP2,CAMP_lscWeak,below GDP cutoff,,,trn_pass_road_LDV,trn_pass_road,S2S1,0.95,2040,10
+SSP2,CAMP_lscWeak,CAZ,BEV,Bus,Bus,trn_pass_road,FV,2,2040,10
+SSP2,CAMP_lscWeak,CAZ,FCEV,Bus,Bus,trn_pass_road,FV,1.5,2040,10
+SSP2,CAMP_lscWeak,CAZ,Liquids,Bus,Bus,trn_pass_road,FV,1,2050,10
+SSP2,CAMP_lscWeak,CAZ,Hydrogen,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SSP2,CAMP_lscWeak,CAZ,Liquids,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SSP2,CAMP_lscWeak,CAZ,Liquids,Ship,Domestic Ship_tmp_subsectorL2,Domestic Ship,FV,1,2050,10
+SSP2,CAMP_lscWeak,CAZ,Electric,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SSP2,CAMP_lscWeak,CAZ,Liquids,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SSP2,CAMP_lscWeak,CAZ,Electric,Rail,HSR_tmp_subsectorL2,HSR,FV,1,2050,10
+SSP2,CAMP_lscWeak,CAZ,Liquids,Aviation,International Aviation_tmp_subsectorL2,International Aviation,FV,1,2050,10
+SSP2,CAMP_lscWeak,CAZ,Liquids,Ship,International Ship_tmp_subsectorL2,International Ship,FV,1,2050,10
+SSP2,CAMP_lscWeak,CAZ,BEV,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SSP2,CAMP_lscWeak,CAZ,Liquids,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SSP2,CAMP_lscWeak,CAZ,Electric,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SSP2,CAMP_lscWeak,CAZ,Liquids,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SSP2,CAMP_lscWeak,CAZ,BEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,3,2040,10
+SSP2,CAMP_lscWeak,CAZ,FCEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,2,2040,10
+SSP2,CAMP_lscWeak,CAZ,Liquids,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,10
+SSP2,CAMP_lscWeak,CAZ,BEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,3,2040,10
+SSP2,CAMP_lscWeak,CAZ,FCEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,2,2040,10
+SSP2,CAMP_lscWeak,CAZ,Liquids,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,10
+SSP2,CAMP_lscWeak,USA,BEV,Bus,Bus,trn_pass_road,FV,2,2035,10
+SSP2,CAMP_lscWeak,USA,FCEV,Bus,Bus,trn_pass_road,FV,2,2035,10
+SSP2,CAMP_lscWeak,USA,Liquids,Bus,Bus,trn_pass_road,FV,1,2050,10
+SSP2,CAMP_lscWeak,USA,Hydrogen,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SSP2,CAMP_lscWeak,USA,Liquids,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SSP2,CAMP_lscWeak,USA,Liquids,Ship,Domestic Ship_tmp_subsectorL2,Domestic Ship,FV,1,2050,10
+SSP2,CAMP_lscWeak,USA,Electric,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SSP2,CAMP_lscWeak,USA,Liquids,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SSP2,CAMP_lscWeak,USA,Electric,Rail,HSR_tmp_subsectorL2,HSR,FV,1,2050,10
+SSP2,CAMP_lscWeak,USA,Liquids,Aviation,International Aviation_tmp_subsectorL2,International Aviation,FV,1,2050,10
+SSP2,CAMP_lscWeak,USA,Liquids,Ship,International Ship_tmp_subsectorL2,International Ship,FV,1,2050,10
+SSP2,CAMP_lscWeak,USA,BEV,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SSP2,CAMP_lscWeak,USA,Liquids,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SSP2,CAMP_lscWeak,USA,Electric,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SSP2,CAMP_lscWeak,USA,Liquids,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SSP2,CAMP_lscWeak,USA,BEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,3,2035,10
+SSP2,CAMP_lscWeak,USA,FCEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,2,2035,10
+SSP2,CAMP_lscWeak,USA,Liquids,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,10
+SSP2,CAMP_lscWeak,USA,BEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,3,2035,10
+SSP2,CAMP_lscWeak,USA,FCEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,2,2035,10
+SSP2,CAMP_lscWeak,USA,Liquids,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,10
+SSP2,CAMP_lscWeak,above GDP cutoff,BEV,Bus,Bus,trn_pass_road,FV,2,2040,10
+SSP2,CAMP_lscWeak,above GDP cutoff,FCEV,Bus,Bus,trn_pass_road,FV,2,2040,10
+SSP2,CAMP_lscWeak,above GDP cutoff,Liquids,Bus,Bus,trn_pass_road,FV,1,2050,10
+SSP2,CAMP_lscWeak,above GDP cutoff,Hydrogen,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SSP2,CAMP_lscWeak,above GDP cutoff,Liquids,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SSP2,CAMP_lscWeak,above GDP cutoff,Liquids,Ship,Domestic Ship_tmp_subsectorL2,Domestic Ship,FV,1,2050,10
+SSP2,CAMP_lscWeak,above GDP cutoff,Electric,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1.5,2050,10
+SSP2,CAMP_lscWeak,above GDP cutoff,Liquids,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1.5,2050,10
+SSP2,CAMP_lscWeak,above GDP cutoff,Electric,Rail,HSR_tmp_subsectorL2,HSR,FV,1.5,2050,10
+SSP2,CAMP_lscWeak,above GDP cutoff,Liquids,Aviation,International Aviation_tmp_subsectorL2,International Aviation,FV,1,2050,10
+SSP2,CAMP_lscWeak,above GDP cutoff,Liquids,Ship,International Ship_tmp_subsectorL2,International Ship,FV,1,2050,10
+SSP2,CAMP_lscWeak,above GDP cutoff,BEV,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SSP2,CAMP_lscWeak,above GDP cutoff,Liquids,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SSP2,CAMP_lscWeak,above GDP cutoff,Electric,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1.5,2050,10
+SSP2,CAMP_lscWeak,above GDP cutoff,Liquids,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1.5,2050,10
+SSP2,CAMP_lscWeak,above GDP cutoff,BEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2040,10
+SSP2,CAMP_lscWeak,above GDP cutoff,FCEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2040,10
+SSP2,CAMP_lscWeak,above GDP cutoff,Liquids,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,10
+SSP2,CAMP_lscWeak,above GDP cutoff,BEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2040,10
+SSP2,CAMP_lscWeak,above GDP cutoff,FCEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2040,10
+SSP2,CAMP_lscWeak,above GDP cutoff,Liquids,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,10
+SSP2,CAMP_lscWeak,below GDP cutoff,BEV,Bus,Bus,trn_pass_road,FV,1.5,2040,10
+SSP2,CAMP_lscWeak,below GDP cutoff,FCEV,Bus,Bus,trn_pass_road,FV,1.5,2040,10
+SSP2,CAMP_lscWeak,below GDP cutoff,Liquids,Bus,Bus,trn_pass_road,FV,1,2050,10
+SSP2,CAMP_lscWeak,below GDP cutoff,Hydrogen,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SSP2,CAMP_lscWeak,below GDP cutoff,Liquids,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SSP2,CAMP_lscWeak,below GDP cutoff,Liquids,Ship,Domestic Ship_tmp_subsectorL2,Domestic Ship,FV,1,2050,10
+SSP2,CAMP_lscWeak,below GDP cutoff,Electric,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SSP2,CAMP_lscWeak,below GDP cutoff,Liquids,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SSP2,CAMP_lscWeak,below GDP cutoff,Electric,Rail,HSR_tmp_subsectorL2,HSR,FV,1,2050,10
+SSP2,CAMP_lscWeak,below GDP cutoff,Liquids,Aviation,International Aviation_tmp_subsectorL2,International Aviation,FV,1,2050,10
+SSP2,CAMP_lscWeak,below GDP cutoff,Liquids,Ship,International Ship_tmp_subsectorL2,International Ship,FV,1,2050,10
+SSP2,CAMP_lscWeak,below GDP cutoff,BEV,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SSP2,CAMP_lscWeak,below GDP cutoff,Liquids,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SSP2,CAMP_lscWeak,below GDP cutoff,Electric,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SSP2,CAMP_lscWeak,below GDP cutoff,Liquids,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SSP2,CAMP_lscWeak,below GDP cutoff,BEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,2,2040,10
+SSP2,CAMP_lscWeak,below GDP cutoff,FCEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1.5,2040,10
+SSP2,CAMP_lscWeak,below GDP cutoff,Liquids,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,10
+SSP2,CAMP_lscWeak,below GDP cutoff,BEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,2,2040,10
+SSP2,CAMP_lscWeak,below GDP cutoff,FCEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1.5,2040,10
+SSP2,CAMP_lscWeak,below GDP cutoff,Liquids,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,10
+SSP2,ECEMF_HighEl_HighEff,above GDP cutoff,,,,Cycle,S1S,1.5,2050,10
+SSP2,ECEMF_HighEl_HighEff,above GDP cutoff,,,,Domestic Aviation,S1S,0.5,2035,10
+SSP2,ECEMF_HighEl_HighEff,above GDP cutoff,,,,Domestic Ship,S1S,1.5,2050,10
+SSP2,ECEMF_HighEl_HighEff,above GDP cutoff,,,,Freight Rail,S1S,1.5,2050,10
+SSP2,ECEMF_HighEl_HighEff,above GDP cutoff,,,,HSR,S1S,1,2050,10
+SSP2,ECEMF_HighEl_HighEff,above GDP cutoff,,,,Passenger Rail,S1S,1.5,2050,10
+SSP2,ECEMF_HighEl_HighEff,above GDP cutoff,,,,trn_freight_road,S1S,0.7,2035,10
+SSP2,ECEMF_HighEl_HighEff,above GDP cutoff,,,,trn_pass_road,S1S,0.7,2035,10
+SSP2,ECEMF_HighEl_HighEff,above GDP cutoff,,,,Walk,S1S,1.5,2050,10
+SSP2,ECEMF_HighEl_HighEff,below GDP cutoff,,,,Cycle,S1S,1.5,2050,10
+SSP2,ECEMF_HighEl_HighEff,below GDP cutoff,,,,Domestic Aviation,S1S,0.5,2035,10
+SSP2,ECEMF_HighEl_HighEff,below GDP cutoff,,,,Domestic Ship,S1S,1.5,2050,10
+SSP2,ECEMF_HighEl_HighEff,below GDP cutoff,,,,Freight Rail,S1S,1.5,2050,10
+SSP2,ECEMF_HighEl_HighEff,below GDP cutoff,,,,HSR,S1S,1,2050,10
+SSP2,ECEMF_HighEl_HighEff,below GDP cutoff,,,,Passenger Rail,S1S,1.5,2050,10
+SSP2,ECEMF_HighEl_HighEff,below GDP cutoff,,,,trn_freight_road,S1S,0.7,2035,10
+SSP2,ECEMF_HighEl_HighEff,below GDP cutoff,,,,trn_pass_road,S1S,0.7,2035,10
+SSP2,ECEMF_HighEl_HighEff,below GDP cutoff,,,,Walk,S1S,1.5,2050,10
+SSP2,ECEMF_HighEl_HighEff,above GDP cutoff,,,Bus,trn_pass_road,S2S1,1.5,2050,10
+SSP2,ECEMF_HighEl_HighEff,above GDP cutoff,,,trn_pass_road_LDV,trn_pass_road,S2S1,0.7,2035,10
+SSP2,ECEMF_HighEl_HighEff,below GDP cutoff,,,Bus,trn_pass_road,S2S1,1.5,2050,10
+SSP2,ECEMF_HighEl_HighEff,below GDP cutoff,,,trn_pass_road_LDV,trn_pass_road,S2S1,0.7,2035,10
+SSP2,ECEMF_HighEl_HighEff,above GDP cutoff,BEV,Bus,Bus,trn_pass_road,FV,10,2035,15
+SSP2,ECEMF_HighEl_HighEff,above GDP cutoff,FCEV,Bus,Bus,trn_pass_road,FV,1.1,2035,5
+SSP2,ECEMF_HighEl_HighEff,above GDP cutoff,Liquids,Bus,Bus,trn_pass_road,FV,1,2050,10
+SSP2,ECEMF_HighEl_HighEff,above GDP cutoff,Hydrogen,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1.1,2050,5
+SSP2,ECEMF_HighEl_HighEff,above GDP cutoff,Liquids,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SSP2,ECEMF_HighEl_HighEff,above GDP cutoff,Liquids,Ship,Domestic Ship_tmp_subsectorL2,Domestic Ship,FV,1,2050,10
+SSP2,ECEMF_HighEl_HighEff,above GDP cutoff,Electric,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,5,2050,15
+SSP2,ECEMF_HighEl_HighEff,above GDP cutoff,Liquids,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SSP2,ECEMF_HighEl_HighEff,above GDP cutoff,Electric,Rail,HSR_tmp_subsectorL2,HSR,FV,5,2050,15
+SSP2,ECEMF_HighEl_HighEff,above GDP cutoff,Liquids,Aviation,International Aviation_tmp_subsectorL2,International Aviation,FV,1,2050,10
+SSP2,ECEMF_HighEl_HighEff,above GDP cutoff,Liquids,Ship,International Ship_tmp_subsectorL2,International Ship,FV,1,2050,10
+SSP2,ECEMF_HighEl_HighEff,above GDP cutoff,BEV,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,7,2050,15
+SSP2,ECEMF_HighEl_HighEff,above GDP cutoff,Liquids,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SSP2,ECEMF_HighEl_HighEff,above GDP cutoff,Electric,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,5,2050,15
+SSP2,ECEMF_HighEl_HighEff,above GDP cutoff,Liquids,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SSP2,ECEMF_HighEl_HighEff,above GDP cutoff,BEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,40,2040,3
+SSP2,ECEMF_HighEl_HighEff,above GDP cutoff,FCEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,10,2040,3
+SSP2,ECEMF_HighEl_HighEff,above GDP cutoff,Liquids,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,3
+SSP2,ECEMF_HighEl_HighEff,above GDP cutoff,BEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,50,2040,5
+SSP2,ECEMF_HighEl_HighEff,above GDP cutoff,FCEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,60,2040,3
+SSP2,ECEMF_HighEl_HighEff,above GDP cutoff,Liquids,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,3
+SSP2,ECEMF_HighEl_HighEff,below GDP cutoff,BEV,Bus,Bus,trn_pass_road,FV,13,2030,15
+SSP2,ECEMF_HighEl_HighEff,below GDP cutoff,FCEV,Bus,Bus,trn_pass_road,FV,1.1,2035,5
+SSP2,ECEMF_HighEl_HighEff,below GDP cutoff,Liquids,Bus,Bus,trn_pass_road,FV,1,2050,10
+SSP2,ECEMF_HighEl_HighEff,below GDP cutoff,Hydrogen,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,2,2050,5
+SSP2,ECEMF_HighEl_HighEff,below GDP cutoff,Liquids,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SSP2,ECEMF_HighEl_HighEff,below GDP cutoff,Liquids,Ship,Domestic Ship_tmp_subsectorL2,Domestic Ship,FV,1,2050,10
+SSP2,ECEMF_HighEl_HighEff,below GDP cutoff,Electric,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,6,2040,15
+SSP2,ECEMF_HighEl_HighEff,below GDP cutoff,Liquids,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SSP2,ECEMF_HighEl_HighEff,below GDP cutoff,Electric,Rail,HSR_tmp_subsectorL2,HSR,FV,6,2040,15
+SSP2,ECEMF_HighEl_HighEff,below GDP cutoff,Liquids,Aviation,International Aviation_tmp_subsectorL2,International Aviation,FV,1,2050,10
+SSP2,ECEMF_HighEl_HighEff,below GDP cutoff,Liquids,Ship,International Ship_tmp_subsectorL2,International Ship,FV,1,2050,10
+SSP2,ECEMF_HighEl_HighEff,below GDP cutoff,BEV,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,7,2030,15
+SSP2,ECEMF_HighEl_HighEff,below GDP cutoff,Liquids,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SSP2,ECEMF_HighEl_HighEff,below GDP cutoff,Electric,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,6,2040,15
+SSP2,ECEMF_HighEl_HighEff,below GDP cutoff,Liquids,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SSP2,ECEMF_HighEl_HighEff,below GDP cutoff,BEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,10,2040,3
+SSP2,ECEMF_HighEl_HighEff,below GDP cutoff,FCEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,10,2040,3
+SSP2,ECEMF_HighEl_HighEff,below GDP cutoff,Liquids,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,3
+SSP2,ECEMF_HighEl_HighEff,below GDP cutoff,BEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,5,2035,5
+SSP2,ECEMF_HighEl_HighEff,below GDP cutoff,FCEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,7,2035,3
+SSP2,ECEMF_HighEl_HighEff,below GDP cutoff,Liquids,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,3
+SSP2,ECEMF_HighEl_LifestCha,above GDP cutoff,,,,Cycle,S1S,2,2050,10
+SSP2,ECEMF_HighEl_LifestCha,above GDP cutoff,,,,Domestic Aviation,S1S,0.25,2035,10
+SSP2,ECEMF_HighEl_LifestCha,above GDP cutoff,,,,Domestic Ship,S1S,1.5,2050,10
+SSP2,ECEMF_HighEl_LifestCha,above GDP cutoff,,,,Freight Rail,S1S,1.5,2050,10
+SSP2,ECEMF_HighEl_LifestCha,above GDP cutoff,,,,HSR,S1S,1,2050,10
+SSP2,ECEMF_HighEl_LifestCha,above GDP cutoff,,,,Passenger Rail,S1S,2,2050,10
+SSP2,ECEMF_HighEl_LifestCha,above GDP cutoff,,,,trn_freight_road,S1S,0.7,2035,10
+SSP2,ECEMF_HighEl_LifestCha,above GDP cutoff,,,,trn_pass_road,S1S,0.5,2035,10
+SSP2,ECEMF_HighEl_LifestCha,above GDP cutoff,,,,Walk,S1S,2,2050,10
+SSP2,ECEMF_HighEl_LifestCha,below GDP cutoff,,,,Cycle,S1S,2,2050,10
+SSP2,ECEMF_HighEl_LifestCha,below GDP cutoff,,,,Domestic Aviation,S1S,0.25,2035,10
+SSP2,ECEMF_HighEl_LifestCha,below GDP cutoff,,,,Domestic Ship,S1S,1.5,2050,10
+SSP2,ECEMF_HighEl_LifestCha,below GDP cutoff,,,,Freight Rail,S1S,1.5,2050,10
+SSP2,ECEMF_HighEl_LifestCha,below GDP cutoff,,,,HSR,S1S,1,2050,10
+SSP2,ECEMF_HighEl_LifestCha,below GDP cutoff,,,,Passenger Rail,S1S,2,2050,10
+SSP2,ECEMF_HighEl_LifestCha,below GDP cutoff,,,,trn_freight_road,S1S,0.7,2035,10
+SSP2,ECEMF_HighEl_LifestCha,below GDP cutoff,,,,trn_pass_road,S1S,0.5,2035,10
+SSP2,ECEMF_HighEl_LifestCha,below GDP cutoff,,,,Walk,S1S,2,2050,10
+SSP2,ECEMF_HighEl_LifestCha,above GDP cutoff,,,Bus,trn_pass_road,S2S1,2,2050,10
+SSP2,ECEMF_HighEl_LifestCha,above GDP cutoff,,,trn_pass_road_LDV,trn_pass_road,S2S1,0.5,2035,10
+SSP2,ECEMF_HighEl_LifestCha,below GDP cutoff,,,Bus,trn_pass_road,S2S1,2,2050,10
+SSP2,ECEMF_HighEl_LifestCha,below GDP cutoff,,,trn_pass_road_LDV,trn_pass_road,S2S1,0.5,2035,10
+SSP2,ECEMF_HighEl_LifestCha,above GDP cutoff,BEV,Bus,Bus,trn_pass_road,FV,10,2035,15
+SSP2,ECEMF_HighEl_LifestCha,above GDP cutoff,FCEV,Bus,Bus,trn_pass_road,FV,1.1,2035,5
+SSP2,ECEMF_HighEl_LifestCha,above GDP cutoff,Liquids,Bus,Bus,trn_pass_road,FV,1,2050,10
+SSP2,ECEMF_HighEl_LifestCha,above GDP cutoff,Hydrogen,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1.1,2050,5
+SSP2,ECEMF_HighEl_LifestCha,above GDP cutoff,Liquids,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SSP2,ECEMF_HighEl_LifestCha,above GDP cutoff,Liquids,Ship,Domestic Ship_tmp_subsectorL2,Domestic Ship,FV,1,2050,10
+SSP2,ECEMF_HighEl_LifestCha,above GDP cutoff,Electric,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,5,2050,15
+SSP2,ECEMF_HighEl_LifestCha,above GDP cutoff,Liquids,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SSP2,ECEMF_HighEl_LifestCha,above GDP cutoff,Electric,Rail,HSR_tmp_subsectorL2,HSR,FV,5,2050,15
+SSP2,ECEMF_HighEl_LifestCha,above GDP cutoff,Liquids,Aviation,International Aviation_tmp_subsectorL2,International Aviation,FV,1,2050,10
+SSP2,ECEMF_HighEl_LifestCha,above GDP cutoff,Liquids,Ship,International Ship_tmp_subsectorL2,International Ship,FV,1,2050,10
+SSP2,ECEMF_HighEl_LifestCha,above GDP cutoff,BEV,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,7,2050,15
+SSP2,ECEMF_HighEl_LifestCha,above GDP cutoff,Liquids,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SSP2,ECEMF_HighEl_LifestCha,above GDP cutoff,Electric,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,5,2050,15
+SSP2,ECEMF_HighEl_LifestCha,above GDP cutoff,Liquids,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SSP2,ECEMF_HighEl_LifestCha,above GDP cutoff,BEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,40,2040,3
+SSP2,ECEMF_HighEl_LifestCha,above GDP cutoff,FCEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,10,2040,3
+SSP2,ECEMF_HighEl_LifestCha,above GDP cutoff,Liquids,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,3
+SSP2,ECEMF_HighEl_LifestCha,above GDP cutoff,BEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,50,2040,5
+SSP2,ECEMF_HighEl_LifestCha,above GDP cutoff,FCEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,60,2040,3
+SSP2,ECEMF_HighEl_LifestCha,above GDP cutoff,Liquids,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,3
+SSP2,ECEMF_HighEl_LifestCha,below GDP cutoff,BEV,Bus,Bus,trn_pass_road,FV,13,2030,15
+SSP2,ECEMF_HighEl_LifestCha,below GDP cutoff,FCEV,Bus,Bus,trn_pass_road,FV,1.1,2035,5
+SSP2,ECEMF_HighEl_LifestCha,below GDP cutoff,Liquids,Bus,Bus,trn_pass_road,FV,1,2050,10
+SSP2,ECEMF_HighEl_LifestCha,below GDP cutoff,Hydrogen,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,2,2050,5
+SSP2,ECEMF_HighEl_LifestCha,below GDP cutoff,Liquids,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SSP2,ECEMF_HighEl_LifestCha,below GDP cutoff,Liquids,Ship,Domestic Ship_tmp_subsectorL2,Domestic Ship,FV,1,2050,10
+SSP2,ECEMF_HighEl_LifestCha,below GDP cutoff,Electric,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,6,2040,15
+SSP2,ECEMF_HighEl_LifestCha,below GDP cutoff,Liquids,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SSP2,ECEMF_HighEl_LifestCha,below GDP cutoff,Electric,Rail,HSR_tmp_subsectorL2,HSR,FV,6,2040,15
+SSP2,ECEMF_HighEl_LifestCha,below GDP cutoff,Liquids,Aviation,International Aviation_tmp_subsectorL2,International Aviation,FV,1,2050,10
+SSP2,ECEMF_HighEl_LifestCha,below GDP cutoff,Liquids,Ship,International Ship_tmp_subsectorL2,International Ship,FV,1,2050,10
+SSP2,ECEMF_HighEl_LifestCha,below GDP cutoff,BEV,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,7,2030,15
+SSP2,ECEMF_HighEl_LifestCha,below GDP cutoff,Liquids,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SSP2,ECEMF_HighEl_LifestCha,below GDP cutoff,Electric,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,6,2040,15
+SSP2,ECEMF_HighEl_LifestCha,below GDP cutoff,Liquids,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SSP2,ECEMF_HighEl_LifestCha,below GDP cutoff,BEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,10,2040,3
+SSP2,ECEMF_HighEl_LifestCha,below GDP cutoff,FCEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,10,2040,3
+SSP2,ECEMF_HighEl_LifestCha,below GDP cutoff,Liquids,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,3
+SSP2,ECEMF_HighEl_LifestCha,below GDP cutoff,BEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,5,2035,5
+SSP2,ECEMF_HighEl_LifestCha,below GDP cutoff,FCEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,7,2035,3
+SSP2,ECEMF_HighEl_LifestCha,below GDP cutoff,Liquids,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,3
+SSP2,ECEMF_HighEl_ModEff,above GDP cutoff,,,,Cycle,S1S,1,2050,10
+SSP2,ECEMF_HighEl_ModEff,above GDP cutoff,,,,Domestic Aviation,S1S,0.75,2035,10
+SSP2,ECEMF_HighEl_ModEff,above GDP cutoff,,,,Domestic Ship,S1S,1,2050,10
+SSP2,ECEMF_HighEl_ModEff,above GDP cutoff,,,,Freight Rail,S1S,1,2050,10
+SSP2,ECEMF_HighEl_ModEff,above GDP cutoff,,,,HSR,S1S,1,2050,10
+SSP2,ECEMF_HighEl_ModEff,above GDP cutoff,,,,Passenger Rail,S1S,1,2050,10
+SSP2,ECEMF_HighEl_ModEff,above GDP cutoff,,,,trn_freight_road,S1S,0.9,2035,10
+SSP2,ECEMF_HighEl_ModEff,above GDP cutoff,,,,trn_pass_road,S1S,0.9,2035,10
+SSP2,ECEMF_HighEl_ModEff,above GDP cutoff,,,,Walk,S1S,1,2050,10
+SSP2,ECEMF_HighEl_ModEff,below GDP cutoff,,,,Cycle,S1S,1,2050,10
+SSP2,ECEMF_HighEl_ModEff,below GDP cutoff,,,,Domestic Aviation,S1S,0.75,2035,10
+SSP2,ECEMF_HighEl_ModEff,below GDP cutoff,,,,Domestic Ship,S1S,1,2050,10
+SSP2,ECEMF_HighEl_ModEff,below GDP cutoff,,,,Freight Rail,S1S,1,2050,10
+SSP2,ECEMF_HighEl_ModEff,below GDP cutoff,,,,HSR,S1S,1,2050,10
+SSP2,ECEMF_HighEl_ModEff,below GDP cutoff,,,,Passenger Rail,S1S,1,2050,10
+SSP2,ECEMF_HighEl_ModEff,below GDP cutoff,,,,trn_freight_road,S1S,0.9,2035,10
+SSP2,ECEMF_HighEl_ModEff,below GDP cutoff,,,,trn_pass_road,S1S,0.9,2035,10
+SSP2,ECEMF_HighEl_ModEff,below GDP cutoff,,,,Walk,S1S,1,2050,10
+SSP2,ECEMF_HighEl_ModEff,above GDP cutoff,,,Bus,trn_pass_road,S2S1,1,2050,10
+SSP2,ECEMF_HighEl_ModEff,above GDP cutoff,,,trn_pass_road_LDV,trn_pass_road,S2S1,0.9,2035,10
+SSP2,ECEMF_HighEl_ModEff,below GDP cutoff,,,Bus,trn_pass_road,S2S1,1,2050,10
+SSP2,ECEMF_HighEl_ModEff,below GDP cutoff,,,trn_pass_road_LDV,trn_pass_road,S2S1,0.9,2035,10
+SSP2,ECEMF_HighEl_ModEff,above GDP cutoff,BEV,Bus,Bus,trn_pass_road,FV,6,2035,15
+SSP2,ECEMF_HighEl_ModEff,above GDP cutoff,FCEV,Bus,Bus,trn_pass_road,FV,1.1,2035,5
+SSP2,ECEMF_HighEl_ModEff,above GDP cutoff,Liquids,Bus,Bus,trn_pass_road,FV,1,2050,10
+SSP2,ECEMF_HighEl_ModEff,above GDP cutoff,Hydrogen,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1.1,2050,5
+SSP2,ECEMF_HighEl_ModEff,above GDP cutoff,Liquids,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SSP2,ECEMF_HighEl_ModEff,above GDP cutoff,Liquids,Ship,Domestic Ship_tmp_subsectorL2,Domestic Ship,FV,1,2050,10
+SSP2,ECEMF_HighEl_ModEff,above GDP cutoff,Electric,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,3,2050,15
+SSP2,ECEMF_HighEl_ModEff,above GDP cutoff,Liquids,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SSP2,ECEMF_HighEl_ModEff,above GDP cutoff,Electric,Rail,HSR_tmp_subsectorL2,HSR,FV,3,2050,15
+SSP2,ECEMF_HighEl_ModEff,above GDP cutoff,Liquids,Aviation,International Aviation_tmp_subsectorL2,International Aviation,FV,1,2050,10
+SSP2,ECEMF_HighEl_ModEff,above GDP cutoff,Liquids,Ship,International Ship_tmp_subsectorL2,International Ship,FV,1,2050,10
+SSP2,ECEMF_HighEl_ModEff,above GDP cutoff,BEV,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,3,2050,15
+SSP2,ECEMF_HighEl_ModEff,above GDP cutoff,Liquids,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SSP2,ECEMF_HighEl_ModEff,above GDP cutoff,Electric,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,3,2050,15
+SSP2,ECEMF_HighEl_ModEff,above GDP cutoff,Liquids,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SSP2,ECEMF_HighEl_ModEff,above GDP cutoff,BEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,40,2040,3
+SSP2,ECEMF_HighEl_ModEff,above GDP cutoff,FCEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,10,2040,3
+SSP2,ECEMF_HighEl_ModEff,above GDP cutoff,Liquids,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,3
+SSP2,ECEMF_HighEl_ModEff,above GDP cutoff,BEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,50,2040,5
+SSP2,ECEMF_HighEl_ModEff,above GDP cutoff,FCEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,60,2040,3
+SSP2,ECEMF_HighEl_ModEff,above GDP cutoff,Liquids,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,3
+SSP2,ECEMF_HighEl_ModEff,below GDP cutoff,BEV,Bus,Bus,trn_pass_road,FV,10,2030,15
+SSP2,ECEMF_HighEl_ModEff,below GDP cutoff,FCEV,Bus,Bus,trn_pass_road,FV,1.1,2035,5
+SSP2,ECEMF_HighEl_ModEff,below GDP cutoff,Liquids,Bus,Bus,trn_pass_road,FV,1,2050,10
+SSP2,ECEMF_HighEl_ModEff,below GDP cutoff,Hydrogen,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,2,2050,5
+SSP2,ECEMF_HighEl_ModEff,below GDP cutoff,Liquids,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SSP2,ECEMF_HighEl_ModEff,below GDP cutoff,Liquids,Ship,Domestic Ship_tmp_subsectorL2,Domestic Ship,FV,1,2050,10
+SSP2,ECEMF_HighEl_ModEff,below GDP cutoff,Electric,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,4,2040,15
+SSP2,ECEMF_HighEl_ModEff,below GDP cutoff,Liquids,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SSP2,ECEMF_HighEl_ModEff,below GDP cutoff,Electric,Rail,HSR_tmp_subsectorL2,HSR,FV,4,2040,15
+SSP2,ECEMF_HighEl_ModEff,below GDP cutoff,Liquids,Aviation,International Aviation_tmp_subsectorL2,International Aviation,FV,1,2050,10
+SSP2,ECEMF_HighEl_ModEff,below GDP cutoff,Liquids,Ship,International Ship_tmp_subsectorL2,International Ship,FV,1,2050,10
+SSP2,ECEMF_HighEl_ModEff,below GDP cutoff,BEV,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,5,2030,15
+SSP2,ECEMF_HighEl_ModEff,below GDP cutoff,Liquids,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SSP2,ECEMF_HighEl_ModEff,below GDP cutoff,Electric,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,4,2040,15
+SSP2,ECEMF_HighEl_ModEff,below GDP cutoff,Liquids,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SSP2,ECEMF_HighEl_ModEff,below GDP cutoff,BEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,10,2040,3
+SSP2,ECEMF_HighEl_ModEff,below GDP cutoff,FCEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,10,2040,3
+SSP2,ECEMF_HighEl_ModEff,below GDP cutoff,Liquids,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,3
+SSP2,ECEMF_HighEl_ModEff,below GDP cutoff,BEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,5,2035,5
+SSP2,ECEMF_HighEl_ModEff,below GDP cutoff,FCEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,7,2035,3
+SSP2,ECEMF_HighEl_ModEff,below GDP cutoff,Liquids,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,3
+SSP2,ECEMF_HighH2_HighEff,above GDP cutoff,,,,Cycle,S1S,1.5,2050,10
+SSP2,ECEMF_HighH2_HighEff,above GDP cutoff,,,,Domestic Aviation,S1S,0.5,2035,10
+SSP2,ECEMF_HighH2_HighEff,above GDP cutoff,,,,Domestic Ship,S1S,1.5,2050,10
+SSP2,ECEMF_HighH2_HighEff,above GDP cutoff,,,,Freight Rail,S1S,1.5,2050,10
+SSP2,ECEMF_HighH2_HighEff,above GDP cutoff,,,,HSR,S1S,1,2050,10
+SSP2,ECEMF_HighH2_HighEff,above GDP cutoff,,,,Passenger Rail,S1S,1.5,2050,10
+SSP2,ECEMF_HighH2_HighEff,above GDP cutoff,,,,trn_freight_road,S1S,0.7,2035,10
+SSP2,ECEMF_HighH2_HighEff,above GDP cutoff,,,,trn_pass_road,S1S,0.7,2035,10
+SSP2,ECEMF_HighH2_HighEff,above GDP cutoff,,,,Walk,S1S,1.5,2050,10
+SSP2,ECEMF_HighH2_HighEff,below GDP cutoff,,,,Cycle,S1S,1.5,2050,10
+SSP2,ECEMF_HighH2_HighEff,below GDP cutoff,,,,Domestic Aviation,S1S,0.5,2035,10
+SSP2,ECEMF_HighH2_HighEff,below GDP cutoff,,,,Domestic Ship,S1S,1.5,2050,10
+SSP2,ECEMF_HighH2_HighEff,below GDP cutoff,,,,Freight Rail,S1S,1.5,2050,10
+SSP2,ECEMF_HighH2_HighEff,below GDP cutoff,,,,HSR,S1S,1,2050,10
+SSP2,ECEMF_HighH2_HighEff,below GDP cutoff,,,,Passenger Rail,S1S,1.5,2050,10
+SSP2,ECEMF_HighH2_HighEff,below GDP cutoff,,,,trn_freight_road,S1S,0.7,2035,10
+SSP2,ECEMF_HighH2_HighEff,below GDP cutoff,,,,trn_pass_road,S1S,0.7,2035,10
+SSP2,ECEMF_HighH2_HighEff,below GDP cutoff,,,,Walk,S1S,1.5,2050,10
+SSP2,ECEMF_HighH2_HighEff,above GDP cutoff,,,Bus,trn_pass_road,S2S1,1.5,2050,10
+SSP2,ECEMF_HighH2_HighEff,above GDP cutoff,,,trn_pass_road_LDV,trn_pass_road,S2S1,0.7,2035,10
+SSP2,ECEMF_HighH2_HighEff,below GDP cutoff,,,Bus,trn_pass_road,S2S1,1.5,2050,10
+SSP2,ECEMF_HighH2_HighEff,below GDP cutoff,,,trn_pass_road_LDV,trn_pass_road,S2S1,0.7,2035,10
+SSP2,ECEMF_HighH2_HighEff,above GDP cutoff,BEV,Bus,Bus,trn_pass_road,FV,3,2060,15
+SSP2,ECEMF_HighH2_HighEff,above GDP cutoff,FCEV,Bus,Bus,trn_pass_road,FV,220,2035,5
+SSP2,ECEMF_HighH2_HighEff,above GDP cutoff,Liquids,Bus,Bus,trn_pass_road,FV,1,2050,10
+SSP2,ECEMF_HighH2_HighEff,above GDP cutoff,Hydrogen,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,3,2055,5
+SSP2,ECEMF_HighH2_HighEff,above GDP cutoff,Liquids,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SSP2,ECEMF_HighH2_HighEff,above GDP cutoff,Liquids,Ship,Domestic Ship_tmp_subsectorL2,Domestic Ship,FV,1,2050,10
+SSP2,ECEMF_HighH2_HighEff,above GDP cutoff,Electric,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,2.5,2050,10
+SSP2,ECEMF_HighH2_HighEff,above GDP cutoff,Liquids,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SSP2,ECEMF_HighH2_HighEff,above GDP cutoff,Electric,Rail,HSR_tmp_subsectorL2,HSR,FV,2.5,2050,10
+SSP2,ECEMF_HighH2_HighEff,above GDP cutoff,Liquids,Aviation,International Aviation_tmp_subsectorL2,International Aviation,FV,1,2050,10
+SSP2,ECEMF_HighH2_HighEff,above GDP cutoff,Liquids,Ship,International Ship_tmp_subsectorL2,International Ship,FV,1,2050,10
+SSP2,ECEMF_HighH2_HighEff,above GDP cutoff,BEV,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,3,2050,10
+SSP2,ECEMF_HighH2_HighEff,above GDP cutoff,Liquids,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SSP2,ECEMF_HighH2_HighEff,above GDP cutoff,Electric,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,2.5,2050,10
+SSP2,ECEMF_HighH2_HighEff,above GDP cutoff,Liquids,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SSP2,ECEMF_HighH2_HighEff,above GDP cutoff,BEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,40,2040,3
+SSP2,ECEMF_HighH2_HighEff,above GDP cutoff,FCEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,50,2040,3
+SSP2,ECEMF_HighH2_HighEff,above GDP cutoff,Liquids,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,3
+SSP2,ECEMF_HighH2_HighEff,above GDP cutoff,BEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,40,2040,5
+SSP2,ECEMF_HighH2_HighEff,above GDP cutoff,FCEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,250,2040,3
+SSP2,ECEMF_HighH2_HighEff,above GDP cutoff,Liquids,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,3
+SSP2,ECEMF_HighH2_HighEff,below GDP cutoff,BEV,Bus,Bus,trn_pass_road,FV,3,2060,15
+SSP2,ECEMF_HighH2_HighEff,below GDP cutoff,FCEV,Bus,Bus,trn_pass_road,FV,160,2040,5
+SSP2,ECEMF_HighH2_HighEff,below GDP cutoff,Liquids,Bus,Bus,trn_pass_road,FV,1,2050,10
+SSP2,ECEMF_HighH2_HighEff,below GDP cutoff,Hydrogen,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,5,2055,10
+SSP2,ECEMF_HighH2_HighEff,below GDP cutoff,Liquids,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SSP2,ECEMF_HighH2_HighEff,below GDP cutoff,Liquids,Ship,Domestic Ship_tmp_subsectorL2,Domestic Ship,FV,1,2050,10
+SSP2,ECEMF_HighH2_HighEff,below GDP cutoff,Electric,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,2,2050,10
+SSP2,ECEMF_HighH2_HighEff,below GDP cutoff,Liquids,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SSP2,ECEMF_HighH2_HighEff,below GDP cutoff,Electric,Rail,HSR_tmp_subsectorL2,HSR,FV,2,2050,10
+SSP2,ECEMF_HighH2_HighEff,below GDP cutoff,Liquids,Aviation,International Aviation_tmp_subsectorL2,International Aviation,FV,1,2050,10
+SSP2,ECEMF_HighH2_HighEff,below GDP cutoff,Liquids,Ship,International Ship_tmp_subsectorL2,International Ship,FV,1,2050,10
+SSP2,ECEMF_HighH2_HighEff,below GDP cutoff,BEV,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,3,2050,10
+SSP2,ECEMF_HighH2_HighEff,below GDP cutoff,Liquids,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SSP2,ECEMF_HighH2_HighEff,below GDP cutoff,Electric,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,2,2050,10
+SSP2,ECEMF_HighH2_HighEff,below GDP cutoff,Liquids,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SSP2,ECEMF_HighH2_HighEff,below GDP cutoff,BEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,10,2040,3
+SSP2,ECEMF_HighH2_HighEff,below GDP cutoff,FCEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,10,2040,3
+SSP2,ECEMF_HighH2_HighEff,below GDP cutoff,Liquids,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,3
+SSP2,ECEMF_HighH2_HighEff,below GDP cutoff,BEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,5,2035,5
+SSP2,ECEMF_HighH2_HighEff,below GDP cutoff,FCEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,30,2035,3
+SSP2,ECEMF_HighH2_HighEff,below GDP cutoff,Liquids,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,3
+SSP2,ECEMF_HighH2_LifestCha,above GDP cutoff,,,,Cycle,S1S,2,2050,10
+SSP2,ECEMF_HighH2_LifestCha,above GDP cutoff,,,,Domestic Aviation,S1S,0.25,2035,10
+SSP2,ECEMF_HighH2_LifestCha,above GDP cutoff,,,,Domestic Ship,S1S,1.5,2050,10
+SSP2,ECEMF_HighH2_LifestCha,above GDP cutoff,,,,Freight Rail,S1S,1.5,2050,10
+SSP2,ECEMF_HighH2_LifestCha,above GDP cutoff,,,,HSR,S1S,1,2050,10
+SSP2,ECEMF_HighH2_LifestCha,above GDP cutoff,,,,Passenger Rail,S1S,2,2050,10
+SSP2,ECEMF_HighH2_LifestCha,above GDP cutoff,,,,trn_freight_road,S1S,0.7,2035,10
+SSP2,ECEMF_HighH2_LifestCha,above GDP cutoff,,,,trn_pass_road,S1S,0.5,2035,10
+SSP2,ECEMF_HighH2_LifestCha,above GDP cutoff,,,,Walk,S1S,2,2050,10
+SSP2,ECEMF_HighH2_LifestCha,below GDP cutoff,,,,Cycle,S1S,2,2050,10
+SSP2,ECEMF_HighH2_LifestCha,below GDP cutoff,,,,Domestic Aviation,S1S,0.25,2035,10
+SSP2,ECEMF_HighH2_LifestCha,below GDP cutoff,,,,Domestic Ship,S1S,1.5,2050,10
+SSP2,ECEMF_HighH2_LifestCha,below GDP cutoff,,,,Freight Rail,S1S,1.5,2050,10
+SSP2,ECEMF_HighH2_LifestCha,below GDP cutoff,,,,HSR,S1S,1,2050,10
+SSP2,ECEMF_HighH2_LifestCha,below GDP cutoff,,,,Passenger Rail,S1S,2,2050,10
+SSP2,ECEMF_HighH2_LifestCha,below GDP cutoff,,,,trn_freight_road,S1S,0.7,2035,10
+SSP2,ECEMF_HighH2_LifestCha,below GDP cutoff,,,,trn_pass_road,S1S,0.5,2035,10
+SSP2,ECEMF_HighH2_LifestCha,below GDP cutoff,,,,Walk,S1S,2,2050,10
+SSP2,ECEMF_HighH2_LifestCha,above GDP cutoff,,,Bus,trn_pass_road,S2S1,2,2050,10
+SSP2,ECEMF_HighH2_LifestCha,above GDP cutoff,,,trn_pass_road_LDV,trn_pass_road,S2S1,0.5,2035,10
+SSP2,ECEMF_HighH2_LifestCha,below GDP cutoff,,,Bus,trn_pass_road,S2S1,2,2050,10
+SSP2,ECEMF_HighH2_LifestCha,below GDP cutoff,,,trn_pass_road_LDV,trn_pass_road,S2S1,0.5,2035,10
+SSP2,ECEMF_HighH2_LifestCha,above GDP cutoff,BEV,Bus,Bus,trn_pass_road,FV,3,2060,15
+SSP2,ECEMF_HighH2_LifestCha,above GDP cutoff,FCEV,Bus,Bus,trn_pass_road,FV,220,2035,5
+SSP2,ECEMF_HighH2_LifestCha,above GDP cutoff,Liquids,Bus,Bus,trn_pass_road,FV,1,2050,10
+SSP2,ECEMF_HighH2_LifestCha,above GDP cutoff,Hydrogen,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,3,2055,5
+SSP2,ECEMF_HighH2_LifestCha,above GDP cutoff,Liquids,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SSP2,ECEMF_HighH2_LifestCha,above GDP cutoff,Liquids,Ship,Domestic Ship_tmp_subsectorL2,Domestic Ship,FV,1,2050,10
+SSP2,ECEMF_HighH2_LifestCha,above GDP cutoff,Electric,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,2.5,2050,10
+SSP2,ECEMF_HighH2_LifestCha,above GDP cutoff,Liquids,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SSP2,ECEMF_HighH2_LifestCha,above GDP cutoff,Electric,Rail,HSR_tmp_subsectorL2,HSR,FV,2.5,2050,10
+SSP2,ECEMF_HighH2_LifestCha,above GDP cutoff,Liquids,Aviation,International Aviation_tmp_subsectorL2,International Aviation,FV,1,2050,10
+SSP2,ECEMF_HighH2_LifestCha,above GDP cutoff,Liquids,Ship,International Ship_tmp_subsectorL2,International Ship,FV,1,2050,10
+SSP2,ECEMF_HighH2_LifestCha,above GDP cutoff,BEV,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,3,2050,10
+SSP2,ECEMF_HighH2_LifestCha,above GDP cutoff,Liquids,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SSP2,ECEMF_HighH2_LifestCha,above GDP cutoff,Electric,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,2.5,2050,10
+SSP2,ECEMF_HighH2_LifestCha,above GDP cutoff,Liquids,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SSP2,ECEMF_HighH2_LifestCha,above GDP cutoff,BEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,40,2040,3
+SSP2,ECEMF_HighH2_LifestCha,above GDP cutoff,FCEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,50,2040,3
+SSP2,ECEMF_HighH2_LifestCha,above GDP cutoff,Liquids,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,3
+SSP2,ECEMF_HighH2_LifestCha,above GDP cutoff,BEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,40,2040,5
+SSP2,ECEMF_HighH2_LifestCha,above GDP cutoff,FCEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,250,2040,3
+SSP2,ECEMF_HighH2_LifestCha,above GDP cutoff,Liquids,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,3
+SSP2,ECEMF_HighH2_LifestCha,below GDP cutoff,BEV,Bus,Bus,trn_pass_road,FV,3,2060,15
+SSP2,ECEMF_HighH2_LifestCha,below GDP cutoff,FCEV,Bus,Bus,trn_pass_road,FV,160,2040,5
+SSP2,ECEMF_HighH2_LifestCha,below GDP cutoff,Liquids,Bus,Bus,trn_pass_road,FV,1,2050,10
+SSP2,ECEMF_HighH2_LifestCha,below GDP cutoff,Hydrogen,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,5,2055,10
+SSP2,ECEMF_HighH2_LifestCha,below GDP cutoff,Liquids,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SSP2,ECEMF_HighH2_LifestCha,below GDP cutoff,Liquids,Ship,Domestic Ship_tmp_subsectorL2,Domestic Ship,FV,1,2050,10
+SSP2,ECEMF_HighH2_LifestCha,below GDP cutoff,Electric,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,2,2050,10
+SSP2,ECEMF_HighH2_LifestCha,below GDP cutoff,Liquids,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SSP2,ECEMF_HighH2_LifestCha,below GDP cutoff,Electric,Rail,HSR_tmp_subsectorL2,HSR,FV,2,2050,10
+SSP2,ECEMF_HighH2_LifestCha,below GDP cutoff,Liquids,Aviation,International Aviation_tmp_subsectorL2,International Aviation,FV,1,2050,10
+SSP2,ECEMF_HighH2_LifestCha,below GDP cutoff,Liquids,Ship,International Ship_tmp_subsectorL2,International Ship,FV,1,2050,10
+SSP2,ECEMF_HighH2_LifestCha,below GDP cutoff,BEV,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,3,2050,10
+SSP2,ECEMF_HighH2_LifestCha,below GDP cutoff,Liquids,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SSP2,ECEMF_HighH2_LifestCha,below GDP cutoff,Electric,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,2,2050,10
+SSP2,ECEMF_HighH2_LifestCha,below GDP cutoff,Liquids,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SSP2,ECEMF_HighH2_LifestCha,below GDP cutoff,BEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,10,2040,3
+SSP2,ECEMF_HighH2_LifestCha,below GDP cutoff,FCEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,10,2040,3
+SSP2,ECEMF_HighH2_LifestCha,below GDP cutoff,Liquids,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,3
+SSP2,ECEMF_HighH2_LifestCha,below GDP cutoff,BEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,5,2035,5
+SSP2,ECEMF_HighH2_LifestCha,below GDP cutoff,FCEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,30,2035,3
+SSP2,ECEMF_HighH2_LifestCha,below GDP cutoff,Liquids,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,3
+SSP2,ECEMF_HighH2_ModEff,above GDP cutoff,,,,Cycle,S1S,1,2050,10
+SSP2,ECEMF_HighH2_ModEff,above GDP cutoff,,,,Domestic Aviation,S1S,0.75,2035,10
+SSP2,ECEMF_HighH2_ModEff,above GDP cutoff,,,,Domestic Ship,S1S,1,2050,10
+SSP2,ECEMF_HighH2_ModEff,above GDP cutoff,,,,Freight Rail,S1S,1,2050,10
+SSP2,ECEMF_HighH2_ModEff,above GDP cutoff,,,,HSR,S1S,1,2050,10
+SSP2,ECEMF_HighH2_ModEff,above GDP cutoff,,,,Passenger Rail,S1S,1,2050,10
+SSP2,ECEMF_HighH2_ModEff,above GDP cutoff,,,,trn_freight_road,S1S,0.9,2035,10
+SSP2,ECEMF_HighH2_ModEff,above GDP cutoff,,,,trn_pass_road,S1S,0.9,2035,10
+SSP2,ECEMF_HighH2_ModEff,above GDP cutoff,,,,Walk,S1S,1,2050,10
+SSP2,ECEMF_HighH2_ModEff,below GDP cutoff,,,,Cycle,S1S,1,2050,10
+SSP2,ECEMF_HighH2_ModEff,below GDP cutoff,,,,Domestic Aviation,S1S,0.75,2035,10
+SSP2,ECEMF_HighH2_ModEff,below GDP cutoff,,,,Domestic Ship,S1S,1,2050,10
+SSP2,ECEMF_HighH2_ModEff,below GDP cutoff,,,,Freight Rail,S1S,1,2050,10
+SSP2,ECEMF_HighH2_ModEff,below GDP cutoff,,,,HSR,S1S,1,2050,10
+SSP2,ECEMF_HighH2_ModEff,below GDP cutoff,,,,Passenger Rail,S1S,1,2050,10
+SSP2,ECEMF_HighH2_ModEff,below GDP cutoff,,,,trn_freight_road,S1S,0.9,2035,10
+SSP2,ECEMF_HighH2_ModEff,below GDP cutoff,,,,trn_pass_road,S1S,0.9,2035,10
+SSP2,ECEMF_HighH2_ModEff,below GDP cutoff,,,,Walk,S1S,1,2050,10
+SSP2,ECEMF_HighH2_ModEff,above GDP cutoff,,,Bus,trn_pass_road,S2S1,1,2050,10
+SSP2,ECEMF_HighH2_ModEff,above GDP cutoff,,,trn_pass_road_LDV,trn_pass_road,S2S1,0.9,2035,10
+SSP2,ECEMF_HighH2_ModEff,below GDP cutoff,,,Bus,trn_pass_road,S2S1,1,2050,10
+SSP2,ECEMF_HighH2_ModEff,below GDP cutoff,,,trn_pass_road_LDV,trn_pass_road,S2S1,0.9,2035,10
+SSP2,ECEMF_HighH2_ModEff,above GDP cutoff,BEV,Bus,Bus,trn_pass_road,FV,3,2060,15
+SSP2,ECEMF_HighH2_ModEff,above GDP cutoff,FCEV,Bus,Bus,trn_pass_road,FV,200,2035,5
+SSP2,ECEMF_HighH2_ModEff,above GDP cutoff,Liquids,Bus,Bus,trn_pass_road,FV,1,2050,10
+SSP2,ECEMF_HighH2_ModEff,above GDP cutoff,Hydrogen,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,3,2055,5
+SSP2,ECEMF_HighH2_ModEff,above GDP cutoff,Liquids,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SSP2,ECEMF_HighH2_ModEff,above GDP cutoff,Liquids,Ship,Domestic Ship_tmp_subsectorL2,Domestic Ship,FV,1,2050,10
+SSP2,ECEMF_HighH2_ModEff,above GDP cutoff,Electric,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1.5,2050,10
+SSP2,ECEMF_HighH2_ModEff,above GDP cutoff,Liquids,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SSP2,ECEMF_HighH2_ModEff,above GDP cutoff,Electric,Rail,HSR_tmp_subsectorL2,HSR,FV,1.5,2050,10
+SSP2,ECEMF_HighH2_ModEff,above GDP cutoff,Liquids,Aviation,International Aviation_tmp_subsectorL2,International Aviation,FV,1,2050,10
+SSP2,ECEMF_HighH2_ModEff,above GDP cutoff,Liquids,Ship,International Ship_tmp_subsectorL2,International Ship,FV,1,2050,10
+SSP2,ECEMF_HighH2_ModEff,above GDP cutoff,BEV,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,3,2050,10
+SSP2,ECEMF_HighH2_ModEff,above GDP cutoff,Liquids,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SSP2,ECEMF_HighH2_ModEff,above GDP cutoff,Electric,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1.5,2050,10
+SSP2,ECEMF_HighH2_ModEff,above GDP cutoff,Liquids,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SSP2,ECEMF_HighH2_ModEff,above GDP cutoff,BEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,40,2040,3
+SSP2,ECEMF_HighH2_ModEff,above GDP cutoff,FCEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,50,2040,3
+SSP2,ECEMF_HighH2_ModEff,above GDP cutoff,Liquids,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,3
+SSP2,ECEMF_HighH2_ModEff,above GDP cutoff,BEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,40,2040,5
+SSP2,ECEMF_HighH2_ModEff,above GDP cutoff,FCEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,250,2040,3
+SSP2,ECEMF_HighH2_ModEff,above GDP cutoff,Liquids,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,3
+SSP2,ECEMF_HighH2_ModEff,below GDP cutoff,BEV,Bus,Bus,trn_pass_road,FV,3,2060,15
+SSP2,ECEMF_HighH2_ModEff,below GDP cutoff,FCEV,Bus,Bus,trn_pass_road,FV,150,2040,5
+SSP2,ECEMF_HighH2_ModEff,below GDP cutoff,Liquids,Bus,Bus,trn_pass_road,FV,1,2050,10
+SSP2,ECEMF_HighH2_ModEff,below GDP cutoff,Hydrogen,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,2.5,2055,10
+SSP2,ECEMF_HighH2_ModEff,below GDP cutoff,Liquids,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SSP2,ECEMF_HighH2_ModEff,below GDP cutoff,Liquids,Ship,Domestic Ship_tmp_subsectorL2,Domestic Ship,FV,1,2050,10
+SSP2,ECEMF_HighH2_ModEff,below GDP cutoff,Electric,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,2.5,2050,10
+SSP2,ECEMF_HighH2_ModEff,below GDP cutoff,Liquids,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SSP2,ECEMF_HighH2_ModEff,below GDP cutoff,Electric,Rail,HSR_tmp_subsectorL2,HSR,FV,2.5,2050,10
+SSP2,ECEMF_HighH2_ModEff,below GDP cutoff,Liquids,Aviation,International Aviation_tmp_subsectorL2,International Aviation,FV,1,2050,10
+SSP2,ECEMF_HighH2_ModEff,below GDP cutoff,Liquids,Ship,International Ship_tmp_subsectorL2,International Ship,FV,1,2050,10
+SSP2,ECEMF_HighH2_ModEff,below GDP cutoff,BEV,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,2.5,2050,10
+SSP2,ECEMF_HighH2_ModEff,below GDP cutoff,Liquids,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SSP2,ECEMF_HighH2_ModEff,below GDP cutoff,Electric,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,2.5,2050,10
+SSP2,ECEMF_HighH2_ModEff,below GDP cutoff,Liquids,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SSP2,ECEMF_HighH2_ModEff,below GDP cutoff,BEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,10,2040,3
+SSP2,ECEMF_HighH2_ModEff,below GDP cutoff,FCEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,10,2040,3
+SSP2,ECEMF_HighH2_ModEff,below GDP cutoff,Liquids,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,3
+SSP2,ECEMF_HighH2_ModEff,below GDP cutoff,BEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,5,2035,5
+SSP2,ECEMF_HighH2_ModEff,below GDP cutoff,FCEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,30,2035,3
+SSP2,ECEMF_HighH2_ModEff,below GDP cutoff,Liquids,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,3
+SSP2,HydrHype4,above GDP cutoff,,,,Cycle,S1S,1,2050,10
+SSP2,HydrHype4,above GDP cutoff,,,,Domestic Aviation,S1S,0.25,2035,10
+SSP2,HydrHype4,above GDP cutoff,,,,Domestic Ship,S1S,1,2050,10
+SSP2,HydrHype4,above GDP cutoff,,,,Freight Rail,S1S,1,2050,10
+SSP2,HydrHype4,above GDP cutoff,,,,HSR,S1S,1,2050,10
+SSP2,HydrHype4,above GDP cutoff,,,,Passenger Rail,S1S,1,2050,10
+SSP2,HydrHype4,above GDP cutoff,,,,trn_freight_road,S1S,0.5,2035,10
+SSP2,HydrHype4,above GDP cutoff,,,,trn_pass_road,S1S,0.7,2035,10
+SSP2,HydrHype4,above GDP cutoff,,,,Walk,S1S,1,2050,10
+SSP2,HydrHype4,below GDP cutoff,,,,Cycle,S1S,1,2050,10
+SSP2,HydrHype4,below GDP cutoff,,,,Domestic Aviation,S1S,0.25,2035,10
+SSP2,HydrHype4,below GDP cutoff,,,,Domestic Ship,S1S,1,2050,10
+SSP2,HydrHype4,below GDP cutoff,,,,Freight Rail,S1S,1,2050,10
+SSP2,HydrHype4,below GDP cutoff,,,,HSR,S1S,1,2050,10
+SSP2,HydrHype4,below GDP cutoff,,,,Passenger Rail,S1S,1,2050,10
+SSP2,HydrHype4,below GDP cutoff,,,,trn_freight_road,S1S,0.5,2035,10
+SSP2,HydrHype4,below GDP cutoff,,,,trn_pass_road,S1S,0.7,2035,10
+SSP2,HydrHype4,below GDP cutoff,,,,Walk,S1S,1,2050,10
+SSP2,HydrHype4,above GDP cutoff,,,Bus,trn_pass_road,S2S1,1,2050,10
+SSP2,HydrHype4,above GDP cutoff,,,trn_pass_road_LDV,trn_pass_road,S2S1,0.7,2035,10
+SSP2,HydrHype4,below GDP cutoff,,,Bus,trn_pass_road,S2S1,1,2050,10
+SSP2,HydrHype4,below GDP cutoff,,,trn_pass_road_LDV,trn_pass_road,S2S1,0.7,2035,10
+SSP2,HydrHype4,above GDP cutoff,BEV,Bus,Bus,trn_pass_road,FV,3,2060,15
+SSP2,HydrHype4,above GDP cutoff,FCEV,Bus,Bus,trn_pass_road,FV,200,2035,5
+SSP2,HydrHype4,above GDP cutoff,Liquids,Bus,Bus,trn_pass_road,FV,1,2050,10
+SSP2,HydrHype4,above GDP cutoff,Hydrogen,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,3,2055,5
+SSP2,HydrHype4,above GDP cutoff,Liquids,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SSP2,HydrHype4,above GDP cutoff,Liquids,Ship,Domestic Ship_tmp_subsectorL2,Domestic Ship,FV,1,2050,10
+SSP2,HydrHype4,above GDP cutoff,Electric,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SSP2,HydrHype4,above GDP cutoff,Liquids,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SSP2,HydrHype4,above GDP cutoff,Electric,Rail,HSR_tmp_subsectorL2,HSR,FV,1,2050,10
+SSP2,HydrHype4,above GDP cutoff,Liquids,Aviation,International Aviation_tmp_subsectorL2,International Aviation,FV,1,2050,10
+SSP2,HydrHype4,above GDP cutoff,Liquids,Ship,International Ship_tmp_subsectorL2,International Ship,FV,1,2050,10
+SSP2,HydrHype4,above GDP cutoff,BEV,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SSP2,HydrHype4,above GDP cutoff,Liquids,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SSP2,HydrHype4,above GDP cutoff,Electric,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SSP2,HydrHype4,above GDP cutoff,Liquids,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SSP2,HydrHype4,above GDP cutoff,BEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,40,2040,3
+SSP2,HydrHype4,above GDP cutoff,FCEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,50,2040,3
+SSP2,HydrHype4,above GDP cutoff,Liquids,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,3
+SSP2,HydrHype4,above GDP cutoff,BEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,40,2040,5
+SSP2,HydrHype4,above GDP cutoff,FCEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,250,2040,3
+SSP2,HydrHype4,above GDP cutoff,Liquids,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,3
+SSP2,HydrHype4,below GDP cutoff,BEV,Bus,Bus,trn_pass_road,FV,3,2060,15
+SSP2,HydrHype4,below GDP cutoff,FCEV,Bus,Bus,trn_pass_road,FV,150,2040,5
+SSP2,HydrHype4,below GDP cutoff,Liquids,Bus,Bus,trn_pass_road,FV,1,2050,10
+SSP2,HydrHype4,below GDP cutoff,Hydrogen,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,2.5,2055,10
+SSP2,HydrHype4,below GDP cutoff,Liquids,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SSP2,HydrHype4,below GDP cutoff,Liquids,Ship,Domestic Ship_tmp_subsectorL2,Domestic Ship,FV,1,2050,10
+SSP2,HydrHype4,below GDP cutoff,Electric,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SSP2,HydrHype4,below GDP cutoff,Liquids,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SSP2,HydrHype4,below GDP cutoff,Electric,Rail,HSR_tmp_subsectorL2,HSR,FV,1,2050,10
+SSP2,HydrHype4,below GDP cutoff,Liquids,Aviation,International Aviation_tmp_subsectorL2,International Aviation,FV,1,2050,10
+SSP2,HydrHype4,below GDP cutoff,Liquids,Ship,International Ship_tmp_subsectorL2,International Ship,FV,1,2050,10
+SSP2,HydrHype4,below GDP cutoff,BEV,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SSP2,HydrHype4,below GDP cutoff,Liquids,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SSP2,HydrHype4,below GDP cutoff,Electric,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SSP2,HydrHype4,below GDP cutoff,Liquids,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SSP2,HydrHype4,below GDP cutoff,BEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,10,2040,3
+SSP2,HydrHype4,below GDP cutoff,FCEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,10,2040,3
+SSP2,HydrHype4,below GDP cutoff,Liquids,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,3
+SSP2,HydrHype4,below GDP cutoff,BEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,5,2035,5
+SSP2,HydrHype4,below GDP cutoff,FCEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,30,2035,3
+SSP2,HydrHype4,below GDP cutoff,Liquids,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,3
+SSP2,Mix2,above GDP cutoff,,,,Cycle,S1S,1,2050,10
+SSP2,Mix2,above GDP cutoff,,,,Domestic Aviation,S1S,0.75,2035,10
+SSP2,Mix2,above GDP cutoff,,,,Domestic Ship,S1S,1,2050,10
+SSP2,Mix2,above GDP cutoff,,,,Freight Rail,S1S,1,2050,10
+SSP2,Mix2,above GDP cutoff,,,,HSR,S1S,1,2050,10
+SSP2,Mix2,above GDP cutoff,,,,Passenger Rail,S1S,1,2050,10
+SSP2,Mix2,above GDP cutoff,,,,trn_freight_road,S1S,0.9,2035,10
+SSP2,Mix2,above GDP cutoff,,,,trn_pass_road,S1S,0.9,2035,10
+SSP2,Mix2,above GDP cutoff,,,,Walk,S1S,1,2050,10
+SSP2,Mix2,below GDP cutoff,,,,Cycle,S1S,1,2050,10
+SSP2,Mix2,below GDP cutoff,,,,Domestic Aviation,S1S,0.75,2035,10
+SSP2,Mix2,below GDP cutoff,,,,Domestic Ship,S1S,1,2050,10
+SSP2,Mix2,below GDP cutoff,,,,Freight Rail,S1S,1,2050,10
+SSP2,Mix2,below GDP cutoff,,,,HSR,S1S,1,2050,10
+SSP2,Mix2,below GDP cutoff,,,,Passenger Rail,S1S,1,2050,10
+SSP2,Mix2,below GDP cutoff,,,,trn_freight_road,S1S,0.9,2035,10
+SSP2,Mix2,below GDP cutoff,,,,trn_pass_road,S1S,0.9,2035,10
+SSP2,Mix2,below GDP cutoff,,,,Walk,S1S,1,2050,10
+SSP2,Mix2,above GDP cutoff,,,Bus,trn_pass_road,S2S1,1,2050,10
+SSP2,Mix2,above GDP cutoff,,,trn_pass_road_LDV,trn_pass_road,S2S1,0.9,2035,10
+SSP2,Mix2,below GDP cutoff,,,Bus,trn_pass_road,S2S1,1,2050,10
+SSP2,Mix2,below GDP cutoff,,,trn_pass_road_LDV,trn_pass_road,S2S1,0.9,2035,10
+SSP2,Mix2,above GDP cutoff,BEV,Bus,Bus,trn_pass_road,FV,2,2035,10
+SSP2,Mix2,above GDP cutoff,FCEV,Bus,Bus,trn_pass_road,FV,2,2035,10
+SSP2,Mix2,above GDP cutoff,Liquids,Bus,Bus,trn_pass_road,FV,1,2050,10
+SSP2,Mix2,above GDP cutoff,Hydrogen,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SSP2,Mix2,above GDP cutoff,Liquids,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SSP2,Mix2,above GDP cutoff,Liquids,Ship,Domestic Ship_tmp_subsectorL2,Domestic Ship,FV,1,2050,10
+SSP2,Mix2,above GDP cutoff,Electric,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SSP2,Mix2,above GDP cutoff,Liquids,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SSP2,Mix2,above GDP cutoff,Electric,Rail,HSR_tmp_subsectorL2,HSR,FV,1,2050,10
+SSP2,Mix2,above GDP cutoff,Liquids,Aviation,International Aviation_tmp_subsectorL2,International Aviation,FV,1,2050,10
+SSP2,Mix2,above GDP cutoff,Liquids,Ship,International Ship_tmp_subsectorL2,International Ship,FV,1,2050,10
+SSP2,Mix4,above GDP cutoff,BEV,Bus,Bus,trn_pass_road,FV,6,2035,10
+SSP2,Mix2,above GDP cutoff,Liquids,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SSP2,Mix2,above GDP cutoff,Electric,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SSP2,Mix2,above GDP cutoff,Liquids,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SSP2,Mix2,above GDP cutoff,BEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,10,2035,10
+SSP2,Mix2,above GDP cutoff,FCEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,2,2035,10
+SSP2,Mix2,above GDP cutoff,Liquids,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,10
+SSP2,Mix4,above GDP cutoff,BEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,50,2040,5
+SSP2,Mix2,above GDP cutoff,FCEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,2,2035,10
+SSP2,Mix2,above GDP cutoff,Liquids,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,10
+SSP2,Mix2,below GDP cutoff,BEV,Bus,Bus,trn_pass_road,FV,1.5,2035,10
+SSP2,Mix2,below GDP cutoff,FCEV,Bus,Bus,trn_pass_road,FV,1.5,2035,10
+SSP2,Mix2,below GDP cutoff,Liquids,Bus,Bus,trn_pass_road,FV,1,2050,10
+SSP2,Mix2,below GDP cutoff,Hydrogen,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SSP2,Mix2,below GDP cutoff,Liquids,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SSP2,Mix2,below GDP cutoff,Liquids,Ship,Domestic Ship_tmp_subsectorL2,Domestic Ship,FV,1,2050,10
+SSP2,Mix2,below GDP cutoff,Electric,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SSP2,Mix2,below GDP cutoff,Liquids,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SSP2,Mix2,below GDP cutoff,Electric,Rail,HSR_tmp_subsectorL2,HSR,FV,1,2050,10
+SSP2,Mix2,below GDP cutoff,Liquids,Aviation,International Aviation_tmp_subsectorL2,International Aviation,FV,1,2050,10
+SSP2,Mix2,below GDP cutoff,Liquids,Ship,International Ship_tmp_subsectorL2,International Ship,FV,1,2050,10
+SSP2,Mix2,below GDP cutoff,BEV,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SSP2,Mix2,below GDP cutoff,Liquids,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SSP2,Mix2,below GDP cutoff,Electric,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SSP2,Mix2,below GDP cutoff,Liquids,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SSP2,Mix2,below GDP cutoff,BEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,3,2035,10
+SSP2,Mix2,below GDP cutoff,FCEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1.5,2035,10
+SSP2,Mix2,below GDP cutoff,Liquids,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,10
+SSP2,Mix3,below GDP cutoff,BEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,5,2035,10
+SSP2,Mix2,below GDP cutoff,FCEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1.5,2035,10
+SSP2,Mix2,below GDP cutoff,Liquids,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,10
+SSP2,Mix3,above GDP cutoff,,,,Cycle,S1S,1,2050,10
+SSP2,Mix3,above GDP cutoff,,,,Domestic Aviation,S1S,0.5,2035,10
+SSP2,Mix3,above GDP cutoff,,,,Domestic Ship,S1S,1,2050,10
+SSP2,Mix3,above GDP cutoff,,,,Freight Rail,S1S,1,2050,10
+SSP2,Mix3,above GDP cutoff,,,,HSR,S1S,1,2050,10
+SSP2,Mix3,above GDP cutoff,,,,Passenger Rail,S1S,1,2050,10
+SSP2,Mix3,above GDP cutoff,,,,trn_freight_road,S1S,0.7,2035,10
+SSP2,Mix3,above GDP cutoff,,,,trn_pass_road,S1S,0.8,2035,10
+SSP2,Mix3,above GDP cutoff,,,,Walk,S1S,1,2050,10
+SSP2,Mix3,below GDP cutoff,,,,Cycle,S1S,1,2050,10
+SSP2,Mix3,below GDP cutoff,,,,Domestic Aviation,S1S,0.5,2035,10
+SSP2,Mix3,below GDP cutoff,,,,Domestic Ship,S1S,1,2050,10
+SSP2,Mix3,below GDP cutoff,,,,Freight Rail,S1S,1,2050,10
+SSP2,Mix3,below GDP cutoff,,,,HSR,S1S,1,2050,10
+SSP2,Mix3,below GDP cutoff,,,,Passenger Rail,S1S,1,2050,10
+SSP2,Mix3,below GDP cutoff,,,,trn_freight_road,S1S,0.7,2035,10
+SSP2,Mix3,below GDP cutoff,,,,trn_pass_road,S1S,0.8,2035,10
+SSP2,Mix3,below GDP cutoff,,,,Walk,S1S,1,2050,10
+SSP2,Mix3,above GDP cutoff,,,Bus,trn_pass_road,S2S1,1,2050,10
+SSP2,Mix3,above GDP cutoff,,,trn_pass_road_LDV,trn_pass_road,S2S1,0.8,2035,10
+SSP2,Mix3,below GDP cutoff,,,Bus,trn_pass_road,S2S1,1,2050,10
+SSP2,Mix3,below GDP cutoff,,,trn_pass_road_LDV,trn_pass_road,S2S1,0.8,2035,10
+SSP2,Mix3,above GDP cutoff,BEV,Bus,Bus,trn_pass_road,FV,4,2035,10
+SSP2,Mix3,above GDP cutoff,FCEV,Bus,Bus,trn_pass_road,FV,4,2035,10
+SSP2,Mix3,above GDP cutoff,Liquids,Bus,Bus,trn_pass_road,FV,1,2050,10
+SSP2,Mix3,above GDP cutoff,Hydrogen,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SSP2,Mix3,above GDP cutoff,Liquids,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SSP2,Mix3,above GDP cutoff,Liquids,Ship,Domestic Ship_tmp_subsectorL2,Domestic Ship,FV,1,2050,10
+SSP2,Mix3,above GDP cutoff,Electric,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1.5,2050,10
+SSP2,Mix3,above GDP cutoff,Liquids,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SSP2,Mix3,above GDP cutoff,Electric,Rail,HSR_tmp_subsectorL2,HSR,FV,1.5,2050,10
+SSP2,Mix3,above GDP cutoff,Liquids,Aviation,International Aviation_tmp_subsectorL2,International Aviation,FV,1,2050,10
+SSP2,Mix3,above GDP cutoff,Liquids,Ship,International Ship_tmp_subsectorL2,International Ship,FV,1,2050,10
+SSP2,Mix3,above GDP cutoff,BEV,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SSP2,Mix3,above GDP cutoff,Liquids,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SSP2,Mix3,above GDP cutoff,Electric,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1.5,2050,10
+SSP2,Mix3,above GDP cutoff,Liquids,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SSP2,Mix3,above GDP cutoff,BEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,20,2035,10
+SSP2,Mix3,above GDP cutoff,FCEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,3,2035,10
+SSP2,Mix3,above GDP cutoff,Liquids,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,10
+SSP2,Mix3,above GDP cutoff,BEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,20,2035,10
+SSP2,Mix3,above GDP cutoff,FCEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,7,2035,10
+SSP2,Mix3,above GDP cutoff,Liquids,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,10
+SSP2,Mix3,below GDP cutoff,BEV,Bus,Bus,trn_pass_road,FV,3.5,2035,10
+SSP2,Mix3,below GDP cutoff,FCEV,Bus,Bus,trn_pass_road,FV,3.5,2035,10
+SSP2,Mix3,below GDP cutoff,Liquids,Bus,Bus,trn_pass_road,FV,1,2050,10
+SSP2,Mix3,below GDP cutoff,Hydrogen,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SSP2,Mix3,below GDP cutoff,Liquids,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SSP2,Mix3,below GDP cutoff,Liquids,Ship,Domestic Ship_tmp_subsectorL2,Domestic Ship,FV,1,2050,10
+SSP2,Mix3,below GDP cutoff,Electric,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1.5,2050,10
+SSP2,Mix3,below GDP cutoff,Liquids,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SSP2,Mix3,below GDP cutoff,Electric,Rail,HSR_tmp_subsectorL2,HSR,FV,1.5,2050,10
+SSP2,Mix3,below GDP cutoff,Liquids,Aviation,International Aviation_tmp_subsectorL2,International Aviation,FV,1,2050,10
+SSP2,Mix3,below GDP cutoff,Liquids,Ship,International Ship_tmp_subsectorL2,International Ship,FV,1,2050,10
+SSP2,Mix3,below GDP cutoff,BEV,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SSP2,Mix3,below GDP cutoff,Liquids,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SSP2,Mix3,below GDP cutoff,Electric,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1.5,2050,10
+SSP2,Mix3,below GDP cutoff,Liquids,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SSP2,Mix4,below GDP cutoff,BEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,6,2035,5
+SSP2,Mix3,below GDP cutoff,FCEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,3,2035,10
+SSP2,Mix3,below GDP cutoff,Liquids,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,10
+SSP2,Mix2,below GDP cutoff,BEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,3,2035,10
+SSP2,Mix3,below GDP cutoff,FCEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,7,2035,10
+SSP2,Mix3,below GDP cutoff,Liquids,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,10
+SSP2,Mix4,above GDP cutoff,,,,Cycle,S1S,1,2050,10
+SSP2,Mix4,above GDP cutoff,,,,Domestic Aviation,S1S,0.25,2035,10
+SSP2,Mix4,above GDP cutoff,,,,Domestic Ship,S1S,1,2050,10
+SSP2,Mix4,above GDP cutoff,,,,Freight Rail,S1S,1,2050,10
+SSP2,Mix4,above GDP cutoff,,,,HSR,S1S,1,2050,10
+SSP2,Mix4,above GDP cutoff,,,,Passenger Rail,S1S,1,2050,10
+SSP2,Mix4,above GDP cutoff,,,,trn_freight_road,S1S,0.5,2035,10
+SSP2,Mix4,above GDP cutoff,,,,trn_pass_road,S1S,0.7,2035,10
+SSP2,Mix4,above GDP cutoff,,,,Walk,S1S,1,2050,10
+SSP2,Mix4,below GDP cutoff,,,,Cycle,S1S,1,2050,10
+SSP2,Mix4,below GDP cutoff,,,,Domestic Aviation,S1S,0.25,2035,10
+SSP2,Mix4,below GDP cutoff,,,,Domestic Ship,S1S,1,2050,10
+SSP2,Mix4,below GDP cutoff,,,,Freight Rail,S1S,1,2050,10
+SSP2,Mix4,below GDP cutoff,,,,HSR,S1S,1,2050,10
+SSP2,Mix4,below GDP cutoff,,,,Passenger Rail,S1S,1,2050,10
+SSP2,Mix4,below GDP cutoff,,,,trn_freight_road,S1S,0.5,2035,10
+SSP2,Mix4,below GDP cutoff,,,,trn_pass_road,S1S,0.7,2035,10
+SSP2,Mix4,below GDP cutoff,,,,Walk,S1S,1,2050,10
+SSP2,Mix4,above GDP cutoff,,,Bus,trn_pass_road,S2S1,1,2050,10
+SSP2,Mix4,above GDP cutoff,,,trn_pass_road_LDV,trn_pass_road,S2S1,0.7,2035,10
+SSP2,Mix4,below GDP cutoff,,,Bus,trn_pass_road,S2S1,1,2050,10
+SSP2,Mix4,below GDP cutoff,,,trn_pass_road_LDV,trn_pass_road,S2S1,0.7,2035,10
+SSP2,Mix2,above GDP cutoff,BEV,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SSP2,Mix4,above GDP cutoff,FCEV,Bus,Bus,trn_pass_road,FV,6,2035,10
+SSP2,Mix4,above GDP cutoff,Liquids,Bus,Bus,trn_pass_road,FV,1,2050,10
+SSP2,Mix4,above GDP cutoff,Hydrogen,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SSP2,Mix4,above GDP cutoff,Liquids,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SSP2,Mix4,above GDP cutoff,Liquids,Ship,Domestic Ship_tmp_subsectorL2,Domestic Ship,FV,1,2050,10
+SSP2,Mix4,above GDP cutoff,Electric,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,2,2050,10
+SSP2,Mix4,above GDP cutoff,Liquids,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SSP2,Mix4,above GDP cutoff,Electric,Rail,HSR_tmp_subsectorL2,HSR,FV,2,2050,10
+SSP2,Mix4,above GDP cutoff,Liquids,Aviation,International Aviation_tmp_subsectorL2,International Aviation,FV,1,2050,10
+SSP2,Mix4,above GDP cutoff,Liquids,Ship,International Ship_tmp_subsectorL2,International Ship,FV,1,2050,10
+SSP2,Mix4,above GDP cutoff,BEV,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SSP2,Mix4,above GDP cutoff,Liquids,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SSP2,Mix4,above GDP cutoff,Electric,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,2,2050,10
+SSP2,Mix4,above GDP cutoff,Liquids,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SSP2,Mix2,above GDP cutoff,BEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,10,2035,10
+SSP2,Mix4,above GDP cutoff,FCEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,10,2040,3
+SSP2,Mix4,above GDP cutoff,Liquids,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,3
+SSP2,Mix4,above GDP cutoff,BEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,50,2040,5
+SSP2,Mix4,above GDP cutoff,FCEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,60,2040,3
+SSP2,Mix4,above GDP cutoff,Liquids,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,3
+SSP2,Mix4,below GDP cutoff,BEV,Bus,Bus,trn_pass_road,FV,5,2035,10
+SSP2,Mix4,below GDP cutoff,FCEV,Bus,Bus,trn_pass_road,FV,5,2035,10
+SSP2,Mix4,below GDP cutoff,Liquids,Bus,Bus,trn_pass_road,FV,1,2050,10
+SSP2,Mix4,below GDP cutoff,Hydrogen,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SSP2,Mix4,below GDP cutoff,Liquids,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SSP2,Mix4,below GDP cutoff,Liquids,Ship,Domestic Ship_tmp_subsectorL2,Domestic Ship,FV,1,2050,10
+SSP2,Mix4,below GDP cutoff,Electric,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,2,2050,10
+SSP2,Mix4,below GDP cutoff,Liquids,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SSP2,Mix4,below GDP cutoff,Electric,Rail,HSR_tmp_subsectorL2,HSR,FV,2,2050,10
+SSP2,Mix4,below GDP cutoff,Liquids,Aviation,International Aviation_tmp_subsectorL2,International Aviation,FV,1,2050,10
+SSP2,Mix4,below GDP cutoff,Liquids,Ship,International Ship_tmp_subsectorL2,International Ship,FV,1,2050,10
+SSP2,Mix4,below GDP cutoff,BEV,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SSP2,Mix4,below GDP cutoff,Liquids,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SSP2,Mix4,below GDP cutoff,Electric,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,2,2050,10
+SSP2,Mix4,below GDP cutoff,Liquids,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SSP2,Mix3,below GDP cutoff,BEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,6,2035,10
+SSP2,Mix4,below GDP cutoff,FCEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,10,2040,3
+SSP2,Mix4,below GDP cutoff,Liquids,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,3
+SSP2,Mix4,below GDP cutoff,BEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,10,2040,3
+SSP2,Mix4,below GDP cutoff,FCEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,7,2035,3
+SSP2,Mix4,below GDP cutoff,Liquids,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,3
+SSP2,NAV_act,CAZ,,,,Cycle,S1S,2.5,2040,10
+SSP2,NAV_act,CAZ,,,,Domestic Aviation,S1S,0.3,2040,10
+SSP2,NAV_act,CAZ,,,,Domestic Ship,S1S,1,2040,10
+SSP2,NAV_act,CAZ,,,,Freight Rail,S1S,1,2040,10
+SSP2,NAV_act,CAZ,,,,HSR,S1S,1.7,2040,10
+SSP2,NAV_act,CAZ,,,,Passenger Rail,S1S,4,2040,10
+SSP2,NAV_act,CAZ,,,,trn_freight_road,S1S,0.9,2040,10
+SSP2,NAV_act,CAZ,,,,trn_pass_road,S1S,0.6,2040,10
+SSP2,NAV_act,CAZ,,,,Walk,S1S,2.5,2040,10
+SSP2,NAV_act,USA,,,,Cycle,S1S,2.5,2040,10
+SSP2,NAV_act,USA,,,,Domestic Aviation,S1S,0.3,2040,10
+SSP2,NAV_act,USA,,,,Domestic Ship,S1S,1,2040,10
+SSP2,NAV_act,USA,,,,Freight Rail,S1S,1,2040,10
+SSP2,NAV_act,USA,,,,HSR,S1S,1.7,2040,10
+SSP2,NAV_act,USA,,,,Passenger Rail,S1S,4,2040,10
+SSP2,NAV_act,USA,,,,trn_freight_road,S1S,0.9,2040,10
+SSP2,NAV_act,USA,,,,trn_pass_road,S1S,0.6,2040,10
+SSP2,NAV_act,USA,,,,Walk,S1S,2.5,2040,10
+SSP2,NAV_act,above GDP cutoff,,,,Cycle,S1S,1.8,2040,10
+SSP2,NAV_act,above GDP cutoff,,,,Domestic Aviation,S1S,0.3,2040,10
+SSP2,NAV_act,above GDP cutoff,,,,Domestic Ship,S1S,1,2040,10
+SSP2,NAV_act,above GDP cutoff,,,,Freight Rail,S1S,1,2040,10
+SSP2,NAV_act,above GDP cutoff,,,,HSR,S1S,1.7,2040,10
+SSP2,NAV_act,above GDP cutoff,,,,Passenger Rail,S1S,1.6,2040,10
+SSP2,NAV_act,above GDP cutoff,,,,trn_freight_road,S1S,0.9,2040,10
+SSP2,NAV_act,above GDP cutoff,,,,trn_pass_road,S1S,0.7,2040,10
+SSP2,NAV_act,above GDP cutoff,,,,Walk,S1S,1.7,2040,10
+SSP2,NAV_act,below GDP cutoff,,,,Cycle,S1S,2.5,2040,10
+SSP2,NAV_act,below GDP cutoff,,,,Domestic Aviation,S1S,0.3,2040,10
+SSP2,NAV_act,below GDP cutoff,,,,Domestic Ship,S1S,1,2040,10
+SSP2,NAV_act,below GDP cutoff,,,,Freight Rail,S1S,1,2040,10
+SSP2,NAV_act,below GDP cutoff,,,,HSR,S1S,2.8,2040,10
+SSP2,NAV_act,below GDP cutoff,,,,Passenger Rail,S1S,1.5,2040,10
+SSP2,NAV_act,below GDP cutoff,,,,trn_freight_road,S1S,0.9,2040,10
+SSP2,NAV_act,below GDP cutoff,,,,trn_pass_road,S1S,0.7,2040,10
+SSP2,NAV_act,below GDP cutoff,,,,Walk,S1S,2.5,2040,10
+SSP2,NAV_act,CAZ,,,Bus,trn_pass_road,S2S1,3,2040,10
+SSP2,NAV_act,CAZ,,,trn_pass_road_LDV,trn_pass_road,S2S1,0.7,2040,10
+SSP2,NAV_act,USA,,,Bus,trn_pass_road,S2S1,2,2040,10
+SSP2,NAV_act,USA,,,trn_pass_road_LDV,trn_pass_road,S2S1,0.7,2040,10
+SSP2,NAV_act,above GDP cutoff,,,Bus,trn_pass_road,S2S1,2,2040,10
+SSP2,NAV_act,above GDP cutoff,,,trn_pass_road_LDV,trn_pass_road,S2S1,1,2040,10
+SSP2,NAV_act,below GDP cutoff,,,Bus,trn_pass_road,S2S1,2,2040,10
+SSP2,NAV_act,below GDP cutoff,,,trn_pass_road_LDV,trn_pass_road,S2S1,1,2040,10
+SSP2,NAV_act,CAZ,BEV,Bus,Bus,trn_pass_road,FV,1,2040,10
+SSP2,NAV_act,CAZ,FCEV,Bus,Bus,trn_pass_road,FV,1,2040,10
+SSP2,NAV_act,CAZ,Liquids,Bus,Bus,trn_pass_road,FV,1,2050,10
+SSP2,NAV_act,CAZ,Hydrogen,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SSP2,NAV_act,CAZ,Liquids,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SSP2,NAV_act,CAZ,Liquids,Ship,Domestic Ship_tmp_subsectorL2,Domestic Ship,FV,1,2050,10
+SSP2,NAV_act,CAZ,Electric,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SSP2,NAV_act,CAZ,Liquids,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SSP2,NAV_act,CAZ,Electric,Rail,HSR_tmp_subsectorL2,HSR,FV,1,2050,10
+SSP2,NAV_act,CAZ,Liquids,Aviation,International Aviation_tmp_subsectorL2,International Aviation,FV,1,2050,10
+SSP2,NAV_act,CAZ,Liquids,Ship,International Ship_tmp_subsectorL2,International Ship,FV,1,2050,10
+SSP2,NAV_act,CAZ,BEV,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SSP2,NAV_act,CAZ,Liquids,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SSP2,NAV_act,CAZ,Electric,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SSP2,NAV_act,CAZ,Liquids,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SSP2,NAV_act,CAZ,BEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2040,10
+SSP2,NAV_act,CAZ,FCEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2040,10
+SSP2,NAV_act,CAZ,Liquids,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,10
+SSP2,NAV_act,CAZ,BEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2040,10
+SSP2,NAV_act,CAZ,FCEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2040,10
+SSP2,NAV_act,CAZ,Liquids,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,10
+SSP2,NAV_act,USA,BEV,Bus,Bus,trn_pass_road,FV,1,2035,10
+SSP2,NAV_act,USA,FCEV,Bus,Bus,trn_pass_road,FV,1,2035,10
+SSP2,NAV_act,USA,Liquids,Bus,Bus,trn_pass_road,FV,1,2050,10
+SSP2,NAV_act,USA,Hydrogen,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SSP2,NAV_act,USA,Liquids,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SSP2,NAV_act,USA,Liquids,Ship,Domestic Ship_tmp_subsectorL2,Domestic Ship,FV,1,2050,10
+SSP2,NAV_act,USA,Electric,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SSP2,NAV_act,USA,Liquids,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SSP2,NAV_act,USA,Electric,Rail,HSR_tmp_subsectorL2,HSR,FV,1,2050,10
+SSP2,NAV_act,USA,Liquids,Aviation,International Aviation_tmp_subsectorL2,International Aviation,FV,1,2050,10
+SSP2,NAV_act,USA,Liquids,Ship,International Ship_tmp_subsectorL2,International Ship,FV,1,2050,10
+SSP2,NAV_act,USA,BEV,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SSP2,NAV_act,USA,Liquids,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SSP2,NAV_act,USA,Electric,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SSP2,NAV_act,USA,Liquids,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SSP2,NAV_act,USA,BEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2035,10
+SSP2,NAV_act,USA,FCEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2035,10
+SSP2,NAV_act,USA,Liquids,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,10
+SSP2,NAV_act,USA,BEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2035,10
+SSP2,NAV_act,USA,FCEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2035,10
+SSP2,NAV_act,USA,Liquids,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,10
+SSP2,NAV_act,above GDP cutoff,BEV,Bus,Bus,trn_pass_road,FV,1,2040,10
+SSP2,NAV_act,above GDP cutoff,FCEV,Bus,Bus,trn_pass_road,FV,1,2040,10
+SSP2,NAV_act,above GDP cutoff,Liquids,Bus,Bus,trn_pass_road,FV,1,2050,10
+SSP2,NAV_act,above GDP cutoff,Hydrogen,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SSP2,NAV_act,above GDP cutoff,Liquids,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SSP2,NAV_act,above GDP cutoff,Liquids,Ship,Domestic Ship_tmp_subsectorL2,Domestic Ship,FV,1,2050,10
+SSP2,NAV_act,above GDP cutoff,Electric,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SSP2,NAV_act,above GDP cutoff,Liquids,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SSP2,NAV_act,above GDP cutoff,Electric,Rail,HSR_tmp_subsectorL2,HSR,FV,1,2050,10
+SSP2,NAV_act,above GDP cutoff,Liquids,Aviation,International Aviation_tmp_subsectorL2,International Aviation,FV,1,2050,10
+SSP2,NAV_act,above GDP cutoff,Liquids,Ship,International Ship_tmp_subsectorL2,International Ship,FV,1,2050,10
+SSP2,NAV_act,above GDP cutoff,BEV,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SSP2,NAV_act,above GDP cutoff,Liquids,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SSP2,NAV_act,above GDP cutoff,Electric,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SSP2,NAV_act,above GDP cutoff,Liquids,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SSP2,NAV_act,above GDP cutoff,BEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2040,10
+SSP2,NAV_act,above GDP cutoff,FCEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2040,10
+SSP2,NAV_act,above GDP cutoff,Liquids,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,10
+SSP2,NAV_act,above GDP cutoff,BEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2040,10
+SSP2,NAV_act,above GDP cutoff,FCEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2040,10
+SSP2,NAV_act,above GDP cutoff,Liquids,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,10
+SSP2,NAV_act,below GDP cutoff,BEV,Bus,Bus,trn_pass_road,FV,1,2040,10
+SSP2,NAV_act,below GDP cutoff,FCEV,Bus,Bus,trn_pass_road,FV,1,2040,10
+SSP2,NAV_act,below GDP cutoff,Liquids,Bus,Bus,trn_pass_road,FV,1,2050,10
+SSP2,NAV_act,below GDP cutoff,Hydrogen,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SSP2,NAV_act,below GDP cutoff,Liquids,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SSP2,NAV_act,below GDP cutoff,Liquids,Ship,Domestic Ship_tmp_subsectorL2,Domestic Ship,FV,1,2050,10
+SSP2,NAV_act,below GDP cutoff,Electric,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SSP2,NAV_act,below GDP cutoff,Liquids,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SSP2,NAV_act,below GDP cutoff,Electric,Rail,HSR_tmp_subsectorL2,HSR,FV,1,2050,10
+SSP2,NAV_act,below GDP cutoff,Liquids,Aviation,International Aviation_tmp_subsectorL2,International Aviation,FV,1,2050,10
+SSP2,NAV_act,below GDP cutoff,Liquids,Ship,International Ship_tmp_subsectorL2,International Ship,FV,1,2050,10
+SSP2,NAV_act,below GDP cutoff,BEV,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SSP2,NAV_act,below GDP cutoff,Liquids,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SSP2,NAV_act,below GDP cutoff,Electric,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SSP2,NAV_act,below GDP cutoff,Liquids,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SSP2,NAV_act,below GDP cutoff,BEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2040,10
+SSP2,NAV_act,below GDP cutoff,FCEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2040,10
+SSP2,NAV_act,below GDP cutoff,Liquids,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,10
+SSP2,NAV_act,below GDP cutoff,BEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2040,10
+SSP2,NAV_act,below GDP cutoff,FCEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2040,10
+SSP2,NAV_act,below GDP cutoff,Liquids,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,10
+SSP2,NAV_all,CAZ,,,,Cycle,S1S,2.5,2040,10
+SSP2,NAV_all,CAZ,,,,Domestic Aviation,S1S,0.3,2040,10
+SSP2,NAV_all,CAZ,,,,Domestic Ship,S1S,1,2040,10
+SSP2,NAV_all,CAZ,,,,Freight Rail,S1S,1,2040,10
+SSP2,NAV_all,CAZ,,,,HSR,S1S,1.7,2040,10
+SSP2,NAV_all,CAZ,,,,Passenger Rail,S1S,4,2040,10
+SSP2,NAV_all,CAZ,,,,trn_freight_road,S1S,0.9,2040,10
+SSP2,NAV_all,CAZ,,,,trn_pass_road,S1S,0.6,2040,10
+SSP2,NAV_all,CAZ,,,,Walk,S1S,2.5,2040,10
+SSP2,NAV_all,USA,,,,Cycle,S1S,2.5,2040,10
+SSP2,NAV_all,USA,,,,Domestic Aviation,S1S,0.3,2040,10
+SSP2,NAV_all,USA,,,,Domestic Ship,S1S,1,2040,10
+SSP2,NAV_all,USA,,,,Freight Rail,S1S,1,2040,10
+SSP2,NAV_all,USA,,,,HSR,S1S,1.7,2040,10
+SSP2,NAV_all,USA,,,,Passenger Rail,S1S,4,2040,10
+SSP2,NAV_all,USA,,,,trn_freight_road,S1S,0.9,2040,10
+SSP2,NAV_all,USA,,,,trn_pass_road,S1S,0.6,2040,10
+SSP2,NAV_all,USA,,,,Walk,S1S,2.5,2040,10
+SSP2,NAV_all,above GDP cutoff,,,,Cycle,S1S,1.8,2040,10
+SSP2,NAV_all,above GDP cutoff,,,,Domestic Aviation,S1S,0.3,2040,10
+SSP2,NAV_all,above GDP cutoff,,,,Domestic Ship,S1S,1,2040,10
+SSP2,NAV_all,above GDP cutoff,,,,Freight Rail,S1S,1,2040,10
+SSP2,NAV_all,above GDP cutoff,,,,HSR,S1S,1.7,2040,10
+SSP2,NAV_all,above GDP cutoff,,,,Passenger Rail,S1S,1.6,2040,10
+SSP2,NAV_all,above GDP cutoff,,,,trn_freight_road,S1S,0.9,2040,10
+SSP2,NAV_all,above GDP cutoff,,,,trn_pass_road,S1S,0.7,2040,10
+SSP2,NAV_all,above GDP cutoff,,,,Walk,S1S,1.7,2040,10
+SSP2,NAV_all,below GDP cutoff,,,,Cycle,S1S,2.5,2040,10
+SSP2,NAV_all,below GDP cutoff,,,,Domestic Aviation,S1S,0.3,2040,10
+SSP2,NAV_all,below GDP cutoff,,,,Domestic Ship,S1S,1,2040,10
+SSP2,NAV_all,below GDP cutoff,,,,Freight Rail,S1S,1,2040,10
+SSP2,NAV_all,below GDP cutoff,,,,HSR,S1S,2.8,2040,10
+SSP2,NAV_all,below GDP cutoff,,,,Passenger Rail,S1S,1.5,2040,10
+SSP2,NAV_all,below GDP cutoff,,,,trn_freight_road,S1S,0.9,2040,10
+SSP2,NAV_all,below GDP cutoff,,,,trn_pass_road,S1S,0.7,2040,10
+SSP2,NAV_all,below GDP cutoff,,,,Walk,S1S,2.5,2040,10
+SSP2,NAV_all,CAZ,,,Bus,trn_pass_road,S2S1,3,2040,10
+SSP2,NAV_all,CAZ,,,trn_pass_road_LDV,trn_pass_road,S2S1,0.7,2040,10
+SSP2,NAV_all,USA,,,Bus,trn_pass_road,S2S1,2,2040,10
+SSP2,NAV_all,USA,,,trn_pass_road_LDV,trn_pass_road,S2S1,0.7,2040,10
+SSP2,NAV_all,above GDP cutoff,,,Bus,trn_pass_road,S2S1,2,2040,10
+SSP2,NAV_all,above GDP cutoff,,,trn_pass_road_LDV,trn_pass_road,S2S1,1,2040,10
+SSP2,NAV_all,below GDP cutoff,,,Bus,trn_pass_road,S2S1,2,2040,10
+SSP2,NAV_all,below GDP cutoff,,,trn_pass_road_LDV,trn_pass_road,S2S1,1,2040,10
+SSP2,NAV_all,above GDP cutoff,BEV,Bus,Bus,trn_pass_road,FV,9,2025,10
+SSP2,NAV_all,above GDP cutoff,FCEV,Bus,Bus,trn_pass_road,FV,6,2025,10
+SSP2,NAV_all,above GDP cutoff,Liquids,Bus,Bus,trn_pass_road,FV,0.01,2025,10
+SSP2,NAV_all,above GDP cutoff,Hydrogen,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,10,2045,10
+SSP2,NAV_all,above GDP cutoff,Liquids,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,0.1,2045,10
+SSP2,NAV_all,above GDP cutoff,Liquids,Ship,Domestic Ship_tmp_subsectorL2,Domestic Ship,FV,0.1,2050,10
+SSP2,NAV_all,above GDP cutoff,Electric,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,2,2040,10
+SSP2,NAV_all,above GDP cutoff,Liquids,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,0.1,2040,10
+SSP2,NAV_all,above GDP cutoff,Electric,Rail,HSR_tmp_subsectorL2,HSR,FV,2,2040,10
+SSP2,NAV_all,above GDP cutoff,Liquids,Aviation,International Aviation_tmp_subsectorL2,International Aviation,FV,0.1,2045,10
+SSP2,NAV_all,above GDP cutoff,Liquids,Ship,International Ship_tmp_subsectorL2,International Ship,FV,0.1,2050,10
+SSP2,NAV_all,above GDP cutoff,BEV,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,4,2030,10
+SSP2,NAV_all,above GDP cutoff,Liquids,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,0.05,2030,10
+SSP2,NAV_all,above GDP cutoff,Electric,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,2,2040,10
+SSP2,NAV_all,above GDP cutoff,Liquids,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,0.1,2040,10
+SSP2,NAV_all,above GDP cutoff,BEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,4,2025,10
+SSP2,NAV_all,above GDP cutoff,FCEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,4,2025,10
+SSP2,NAV_all,above GDP cutoff,Liquids,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,0.01,2025,10
+SSP2,NAV_all,above GDP cutoff,BEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,4,2025,10
+SSP2,NAV_all,above GDP cutoff,FCEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,9,2025,10
+SSP2,NAV_all,above GDP cutoff,Liquids,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,0.01,2025,10
+SSP2,NAV_all,below GDP cutoff,BEV,Bus,Bus,trn_pass_road,FV,7,2025,10
+SSP2,NAV_all,below GDP cutoff,FCEV,Bus,Bus,trn_pass_road,FV,5,2025,10
+SSP2,NAV_all,below GDP cutoff,Liquids,Bus,Bus,trn_pass_road,FV,0.01,2025,10
+SSP2,NAV_all,below GDP cutoff,Hydrogen,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,10,2045,10
+SSP2,NAV_all,below GDP cutoff,Liquids,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,0.1,2045,10
+SSP2,NAV_all,below GDP cutoff,Liquids,Ship,Domestic Ship_tmp_subsectorL2,Domestic Ship,FV,0.1,2050,10
+SSP2,NAV_all,below GDP cutoff,Electric,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,2,2040,10
+SSP2,NAV_all,below GDP cutoff,Liquids,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,0.1,2040,10
+SSP2,NAV_all,below GDP cutoff,Electric,Rail,HSR_tmp_subsectorL2,HSR,FV,2,2040,10
+SSP2,NAV_all,below GDP cutoff,Liquids,Aviation,International Aviation_tmp_subsectorL2,International Aviation,FV,0.1,2045,10
+SSP2,NAV_all,below GDP cutoff,Liquids,Ship,International Ship_tmp_subsectorL2,International Ship,FV,0.1,2050,10
+SSP2,NAV_all,below GDP cutoff,BEV,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,4,2030,10
+SSP2,NAV_all,below GDP cutoff,Liquids,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,0.05,2030,10
+SSP2,NAV_all,below GDP cutoff,Electric,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,2,2040,10
+SSP2,NAV_all,below GDP cutoff,Liquids,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,0.1,2040,10
+SSP2,NAV_all,below GDP cutoff,BEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,4,2025,10
+SSP2,NAV_all,below GDP cutoff,FCEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,4,2025,10
+SSP2,NAV_all,below GDP cutoff,Liquids,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,0.01,2025,10
+SSP2,NAV_all,below GDP cutoff,BEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1.5,2025,10
+SSP2,NAV_all,below GDP cutoff,FCEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,9,2025,10
+SSP2,NAV_all,below GDP cutoff,Liquids,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,0.01,2025,10
+SSP2,NAV_ele,above GDP cutoff,,,,Cycle,S1S,1,2040,10
+SSP2,NAV_ele,above GDP cutoff,,,,Domestic Aviation,S1S,1,2040,10
+SSP2,NAV_ele,above GDP cutoff,,,,Domestic Ship,S1S,1,2040,10
+SSP2,NAV_ele,above GDP cutoff,,,,Freight Rail,S1S,1,2040,10
+SSP2,NAV_ele,above GDP cutoff,,,,HSR,S1S,1,2040,10
+SSP2,NAV_ele,above GDP cutoff,,,,Passenger Rail,S1S,1,2040,10
+SSP2,NAV_ele,above GDP cutoff,,,,trn_freight_road,S1S,1,2040,10
+SSP2,NAV_ele,above GDP cutoff,,,,trn_pass_road,S1S,1,2040,10
+SSP2,NAV_ele,above GDP cutoff,,,,Walk,S1S,1,2040,10
+SSP2,NAV_ele,below GDP cutoff,,,,Cycle,S1S,1,2040,10
+SSP2,NAV_ele,below GDP cutoff,,,,Domestic Aviation,S1S,1,2040,10
+SSP2,NAV_ele,below GDP cutoff,,,,Domestic Ship,S1S,1,2040,10
+SSP2,NAV_ele,below GDP cutoff,,,,Freight Rail,S1S,1,2040,10
+SSP2,NAV_ele,below GDP cutoff,,,,HSR,S1S,1,2040,10
+SSP2,NAV_ele,below GDP cutoff,,,,Passenger Rail,S1S,1,2040,10
+SSP2,NAV_ele,below GDP cutoff,,,,trn_freight_road,S1S,1,2040,10
+SSP2,NAV_ele,below GDP cutoff,,,,trn_pass_road,S1S,1,2040,10
+SSP2,NAV_ele,below GDP cutoff,,,,Walk,S1S,1,2040,10
+SSP2,NAV_ele,above GDP cutoff,,,Bus,trn_pass_road,S2S1,1,2040,10
+SSP2,NAV_ele,above GDP cutoff,,,trn_pass_road_LDV,trn_pass_road,S2S1,1,2040,10
+SSP2,NAV_ele,below GDP cutoff,,,Bus,trn_pass_road,S2S1,1,2040,10
+SSP2,NAV_ele,below GDP cutoff,,,trn_pass_road_LDV,trn_pass_road,S2S1,1,2040,10
+SSP2,NAV_ele,above GDP cutoff,BEV,Bus,Bus,trn_pass_road,FV,9,2025,10
+SSP2,NAV_ele,above GDP cutoff,FCEV,Bus,Bus,trn_pass_road,FV,6,2025,10
+SSP2,NAV_ele,above GDP cutoff,Liquids,Bus,Bus,trn_pass_road,FV,0.01,2025,10
+SSP2,NAV_ele,above GDP cutoff,Hydrogen,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,10,2045,10
+SSP2,NAV_ele,above GDP cutoff,Liquids,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,0.1,2045,10
+SSP2,NAV_ele,above GDP cutoff,Liquids,Ship,Domestic Ship_tmp_subsectorL2,Domestic Ship,FV,0.1,2050,10
+SSP2,NAV_ele,above GDP cutoff,Electric,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,2,2040,10
+SSP2,NAV_ele,above GDP cutoff,Liquids,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,0.1,2040,10
+SSP2,NAV_ele,above GDP cutoff,Electric,Rail,HSR_tmp_subsectorL2,HSR,FV,2,2040,10
+SSP2,NAV_ele,above GDP cutoff,Liquids,Aviation,International Aviation_tmp_subsectorL2,International Aviation,FV,0.1,2045,10
+SSP2,NAV_ele,above GDP cutoff,Liquids,Ship,International Ship_tmp_subsectorL2,International Ship,FV,0.1,2050,10
+SSP2,NAV_ele,above GDP cutoff,BEV,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,4,2030,10
+SSP2,NAV_ele,above GDP cutoff,Liquids,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,0.05,2030,10
+SSP2,NAV_ele,above GDP cutoff,Electric,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,2,2040,10
+SSP2,NAV_ele,above GDP cutoff,Liquids,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,0.1,2040,10
+SSP2,NAV_ele,above GDP cutoff,BEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,4,2025,10
+SSP2,NAV_ele,above GDP cutoff,FCEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,4,2025,10
+SSP2,NAV_ele,above GDP cutoff,Liquids,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,0.01,2025,10
+SSP2,NAV_ele,above GDP cutoff,BEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,4,2025,10
+SSP2,NAV_ele,above GDP cutoff,FCEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,9,2025,10
+SSP2,NAV_ele,above GDP cutoff,Liquids,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,0.01,2025,10
+SSP2,NAV_ele,below GDP cutoff,BEV,Bus,Bus,trn_pass_road,FV,7,2025,10
+SSP2,NAV_ele,below GDP cutoff,FCEV,Bus,Bus,trn_pass_road,FV,5,2025,10
+SSP2,NAV_ele,below GDP cutoff,Liquids,Bus,Bus,trn_pass_road,FV,0.01,2025,10
+SSP2,NAV_ele,below GDP cutoff,Hydrogen,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,10,2045,10
+SSP2,NAV_ele,below GDP cutoff,Liquids,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,0.1,2045,10
+SSP2,NAV_ele,below GDP cutoff,Liquids,Ship,Domestic Ship_tmp_subsectorL2,Domestic Ship,FV,0.1,2050,10
+SSP2,NAV_ele,below GDP cutoff,Electric,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,2,2040,10
+SSP2,NAV_ele,below GDP cutoff,Liquids,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,0.1,2040,10
+SSP2,NAV_ele,below GDP cutoff,Electric,Rail,HSR_tmp_subsectorL2,HSR,FV,2,2040,10
+SSP2,NAV_ele,below GDP cutoff,Liquids,Aviation,International Aviation_tmp_subsectorL2,International Aviation,FV,0.1,2045,10
+SSP2,NAV_ele,below GDP cutoff,Liquids,Ship,International Ship_tmp_subsectorL2,International Ship,FV,0.1,2050,10
+SSP2,NAV_ele,below GDP cutoff,BEV,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,4,2030,10
+SSP2,NAV_ele,below GDP cutoff,Liquids,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,0.05,2030,10
+SSP2,NAV_ele,below GDP cutoff,Electric,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,2,2040,10
+SSP2,NAV_ele,below GDP cutoff,Liquids,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,0.1,2040,10
+SSP2,NAV_ele,below GDP cutoff,BEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,4,2025,10
+SSP2,NAV_ele,below GDP cutoff,FCEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,4,2025,10
+SSP2,NAV_ele,below GDP cutoff,Liquids,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,0.01,2025,10
+SSP2,NAV_ele,below GDP cutoff,BEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1.5,2025,10
+SSP2,NAV_ele,below GDP cutoff,FCEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,9,2025,10
+SSP2,NAV_ele,below GDP cutoff,Liquids,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,0.01,2025,10
+SSP2,NAV_lce,CAZ,,,,Cycle,S1S,2.5,2040,10
+SSP2,NAV_lce,CAZ,,,,Domestic Aviation,S1S,0.3,2040,10
+SSP2,NAV_lce,CAZ,,,,Domestic Ship,S1S,1,2040,10
+SSP2,NAV_lce,CAZ,,,,Freight Rail,S1S,1,2040,10
+SSP2,NAV_lce,CAZ,,,,HSR,S1S,1.7,2040,10
+SSP2,NAV_lce,CAZ,,,,Passenger Rail,S1S,4,2040,10
+SSP2,NAV_lce,CAZ,,,,trn_freight_road,S1S,0.9,2040,10
+SSP2,NAV_lce,CAZ,,,,trn_pass_road,S1S,0.6,2040,10
+SSP2,NAV_lce,CAZ,,,,Walk,S1S,2.5,2040,10
+SSP2,NAV_lce,USA,,,,Cycle,S1S,2.5,2040,10
+SSP2,NAV_lce,USA,,,,Domestic Aviation,S1S,0.3,2040,10
+SSP2,NAV_lce,USA,,,,Domestic Ship,S1S,1,2040,10
+SSP2,NAV_lce,USA,,,,Freight Rail,S1S,1,2040,10
+SSP2,NAV_lce,USA,,,,HSR,S1S,1.7,2040,10
+SSP2,NAV_lce,USA,,,,Passenger Rail,S1S,4,2040,10
+SSP2,NAV_lce,USA,,,,trn_freight_road,S1S,0.9,2040,10
+SSP2,NAV_lce,USA,,,,trn_pass_road,S1S,0.6,2040,10
+SSP2,NAV_lce,USA,,,,Walk,S1S,2.5,2040,10
+SSP2,NAV_lce,above GDP cutoff,,,,Cycle,S1S,1.8,2040,10
+SSP2,NAV_lce,above GDP cutoff,,,,Domestic Aviation,S1S,0.3,2040,10
+SSP2,NAV_lce,above GDP cutoff,,,,Domestic Ship,S1S,1,2040,10
+SSP2,NAV_lce,above GDP cutoff,,,,Freight Rail,S1S,1,2040,10
+SSP2,NAV_lce,above GDP cutoff,,,,HSR,S1S,1.7,2040,10
+SSP2,NAV_lce,above GDP cutoff,,,,Passenger Rail,S1S,1.6,2040,10
+SSP2,NAV_lce,above GDP cutoff,,,,trn_freight_road,S1S,0.9,2040,10
+SSP2,NAV_lce,above GDP cutoff,,,,trn_pass_road,S1S,0.7,2040,10
+SSP2,NAV_lce,above GDP cutoff,,,,Walk,S1S,1.7,2040,10
+SSP2,NAV_lce,below GDP cutoff,,,,Cycle,S1S,2.5,2040,10
+SSP2,NAV_lce,below GDP cutoff,,,,Domestic Aviation,S1S,0.3,2040,10
+SSP2,NAV_lce,below GDP cutoff,,,,Domestic Ship,S1S,1,2040,10
+SSP2,NAV_lce,below GDP cutoff,,,,Freight Rail,S1S,1,2040,10
+SSP2,NAV_lce,below GDP cutoff,,,,HSR,S1S,2.8,2040,10
+SSP2,NAV_lce,below GDP cutoff,,,,Passenger Rail,S1S,1.5,2040,10
+SSP2,NAV_lce,below GDP cutoff,,,,trn_freight_road,S1S,0.9,2040,10
+SSP2,NAV_lce,below GDP cutoff,,,,trn_pass_road,S1S,0.7,2040,10
+SSP2,NAV_lce,below GDP cutoff,,,,Walk,S1S,2.5,2040,10
+SSP2,NAV_lce,CAZ,,,Bus,trn_pass_road,S2S1,3,2040,10
+SSP2,NAV_lce,CAZ,,,trn_pass_road_LDV,trn_pass_road,S2S1,0.7,2040,10
+SSP2,NAV_lce,USA,,,Bus,trn_pass_road,S2S1,2,2040,10
+SSP2,NAV_lce,USA,,,trn_pass_road_LDV,trn_pass_road,S2S1,0.7,2040,10
+SSP2,NAV_lce,above GDP cutoff,,,Bus,trn_pass_road,S2S1,2,2040,10
+SSP2,NAV_lce,above GDP cutoff,,,trn_pass_road_LDV,trn_pass_road,S2S1,1,2040,10
+SSP2,NAV_lce,below GDP cutoff,,,Bus,trn_pass_road,S2S1,2,2040,10
+SSP2,NAV_lce,below GDP cutoff,,,trn_pass_road_LDV,trn_pass_road,S2S1,1,2040,10
+SSP2,NAV_lce,CAZ,BEV,Bus,Bus,trn_pass_road,FV,1,2040,10
+SSP2,NAV_lce,CAZ,FCEV,Bus,Bus,trn_pass_road,FV,1,2040,10
+SSP2,NAV_lce,CAZ,Liquids,Bus,Bus,trn_pass_road,FV,1,2050,10
+SSP2,NAV_lce,CAZ,Hydrogen,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SSP2,NAV_lce,CAZ,Liquids,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SSP2,NAV_lce,CAZ,Liquids,Ship,Domestic Ship_tmp_subsectorL2,Domestic Ship,FV,1,2050,10
+SSP2,NAV_lce,CAZ,Electric,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SSP2,NAV_lce,CAZ,Liquids,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SSP2,NAV_lce,CAZ,Electric,Rail,HSR_tmp_subsectorL2,HSR,FV,1,2050,10
+SSP2,NAV_lce,CAZ,Liquids,Aviation,International Aviation_tmp_subsectorL2,International Aviation,FV,1,2050,10
+SSP2,NAV_lce,CAZ,Liquids,Ship,International Ship_tmp_subsectorL2,International Ship,FV,1,2050,10
+SSP2,NAV_lce,CAZ,BEV,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SSP2,NAV_lce,CAZ,Liquids,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SSP2,NAV_lce,CAZ,Electric,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SSP2,NAV_lce,CAZ,Liquids,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SSP2,NAV_lce,CAZ,BEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2040,10
+SSP2,NAV_lce,CAZ,FCEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2040,10
+SSP2,NAV_lce,CAZ,Liquids,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,10
+SSP2,NAV_lce,CAZ,BEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2040,10
+SSP2,NAV_lce,CAZ,FCEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2040,10
+SSP2,NAV_lce,CAZ,Liquids,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,10
+SSP2,NAV_lce,USA,BEV,Bus,Bus,trn_pass_road,FV,1,2035,10
+SSP2,NAV_lce,USA,FCEV,Bus,Bus,trn_pass_road,FV,1,2035,10
+SSP2,NAV_lce,USA,Liquids,Bus,Bus,trn_pass_road,FV,1,2050,10
+SSP2,NAV_lce,USA,Hydrogen,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SSP2,NAV_lce,USA,Liquids,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SSP2,NAV_lce,USA,Liquids,Ship,Domestic Ship_tmp_subsectorL2,Domestic Ship,FV,1,2050,10
+SSP2,NAV_lce,USA,Electric,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SSP2,NAV_lce,USA,Liquids,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SSP2,NAV_lce,USA,Electric,Rail,HSR_tmp_subsectorL2,HSR,FV,1,2050,10
+SSP2,NAV_lce,USA,Liquids,Aviation,International Aviation_tmp_subsectorL2,International Aviation,FV,1,2050,10
+SSP2,NAV_lce,USA,Liquids,Ship,International Ship_tmp_subsectorL2,International Ship,FV,1,2050,10
+SSP2,NAV_lce,USA,BEV,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SSP2,NAV_lce,USA,Liquids,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SSP2,NAV_lce,USA,Electric,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SSP2,NAV_lce,USA,Liquids,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SSP2,NAV_lce,USA,BEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2035,10
+SSP2,NAV_lce,USA,FCEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2035,10
+SSP2,NAV_lce,USA,Liquids,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,10
+SSP2,NAV_lce,USA,BEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2035,10
+SSP2,NAV_lce,USA,FCEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2035,10
+SSP2,NAV_lce,USA,Liquids,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,10
+SSP2,NAV_lce,above GDP cutoff,BEV,Bus,Bus,trn_pass_road,FV,1,2040,10
+SSP2,NAV_lce,above GDP cutoff,FCEV,Bus,Bus,trn_pass_road,FV,1,2040,10
+SSP2,NAV_lce,above GDP cutoff,Liquids,Bus,Bus,trn_pass_road,FV,1,2050,10
+SSP2,NAV_lce,above GDP cutoff,Hydrogen,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SSP2,NAV_lce,above GDP cutoff,Liquids,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SSP2,NAV_lce,above GDP cutoff,Liquids,Ship,Domestic Ship_tmp_subsectorL2,Domestic Ship,FV,1,2050,10
+SSP2,NAV_lce,above GDP cutoff,Electric,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SSP2,NAV_lce,above GDP cutoff,Liquids,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SSP2,NAV_lce,above GDP cutoff,Electric,Rail,HSR_tmp_subsectorL2,HSR,FV,1,2050,10
+SSP2,NAV_lce,above GDP cutoff,Liquids,Aviation,International Aviation_tmp_subsectorL2,International Aviation,FV,1,2050,10
+SSP2,NAV_lce,above GDP cutoff,Liquids,Ship,International Ship_tmp_subsectorL2,International Ship,FV,1,2050,10
+SSP2,NAV_lce,above GDP cutoff,BEV,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SSP2,NAV_lce,above GDP cutoff,Liquids,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SSP2,NAV_lce,above GDP cutoff,Electric,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SSP2,NAV_lce,above GDP cutoff,Liquids,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SSP2,NAV_lce,above GDP cutoff,BEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2040,10
+SSP2,NAV_lce,above GDP cutoff,FCEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2040,10
+SSP2,NAV_lce,above GDP cutoff,Liquids,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,10
+SSP2,NAV_lce,above GDP cutoff,BEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2040,10
+SSP2,NAV_lce,above GDP cutoff,FCEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2040,10
+SSP2,NAV_lce,above GDP cutoff,Liquids,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,10
+SSP2,NAV_lce,below GDP cutoff,BEV,Bus,Bus,trn_pass_road,FV,1,2040,10
+SSP2,NAV_lce,below GDP cutoff,FCEV,Bus,Bus,trn_pass_road,FV,1,2040,10
+SSP2,NAV_lce,below GDP cutoff,Liquids,Bus,Bus,trn_pass_road,FV,1,2050,10
+SSP2,NAV_lce,below GDP cutoff,Hydrogen,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SSP2,NAV_lce,below GDP cutoff,Liquids,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SSP2,NAV_lce,below GDP cutoff,Liquids,Ship,Domestic Ship_tmp_subsectorL2,Domestic Ship,FV,1,2050,10
+SSP2,NAV_lce,below GDP cutoff,Electric,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SSP2,NAV_lce,below GDP cutoff,Liquids,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SSP2,NAV_lce,below GDP cutoff,Electric,Rail,HSR_tmp_subsectorL2,HSR,FV,1,2050,10
+SSP2,NAV_lce,below GDP cutoff,Liquids,Aviation,International Aviation_tmp_subsectorL2,International Aviation,FV,1,2050,10
+SSP2,NAV_lce,below GDP cutoff,Liquids,Ship,International Ship_tmp_subsectorL2,International Ship,FV,1,2050,10
+SSP2,NAV_lce,below GDP cutoff,BEV,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SSP2,NAV_lce,below GDP cutoff,Liquids,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SSP2,NAV_lce,below GDP cutoff,Electric,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SSP2,NAV_lce,below GDP cutoff,Liquids,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SSP2,NAV_lce,below GDP cutoff,BEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2040,10
+SSP2,NAV_lce,below GDP cutoff,FCEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2040,10
+SSP2,NAV_lce,below GDP cutoff,Liquids,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,10
+SSP2,NAV_lce,below GDP cutoff,BEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2040,10
+SSP2,NAV_lce,below GDP cutoff,FCEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2040,10
+SSP2,NAV_lce,below GDP cutoff,Liquids,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,10
+SSP5,Mix2,above GDP cutoff,,,,Cycle,S1S,1,2050,10
+SSP5,Mix2,above GDP cutoff,,,,Domestic Aviation,S1S,0.75,2035,10
+SSP5,Mix2,above GDP cutoff,,,,Domestic Ship,S1S,1,2050,10
+SSP5,Mix2,above GDP cutoff,,,,Freight Rail,S1S,1,2050,10
+SSP5,Mix2,above GDP cutoff,,,,HSR,S1S,1,2050,10
+SSP5,Mix2,above GDP cutoff,,,,Passenger Rail,S1S,1,2050,10
+SSP5,Mix2,above GDP cutoff,,,,trn_freight_road,S1S,0.9,2035,10
+SSP5,Mix2,above GDP cutoff,,,,trn_pass_road,S1S,0.9,2035,10
+SSP5,Mix2,above GDP cutoff,,,,Walk,S1S,1,2050,10
+SSP5,Mix2,below GDP cutoff,,,,Cycle,S1S,1,2050,10
+SSP5,Mix2,below GDP cutoff,,,,Domestic Aviation,S1S,0.75,2035,10
+SSP5,Mix2,below GDP cutoff,,,,Domestic Ship,S1S,1,2050,10
+SSP5,Mix2,below GDP cutoff,,,,Freight Rail,S1S,1,2050,10
+SSP5,Mix2,below GDP cutoff,,,,HSR,S1S,1,2050,10
+SSP5,Mix2,below GDP cutoff,,,,Passenger Rail,S1S,1,2050,10
+SSP5,Mix2,below GDP cutoff,,,,trn_freight_road,S1S,0.9,2035,10
+SSP5,Mix2,below GDP cutoff,,,,trn_pass_road,S1S,0.9,2035,10
+SSP5,Mix2,below GDP cutoff,,,,Walk,S1S,1,2050,10
+SSP5,Mix2,above GDP cutoff,,,Bus,trn_pass_road,S2S1,1,2050,10
+SSP5,Mix2,above GDP cutoff,,,trn_pass_road_LDV,trn_pass_road,S2S1,0.9,2035,10
+SSP5,Mix2,below GDP cutoff,,,Bus,trn_pass_road,S2S1,1,2050,10
+SSP5,Mix2,below GDP cutoff,,,trn_pass_road_LDV,trn_pass_road,S2S1,0.9,2035,10
+SSP5,Mix2,above GDP cutoff,BEV,Bus,Bus,trn_pass_road,FV,2,2035,10
+SSP5,Mix2,above GDP cutoff,FCEV,Bus,Bus,trn_pass_road,FV,2,2035,10
+SSP5,Mix2,above GDP cutoff,Liquids,Bus,Bus,trn_pass_road,FV,1,2050,10
+SSP5,Mix2,above GDP cutoff,Hydrogen,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SSP5,Mix2,above GDP cutoff,Liquids,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SSP5,Mix2,above GDP cutoff,Liquids,Ship,Domestic Ship_tmp_subsectorL2,Domestic Ship,FV,1,2050,10
+SSP5,Mix2,above GDP cutoff,Electric,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SSP5,Mix2,above GDP cutoff,Liquids,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SSP5,Mix2,above GDP cutoff,Electric,Rail,HSR_tmp_subsectorL2,HSR,FV,1,2050,10
+SSP5,Mix2,above GDP cutoff,Liquids,Aviation,International Aviation_tmp_subsectorL2,International Aviation,FV,1,2050,10
+SSP5,Mix2,above GDP cutoff,Liquids,Ship,International Ship_tmp_subsectorL2,International Ship,FV,1,2050,10
+SSP5,Mix2,above GDP cutoff,BEV,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SSP5,Mix2,above GDP cutoff,Liquids,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SSP5,Mix2,above GDP cutoff,Electric,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SSP5,Mix2,above GDP cutoff,Liquids,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SSP5,Mix2,above GDP cutoff,BEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,2,2035,10
+SSP5,Mix2,above GDP cutoff,FCEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,2,2035,10
+SSP5,Mix2,above GDP cutoff,Liquids,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,10
+SSP5,Mix2,above GDP cutoff,BEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,2,2035,10
+SSP5,Mix2,above GDP cutoff,FCEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,2,2035,10
+SSP5,Mix2,above GDP cutoff,Liquids,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,10
+SSP5,Mix2,below GDP cutoff,BEV,Bus,Bus,trn_pass_road,FV,1.5,2035,10
+SSP5,Mix2,below GDP cutoff,FCEV,Bus,Bus,trn_pass_road,FV,1.5,2035,10
+SSP5,Mix2,below GDP cutoff,Liquids,Bus,Bus,trn_pass_road,FV,1,2050,10
+SSP5,Mix2,below GDP cutoff,Hydrogen,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SSP5,Mix2,below GDP cutoff,Liquids,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SSP5,Mix2,below GDP cutoff,Liquids,Ship,Domestic Ship_tmp_subsectorL2,Domestic Ship,FV,1,2050,10
+SSP5,Mix2,below GDP cutoff,Electric,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SSP5,Mix2,below GDP cutoff,Liquids,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SSP5,Mix2,below GDP cutoff,Electric,Rail,HSR_tmp_subsectorL2,HSR,FV,1,2050,10
+SSP5,Mix2,below GDP cutoff,Liquids,Aviation,International Aviation_tmp_subsectorL2,International Aviation,FV,1,2050,10
+SSP5,Mix2,below GDP cutoff,Liquids,Ship,International Ship_tmp_subsectorL2,International Ship,FV,1,2050,10
+SSP5,Mix2,below GDP cutoff,BEV,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SSP5,Mix2,below GDP cutoff,Liquids,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SSP5,Mix2,below GDP cutoff,Electric,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SSP5,Mix2,below GDP cutoff,Liquids,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SSP5,Mix2,below GDP cutoff,BEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1.5,2035,10
+SSP5,Mix2,below GDP cutoff,FCEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1.5,2035,10
+SSP5,Mix2,below GDP cutoff,Liquids,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,10
+SSP5,Mix2,below GDP cutoff,BEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1.5,2035,10
+SSP5,Mix2,below GDP cutoff,FCEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1.5,2035,10
+SSP5,Mix2,below GDP cutoff,Liquids,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,10
+SSP5,Mix3,above GDP cutoff,,,,Cycle,S1S,1,2050,10
+SSP5,Mix3,above GDP cutoff,,,,Domestic Aviation,S1S,0.5,2035,10
+SSP5,Mix3,above GDP cutoff,,,,Domestic Ship,S1S,1,2050,10
+SSP5,Mix3,above GDP cutoff,,,,Freight Rail,S1S,1,2050,10
+SSP5,Mix3,above GDP cutoff,,,,HSR,S1S,1,2050,10
+SSP5,Mix3,above GDP cutoff,,,,Passenger Rail,S1S,1,2050,10
+SSP5,Mix3,above GDP cutoff,,,,trn_freight_road,S1S,0.7,2035,10
+SSP5,Mix3,above GDP cutoff,,,,trn_pass_road,S1S,0.7,2035,10
+SSP5,Mix3,above GDP cutoff,,,,Walk,S1S,1,2050,10
+SSP5,Mix3,below GDP cutoff,,,,Cycle,S1S,1,2050,10
+SSP5,Mix3,below GDP cutoff,,,,Domestic Aviation,S1S,0.5,2035,10
+SSP5,Mix3,below GDP cutoff,,,,Domestic Ship,S1S,1,2050,10
+SSP5,Mix3,below GDP cutoff,,,,Freight Rail,S1S,1,2050,10
+SSP5,Mix3,below GDP cutoff,,,,HSR,S1S,1,2050,10
+SSP5,Mix3,below GDP cutoff,,,,Passenger Rail,S1S,1,2050,10
+SSP5,Mix3,below GDP cutoff,,,,trn_freight_road,S1S,0.7,2035,10
+SSP5,Mix3,below GDP cutoff,,,,trn_pass_road,S1S,0.7,2035,10
+SSP5,Mix3,below GDP cutoff,,,,Walk,S1S,1,2050,10
+SSP5,Mix3,above GDP cutoff,,,Bus,trn_pass_road,S2S1,1,2050,10
+SSP5,Mix3,above GDP cutoff,,,trn_pass_road_LDV,trn_pass_road,S2S1,0.7,2035,10
+SSP5,Mix3,below GDP cutoff,,,Bus,trn_pass_road,S2S1,1,2050,10
+SSP5,Mix3,below GDP cutoff,,,trn_pass_road_LDV,trn_pass_road,S2S1,0.7,2035,10
+SSP5,Mix3,above GDP cutoff,BEV,Bus,Bus,trn_pass_road,FV,4,2035,10
+SSP5,Mix3,above GDP cutoff,FCEV,Bus,Bus,trn_pass_road,FV,4,2035,10
+SSP5,Mix3,above GDP cutoff,Liquids,Bus,Bus,trn_pass_road,FV,1,2050,10
+SSP5,Mix3,above GDP cutoff,Hydrogen,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SSP5,Mix3,above GDP cutoff,Liquids,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SSP5,Mix3,above GDP cutoff,Liquids,Ship,Domestic Ship_tmp_subsectorL2,Domestic Ship,FV,1,2050,10
+SSP5,Mix3,above GDP cutoff,Electric,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SSP5,Mix3,above GDP cutoff,Liquids,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SSP5,Mix3,above GDP cutoff,Electric,Rail,HSR_tmp_subsectorL2,HSR,FV,1,2050,10
+SSP5,Mix3,above GDP cutoff,Liquids,Aviation,International Aviation_tmp_subsectorL2,International Aviation,FV,1,2050,10
+SSP5,Mix3,above GDP cutoff,Liquids,Ship,International Ship_tmp_subsectorL2,International Ship,FV,1,2050,10
+SSP5,Mix3,above GDP cutoff,BEV,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SSP5,Mix3,above GDP cutoff,Liquids,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SSP5,Mix3,above GDP cutoff,Electric,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SSP5,Mix3,above GDP cutoff,Liquids,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SSP5,Mix3,above GDP cutoff,BEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,4,2035,10
+SSP5,Mix3,above GDP cutoff,FCEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,4,2035,10
+SSP5,Mix3,above GDP cutoff,Liquids,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,10
+SSP5,Mix3,above GDP cutoff,BEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,7,2035,10
+SSP5,Mix3,above GDP cutoff,FCEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,20,2035,10
+SSP5,Mix3,above GDP cutoff,Liquids,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,10
+SSP5,Mix3,below GDP cutoff,BEV,Bus,Bus,trn_pass_road,FV,3.5,2035,10
+SSP5,Mix3,below GDP cutoff,FCEV,Bus,Bus,trn_pass_road,FV,3.5,2035,10
+SSP5,Mix3,below GDP cutoff,Liquids,Bus,Bus,trn_pass_road,FV,1,2050,10
+SSP5,Mix3,below GDP cutoff,Hydrogen,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SSP5,Mix3,below GDP cutoff,Liquids,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SSP5,Mix3,below GDP cutoff,Liquids,Ship,Domestic Ship_tmp_subsectorL2,Domestic Ship,FV,1,2050,10
+SSP5,Mix3,below GDP cutoff,Electric,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SSP5,Mix3,below GDP cutoff,Liquids,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SSP5,Mix3,below GDP cutoff,Electric,Rail,HSR_tmp_subsectorL2,HSR,FV,1,2050,10
+SSP5,Mix3,below GDP cutoff,Liquids,Aviation,International Aviation_tmp_subsectorL2,International Aviation,FV,1,2050,10
+SSP5,Mix3,below GDP cutoff,Liquids,Ship,International Ship_tmp_subsectorL2,International Ship,FV,1,2050,10
+SSP5,Mix3,below GDP cutoff,BEV,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SSP5,Mix3,below GDP cutoff,Liquids,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SSP5,Mix3,below GDP cutoff,Electric,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SSP5,Mix3,below GDP cutoff,Liquids,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SSP5,Mix3,below GDP cutoff,BEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,3.5,2035,10
+SSP5,Mix3,below GDP cutoff,FCEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,3.5,2035,10
+SSP5,Mix3,below GDP cutoff,Liquids,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,10
+SSP5,Mix3,below GDP cutoff,BEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,5,2035,10
+SSP5,Mix3,below GDP cutoff,FCEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,17,2035,10
+SSP5,Mix3,below GDP cutoff,Liquids,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,10
+SSP5,Mix4,above GDP cutoff,,,,Cycle,S1S,1,2050,10
+SSP5,Mix4,above GDP cutoff,,,,Domestic Aviation,S1S,0.25,2035,10
+SSP5,Mix4,above GDP cutoff,,,,Domestic Ship,S1S,1,2050,10
+SSP5,Mix4,above GDP cutoff,,,,Freight Rail,S1S,1,2050,10
+SSP5,Mix4,above GDP cutoff,,,,HSR,S1S,1,2050,10
+SSP5,Mix4,above GDP cutoff,,,,Passenger Rail,S1S,1,2050,10
+SSP5,Mix4,above GDP cutoff,,,,trn_freight_road,S1S,0.5,2035,10
+SSP5,Mix4,above GDP cutoff,,,,trn_pass_road,S1S,0.5,2035,10
+SSP5,Mix4,above GDP cutoff,,,,Walk,S1S,1,2050,10
+SSP5,Mix4,below GDP cutoff,,,,Cycle,S1S,1,2050,10
+SSP5,Mix4,below GDP cutoff,,,,Domestic Aviation,S1S,0.25,2035,10
+SSP5,Mix4,below GDP cutoff,,,,Domestic Ship,S1S,1,2050,10
+SSP5,Mix4,below GDP cutoff,,,,Freight Rail,S1S,1,2050,10
+SSP5,Mix4,below GDP cutoff,,,,HSR,S1S,1,2050,10
+SSP5,Mix4,below GDP cutoff,,,,Passenger Rail,S1S,1,2050,10
+SSP5,Mix4,below GDP cutoff,,,,trn_freight_road,S1S,0.5,2035,10
+SSP5,Mix4,below GDP cutoff,,,,trn_pass_road,S1S,0.5,2035,10
+SSP5,Mix4,below GDP cutoff,,,,Walk,S1S,1,2050,10
+SSP5,Mix4,above GDP cutoff,,,Bus,trn_pass_road,S2S1,1,2050,10
+SSP5,Mix4,above GDP cutoff,,,trn_pass_road_LDV,trn_pass_road,S2S1,0.5,2035,10
+SSP5,Mix4,below GDP cutoff,,,Bus,trn_pass_road,S2S1,1,2050,10
+SSP5,Mix4,below GDP cutoff,,,trn_pass_road_LDV,trn_pass_road,S2S1,0.5,2035,10
+SSP5,Mix4,above GDP cutoff,BEV,Bus,Bus,trn_pass_road,FV,6,2035,10
+SSP5,Mix4,above GDP cutoff,FCEV,Bus,Bus,trn_pass_road,FV,6,2035,10
+SSP5,Mix4,above GDP cutoff,Liquids,Bus,Bus,trn_pass_road,FV,1,2050,10
+SSP5,Mix4,above GDP cutoff,Hydrogen,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SSP5,Mix4,above GDP cutoff,Liquids,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SSP5,Mix4,above GDP cutoff,Liquids,Ship,Domestic Ship_tmp_subsectorL2,Domestic Ship,FV,1,2050,10
+SSP5,Mix4,above GDP cutoff,Electric,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SSP5,Mix4,above GDP cutoff,Liquids,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SSP5,Mix4,above GDP cutoff,Electric,Rail,HSR_tmp_subsectorL2,HSR,FV,1,2050,10
+SSP5,Mix4,above GDP cutoff,Liquids,Aviation,International Aviation_tmp_subsectorL2,International Aviation,FV,1,2050,10
+SSP5,Mix4,above GDP cutoff,Liquids,Ship,International Ship_tmp_subsectorL2,International Ship,FV,1,2050,10
+SSP5,Mix4,above GDP cutoff,BEV,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SSP5,Mix4,above GDP cutoff,Liquids,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SSP5,Mix4,above GDP cutoff,Electric,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SSP5,Mix4,above GDP cutoff,Liquids,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SSP5,Mix4,above GDP cutoff,BEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,6,2035,10
+SSP5,Mix4,above GDP cutoff,FCEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,6,2035,10
+SSP5,Mix4,above GDP cutoff,Liquids,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,10
+SSP5,Mix4,above GDP cutoff,BEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,20,2035,10
+SSP5,Mix4,above GDP cutoff,FCEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,100,2035,10
+SSP5,Mix4,above GDP cutoff,Liquids,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,10
+SSP5,Mix4,below GDP cutoff,BEV,Bus,Bus,trn_pass_road,FV,5,2035,10
+SSP5,Mix4,below GDP cutoff,FCEV,Bus,Bus,trn_pass_road,FV,5,2035,10
+SSP5,Mix4,below GDP cutoff,Liquids,Bus,Bus,trn_pass_road,FV,1,2050,10
+SSP5,Mix4,below GDP cutoff,Hydrogen,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SSP5,Mix4,below GDP cutoff,Liquids,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SSP5,Mix4,below GDP cutoff,Liquids,Ship,Domestic Ship_tmp_subsectorL2,Domestic Ship,FV,1,2050,10
+SSP5,Mix4,below GDP cutoff,Electric,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SSP5,Mix4,below GDP cutoff,Liquids,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SSP5,Mix4,below GDP cutoff,Electric,Rail,HSR_tmp_subsectorL2,HSR,FV,1,2050,10
+SSP5,Mix4,below GDP cutoff,Liquids,Aviation,International Aviation_tmp_subsectorL2,International Aviation,FV,1,2050,10
+SSP5,Mix4,below GDP cutoff,Liquids,Ship,International Ship_tmp_subsectorL2,International Ship,FV,1,2050,10
+SSP5,Mix4,below GDP cutoff,BEV,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SSP5,Mix4,below GDP cutoff,Liquids,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SSP5,Mix4,below GDP cutoff,Electric,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SSP5,Mix4,below GDP cutoff,Liquids,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SSP5,Mix4,below GDP cutoff,BEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,5,2035,10
+SSP5,Mix4,below GDP cutoff,FCEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,5,2035,10
+SSP5,Mix4,below GDP cutoff,Liquids,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,10
+SSP5,Mix4,below GDP cutoff,BEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,17,2035,10
+SSP5,Mix4,below GDP cutoff,FCEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,85,2035,10
+SSP5,Mix4,below GDP cutoff,Liquids,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,10
+SSP3,CAMP_lscStrong,CAZ,,,,Cycle,S1S,2.5,2040,10
+SSP3,CAMP_lscStrong,CAZ,,,,Domestic Aviation,S1S,0.3,2040,10
+SSP3,CAMP_lscStrong,CAZ,,,,Domestic Ship,S1S,1,2040,10
+SSP3,CAMP_lscStrong,CAZ,,,,Freight Rail,S1S,1,2040,10
+SSP3,CAMP_lscStrong,CAZ,,,,HSR,S1S,1.7,2040,10
+SSP3,CAMP_lscStrong,CAZ,,,,Passenger Rail,S1S,4,2040,10
+SSP3,CAMP_lscStrong,CAZ,,,,trn_freight_road,S1S,0.9,2040,10
+SSP3,CAMP_lscStrong,CAZ,,,,trn_pass_road,S1S,0.6,2040,10
+SSP3,CAMP_lscStrong,CAZ,,,,Walk,S1S,2.5,2040,10
+SSP3,CAMP_lscStrong,USA,,,,Cycle,S1S,2.5,2040,10
+SSP3,CAMP_lscStrong,USA,,,,Domestic Aviation,S1S,0.3,2040,10
+SSP3,CAMP_lscStrong,USA,,,,Domestic Ship,S1S,1,2040,10
+SSP3,CAMP_lscStrong,USA,,,,Freight Rail,S1S,1,2040,10
+SSP3,CAMP_lscStrong,USA,,,,HSR,S1S,1.7,2040,10
+SSP3,CAMP_lscStrong,USA,,,,Passenger Rail,S1S,4,2040,10
+SSP3,CAMP_lscStrong,USA,,,,trn_freight_road,S1S,0.9,2040,10
+SSP3,CAMP_lscStrong,USA,,,,trn_pass_road,S1S,0.6,2040,10
+SSP3,CAMP_lscStrong,USA,,,,Walk,S1S,2.5,2040,10
+SSP3,CAMP_lscStrong,above GDP cutoff,,,,Cycle,S1S,3,2040,10
+SSP3,CAMP_lscStrong,above GDP cutoff,,,,Domestic Aviation,S1S,0.3,2040,10
+SSP3,CAMP_lscStrong,above GDP cutoff,,,,Domestic Ship,S1S,1,2040,10
+SSP3,CAMP_lscStrong,above GDP cutoff,,,,Freight Rail,S1S,1,2040,10
+SSP3,CAMP_lscStrong,above GDP cutoff,,,,HSR,S1S,2,2040,10
+SSP3,CAMP_lscStrong,above GDP cutoff,,,,Passenger Rail,S1S,2,2040,10
+SSP3,CAMP_lscStrong,above GDP cutoff,,,,trn_freight_road,S1S,0.7,2040,10
+SSP3,CAMP_lscStrong,above GDP cutoff,,,,trn_pass_road,S1S,0.75,2040,10
+SSP3,CAMP_lscStrong,above GDP cutoff,,,,Walk,S1S,3,2040,10
+SSP3,CAMP_lscStrong,below GDP cutoff,,,,Cycle,S1S,2.5,2040,10
+SSP3,CAMP_lscStrong,below GDP cutoff,,,,Domestic Aviation,S1S,0.3,2040,10
+SSP3,CAMP_lscStrong,below GDP cutoff,,,,Domestic Ship,S1S,1,2040,10
+SSP3,CAMP_lscStrong,below GDP cutoff,,,,Freight Rail,S1S,1,2040,10
+SSP3,CAMP_lscStrong,below GDP cutoff,,,,HSR,S1S,2.8,2040,10
+SSP3,CAMP_lscStrong,below GDP cutoff,,,,Passenger Rail,S1S,1.5,2040,10
+SSP3,CAMP_lscStrong,below GDP cutoff,,,,trn_freight_road,S1S,0.9,2040,10
+SSP3,CAMP_lscStrong,below GDP cutoff,,,,trn_pass_road,S1S,0.7,2040,10
+SSP3,CAMP_lscStrong,below GDP cutoff,,,,Walk,S1S,2.5,2040,10
+SSP3,CAMP_lscStrong,CAZ,,,Bus,trn_pass_road,S2S1,3,2040,10
+SSP3,CAMP_lscStrong,CAZ,,,trn_pass_road_LDV,trn_pass_road,S2S1,0.7,2040,10
+SSP3,CAMP_lscStrong,USA,,,Bus,trn_pass_road,S2S1,2,2040,10
+SSP3,CAMP_lscStrong,USA,,,trn_pass_road_LDV,trn_pass_road,S2S1,0.7,2040,10
+SSP3,CAMP_lscStrong,above GDP cutoff,,,Bus,trn_pass_road,S2S1,2.5,2040,10
+SSP3,CAMP_lscStrong,above GDP cutoff,,,trn_pass_road_LDV,trn_pass_road,S2S1,0.75,2035,10
+SSP3,CAMP_lscStrong,below GDP cutoff,,,Bus,trn_pass_road,S2S1,2,2040,10
+SSP3,CAMP_lscStrong,below GDP cutoff,,,trn_pass_road_LDV,trn_pass_road,S2S1,1,2040,10
+SSP3,CAMP_lscStrong,CAZ,BEV,Bus,Bus,trn_pass_road,FV,2,2040,10
+SSP3,CAMP_lscStrong,CAZ,FCEV,Bus,Bus,trn_pass_road,FV,1.5,2040,10
+SSP3,CAMP_lscStrong,CAZ,Liquids,Bus,Bus,trn_pass_road,FV,1,2050,10
+SSP3,CAMP_lscStrong,CAZ,Hydrogen,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SSP3,CAMP_lscStrong,CAZ,Liquids,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SSP3,CAMP_lscStrong,CAZ,Liquids,Ship,Domestic Ship_tmp_subsectorL2,Domestic Ship,FV,1,2050,10
+SSP3,CAMP_lscStrong,CAZ,Electric,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SSP3,CAMP_lscStrong,CAZ,Liquids,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SSP3,CAMP_lscStrong,CAZ,Electric,Rail,HSR_tmp_subsectorL2,HSR,FV,1,2050,10
+SSP3,CAMP_lscStrong,CAZ,Liquids,Aviation,International Aviation_tmp_subsectorL2,International Aviation,FV,1,2050,10
+SSP3,CAMP_lscStrong,CAZ,Liquids,Ship,International Ship_tmp_subsectorL2,International Ship,FV,1,2050,10
+SSP3,CAMP_lscStrong,CAZ,BEV,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SSP3,CAMP_lscStrong,CAZ,Liquids,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SSP3,CAMP_lscStrong,CAZ,Electric,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SSP3,CAMP_lscStrong,CAZ,Liquids,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SSP3,CAMP_lscStrong,CAZ,BEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,3,2040,10
+SSP3,CAMP_lscStrong,CAZ,FCEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,2,2040,10
+SSP3,CAMP_lscStrong,CAZ,Liquids,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,10
+SSP3,CAMP_lscStrong,CAZ,BEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,3,2040,10
+SSP3,CAMP_lscStrong,CAZ,FCEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,2,2040,10
+SSP3,CAMP_lscStrong,CAZ,Liquids,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,10
+SSP3,CAMP_lscStrong,USA,BEV,Bus,Bus,trn_pass_road,FV,4,2035,10
+SSP3,CAMP_lscStrong,USA,FCEV,Bus,Bus,trn_pass_road,FV,2,2035,10
+SSP3,CAMP_lscStrong,USA,Liquids,Bus,Bus,trn_pass_road,FV,1,2050,10
+SSP3,CAMP_lscStrong,USA,Hydrogen,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SSP3,CAMP_lscStrong,USA,Liquids,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SSP3,CAMP_lscStrong,USA,Liquids,Ship,Domestic Ship_tmp_subsectorL2,Domestic Ship,FV,1,2050,10
+SSP3,CAMP_lscStrong,USA,Electric,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SSP3,CAMP_lscStrong,USA,Liquids,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SSP3,CAMP_lscStrong,USA,Electric,Rail,HSR_tmp_subsectorL2,HSR,FV,1,2050,10
+SSP3,CAMP_lscStrong,USA,Liquids,Aviation,International Aviation_tmp_subsectorL2,International Aviation,FV,1,2050,10
+SSP3,CAMP_lscStrong,USA,Liquids,Ship,International Ship_tmp_subsectorL2,International Ship,FV,1,2050,10
+SSP3,CAMP_lscStrong,USA,BEV,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SSP3,CAMP_lscStrong,USA,Liquids,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SSP3,CAMP_lscStrong,USA,Electric,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SSP3,CAMP_lscStrong,USA,Liquids,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SSP3,CAMP_lscStrong,USA,BEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,3,2035,10
+SSP3,CAMP_lscStrong,USA,FCEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,2,2035,10
+SSP3,CAMP_lscStrong,USA,Liquids,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,10
+SSP3,CAMP_lscStrong,USA,BEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,3,2035,10
+SSP3,CAMP_lscStrong,USA,FCEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,2,2035,10
+SSP3,CAMP_lscStrong,USA,Liquids,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,10
+SSP3,CAMP_lscStrong,above GDP cutoff,BEV,Bus,Bus,trn_pass_road,FV,2,2040,10
+SSP3,CAMP_lscStrong,above GDP cutoff,FCEV,Bus,Bus,trn_pass_road,FV,2,2040,10
+SSP3,CAMP_lscStrong,above GDP cutoff,Liquids,Bus,Bus,trn_pass_road,FV,1,2050,10
+SSP3,CAMP_lscStrong,above GDP cutoff,Hydrogen,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SSP3,CAMP_lscStrong,above GDP cutoff,Liquids,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SSP3,CAMP_lscStrong,above GDP cutoff,Liquids,Ship,Domestic Ship_tmp_subsectorL2,Domestic Ship,FV,1,2050,10
+SSP3,CAMP_lscStrong,above GDP cutoff,Electric,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,2,2050,10
+SSP3,CAMP_lscStrong,above GDP cutoff,Liquids,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,2,2050,10
+SSP3,CAMP_lscStrong,above GDP cutoff,Electric,Rail,HSR_tmp_subsectorL2,HSR,FV,2,2050,10
+SSP3,CAMP_lscStrong,above GDP cutoff,Liquids,Aviation,International Aviation_tmp_subsectorL2,International Aviation,FV,1,2050,10
+SSP3,CAMP_lscStrong,above GDP cutoff,Liquids,Ship,International Ship_tmp_subsectorL2,International Ship,FV,1,2050,10
+SSP3,CAMP_lscStrong,above GDP cutoff,BEV,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SSP3,CAMP_lscStrong,above GDP cutoff,Liquids,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SSP3,CAMP_lscStrong,above GDP cutoff,Electric,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,2,2050,10
+SSP3,CAMP_lscStrong,above GDP cutoff,Liquids,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,2,2050,10
+SSP3,CAMP_lscStrong,above GDP cutoff,BEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2040,10
+SSP3,CAMP_lscStrong,above GDP cutoff,FCEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2040,10
+SSP3,CAMP_lscStrong,above GDP cutoff,Liquids,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,10
+SSP3,CAMP_lscStrong,above GDP cutoff,BEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2040,10
+SSP3,CAMP_lscStrong,above GDP cutoff,FCEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2040,10
+SSP3,CAMP_lscStrong,above GDP cutoff,Liquids,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,10
+SSP3,CAMP_lscStrong,below GDP cutoff,BEV,Bus,Bus,trn_pass_road,FV,3,2040,10
+SSP3,CAMP_lscStrong,below GDP cutoff,FCEV,Bus,Bus,trn_pass_road,FV,1.5,2040,10
+SSP3,CAMP_lscStrong,below GDP cutoff,Liquids,Bus,Bus,trn_pass_road,FV,1,2050,10
+SSP3,CAMP_lscStrong,below GDP cutoff,Hydrogen,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SSP3,CAMP_lscStrong,below GDP cutoff,Liquids,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SSP3,CAMP_lscStrong,below GDP cutoff,Liquids,Ship,Domestic Ship_tmp_subsectorL2,Domestic Ship,FV,1,2050,10
+SSP3,CAMP_lscStrong,below GDP cutoff,Electric,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SSP3,CAMP_lscStrong,below GDP cutoff,Liquids,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SSP3,CAMP_lscStrong,below GDP cutoff,Electric,Rail,HSR_tmp_subsectorL2,HSR,FV,1,2050,10
+SSP3,CAMP_lscStrong,below GDP cutoff,Liquids,Aviation,International Aviation_tmp_subsectorL2,International Aviation,FV,1,2050,10
+SSP3,CAMP_lscStrong,below GDP cutoff,Liquids,Ship,International Ship_tmp_subsectorL2,International Ship,FV,1,2050,10
+SSP3,CAMP_lscStrong,below GDP cutoff,BEV,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SSP3,CAMP_lscStrong,below GDP cutoff,Liquids,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SSP3,CAMP_lscStrong,below GDP cutoff,Electric,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SSP3,CAMP_lscStrong,below GDP cutoff,Liquids,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SSP3,CAMP_lscStrong,below GDP cutoff,BEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,2,2040,10
+SSP3,CAMP_lscStrong,below GDP cutoff,FCEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1.5,2040,10
+SSP3,CAMP_lscStrong,below GDP cutoff,Liquids,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,10
+SSP3,CAMP_lscStrong,below GDP cutoff,BEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,2,2040,10
+SSP3,CAMP_lscStrong,below GDP cutoff,FCEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1.5,2040,10
+SSP3,CAMP_lscStrong,below GDP cutoff,Liquids,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,10
+SSP3,CAMP_lscWeak,CAZ,,,,Cycle,S1S,1.75,2040,10
+SSP3,CAMP_lscWeak,CAZ,,,,Domestic Aviation,S1S,0.53,2040,10
+SSP3,CAMP_lscWeak,CAZ,,,,Domestic Ship,S1S,1,2040,10
+SSP3,CAMP_lscWeak,CAZ,,,,Freight Rail,S1S,1,2040,10
+SSP3,CAMP_lscWeak,CAZ,,,,HSR,S1S,1.35,2040,10
+SSP3,CAMP_lscWeak,CAZ,,,,Passenger Rail,S1S,2,2040,10
+SSP3,CAMP_lscWeak,CAZ,,,,trn_freight_road,S1S,0.9,2040,10
+SSP3,CAMP_lscWeak,CAZ,,,,trn_pass_road,S1S,0.65,2040,10
+SSP3,CAMP_lscWeak,CAZ,,,,Walk,S1S,1.75,2040,10
+SSP3,CAMP_lscWeak,USA,,,,Cycle,S1S,1.75,2040,10
+SSP3,CAMP_lscWeak,USA,,,,Domestic Aviation,S1S,0.53,2040,10
+SSP3,CAMP_lscWeak,USA,,,,Domestic Ship,S1S,1,2040,10
+SSP3,CAMP_lscWeak,USA,,,,Freight Rail,S1S,1,2040,10
+SSP3,CAMP_lscWeak,USA,,,,HSR,S1S,1.35,2040,10
+SSP3,CAMP_lscWeak,USA,,,,Passenger Rail,S1S,2,2040,10
+SSP3,CAMP_lscWeak,USA,,,,trn_freight_road,S1S,0.9,2040,10
+SSP3,CAMP_lscWeak,USA,,,,trn_pass_road,S1S,0.65,2040,10
+SSP3,CAMP_lscWeak,USA,,,,Walk,S1S,1.75,2040,10
+SSP3,CAMP_lscWeak,above GDP cutoff,,,,Cycle,S1S,2.25,2040,10
+SSP3,CAMP_lscWeak,above GDP cutoff,,,,Domestic Aviation,S1S,0.4,2040,10
+SSP3,CAMP_lscWeak,above GDP cutoff,,,,Domestic Ship,S1S,1,2040,10
+SSP3,CAMP_lscWeak,above GDP cutoff,,,,Freight Rail,S1S,1,2040,10
+SSP3,CAMP_lscWeak,above GDP cutoff,,,,HSR,S1S,1.6,2040,10
+SSP3,CAMP_lscWeak,above GDP cutoff,,,,Passenger Rail,S1S,1.6,2040,10
+SSP3,CAMP_lscWeak,above GDP cutoff,,,,trn_freight_road,S1S,0.75,2040,10
+SSP3,CAMP_lscWeak,above GDP cutoff,,,,trn_pass_road,S1S,0.8,2040,10
+SSP3,CAMP_lscWeak,above GDP cutoff,,,,Walk,S1S,2.25,2040,10
+SSP3,CAMP_lscWeak,below GDP cutoff,,,,Cycle,S1S,1.75,2040,10
+SSP3,CAMP_lscWeak,below GDP cutoff,,,,Domestic Aviation,S1S,0.53,2040,10
+SSP3,CAMP_lscWeak,below GDP cutoff,,,,Domestic Ship,S1S,1,2040,10
+SSP3,CAMP_lscWeak,below GDP cutoff,,,,Freight Rail,S1S,1,2040,10
+SSP3,CAMP_lscWeak,below GDP cutoff,,,,HSR,S1S,1.9,2040,10
+SSP3,CAMP_lscWeak,below GDP cutoff,,,,Passenger Rail,S1S,1.25,2040,10
+SSP3,CAMP_lscWeak,below GDP cutoff,,,,trn_freight_road,S1S,0.9,2040,10
+SSP3,CAMP_lscWeak,below GDP cutoff,,,,trn_pass_road,S1S,0.8,2040,10
+SSP3,CAMP_lscWeak,below GDP cutoff,,,,Walk,S1S,1.75,2040,10
+SSP3,CAMP_lscWeak,CAZ,,,Bus,trn_pass_road,S2S1,2,2040,10
+SSP3,CAMP_lscWeak,CAZ,,,trn_pass_road_LDV,trn_pass_road,S2S1,0.7,2040,10
+SSP3,CAMP_lscWeak,USA,,,Bus,trn_pass_road,S2S1,1.5,2040,10
+SSP3,CAMP_lscWeak,USA,,,trn_pass_road_LDV,trn_pass_road,S2S1,0.7,2040,10
+SSP3,CAMP_lscWeak,above GDP cutoff,,,Bus,trn_pass_road,S2S1,2,2040,10
+SSP3,CAMP_lscWeak,above GDP cutoff,,,trn_pass_road_LDV,trn_pass_road,S2S1,0.8,2035,10
+SSP3,CAMP_lscWeak,below GDP cutoff,,,Bus,trn_pass_road,S2S1,1.5,2040,10
+SSP3,CAMP_lscWeak,below GDP cutoff,,,trn_pass_road_LDV,trn_pass_road,S2S1,0.95,2040,10
+SSP3,CAMP_lscWeak,CAZ,BEV,Bus,Bus,trn_pass_road,FV,2,2040,10
+SSP3,CAMP_lscWeak,CAZ,FCEV,Bus,Bus,trn_pass_road,FV,1.5,2040,10
+SSP3,CAMP_lscWeak,CAZ,Liquids,Bus,Bus,trn_pass_road,FV,1,2050,10
+SSP3,CAMP_lscWeak,CAZ,Hydrogen,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SSP3,CAMP_lscWeak,CAZ,Liquids,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SSP3,CAMP_lscWeak,CAZ,Liquids,Ship,Domestic Ship_tmp_subsectorL2,Domestic Ship,FV,1,2050,10
+SSP3,CAMP_lscWeak,CAZ,Electric,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SSP3,CAMP_lscWeak,CAZ,Liquids,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SSP3,CAMP_lscWeak,CAZ,Electric,Rail,HSR_tmp_subsectorL2,HSR,FV,1,2050,10
+SSP3,CAMP_lscWeak,CAZ,Liquids,Aviation,International Aviation_tmp_subsectorL2,International Aviation,FV,1,2050,10
+SSP3,CAMP_lscWeak,CAZ,Liquids,Ship,International Ship_tmp_subsectorL2,International Ship,FV,1,2050,10
+SSP3,CAMP_lscWeak,CAZ,BEV,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SSP3,CAMP_lscWeak,CAZ,Liquids,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SSP3,CAMP_lscWeak,CAZ,Electric,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SSP3,CAMP_lscWeak,CAZ,Liquids,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SSP3,CAMP_lscWeak,CAZ,BEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,3,2040,10
+SSP3,CAMP_lscWeak,CAZ,FCEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,2,2040,10
+SSP3,CAMP_lscWeak,CAZ,Liquids,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,10
+SSP3,CAMP_lscWeak,CAZ,BEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,3,2040,10
+SSP3,CAMP_lscWeak,CAZ,FCEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,2,2040,10
+SSP3,CAMP_lscWeak,CAZ,Liquids,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,10
+SSP3,CAMP_lscWeak,USA,BEV,Bus,Bus,trn_pass_road,FV,2,2035,10
+SSP3,CAMP_lscWeak,USA,FCEV,Bus,Bus,trn_pass_road,FV,2,2035,10
+SSP3,CAMP_lscWeak,USA,Liquids,Bus,Bus,trn_pass_road,FV,1,2050,10
+SSP3,CAMP_lscWeak,USA,Hydrogen,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SSP3,CAMP_lscWeak,USA,Liquids,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SSP3,CAMP_lscWeak,USA,Liquids,Ship,Domestic Ship_tmp_subsectorL2,Domestic Ship,FV,1,2050,10
+SSP3,CAMP_lscWeak,USA,Electric,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SSP3,CAMP_lscWeak,USA,Liquids,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SSP3,CAMP_lscWeak,USA,Electric,Rail,HSR_tmp_subsectorL2,HSR,FV,1,2050,10
+SSP3,CAMP_lscWeak,USA,Liquids,Aviation,International Aviation_tmp_subsectorL2,International Aviation,FV,1,2050,10
+SSP3,CAMP_lscWeak,USA,Liquids,Ship,International Ship_tmp_subsectorL2,International Ship,FV,1,2050,10
+SSP3,CAMP_lscWeak,USA,BEV,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SSP3,CAMP_lscWeak,USA,Liquids,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SSP3,CAMP_lscWeak,USA,Electric,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SSP3,CAMP_lscWeak,USA,Liquids,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SSP3,CAMP_lscWeak,USA,BEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,3,2035,10
+SSP3,CAMP_lscWeak,USA,FCEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,2,2035,10
+SSP3,CAMP_lscWeak,USA,Liquids,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,10
+SSP3,CAMP_lscWeak,USA,BEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,3,2035,10
+SSP3,CAMP_lscWeak,USA,FCEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,2,2035,10
+SSP3,CAMP_lscWeak,USA,Liquids,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,10
+SSP3,CAMP_lscWeak,above GDP cutoff,BEV,Bus,Bus,trn_pass_road,FV,2,2040,10
+SSP3,CAMP_lscWeak,above GDP cutoff,FCEV,Bus,Bus,trn_pass_road,FV,2,2040,10
+SSP3,CAMP_lscWeak,above GDP cutoff,Liquids,Bus,Bus,trn_pass_road,FV,1,2050,10
+SSP3,CAMP_lscWeak,above GDP cutoff,Hydrogen,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SSP3,CAMP_lscWeak,above GDP cutoff,Liquids,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SSP3,CAMP_lscWeak,above GDP cutoff,Liquids,Ship,Domestic Ship_tmp_subsectorL2,Domestic Ship,FV,1,2050,10
+SSP3,CAMP_lscWeak,above GDP cutoff,Electric,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1.5,2050,10
+SSP3,CAMP_lscWeak,above GDP cutoff,Liquids,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1.5,2050,10
+SSP3,CAMP_lscWeak,above GDP cutoff,Electric,Rail,HSR_tmp_subsectorL2,HSR,FV,1.5,2050,10
+SSP3,CAMP_lscWeak,above GDP cutoff,Liquids,Aviation,International Aviation_tmp_subsectorL2,International Aviation,FV,1,2050,10
+SSP3,CAMP_lscWeak,above GDP cutoff,Liquids,Ship,International Ship_tmp_subsectorL2,International Ship,FV,1,2050,10
+SSP3,CAMP_lscWeak,above GDP cutoff,BEV,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SSP3,CAMP_lscWeak,above GDP cutoff,Liquids,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SSP3,CAMP_lscWeak,above GDP cutoff,Electric,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1.5,2050,10
+SSP3,CAMP_lscWeak,above GDP cutoff,Liquids,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1.5,2050,10
+SSP3,CAMP_lscWeak,above GDP cutoff,BEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2040,10
+SSP3,CAMP_lscWeak,above GDP cutoff,FCEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2040,10
+SSP3,CAMP_lscWeak,above GDP cutoff,Liquids,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,10
+SSP3,CAMP_lscWeak,above GDP cutoff,BEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2040,10
+SSP3,CAMP_lscWeak,above GDP cutoff,FCEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2040,10
+SSP3,CAMP_lscWeak,above GDP cutoff,Liquids,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,10
+SSP3,CAMP_lscWeak,below GDP cutoff,BEV,Bus,Bus,trn_pass_road,FV,1.5,2040,10
+SSP3,CAMP_lscWeak,below GDP cutoff,FCEV,Bus,Bus,trn_pass_road,FV,1.5,2040,10
+SSP3,CAMP_lscWeak,below GDP cutoff,Liquids,Bus,Bus,trn_pass_road,FV,1,2050,10
+SSP3,CAMP_lscWeak,below GDP cutoff,Hydrogen,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SSP3,CAMP_lscWeak,below GDP cutoff,Liquids,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SSP3,CAMP_lscWeak,below GDP cutoff,Liquids,Ship,Domestic Ship_tmp_subsectorL2,Domestic Ship,FV,1,2050,10
+SSP3,CAMP_lscWeak,below GDP cutoff,Electric,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SSP3,CAMP_lscWeak,below GDP cutoff,Liquids,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SSP3,CAMP_lscWeak,below GDP cutoff,Electric,Rail,HSR_tmp_subsectorL2,HSR,FV,1,2050,10
+SSP3,CAMP_lscWeak,below GDP cutoff,Liquids,Aviation,International Aviation_tmp_subsectorL2,International Aviation,FV,1,2050,10
+SSP3,CAMP_lscWeak,below GDP cutoff,Liquids,Ship,International Ship_tmp_subsectorL2,International Ship,FV,1,2050,10
+SSP3,CAMP_lscWeak,below GDP cutoff,BEV,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SSP3,CAMP_lscWeak,below GDP cutoff,Liquids,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SSP3,CAMP_lscWeak,below GDP cutoff,Electric,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SSP3,CAMP_lscWeak,below GDP cutoff,Liquids,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SSP3,CAMP_lscWeak,below GDP cutoff,BEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,2,2040,10
+SSP3,CAMP_lscWeak,below GDP cutoff,FCEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1.5,2040,10
+SSP3,CAMP_lscWeak,below GDP cutoff,Liquids,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,10
+SSP3,CAMP_lscWeak,below GDP cutoff,BEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,2,2040,10
+SSP3,CAMP_lscWeak,below GDP cutoff,FCEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1.5,2040,10
+SSP3,CAMP_lscWeak,below GDP cutoff,Liquids,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,10
+SSP3,ECEMF_HighEl_HighEff,above GDP cutoff,,,,Cycle,S1S,1.5,2050,10
+SSP3,ECEMF_HighEl_HighEff,above GDP cutoff,,,,Domestic Aviation,S1S,0.5,2035,10
+SSP3,ECEMF_HighEl_HighEff,above GDP cutoff,,,,Domestic Ship,S1S,1.5,2050,10
+SSP3,ECEMF_HighEl_HighEff,above GDP cutoff,,,,Freight Rail,S1S,1.5,2050,10
+SSP3,ECEMF_HighEl_HighEff,above GDP cutoff,,,,HSR,S1S,1,2050,10
+SSP3,ECEMF_HighEl_HighEff,above GDP cutoff,,,,Passenger Rail,S1S,1.5,2050,10
+SSP3,ECEMF_HighEl_HighEff,above GDP cutoff,,,,trn_freight_road,S1S,0.7,2035,10
+SSP3,ECEMF_HighEl_HighEff,above GDP cutoff,,,,trn_pass_road,S1S,0.7,2035,10
+SSP3,ECEMF_HighEl_HighEff,above GDP cutoff,,,,Walk,S1S,1.5,2050,10
+SSP3,ECEMF_HighEl_HighEff,below GDP cutoff,,,,Cycle,S1S,1.5,2050,10
+SSP3,ECEMF_HighEl_HighEff,below GDP cutoff,,,,Domestic Aviation,S1S,0.5,2035,10
+SSP3,ECEMF_HighEl_HighEff,below GDP cutoff,,,,Domestic Ship,S1S,1.5,2050,10
+SSP3,ECEMF_HighEl_HighEff,below GDP cutoff,,,,Freight Rail,S1S,1.5,2050,10
+SSP3,ECEMF_HighEl_HighEff,below GDP cutoff,,,,HSR,S1S,1,2050,10
+SSP3,ECEMF_HighEl_HighEff,below GDP cutoff,,,,Passenger Rail,S1S,1.5,2050,10
+SSP3,ECEMF_HighEl_HighEff,below GDP cutoff,,,,trn_freight_road,S1S,0.7,2035,10
+SSP3,ECEMF_HighEl_HighEff,below GDP cutoff,,,,trn_pass_road,S1S,0.7,2035,10
+SSP3,ECEMF_HighEl_HighEff,below GDP cutoff,,,,Walk,S1S,1.5,2050,10
+SSP3,ECEMF_HighEl_HighEff,above GDP cutoff,,,Bus,trn_pass_road,S2S1,1.5,2050,10
+SSP3,ECEMF_HighEl_HighEff,above GDP cutoff,,,trn_pass_road_LDV,trn_pass_road,S2S1,0.7,2035,10
+SSP3,ECEMF_HighEl_HighEff,below GDP cutoff,,,Bus,trn_pass_road,S2S1,1.5,2050,10
+SSP3,ECEMF_HighEl_HighEff,below GDP cutoff,,,trn_pass_road_LDV,trn_pass_road,S2S1,0.7,2035,10
+SSP3,ECEMF_HighEl_HighEff,above GDP cutoff,BEV,Bus,Bus,trn_pass_road,FV,10,2035,15
+SSP3,ECEMF_HighEl_HighEff,above GDP cutoff,FCEV,Bus,Bus,trn_pass_road,FV,1.1,2035,5
+SSP3,ECEMF_HighEl_HighEff,above GDP cutoff,Liquids,Bus,Bus,trn_pass_road,FV,1,2050,10
+SSP3,ECEMF_HighEl_HighEff,above GDP cutoff,Hydrogen,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1.1,2050,5
+SSP3,ECEMF_HighEl_HighEff,above GDP cutoff,Liquids,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SSP3,ECEMF_HighEl_HighEff,above GDP cutoff,Liquids,Ship,Domestic Ship_tmp_subsectorL2,Domestic Ship,FV,1,2050,10
+SSP3,ECEMF_HighEl_HighEff,above GDP cutoff,Electric,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,5,2050,15
+SSP3,ECEMF_HighEl_HighEff,above GDP cutoff,Liquids,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SSP3,ECEMF_HighEl_HighEff,above GDP cutoff,Electric,Rail,HSR_tmp_subsectorL2,HSR,FV,5,2050,15
+SSP3,ECEMF_HighEl_HighEff,above GDP cutoff,Liquids,Aviation,International Aviation_tmp_subsectorL2,International Aviation,FV,1,2050,10
+SSP3,ECEMF_HighEl_HighEff,above GDP cutoff,Liquids,Ship,International Ship_tmp_subsectorL2,International Ship,FV,1,2050,10
+SSP3,ECEMF_HighEl_HighEff,above GDP cutoff,BEV,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,7,2050,15
+SSP3,ECEMF_HighEl_HighEff,above GDP cutoff,Liquids,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SSP3,ECEMF_HighEl_HighEff,above GDP cutoff,Electric,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,5,2050,15
+SSP3,ECEMF_HighEl_HighEff,above GDP cutoff,Liquids,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SSP3,ECEMF_HighEl_HighEff,above GDP cutoff,BEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,40,2040,3
+SSP3,ECEMF_HighEl_HighEff,above GDP cutoff,FCEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,10,2040,3
+SSP3,ECEMF_HighEl_HighEff,above GDP cutoff,Liquids,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,3
+SSP3,ECEMF_HighEl_HighEff,above GDP cutoff,BEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,50,2040,5
+SSP3,ECEMF_HighEl_HighEff,above GDP cutoff,FCEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,60,2040,3
+SSP3,ECEMF_HighEl_HighEff,above GDP cutoff,Liquids,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,3
+SSP3,ECEMF_HighEl_HighEff,below GDP cutoff,BEV,Bus,Bus,trn_pass_road,FV,13,2030,15
+SSP3,ECEMF_HighEl_HighEff,below GDP cutoff,FCEV,Bus,Bus,trn_pass_road,FV,1.1,2035,5
+SSP3,ECEMF_HighEl_HighEff,below GDP cutoff,Liquids,Bus,Bus,trn_pass_road,FV,1,2050,10
+SSP3,ECEMF_HighEl_HighEff,below GDP cutoff,Hydrogen,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,2,2050,5
+SSP3,ECEMF_HighEl_HighEff,below GDP cutoff,Liquids,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SSP3,ECEMF_HighEl_HighEff,below GDP cutoff,Liquids,Ship,Domestic Ship_tmp_subsectorL2,Domestic Ship,FV,1,2050,10
+SSP3,ECEMF_HighEl_HighEff,below GDP cutoff,Electric,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,6,2040,15
+SSP3,ECEMF_HighEl_HighEff,below GDP cutoff,Liquids,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SSP3,ECEMF_HighEl_HighEff,below GDP cutoff,Electric,Rail,HSR_tmp_subsectorL2,HSR,FV,6,2040,15
+SSP3,ECEMF_HighEl_HighEff,below GDP cutoff,Liquids,Aviation,International Aviation_tmp_subsectorL2,International Aviation,FV,1,2050,10
+SSP3,ECEMF_HighEl_HighEff,below GDP cutoff,Liquids,Ship,International Ship_tmp_subsectorL2,International Ship,FV,1,2050,10
+SSP3,ECEMF_HighEl_HighEff,below GDP cutoff,BEV,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,7,2030,15
+SSP3,ECEMF_HighEl_HighEff,below GDP cutoff,Liquids,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SSP3,ECEMF_HighEl_HighEff,below GDP cutoff,Electric,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,6,2040,15
+SSP3,ECEMF_HighEl_HighEff,below GDP cutoff,Liquids,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SSP3,ECEMF_HighEl_HighEff,below GDP cutoff,BEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,10,2040,3
+SSP3,ECEMF_HighEl_HighEff,below GDP cutoff,FCEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,10,2040,3
+SSP3,ECEMF_HighEl_HighEff,below GDP cutoff,Liquids,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,3
+SSP3,ECEMF_HighEl_HighEff,below GDP cutoff,BEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,5,2035,5
+SSP3,ECEMF_HighEl_HighEff,below GDP cutoff,FCEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,7,2035,3
+SSP3,ECEMF_HighEl_HighEff,below GDP cutoff,Liquids,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,3
+SSP3,ECEMF_HighEl_LifestCha,above GDP cutoff,,,,Cycle,S1S,2,2050,10
+SSP3,ECEMF_HighEl_LifestCha,above GDP cutoff,,,,Domestic Aviation,S1S,0.25,2035,10
+SSP3,ECEMF_HighEl_LifestCha,above GDP cutoff,,,,Domestic Ship,S1S,1.5,2050,10
+SSP3,ECEMF_HighEl_LifestCha,above GDP cutoff,,,,Freight Rail,S1S,1.5,2050,10
+SSP3,ECEMF_HighEl_LifestCha,above GDP cutoff,,,,HSR,S1S,1,2050,10
+SSP3,ECEMF_HighEl_LifestCha,above GDP cutoff,,,,Passenger Rail,S1S,2,2050,10
+SSP3,ECEMF_HighEl_LifestCha,above GDP cutoff,,,,trn_freight_road,S1S,0.7,2035,10
+SSP3,ECEMF_HighEl_LifestCha,above GDP cutoff,,,,trn_pass_road,S1S,0.5,2035,10
+SSP3,ECEMF_HighEl_LifestCha,above GDP cutoff,,,,Walk,S1S,2,2050,10
+SSP3,ECEMF_HighEl_LifestCha,below GDP cutoff,,,,Cycle,S1S,2,2050,10
+SSP3,ECEMF_HighEl_LifestCha,below GDP cutoff,,,,Domestic Aviation,S1S,0.25,2035,10
+SSP3,ECEMF_HighEl_LifestCha,below GDP cutoff,,,,Domestic Ship,S1S,1.5,2050,10
+SSP3,ECEMF_HighEl_LifestCha,below GDP cutoff,,,,Freight Rail,S1S,1.5,2050,10
+SSP3,ECEMF_HighEl_LifestCha,below GDP cutoff,,,,HSR,S1S,1,2050,10
+SSP3,ECEMF_HighEl_LifestCha,below GDP cutoff,,,,Passenger Rail,S1S,2,2050,10
+SSP3,ECEMF_HighEl_LifestCha,below GDP cutoff,,,,trn_freight_road,S1S,0.7,2035,10
+SSP3,ECEMF_HighEl_LifestCha,below GDP cutoff,,,,trn_pass_road,S1S,0.5,2035,10
+SSP3,ECEMF_HighEl_LifestCha,below GDP cutoff,,,,Walk,S1S,2,2050,10
+SSP3,ECEMF_HighEl_LifestCha,above GDP cutoff,,,Bus,trn_pass_road,S2S1,2,2050,10
+SSP3,ECEMF_HighEl_LifestCha,above GDP cutoff,,,trn_pass_road_LDV,trn_pass_road,S2S1,0.5,2035,10
+SSP3,ECEMF_HighEl_LifestCha,below GDP cutoff,,,Bus,trn_pass_road,S2S1,2,2050,10
+SSP3,ECEMF_HighEl_LifestCha,below GDP cutoff,,,trn_pass_road_LDV,trn_pass_road,S2S1,0.5,2035,10
+SSP3,ECEMF_HighEl_LifestCha,above GDP cutoff,BEV,Bus,Bus,trn_pass_road,FV,10,2035,15
+SSP3,ECEMF_HighEl_LifestCha,above GDP cutoff,FCEV,Bus,Bus,trn_pass_road,FV,1.1,2035,5
+SSP3,ECEMF_HighEl_LifestCha,above GDP cutoff,Liquids,Bus,Bus,trn_pass_road,FV,1,2050,10
+SSP3,ECEMF_HighEl_LifestCha,above GDP cutoff,Hydrogen,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1.1,2050,5
+SSP3,ECEMF_HighEl_LifestCha,above GDP cutoff,Liquids,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SSP3,ECEMF_HighEl_LifestCha,above GDP cutoff,Liquids,Ship,Domestic Ship_tmp_subsectorL2,Domestic Ship,FV,1,2050,10
+SSP3,ECEMF_HighEl_LifestCha,above GDP cutoff,Electric,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,5,2050,15
+SSP3,ECEMF_HighEl_LifestCha,above GDP cutoff,Liquids,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SSP3,ECEMF_HighEl_LifestCha,above GDP cutoff,Electric,Rail,HSR_tmp_subsectorL2,HSR,FV,5,2050,15
+SSP3,ECEMF_HighEl_LifestCha,above GDP cutoff,Liquids,Aviation,International Aviation_tmp_subsectorL2,International Aviation,FV,1,2050,10
+SSP3,ECEMF_HighEl_LifestCha,above GDP cutoff,Liquids,Ship,International Ship_tmp_subsectorL2,International Ship,FV,1,2050,10
+SSP3,ECEMF_HighEl_LifestCha,above GDP cutoff,BEV,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,7,2050,15
+SSP3,ECEMF_HighEl_LifestCha,above GDP cutoff,Liquids,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SSP3,ECEMF_HighEl_LifestCha,above GDP cutoff,Electric,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,5,2050,15
+SSP3,ECEMF_HighEl_LifestCha,above GDP cutoff,Liquids,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SSP3,ECEMF_HighEl_LifestCha,above GDP cutoff,BEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,40,2040,3
+SSP3,ECEMF_HighEl_LifestCha,above GDP cutoff,FCEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,10,2040,3
+SSP3,ECEMF_HighEl_LifestCha,above GDP cutoff,Liquids,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,3
+SSP3,ECEMF_HighEl_LifestCha,above GDP cutoff,BEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,50,2040,5
+SSP3,ECEMF_HighEl_LifestCha,above GDP cutoff,FCEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,60,2040,3
+SSP3,ECEMF_HighEl_LifestCha,above GDP cutoff,Liquids,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,3
+SSP3,ECEMF_HighEl_LifestCha,below GDP cutoff,BEV,Bus,Bus,trn_pass_road,FV,13,2030,15
+SSP3,ECEMF_HighEl_LifestCha,below GDP cutoff,FCEV,Bus,Bus,trn_pass_road,FV,1.1,2035,5
+SSP3,ECEMF_HighEl_LifestCha,below GDP cutoff,Liquids,Bus,Bus,trn_pass_road,FV,1,2050,10
+SSP3,ECEMF_HighEl_LifestCha,below GDP cutoff,Hydrogen,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,2,2050,5
+SSP3,ECEMF_HighEl_LifestCha,below GDP cutoff,Liquids,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SSP3,ECEMF_HighEl_LifestCha,below GDP cutoff,Liquids,Ship,Domestic Ship_tmp_subsectorL2,Domestic Ship,FV,1,2050,10
+SSP3,ECEMF_HighEl_LifestCha,below GDP cutoff,Electric,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,6,2040,15
+SSP3,ECEMF_HighEl_LifestCha,below GDP cutoff,Liquids,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SSP3,ECEMF_HighEl_LifestCha,below GDP cutoff,Electric,Rail,HSR_tmp_subsectorL2,HSR,FV,6,2040,15
+SSP3,ECEMF_HighEl_LifestCha,below GDP cutoff,Liquids,Aviation,International Aviation_tmp_subsectorL2,International Aviation,FV,1,2050,10
+SSP3,ECEMF_HighEl_LifestCha,below GDP cutoff,Liquids,Ship,International Ship_tmp_subsectorL2,International Ship,FV,1,2050,10
+SSP3,ECEMF_HighEl_LifestCha,below GDP cutoff,BEV,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,7,2030,15
+SSP3,ECEMF_HighEl_LifestCha,below GDP cutoff,Liquids,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SSP3,ECEMF_HighEl_LifestCha,below GDP cutoff,Electric,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,6,2040,15
+SSP3,ECEMF_HighEl_LifestCha,below GDP cutoff,Liquids,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SSP3,ECEMF_HighEl_LifestCha,below GDP cutoff,BEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,10,2040,3
+SSP3,ECEMF_HighEl_LifestCha,below GDP cutoff,FCEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,10,2040,3
+SSP3,ECEMF_HighEl_LifestCha,below GDP cutoff,Liquids,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,3
+SSP3,ECEMF_HighEl_LifestCha,below GDP cutoff,BEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,5,2035,5
+SSP3,ECEMF_HighEl_LifestCha,below GDP cutoff,FCEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,7,2035,3
+SSP3,ECEMF_HighEl_LifestCha,below GDP cutoff,Liquids,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,3
+SSP3,ECEMF_HighEl_ModEff,above GDP cutoff,,,,Cycle,S1S,1,2050,10
+SSP3,ECEMF_HighEl_ModEff,above GDP cutoff,,,,Domestic Aviation,S1S,0.75,2035,10
+SSP3,ECEMF_HighEl_ModEff,above GDP cutoff,,,,Domestic Ship,S1S,1,2050,10
+SSP3,ECEMF_HighEl_ModEff,above GDP cutoff,,,,Freight Rail,S1S,1,2050,10
+SSP3,ECEMF_HighEl_ModEff,above GDP cutoff,,,,HSR,S1S,1,2050,10
+SSP3,ECEMF_HighEl_ModEff,above GDP cutoff,,,,Passenger Rail,S1S,1,2050,10
+SSP3,ECEMF_HighEl_ModEff,above GDP cutoff,,,,trn_freight_road,S1S,0.9,2035,10
+SSP3,ECEMF_HighEl_ModEff,above GDP cutoff,,,,trn_pass_road,S1S,0.9,2035,10
+SSP3,ECEMF_HighEl_ModEff,above GDP cutoff,,,,Walk,S1S,1,2050,10
+SSP3,ECEMF_HighEl_ModEff,below GDP cutoff,,,,Cycle,S1S,1,2050,10
+SSP3,ECEMF_HighEl_ModEff,below GDP cutoff,,,,Domestic Aviation,S1S,0.75,2035,10
+SSP3,ECEMF_HighEl_ModEff,below GDP cutoff,,,,Domestic Ship,S1S,1,2050,10
+SSP3,ECEMF_HighEl_ModEff,below GDP cutoff,,,,Freight Rail,S1S,1,2050,10
+SSP3,ECEMF_HighEl_ModEff,below GDP cutoff,,,,HSR,S1S,1,2050,10
+SSP3,ECEMF_HighEl_ModEff,below GDP cutoff,,,,Passenger Rail,S1S,1,2050,10
+SSP3,ECEMF_HighEl_ModEff,below GDP cutoff,,,,trn_freight_road,S1S,0.9,2035,10
+SSP3,ECEMF_HighEl_ModEff,below GDP cutoff,,,,trn_pass_road,S1S,0.9,2035,10
+SSP3,ECEMF_HighEl_ModEff,below GDP cutoff,,,,Walk,S1S,1,2050,10
+SSP3,ECEMF_HighEl_ModEff,above GDP cutoff,,,Bus,trn_pass_road,S2S1,1,2050,10
+SSP3,ECEMF_HighEl_ModEff,above GDP cutoff,,,trn_pass_road_LDV,trn_pass_road,S2S1,0.9,2035,10
+SSP3,ECEMF_HighEl_ModEff,below GDP cutoff,,,Bus,trn_pass_road,S2S1,1,2050,10
+SSP3,ECEMF_HighEl_ModEff,below GDP cutoff,,,trn_pass_road_LDV,trn_pass_road,S2S1,0.9,2035,10
+SSP3,ECEMF_HighEl_ModEff,above GDP cutoff,BEV,Bus,Bus,trn_pass_road,FV,6,2035,15
+SSP3,ECEMF_HighEl_ModEff,above GDP cutoff,FCEV,Bus,Bus,trn_pass_road,FV,1.1,2035,5
+SSP3,ECEMF_HighEl_ModEff,above GDP cutoff,Liquids,Bus,Bus,trn_pass_road,FV,1,2050,10
+SSP3,ECEMF_HighEl_ModEff,above GDP cutoff,Hydrogen,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1.1,2050,5
+SSP3,ECEMF_HighEl_ModEff,above GDP cutoff,Liquids,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SSP3,ECEMF_HighEl_ModEff,above GDP cutoff,Liquids,Ship,Domestic Ship_tmp_subsectorL2,Domestic Ship,FV,1,2050,10
+SSP3,ECEMF_HighEl_ModEff,above GDP cutoff,Electric,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,3,2050,15
+SSP3,ECEMF_HighEl_ModEff,above GDP cutoff,Liquids,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SSP3,ECEMF_HighEl_ModEff,above GDP cutoff,Electric,Rail,HSR_tmp_subsectorL2,HSR,FV,3,2050,15
+SSP3,ECEMF_HighEl_ModEff,above GDP cutoff,Liquids,Aviation,International Aviation_tmp_subsectorL2,International Aviation,FV,1,2050,10
+SSP3,ECEMF_HighEl_ModEff,above GDP cutoff,Liquids,Ship,International Ship_tmp_subsectorL2,International Ship,FV,1,2050,10
+SSP3,ECEMF_HighEl_ModEff,above GDP cutoff,BEV,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,3,2050,15
+SSP3,ECEMF_HighEl_ModEff,above GDP cutoff,Liquids,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SSP3,ECEMF_HighEl_ModEff,above GDP cutoff,Electric,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,3,2050,15
+SSP3,ECEMF_HighEl_ModEff,above GDP cutoff,Liquids,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SSP3,ECEMF_HighEl_ModEff,above GDP cutoff,BEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,40,2040,3
+SSP3,ECEMF_HighEl_ModEff,above GDP cutoff,FCEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,10,2040,3
+SSP3,ECEMF_HighEl_ModEff,above GDP cutoff,Liquids,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,3
+SSP3,ECEMF_HighEl_ModEff,above GDP cutoff,BEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,50,2040,5
+SSP3,ECEMF_HighEl_ModEff,above GDP cutoff,FCEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,60,2040,3
+SSP3,ECEMF_HighEl_ModEff,above GDP cutoff,Liquids,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,3
+SSP3,ECEMF_HighEl_ModEff,below GDP cutoff,BEV,Bus,Bus,trn_pass_road,FV,10,2030,15
+SSP3,ECEMF_HighEl_ModEff,below GDP cutoff,FCEV,Bus,Bus,trn_pass_road,FV,1.1,2035,5
+SSP3,ECEMF_HighEl_ModEff,below GDP cutoff,Liquids,Bus,Bus,trn_pass_road,FV,1,2050,10
+SSP3,ECEMF_HighEl_ModEff,below GDP cutoff,Hydrogen,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,2,2050,5
+SSP3,ECEMF_HighEl_ModEff,below GDP cutoff,Liquids,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SSP3,ECEMF_HighEl_ModEff,below GDP cutoff,Liquids,Ship,Domestic Ship_tmp_subsectorL2,Domestic Ship,FV,1,2050,10
+SSP3,ECEMF_HighEl_ModEff,below GDP cutoff,Electric,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,4,2040,15
+SSP3,ECEMF_HighEl_ModEff,below GDP cutoff,Liquids,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SSP3,ECEMF_HighEl_ModEff,below GDP cutoff,Electric,Rail,HSR_tmp_subsectorL2,HSR,FV,4,2040,15
+SSP3,ECEMF_HighEl_ModEff,below GDP cutoff,Liquids,Aviation,International Aviation_tmp_subsectorL2,International Aviation,FV,1,2050,10
+SSP3,ECEMF_HighEl_ModEff,below GDP cutoff,Liquids,Ship,International Ship_tmp_subsectorL2,International Ship,FV,1,2050,10
+SSP3,ECEMF_HighEl_ModEff,below GDP cutoff,BEV,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,5,2030,15
+SSP3,ECEMF_HighEl_ModEff,below GDP cutoff,Liquids,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SSP3,ECEMF_HighEl_ModEff,below GDP cutoff,Electric,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,4,2040,15
+SSP3,ECEMF_HighEl_ModEff,below GDP cutoff,Liquids,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SSP3,ECEMF_HighEl_ModEff,below GDP cutoff,BEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,10,2040,3
+SSP3,ECEMF_HighEl_ModEff,below GDP cutoff,FCEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,10,2040,3
+SSP3,ECEMF_HighEl_ModEff,below GDP cutoff,Liquids,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,3
+SSP3,ECEMF_HighEl_ModEff,below GDP cutoff,BEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,5,2035,5
+SSP3,ECEMF_HighEl_ModEff,below GDP cutoff,FCEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,7,2035,3
+SSP3,ECEMF_HighEl_ModEff,below GDP cutoff,Liquids,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,3
+SSP3,ECEMF_HighH2_HighEff,above GDP cutoff,,,,Cycle,S1S,1.5,2050,10
+SSP3,ECEMF_HighH2_HighEff,above GDP cutoff,,,,Domestic Aviation,S1S,0.5,2035,10
+SSP3,ECEMF_HighH2_HighEff,above GDP cutoff,,,,Domestic Ship,S1S,1.5,2050,10
+SSP3,ECEMF_HighH2_HighEff,above GDP cutoff,,,,Freight Rail,S1S,1.5,2050,10
+SSP3,ECEMF_HighH2_HighEff,above GDP cutoff,,,,HSR,S1S,1,2050,10
+SSP3,ECEMF_HighH2_HighEff,above GDP cutoff,,,,Passenger Rail,S1S,1.5,2050,10
+SSP3,ECEMF_HighH2_HighEff,above GDP cutoff,,,,trn_freight_road,S1S,0.7,2035,10
+SSP3,ECEMF_HighH2_HighEff,above GDP cutoff,,,,trn_pass_road,S1S,0.7,2035,10
+SSP3,ECEMF_HighH2_HighEff,above GDP cutoff,,,,Walk,S1S,1.5,2050,10
+SSP3,ECEMF_HighH2_HighEff,below GDP cutoff,,,,Cycle,S1S,1.5,2050,10
+SSP3,ECEMF_HighH2_HighEff,below GDP cutoff,,,,Domestic Aviation,S1S,0.5,2035,10
+SSP3,ECEMF_HighH2_HighEff,below GDP cutoff,,,,Domestic Ship,S1S,1.5,2050,10
+SSP3,ECEMF_HighH2_HighEff,below GDP cutoff,,,,Freight Rail,S1S,1.5,2050,10
+SSP3,ECEMF_HighH2_HighEff,below GDP cutoff,,,,HSR,S1S,1,2050,10
+SSP3,ECEMF_HighH2_HighEff,below GDP cutoff,,,,Passenger Rail,S1S,1.5,2050,10
+SSP3,ECEMF_HighH2_HighEff,below GDP cutoff,,,,trn_freight_road,S1S,0.7,2035,10
+SSP3,ECEMF_HighH2_HighEff,below GDP cutoff,,,,trn_pass_road,S1S,0.7,2035,10
+SSP3,ECEMF_HighH2_HighEff,below GDP cutoff,,,,Walk,S1S,1.5,2050,10
+SSP3,ECEMF_HighH2_HighEff,above GDP cutoff,,,Bus,trn_pass_road,S2S1,1.5,2050,10
+SSP3,ECEMF_HighH2_HighEff,above GDP cutoff,,,trn_pass_road_LDV,trn_pass_road,S2S1,0.7,2035,10
+SSP3,ECEMF_HighH2_HighEff,below GDP cutoff,,,Bus,trn_pass_road,S2S1,1.5,2050,10
+SSP3,ECEMF_HighH2_HighEff,below GDP cutoff,,,trn_pass_road_LDV,trn_pass_road,S2S1,0.7,2035,10
+SSP3,ECEMF_HighH2_HighEff,above GDP cutoff,BEV,Bus,Bus,trn_pass_road,FV,3,2060,15
+SSP3,ECEMF_HighH2_HighEff,above GDP cutoff,FCEV,Bus,Bus,trn_pass_road,FV,220,2035,5
+SSP3,ECEMF_HighH2_HighEff,above GDP cutoff,Liquids,Bus,Bus,trn_pass_road,FV,1,2050,10
+SSP3,ECEMF_HighH2_HighEff,above GDP cutoff,Hydrogen,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,3,2055,5
+SSP3,ECEMF_HighH2_HighEff,above GDP cutoff,Liquids,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SSP3,ECEMF_HighH2_HighEff,above GDP cutoff,Liquids,Ship,Domestic Ship_tmp_subsectorL2,Domestic Ship,FV,1,2050,10
+SSP3,ECEMF_HighH2_HighEff,above GDP cutoff,Electric,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,2.5,2050,10
+SSP3,ECEMF_HighH2_HighEff,above GDP cutoff,Liquids,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SSP3,ECEMF_HighH2_HighEff,above GDP cutoff,Electric,Rail,HSR_tmp_subsectorL2,HSR,FV,2.5,2050,10
+SSP3,ECEMF_HighH2_HighEff,above GDP cutoff,Liquids,Aviation,International Aviation_tmp_subsectorL2,International Aviation,FV,1,2050,10
+SSP3,ECEMF_HighH2_HighEff,above GDP cutoff,Liquids,Ship,International Ship_tmp_subsectorL2,International Ship,FV,1,2050,10
+SSP3,ECEMF_HighH2_HighEff,above GDP cutoff,BEV,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,3,2050,10
+SSP3,ECEMF_HighH2_HighEff,above GDP cutoff,Liquids,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SSP3,ECEMF_HighH2_HighEff,above GDP cutoff,Electric,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,2.5,2050,10
+SSP3,ECEMF_HighH2_HighEff,above GDP cutoff,Liquids,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SSP3,ECEMF_HighH2_HighEff,above GDP cutoff,BEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,40,2040,3
+SSP3,ECEMF_HighH2_HighEff,above GDP cutoff,FCEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,50,2040,3
+SSP3,ECEMF_HighH2_HighEff,above GDP cutoff,Liquids,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,3
+SSP3,ECEMF_HighH2_HighEff,above GDP cutoff,BEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,40,2040,5
+SSP3,ECEMF_HighH2_HighEff,above GDP cutoff,FCEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,250,2040,3
+SSP3,ECEMF_HighH2_HighEff,above GDP cutoff,Liquids,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,3
+SSP3,ECEMF_HighH2_HighEff,below GDP cutoff,BEV,Bus,Bus,trn_pass_road,FV,3,2060,15
+SSP3,ECEMF_HighH2_HighEff,below GDP cutoff,FCEV,Bus,Bus,trn_pass_road,FV,160,2040,5
+SSP3,ECEMF_HighH2_HighEff,below GDP cutoff,Liquids,Bus,Bus,trn_pass_road,FV,1,2050,10
+SSP3,ECEMF_HighH2_HighEff,below GDP cutoff,Hydrogen,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,5,2055,10
+SSP3,ECEMF_HighH2_HighEff,below GDP cutoff,Liquids,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SSP3,ECEMF_HighH2_HighEff,below GDP cutoff,Liquids,Ship,Domestic Ship_tmp_subsectorL2,Domestic Ship,FV,1,2050,10
+SSP3,ECEMF_HighH2_HighEff,below GDP cutoff,Electric,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,2,2050,10
+SSP3,ECEMF_HighH2_HighEff,below GDP cutoff,Liquids,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SSP3,ECEMF_HighH2_HighEff,below GDP cutoff,Electric,Rail,HSR_tmp_subsectorL2,HSR,FV,2,2050,10
+SSP3,ECEMF_HighH2_HighEff,below GDP cutoff,Liquids,Aviation,International Aviation_tmp_subsectorL2,International Aviation,FV,1,2050,10
+SSP3,ECEMF_HighH2_HighEff,below GDP cutoff,Liquids,Ship,International Ship_tmp_subsectorL2,International Ship,FV,1,2050,10
+SSP3,ECEMF_HighH2_HighEff,below GDP cutoff,BEV,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,3,2050,10
+SSP3,ECEMF_HighH2_HighEff,below GDP cutoff,Liquids,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SSP3,ECEMF_HighH2_HighEff,below GDP cutoff,Electric,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,2,2050,10
+SSP3,ECEMF_HighH2_HighEff,below GDP cutoff,Liquids,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SSP3,ECEMF_HighH2_HighEff,below GDP cutoff,BEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,10,2040,3
+SSP3,ECEMF_HighH2_HighEff,below GDP cutoff,FCEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,10,2040,3
+SSP3,ECEMF_HighH2_HighEff,below GDP cutoff,Liquids,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,3
+SSP3,ECEMF_HighH2_HighEff,below GDP cutoff,BEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,5,2035,5
+SSP3,ECEMF_HighH2_HighEff,below GDP cutoff,FCEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,30,2035,3
+SSP3,ECEMF_HighH2_HighEff,below GDP cutoff,Liquids,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,3
+SSP3,ECEMF_HighH2_LifestCha,above GDP cutoff,,,,Cycle,S1S,2,2050,10
+SSP3,ECEMF_HighH2_LifestCha,above GDP cutoff,,,,Domestic Aviation,S1S,0.25,2035,10
+SSP3,ECEMF_HighH2_LifestCha,above GDP cutoff,,,,Domestic Ship,S1S,1.5,2050,10
+SSP3,ECEMF_HighH2_LifestCha,above GDP cutoff,,,,Freight Rail,S1S,1.5,2050,10
+SSP3,ECEMF_HighH2_LifestCha,above GDP cutoff,,,,HSR,S1S,1,2050,10
+SSP3,ECEMF_HighH2_LifestCha,above GDP cutoff,,,,Passenger Rail,S1S,2,2050,10
+SSP3,ECEMF_HighH2_LifestCha,above GDP cutoff,,,,trn_freight_road,S1S,0.7,2035,10
+SSP3,ECEMF_HighH2_LifestCha,above GDP cutoff,,,,trn_pass_road,S1S,0.5,2035,10
+SSP3,ECEMF_HighH2_LifestCha,above GDP cutoff,,,,Walk,S1S,2,2050,10
+SSP3,ECEMF_HighH2_LifestCha,below GDP cutoff,,,,Cycle,S1S,2,2050,10
+SSP3,ECEMF_HighH2_LifestCha,below GDP cutoff,,,,Domestic Aviation,S1S,0.25,2035,10
+SSP3,ECEMF_HighH2_LifestCha,below GDP cutoff,,,,Domestic Ship,S1S,1.5,2050,10
+SSP3,ECEMF_HighH2_LifestCha,below GDP cutoff,,,,Freight Rail,S1S,1.5,2050,10
+SSP3,ECEMF_HighH2_LifestCha,below GDP cutoff,,,,HSR,S1S,1,2050,10
+SSP3,ECEMF_HighH2_LifestCha,below GDP cutoff,,,,Passenger Rail,S1S,2,2050,10
+SSP3,ECEMF_HighH2_LifestCha,below GDP cutoff,,,,trn_freight_road,S1S,0.7,2035,10
+SSP3,ECEMF_HighH2_LifestCha,below GDP cutoff,,,,trn_pass_road,S1S,0.5,2035,10
+SSP3,ECEMF_HighH2_LifestCha,below GDP cutoff,,,,Walk,S1S,2,2050,10
+SSP3,ECEMF_HighH2_LifestCha,above GDP cutoff,,,Bus,trn_pass_road,S2S1,2,2050,10
+SSP3,ECEMF_HighH2_LifestCha,above GDP cutoff,,,trn_pass_road_LDV,trn_pass_road,S2S1,0.5,2035,10
+SSP3,ECEMF_HighH2_LifestCha,below GDP cutoff,,,Bus,trn_pass_road,S2S1,2,2050,10
+SSP3,ECEMF_HighH2_LifestCha,below GDP cutoff,,,trn_pass_road_LDV,trn_pass_road,S2S1,0.5,2035,10
+SSP3,ECEMF_HighH2_LifestCha,above GDP cutoff,BEV,Bus,Bus,trn_pass_road,FV,3,2060,15
+SSP3,ECEMF_HighH2_LifestCha,above GDP cutoff,FCEV,Bus,Bus,trn_pass_road,FV,220,2035,5
+SSP3,ECEMF_HighH2_LifestCha,above GDP cutoff,Liquids,Bus,Bus,trn_pass_road,FV,1,2050,10
+SSP3,ECEMF_HighH2_LifestCha,above GDP cutoff,Hydrogen,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,3,2055,5
+SSP3,ECEMF_HighH2_LifestCha,above GDP cutoff,Liquids,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SSP3,ECEMF_HighH2_LifestCha,above GDP cutoff,Liquids,Ship,Domestic Ship_tmp_subsectorL2,Domestic Ship,FV,1,2050,10
+SSP3,ECEMF_HighH2_LifestCha,above GDP cutoff,Electric,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,2.5,2050,10
+SSP3,ECEMF_HighH2_LifestCha,above GDP cutoff,Liquids,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SSP3,ECEMF_HighH2_LifestCha,above GDP cutoff,Electric,Rail,HSR_tmp_subsectorL2,HSR,FV,2.5,2050,10
+SSP3,ECEMF_HighH2_LifestCha,above GDP cutoff,Liquids,Aviation,International Aviation_tmp_subsectorL2,International Aviation,FV,1,2050,10
+SSP3,ECEMF_HighH2_LifestCha,above GDP cutoff,Liquids,Ship,International Ship_tmp_subsectorL2,International Ship,FV,1,2050,10
+SSP3,ECEMF_HighH2_LifestCha,above GDP cutoff,BEV,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,3,2050,10
+SSP3,ECEMF_HighH2_LifestCha,above GDP cutoff,Liquids,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SSP3,ECEMF_HighH2_LifestCha,above GDP cutoff,Electric,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,2.5,2050,10
+SSP3,ECEMF_HighH2_LifestCha,above GDP cutoff,Liquids,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SSP3,ECEMF_HighH2_LifestCha,above GDP cutoff,BEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,40,2040,3
+SSP3,ECEMF_HighH2_LifestCha,above GDP cutoff,FCEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,50,2040,3
+SSP3,ECEMF_HighH2_LifestCha,above GDP cutoff,Liquids,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,3
+SSP3,ECEMF_HighH2_LifestCha,above GDP cutoff,BEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,40,2040,5
+SSP3,ECEMF_HighH2_LifestCha,above GDP cutoff,FCEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,250,2040,3
+SSP3,ECEMF_HighH2_LifestCha,above GDP cutoff,Liquids,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,3
+SSP3,ECEMF_HighH2_LifestCha,below GDP cutoff,BEV,Bus,Bus,trn_pass_road,FV,3,2060,15
+SSP3,ECEMF_HighH2_LifestCha,below GDP cutoff,FCEV,Bus,Bus,trn_pass_road,FV,160,2040,5
+SSP3,ECEMF_HighH2_LifestCha,below GDP cutoff,Liquids,Bus,Bus,trn_pass_road,FV,1,2050,10
+SSP3,ECEMF_HighH2_LifestCha,below GDP cutoff,Hydrogen,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,5,2055,10
+SSP3,ECEMF_HighH2_LifestCha,below GDP cutoff,Liquids,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SSP3,ECEMF_HighH2_LifestCha,below GDP cutoff,Liquids,Ship,Domestic Ship_tmp_subsectorL2,Domestic Ship,FV,1,2050,10
+SSP3,ECEMF_HighH2_LifestCha,below GDP cutoff,Electric,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,2,2050,10
+SSP3,ECEMF_HighH2_LifestCha,below GDP cutoff,Liquids,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SSP3,ECEMF_HighH2_LifestCha,below GDP cutoff,Electric,Rail,HSR_tmp_subsectorL2,HSR,FV,2,2050,10
+SSP3,ECEMF_HighH2_LifestCha,below GDP cutoff,Liquids,Aviation,International Aviation_tmp_subsectorL2,International Aviation,FV,1,2050,10
+SSP3,ECEMF_HighH2_LifestCha,below GDP cutoff,Liquids,Ship,International Ship_tmp_subsectorL2,International Ship,FV,1,2050,10
+SSP3,ECEMF_HighH2_LifestCha,below GDP cutoff,BEV,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,3,2050,10
+SSP3,ECEMF_HighH2_LifestCha,below GDP cutoff,Liquids,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SSP3,ECEMF_HighH2_LifestCha,below GDP cutoff,Electric,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,2,2050,10
+SSP3,ECEMF_HighH2_LifestCha,below GDP cutoff,Liquids,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SSP3,ECEMF_HighH2_LifestCha,below GDP cutoff,BEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,10,2040,3
+SSP3,ECEMF_HighH2_LifestCha,below GDP cutoff,FCEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,10,2040,3
+SSP3,ECEMF_HighH2_LifestCha,below GDP cutoff,Liquids,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,3
+SSP3,ECEMF_HighH2_LifestCha,below GDP cutoff,BEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,5,2035,5
+SSP3,ECEMF_HighH2_LifestCha,below GDP cutoff,FCEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,30,2035,3
+SSP3,ECEMF_HighH2_LifestCha,below GDP cutoff,Liquids,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,3
+SSP3,ECEMF_HighH2_ModEff,above GDP cutoff,,,,Cycle,S1S,1,2050,10
+SSP3,ECEMF_HighH2_ModEff,above GDP cutoff,,,,Domestic Aviation,S1S,0.75,2035,10
+SSP3,ECEMF_HighH2_ModEff,above GDP cutoff,,,,Domestic Ship,S1S,1,2050,10
+SSP3,ECEMF_HighH2_ModEff,above GDP cutoff,,,,Freight Rail,S1S,1,2050,10
+SSP3,ECEMF_HighH2_ModEff,above GDP cutoff,,,,HSR,S1S,1,2050,10
+SSP3,ECEMF_HighH2_ModEff,above GDP cutoff,,,,Passenger Rail,S1S,1,2050,10
+SSP3,ECEMF_HighH2_ModEff,above GDP cutoff,,,,trn_freight_road,S1S,0.9,2035,10
+SSP3,ECEMF_HighH2_ModEff,above GDP cutoff,,,,trn_pass_road,S1S,0.9,2035,10
+SSP3,ECEMF_HighH2_ModEff,above GDP cutoff,,,,Walk,S1S,1,2050,10
+SSP3,ECEMF_HighH2_ModEff,below GDP cutoff,,,,Cycle,S1S,1,2050,10
+SSP3,ECEMF_HighH2_ModEff,below GDP cutoff,,,,Domestic Aviation,S1S,0.75,2035,10
+SSP3,ECEMF_HighH2_ModEff,below GDP cutoff,,,,Domestic Ship,S1S,1,2050,10
+SSP3,ECEMF_HighH2_ModEff,below GDP cutoff,,,,Freight Rail,S1S,1,2050,10
+SSP3,ECEMF_HighH2_ModEff,below GDP cutoff,,,,HSR,S1S,1,2050,10
+SSP3,ECEMF_HighH2_ModEff,below GDP cutoff,,,,Passenger Rail,S1S,1,2050,10
+SSP3,ECEMF_HighH2_ModEff,below GDP cutoff,,,,trn_freight_road,S1S,0.9,2035,10
+SSP3,ECEMF_HighH2_ModEff,below GDP cutoff,,,,trn_pass_road,S1S,0.9,2035,10
+SSP3,ECEMF_HighH2_ModEff,below GDP cutoff,,,,Walk,S1S,1,2050,10
+SSP3,ECEMF_HighH2_ModEff,above GDP cutoff,,,Bus,trn_pass_road,S2S1,1,2050,10
+SSP3,ECEMF_HighH2_ModEff,above GDP cutoff,,,trn_pass_road_LDV,trn_pass_road,S2S1,0.9,2035,10
+SSP3,ECEMF_HighH2_ModEff,below GDP cutoff,,,Bus,trn_pass_road,S2S1,1,2050,10
+SSP3,ECEMF_HighH2_ModEff,below GDP cutoff,,,trn_pass_road_LDV,trn_pass_road,S2S1,0.9,2035,10
+SSP3,ECEMF_HighH2_ModEff,above GDP cutoff,BEV,Bus,Bus,trn_pass_road,FV,3,2060,15
+SSP3,ECEMF_HighH2_ModEff,above GDP cutoff,FCEV,Bus,Bus,trn_pass_road,FV,200,2035,5
+SSP3,ECEMF_HighH2_ModEff,above GDP cutoff,Liquids,Bus,Bus,trn_pass_road,FV,1,2050,10
+SSP3,ECEMF_HighH2_ModEff,above GDP cutoff,Hydrogen,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,3,2055,5
+SSP3,ECEMF_HighH2_ModEff,above GDP cutoff,Liquids,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SSP3,ECEMF_HighH2_ModEff,above GDP cutoff,Liquids,Ship,Domestic Ship_tmp_subsectorL2,Domestic Ship,FV,1,2050,10
+SSP3,ECEMF_HighH2_ModEff,above GDP cutoff,Electric,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1.5,2050,10
+SSP3,ECEMF_HighH2_ModEff,above GDP cutoff,Liquids,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SSP3,ECEMF_HighH2_ModEff,above GDP cutoff,Electric,Rail,HSR_tmp_subsectorL2,HSR,FV,1.5,2050,10
+SSP3,ECEMF_HighH2_ModEff,above GDP cutoff,Liquids,Aviation,International Aviation_tmp_subsectorL2,International Aviation,FV,1,2050,10
+SSP3,ECEMF_HighH2_ModEff,above GDP cutoff,Liquids,Ship,International Ship_tmp_subsectorL2,International Ship,FV,1,2050,10
+SSP3,ECEMF_HighH2_ModEff,above GDP cutoff,BEV,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,3,2050,10
+SSP3,ECEMF_HighH2_ModEff,above GDP cutoff,Liquids,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SSP3,ECEMF_HighH2_ModEff,above GDP cutoff,Electric,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1.5,2050,10
+SSP3,ECEMF_HighH2_ModEff,above GDP cutoff,Liquids,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SSP3,ECEMF_HighH2_ModEff,above GDP cutoff,BEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,40,2040,3
+SSP3,ECEMF_HighH2_ModEff,above GDP cutoff,FCEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,50,2040,3
+SSP3,ECEMF_HighH2_ModEff,above GDP cutoff,Liquids,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,3
+SSP3,ECEMF_HighH2_ModEff,above GDP cutoff,BEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,40,2040,5
+SSP3,ECEMF_HighH2_ModEff,above GDP cutoff,FCEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,250,2040,3
+SSP3,ECEMF_HighH2_ModEff,above GDP cutoff,Liquids,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,3
+SSP3,ECEMF_HighH2_ModEff,below GDP cutoff,BEV,Bus,Bus,trn_pass_road,FV,3,2060,15
+SSP3,ECEMF_HighH2_ModEff,below GDP cutoff,FCEV,Bus,Bus,trn_pass_road,FV,150,2040,5
+SSP3,ECEMF_HighH2_ModEff,below GDP cutoff,Liquids,Bus,Bus,trn_pass_road,FV,1,2050,10
+SSP3,ECEMF_HighH2_ModEff,below GDP cutoff,Hydrogen,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,2.5,2055,10
+SSP3,ECEMF_HighH2_ModEff,below GDP cutoff,Liquids,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SSP3,ECEMF_HighH2_ModEff,below GDP cutoff,Liquids,Ship,Domestic Ship_tmp_subsectorL2,Domestic Ship,FV,1,2050,10
+SSP3,ECEMF_HighH2_ModEff,below GDP cutoff,Electric,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,2.5,2050,10
+SSP3,ECEMF_HighH2_ModEff,below GDP cutoff,Liquids,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SSP3,ECEMF_HighH2_ModEff,below GDP cutoff,Electric,Rail,HSR_tmp_subsectorL2,HSR,FV,2.5,2050,10
+SSP3,ECEMF_HighH2_ModEff,below GDP cutoff,Liquids,Aviation,International Aviation_tmp_subsectorL2,International Aviation,FV,1,2050,10
+SSP3,ECEMF_HighH2_ModEff,below GDP cutoff,Liquids,Ship,International Ship_tmp_subsectorL2,International Ship,FV,1,2050,10
+SSP3,ECEMF_HighH2_ModEff,below GDP cutoff,BEV,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,2.5,2050,10
+SSP3,ECEMF_HighH2_ModEff,below GDP cutoff,Liquids,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SSP3,ECEMF_HighH2_ModEff,below GDP cutoff,Electric,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,2.5,2050,10
+SSP3,ECEMF_HighH2_ModEff,below GDP cutoff,Liquids,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SSP3,ECEMF_HighH2_ModEff,below GDP cutoff,BEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,10,2040,3
+SSP3,ECEMF_HighH2_ModEff,below GDP cutoff,FCEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,10,2040,3
+SSP3,ECEMF_HighH2_ModEff,below GDP cutoff,Liquids,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,3
+SSP3,ECEMF_HighH2_ModEff,below GDP cutoff,BEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,5,2035,5
+SSP3,ECEMF_HighH2_ModEff,below GDP cutoff,FCEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,30,2035,3
+SSP3,ECEMF_HighH2_ModEff,below GDP cutoff,Liquids,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,3
+SSP3,HydrHype4,above GDP cutoff,,,,Cycle,S1S,1,2050,10
+SSP3,HydrHype4,above GDP cutoff,,,,Domestic Aviation,S1S,0.25,2035,10
+SSP3,HydrHype4,above GDP cutoff,,,,Domestic Ship,S1S,1,2050,10
+SSP3,HydrHype4,above GDP cutoff,,,,Freight Rail,S1S,1,2050,10
+SSP3,HydrHype4,above GDP cutoff,,,,HSR,S1S,1,2050,10
+SSP3,HydrHype4,above GDP cutoff,,,,Passenger Rail,S1S,1,2050,10
+SSP3,HydrHype4,above GDP cutoff,,,,trn_freight_road,S1S,0.5,2035,10
+SSP3,HydrHype4,above GDP cutoff,,,,trn_pass_road,S1S,0.7,2035,10
+SSP3,HydrHype4,above GDP cutoff,,,,Walk,S1S,1,2050,10
+SSP3,HydrHype4,below GDP cutoff,,,,Cycle,S1S,1,2050,10
+SSP3,HydrHype4,below GDP cutoff,,,,Domestic Aviation,S1S,0.25,2035,10
+SSP3,HydrHype4,below GDP cutoff,,,,Domestic Ship,S1S,1,2050,10
+SSP3,HydrHype4,below GDP cutoff,,,,Freight Rail,S1S,1,2050,10
+SSP3,HydrHype4,below GDP cutoff,,,,HSR,S1S,1,2050,10
+SSP3,HydrHype4,below GDP cutoff,,,,Passenger Rail,S1S,1,2050,10
+SSP3,HydrHype4,below GDP cutoff,,,,trn_freight_road,S1S,0.5,2035,10
+SSP3,HydrHype4,below GDP cutoff,,,,trn_pass_road,S1S,0.7,2035,10
+SSP3,HydrHype4,below GDP cutoff,,,,Walk,S1S,1,2050,10
+SSP3,HydrHype4,above GDP cutoff,,,Bus,trn_pass_road,S2S1,1,2050,10
+SSP3,HydrHype4,above GDP cutoff,,,trn_pass_road_LDV,trn_pass_road,S2S1,0.7,2035,10
+SSP3,HydrHype4,below GDP cutoff,,,Bus,trn_pass_road,S2S1,1,2050,10
+SSP3,HydrHype4,below GDP cutoff,,,trn_pass_road_LDV,trn_pass_road,S2S1,0.7,2035,10
+SSP3,HydrHype4,above GDP cutoff,BEV,Bus,Bus,trn_pass_road,FV,3,2060,15
+SSP3,HydrHype4,above GDP cutoff,FCEV,Bus,Bus,trn_pass_road,FV,200,2035,5
+SSP3,HydrHype4,above GDP cutoff,Liquids,Bus,Bus,trn_pass_road,FV,1,2050,10
+SSP3,HydrHype4,above GDP cutoff,Hydrogen,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,3,2055,5
+SSP3,HydrHype4,above GDP cutoff,Liquids,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SSP3,HydrHype4,above GDP cutoff,Liquids,Ship,Domestic Ship_tmp_subsectorL2,Domestic Ship,FV,1,2050,10
+SSP3,HydrHype4,above GDP cutoff,Electric,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SSP3,HydrHype4,above GDP cutoff,Liquids,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SSP3,HydrHype4,above GDP cutoff,Electric,Rail,HSR_tmp_subsectorL2,HSR,FV,1,2050,10
+SSP3,HydrHype4,above GDP cutoff,Liquids,Aviation,International Aviation_tmp_subsectorL2,International Aviation,FV,1,2050,10
+SSP3,HydrHype4,above GDP cutoff,Liquids,Ship,International Ship_tmp_subsectorL2,International Ship,FV,1,2050,10
+SSP3,HydrHype4,above GDP cutoff,BEV,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SSP3,HydrHype4,above GDP cutoff,Liquids,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SSP3,HydrHype4,above GDP cutoff,Electric,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SSP3,HydrHype4,above GDP cutoff,Liquids,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SSP3,HydrHype4,above GDP cutoff,BEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,40,2040,3
+SSP3,HydrHype4,above GDP cutoff,FCEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,50,2040,3
+SSP3,HydrHype4,above GDP cutoff,Liquids,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,3
+SSP3,HydrHype4,above GDP cutoff,BEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,40,2040,5
+SSP3,HydrHype4,above GDP cutoff,FCEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,250,2040,3
+SSP3,HydrHype4,above GDP cutoff,Liquids,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,3
+SSP3,HydrHype4,below GDP cutoff,BEV,Bus,Bus,trn_pass_road,FV,3,2060,15
+SSP3,HydrHype4,below GDP cutoff,FCEV,Bus,Bus,trn_pass_road,FV,150,2040,5
+SSP3,HydrHype4,below GDP cutoff,Liquids,Bus,Bus,trn_pass_road,FV,1,2050,10
+SSP3,HydrHype4,below GDP cutoff,Hydrogen,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,2.5,2055,10
+SSP3,HydrHype4,below GDP cutoff,Liquids,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SSP3,HydrHype4,below GDP cutoff,Liquids,Ship,Domestic Ship_tmp_subsectorL2,Domestic Ship,FV,1,2050,10
+SSP3,HydrHype4,below GDP cutoff,Electric,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SSP3,HydrHype4,below GDP cutoff,Liquids,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SSP3,HydrHype4,below GDP cutoff,Electric,Rail,HSR_tmp_subsectorL2,HSR,FV,1,2050,10
+SSP3,HydrHype4,below GDP cutoff,Liquids,Aviation,International Aviation_tmp_subsectorL2,International Aviation,FV,1,2050,10
+SSP3,HydrHype4,below GDP cutoff,Liquids,Ship,International Ship_tmp_subsectorL2,International Ship,FV,1,2050,10
+SSP3,HydrHype4,below GDP cutoff,BEV,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SSP3,HydrHype4,below GDP cutoff,Liquids,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SSP3,HydrHype4,below GDP cutoff,Electric,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SSP3,HydrHype4,below GDP cutoff,Liquids,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SSP3,HydrHype4,below GDP cutoff,BEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,10,2040,3
+SSP3,HydrHype4,below GDP cutoff,FCEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,10,2040,3
+SSP3,HydrHype4,below GDP cutoff,Liquids,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,3
+SSP3,HydrHype4,below GDP cutoff,BEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,5,2035,5
+SSP3,HydrHype4,below GDP cutoff,FCEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,30,2035,3
+SSP3,HydrHype4,below GDP cutoff,Liquids,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,3
+SSP3,Mix2,above GDP cutoff,,,,Cycle,S1S,1,2050,10
+SSP3,Mix2,above GDP cutoff,,,,Domestic Aviation,S1S,0.75,2035,10
+SSP3,Mix2,above GDP cutoff,,,,Domestic Ship,S1S,1,2050,10
+SSP3,Mix2,above GDP cutoff,,,,Freight Rail,S1S,1,2050,10
+SSP3,Mix2,above GDP cutoff,,,,HSR,S1S,1,2050,10
+SSP3,Mix2,above GDP cutoff,,,,Passenger Rail,S1S,1,2050,10
+SSP3,Mix2,above GDP cutoff,,,,trn_freight_road,S1S,0.9,2035,10
+SSP3,Mix2,above GDP cutoff,,,,trn_pass_road,S1S,0.9,2035,10
+SSP3,Mix2,above GDP cutoff,,,,Walk,S1S,1,2050,10
+SSP3,Mix2,below GDP cutoff,,,,Cycle,S1S,1,2050,10
+SSP3,Mix2,below GDP cutoff,,,,Domestic Aviation,S1S,0.75,2035,10
+SSP3,Mix2,below GDP cutoff,,,,Domestic Ship,S1S,1,2050,10
+SSP3,Mix2,below GDP cutoff,,,,Freight Rail,S1S,1,2050,10
+SSP3,Mix2,below GDP cutoff,,,,HSR,S1S,1,2050,10
+SSP3,Mix2,below GDP cutoff,,,,Passenger Rail,S1S,1,2050,10
+SSP3,Mix2,below GDP cutoff,,,,trn_freight_road,S1S,0.9,2035,10
+SSP3,Mix2,below GDP cutoff,,,,trn_pass_road,S1S,0.9,2035,10
+SSP3,Mix2,below GDP cutoff,,,,Walk,S1S,1,2050,10
+SSP3,Mix2,above GDP cutoff,,,Bus,trn_pass_road,S2S1,1,2050,10
+SSP3,Mix2,above GDP cutoff,,,trn_pass_road_LDV,trn_pass_road,S2S1,0.9,2035,10
+SSP3,Mix2,below GDP cutoff,,,Bus,trn_pass_road,S2S1,1,2050,10
+SSP3,Mix2,below GDP cutoff,,,trn_pass_road_LDV,trn_pass_road,S2S1,0.9,2035,10
+SSP3,Mix2,above GDP cutoff,BEV,Bus,Bus,trn_pass_road,FV,2,2035,10
+SSP3,Mix2,above GDP cutoff,FCEV,Bus,Bus,trn_pass_road,FV,2,2035,10
+SSP3,Mix2,above GDP cutoff,Liquids,Bus,Bus,trn_pass_road,FV,1,2050,10
+SSP3,Mix2,above GDP cutoff,Hydrogen,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SSP3,Mix2,above GDP cutoff,Liquids,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SSP3,Mix2,above GDP cutoff,Liquids,Ship,Domestic Ship_tmp_subsectorL2,Domestic Ship,FV,1,2050,10
+SSP3,Mix2,above GDP cutoff,Electric,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SSP3,Mix2,above GDP cutoff,Liquids,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SSP3,Mix2,above GDP cutoff,Electric,Rail,HSR_tmp_subsectorL2,HSR,FV,1,2050,10
+SSP3,Mix2,above GDP cutoff,Liquids,Aviation,International Aviation_tmp_subsectorL2,International Aviation,FV,1,2050,10
+SSP3,Mix2,above GDP cutoff,Liquids,Ship,International Ship_tmp_subsectorL2,International Ship,FV,1,2050,10
+SSP3,Mix2,above GDP cutoff,BEV,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SSP3,Mix2,above GDP cutoff,Liquids,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SSP3,Mix2,above GDP cutoff,Electric,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SSP3,Mix2,above GDP cutoff,Liquids,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SSP3,Mix2,above GDP cutoff,BEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,2,2035,10
+SSP3,Mix2,above GDP cutoff,FCEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,2,2035,10
+SSP3,Mix2,above GDP cutoff,Liquids,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,10
+SSP3,Mix2,above GDP cutoff,BEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,2,2035,10
+SSP3,Mix2,above GDP cutoff,FCEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,2,2035,10
+SSP3,Mix2,above GDP cutoff,Liquids,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,10
+SSP3,Mix2,below GDP cutoff,BEV,Bus,Bus,trn_pass_road,FV,1.5,2035,10
+SSP3,Mix2,below GDP cutoff,FCEV,Bus,Bus,trn_pass_road,FV,1.5,2035,10
+SSP3,Mix2,below GDP cutoff,Liquids,Bus,Bus,trn_pass_road,FV,1,2050,10
+SSP3,Mix2,below GDP cutoff,Hydrogen,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SSP3,Mix2,below GDP cutoff,Liquids,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SSP3,Mix2,below GDP cutoff,Liquids,Ship,Domestic Ship_tmp_subsectorL2,Domestic Ship,FV,1,2050,10
+SSP3,Mix2,below GDP cutoff,Electric,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SSP3,Mix2,below GDP cutoff,Liquids,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SSP3,Mix2,below GDP cutoff,Electric,Rail,HSR_tmp_subsectorL2,HSR,FV,1,2050,10
+SSP3,Mix2,below GDP cutoff,Liquids,Aviation,International Aviation_tmp_subsectorL2,International Aviation,FV,1,2050,10
+SSP3,Mix2,below GDP cutoff,Liquids,Ship,International Ship_tmp_subsectorL2,International Ship,FV,1,2050,10
+SSP3,Mix2,below GDP cutoff,BEV,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SSP3,Mix2,below GDP cutoff,Liquids,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SSP3,Mix2,below GDP cutoff,Electric,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SSP3,Mix2,below GDP cutoff,Liquids,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SSP3,Mix2,below GDP cutoff,BEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1.5,2035,10
+SSP3,Mix2,below GDP cutoff,FCEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1.5,2035,10
+SSP3,Mix2,below GDP cutoff,Liquids,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,10
+SSP3,Mix2,below GDP cutoff,BEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1.5,2035,10
+SSP3,Mix2,below GDP cutoff,FCEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1.5,2035,10
+SSP3,Mix2,below GDP cutoff,Liquids,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,10
+SSP3,Mix3,above GDP cutoff,,,,Cycle,S1S,1,2050,10
+SSP3,Mix3,above GDP cutoff,,,,Domestic Aviation,S1S,0.5,2035,10
+SSP3,Mix3,above GDP cutoff,,,,Domestic Ship,S1S,1,2050,10
+SSP3,Mix3,above GDP cutoff,,,,Freight Rail,S1S,1,2050,10
+SSP3,Mix3,above GDP cutoff,,,,HSR,S1S,1,2050,10
+SSP3,Mix3,above GDP cutoff,,,,Passenger Rail,S1S,1,2050,10
+SSP3,Mix3,above GDP cutoff,,,,trn_freight_road,S1S,0.7,2035,10
+SSP3,Mix3,above GDP cutoff,,,,trn_pass_road,S1S,0.8,2035,10
+SSP3,Mix3,above GDP cutoff,,,,Walk,S1S,1,2050,10
+SSP3,Mix3,below GDP cutoff,,,,Cycle,S1S,1,2050,10
+SSP3,Mix3,below GDP cutoff,,,,Domestic Aviation,S1S,0.5,2035,10
+SSP3,Mix3,below GDP cutoff,,,,Domestic Ship,S1S,1,2050,10
+SSP3,Mix3,below GDP cutoff,,,,Freight Rail,S1S,1,2050,10
+SSP3,Mix3,below GDP cutoff,,,,HSR,S1S,1,2050,10
+SSP3,Mix3,below GDP cutoff,,,,Passenger Rail,S1S,1,2050,10
+SSP3,Mix3,below GDP cutoff,,,,trn_freight_road,S1S,0.7,2035,10
+SSP3,Mix3,below GDP cutoff,,,,trn_pass_road,S1S,0.8,2035,10
+SSP3,Mix3,below GDP cutoff,,,,Walk,S1S,1,2050,10
+SSP3,Mix3,above GDP cutoff,,,Bus,trn_pass_road,S2S1,1,2050,10
+SSP3,Mix3,above GDP cutoff,,,trn_pass_road_LDV,trn_pass_road,S2S1,0.8,2035,10
+SSP3,Mix3,below GDP cutoff,,,Bus,trn_pass_road,S2S1,1,2050,10
+SSP3,Mix3,below GDP cutoff,,,trn_pass_road_LDV,trn_pass_road,S2S1,0.8,2035,10
+SSP3,Mix3,above GDP cutoff,BEV,Bus,Bus,trn_pass_road,FV,4,2035,10
+SSP3,Mix3,above GDP cutoff,FCEV,Bus,Bus,trn_pass_road,FV,4,2035,10
+SSP3,Mix3,above GDP cutoff,Liquids,Bus,Bus,trn_pass_road,FV,1,2050,10
+SSP3,Mix3,above GDP cutoff,Hydrogen,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SSP3,Mix3,above GDP cutoff,Liquids,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SSP3,Mix3,above GDP cutoff,Liquids,Ship,Domestic Ship_tmp_subsectorL2,Domestic Ship,FV,1,2050,10
+SSP3,Mix3,above GDP cutoff,Electric,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1.5,2050,10
+SSP3,Mix3,above GDP cutoff,Liquids,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SSP3,Mix3,above GDP cutoff,Electric,Rail,HSR_tmp_subsectorL2,HSR,FV,1.5,2050,10
+SSP3,Mix3,above GDP cutoff,Liquids,Aviation,International Aviation_tmp_subsectorL2,International Aviation,FV,1,2050,10
+SSP3,Mix3,above GDP cutoff,Liquids,Ship,International Ship_tmp_subsectorL2,International Ship,FV,1,2050,10
+SSP3,Mix3,above GDP cutoff,BEV,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SSP3,Mix3,above GDP cutoff,Liquids,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SSP3,Mix3,above GDP cutoff,Electric,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1.5,2050,10
+SSP3,Mix3,above GDP cutoff,Liquids,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SSP3,Mix3,above GDP cutoff,BEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,3,2035,10
+SSP3,Mix3,above GDP cutoff,FCEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,3,2035,10
+SSP3,Mix3,above GDP cutoff,Liquids,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,10
+SSP3,Mix3,above GDP cutoff,BEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,5,2035,10
+SSP3,Mix3,above GDP cutoff,FCEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,7,2035,10
+SSP3,Mix3,above GDP cutoff,Liquids,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,10
+SSP3,Mix3,below GDP cutoff,BEV,Bus,Bus,trn_pass_road,FV,3.5,2035,10
+SSP3,Mix3,below GDP cutoff,FCEV,Bus,Bus,trn_pass_road,FV,3.5,2035,10
+SSP3,Mix3,below GDP cutoff,Liquids,Bus,Bus,trn_pass_road,FV,1,2050,10
+SSP3,Mix3,below GDP cutoff,Hydrogen,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SSP3,Mix3,below GDP cutoff,Liquids,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SSP3,Mix3,below GDP cutoff,Liquids,Ship,Domestic Ship_tmp_subsectorL2,Domestic Ship,FV,1,2050,10
+SSP3,Mix3,below GDP cutoff,Electric,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1.5,2050,10
+SSP3,Mix3,below GDP cutoff,Liquids,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SSP3,Mix3,below GDP cutoff,Electric,Rail,HSR_tmp_subsectorL2,HSR,FV,1.5,2050,10
+SSP3,Mix3,below GDP cutoff,Liquids,Aviation,International Aviation_tmp_subsectorL2,International Aviation,FV,1,2050,10
+SSP3,Mix3,below GDP cutoff,Liquids,Ship,International Ship_tmp_subsectorL2,International Ship,FV,1,2050,10
+SSP3,Mix3,below GDP cutoff,BEV,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SSP3,Mix3,below GDP cutoff,Liquids,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SSP3,Mix3,below GDP cutoff,Electric,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1.5,2050,10
+SSP3,Mix3,below GDP cutoff,Liquids,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SSP3,Mix3,below GDP cutoff,BEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,3,2035,10
+SSP3,Mix3,below GDP cutoff,FCEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,3,2035,10
+SSP3,Mix3,below GDP cutoff,Liquids,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,10
+SSP3,Mix3,below GDP cutoff,BEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,4,2035,10
+SSP3,Mix3,below GDP cutoff,FCEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,7,2035,10
+SSP3,Mix3,below GDP cutoff,Liquids,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,10
+SSP3,Mix4,above GDP cutoff,,,,Cycle,S1S,1,2050,10
+SSP3,Mix4,above GDP cutoff,,,,Domestic Aviation,S1S,0.25,2035,10
+SSP3,Mix4,above GDP cutoff,,,,Domestic Ship,S1S,1,2050,10
+SSP3,Mix4,above GDP cutoff,,,,Freight Rail,S1S,1,2050,10
+SSP3,Mix4,above GDP cutoff,,,,HSR,S1S,1,2050,10
+SSP3,Mix4,above GDP cutoff,,,,Passenger Rail,S1S,1,2050,10
+SSP3,Mix4,above GDP cutoff,,,,trn_freight_road,S1S,0.5,2035,10
+SSP3,Mix4,above GDP cutoff,,,,trn_pass_road,S1S,0.7,2035,10
+SSP3,Mix4,above GDP cutoff,,,,Walk,S1S,1,2050,10
+SSP3,Mix4,below GDP cutoff,,,,Cycle,S1S,1,2050,10
+SSP3,Mix4,below GDP cutoff,,,,Domestic Aviation,S1S,0.25,2035,10
+SSP3,Mix4,below GDP cutoff,,,,Domestic Ship,S1S,1,2050,10
+SSP3,Mix4,below GDP cutoff,,,,Freight Rail,S1S,1,2050,10
+SSP3,Mix4,below GDP cutoff,,,,HSR,S1S,1,2050,10
+SSP3,Mix4,below GDP cutoff,,,,Passenger Rail,S1S,1,2050,10
+SSP3,Mix4,below GDP cutoff,,,,trn_freight_road,S1S,0.5,2035,10
+SSP3,Mix4,below GDP cutoff,,,,trn_pass_road,S1S,0.7,2035,10
+SSP3,Mix4,below GDP cutoff,,,,Walk,S1S,1,2050,10
+SSP3,Mix4,above GDP cutoff,,,Bus,trn_pass_road,S2S1,1,2050,10
+SSP3,Mix4,above GDP cutoff,,,trn_pass_road_LDV,trn_pass_road,S2S1,0.7,2035,10
+SSP3,Mix4,below GDP cutoff,,,Bus,trn_pass_road,S2S1,1,2050,10
+SSP3,Mix4,below GDP cutoff,,,trn_pass_road_LDV,trn_pass_road,S2S1,0.7,2035,10
+SSP3,Mix4,above GDP cutoff,BEV,Bus,Bus,trn_pass_road,FV,6,2035,10
+SSP3,Mix4,above GDP cutoff,FCEV,Bus,Bus,trn_pass_road,FV,6,2035,10
+SSP3,Mix4,above GDP cutoff,Liquids,Bus,Bus,trn_pass_road,FV,1,2050,10
+SSP3,Mix4,above GDP cutoff,Hydrogen,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SSP3,Mix4,above GDP cutoff,Liquids,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SSP3,Mix4,above GDP cutoff,Liquids,Ship,Domestic Ship_tmp_subsectorL2,Domestic Ship,FV,1,2050,10
+SSP3,Mix4,above GDP cutoff,Electric,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,2,2050,10
+SSP3,Mix4,above GDP cutoff,Liquids,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SSP3,Mix4,above GDP cutoff,Electric,Rail,HSR_tmp_subsectorL2,HSR,FV,2,2050,10
+SSP3,Mix4,above GDP cutoff,Liquids,Aviation,International Aviation_tmp_subsectorL2,International Aviation,FV,1,2050,10
+SSP3,Mix4,above GDP cutoff,Liquids,Ship,International Ship_tmp_subsectorL2,International Ship,FV,1,2050,10
+SSP3,Mix4,above GDP cutoff,BEV,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SSP3,Mix4,above GDP cutoff,Liquids,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SSP3,Mix4,above GDP cutoff,Electric,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,2,2050,10
+SSP3,Mix4,above GDP cutoff,Liquids,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SSP3,Mix4,above GDP cutoff,BEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,40,2040,3
+SSP3,Mix4,above GDP cutoff,FCEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,10,2040,3
+SSP3,Mix4,above GDP cutoff,Liquids,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,3
+SSP3,Mix4,above GDP cutoff,BEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,50,2040,5
+SSP3,Mix4,above GDP cutoff,FCEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,60,2040,3
+SSP3,Mix4,above GDP cutoff,Liquids,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,3
+SSP3,Mix4,below GDP cutoff,BEV,Bus,Bus,trn_pass_road,FV,5,2035,10
+SSP3,Mix4,below GDP cutoff,FCEV,Bus,Bus,trn_pass_road,FV,5,2035,10
+SSP3,Mix4,below GDP cutoff,Liquids,Bus,Bus,trn_pass_road,FV,1,2050,10
+SSP3,Mix4,below GDP cutoff,Hydrogen,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SSP3,Mix4,below GDP cutoff,Liquids,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SSP3,Mix4,below GDP cutoff,Liquids,Ship,Domestic Ship_tmp_subsectorL2,Domestic Ship,FV,1,2050,10
+SSP3,Mix4,below GDP cutoff,Electric,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,2,2050,10
+SSP3,Mix4,below GDP cutoff,Liquids,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SSP3,Mix4,below GDP cutoff,Electric,Rail,HSR_tmp_subsectorL2,HSR,FV,2,2050,10
+SSP3,Mix4,below GDP cutoff,Liquids,Aviation,International Aviation_tmp_subsectorL2,International Aviation,FV,1,2050,10
+SSP3,Mix4,below GDP cutoff,Liquids,Ship,International Ship_tmp_subsectorL2,International Ship,FV,1,2050,10
+SSP3,Mix4,below GDP cutoff,BEV,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SSP3,Mix4,below GDP cutoff,Liquids,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SSP3,Mix4,below GDP cutoff,Electric,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,2,2050,10
+SSP3,Mix4,below GDP cutoff,Liquids,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SSP3,Mix4,below GDP cutoff,BEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,10,2040,3
+SSP3,Mix4,below GDP cutoff,FCEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,10,2040,3
+SSP3,Mix4,below GDP cutoff,Liquids,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,3
+SSP3,Mix4,below GDP cutoff,BEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,5,2035,5
+SSP3,Mix4,below GDP cutoff,FCEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,7,2035,3
+SSP3,Mix4,below GDP cutoff,Liquids,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,3
+SSP3,NAV_act,CAZ,,,,Cycle,S1S,2.5,2040,10
+SSP3,NAV_act,CAZ,,,,Domestic Aviation,S1S,0.3,2040,10
+SSP3,NAV_act,CAZ,,,,Domestic Ship,S1S,1,2040,10
+SSP3,NAV_act,CAZ,,,,Freight Rail,S1S,1,2040,10
+SSP3,NAV_act,CAZ,,,,HSR,S1S,1.7,2040,10
+SSP3,NAV_act,CAZ,,,,Passenger Rail,S1S,4,2040,10
+SSP3,NAV_act,CAZ,,,,trn_freight_road,S1S,0.9,2040,10
+SSP3,NAV_act,CAZ,,,,trn_pass_road,S1S,0.6,2040,10
+SSP3,NAV_act,CAZ,,,,Walk,S1S,2.5,2040,10
+SSP3,NAV_act,USA,,,,Cycle,S1S,2.5,2040,10
+SSP3,NAV_act,USA,,,,Domestic Aviation,S1S,0.3,2040,10
+SSP3,NAV_act,USA,,,,Domestic Ship,S1S,1,2040,10
+SSP3,NAV_act,USA,,,,Freight Rail,S1S,1,2040,10
+SSP3,NAV_act,USA,,,,HSR,S1S,1.7,2040,10
+SSP3,NAV_act,USA,,,,Passenger Rail,S1S,4,2040,10
+SSP3,NAV_act,USA,,,,trn_freight_road,S1S,0.9,2040,10
+SSP3,NAV_act,USA,,,,trn_pass_road,S1S,0.6,2040,10
+SSP3,NAV_act,USA,,,,Walk,S1S,2.5,2040,10
+SSP3,NAV_act,above GDP cutoff,,,,Cycle,S1S,1.8,2040,10
+SSP3,NAV_act,above GDP cutoff,,,,Domestic Aviation,S1S,0.3,2040,10
+SSP3,NAV_act,above GDP cutoff,,,,Domestic Ship,S1S,1,2040,10
+SSP3,NAV_act,above GDP cutoff,,,,Freight Rail,S1S,1,2040,10
+SSP3,NAV_act,above GDP cutoff,,,,HSR,S1S,1.7,2040,10
+SSP3,NAV_act,above GDP cutoff,,,,Passenger Rail,S1S,1.6,2040,10
+SSP3,NAV_act,above GDP cutoff,,,,trn_freight_road,S1S,0.9,2040,10
+SSP3,NAV_act,above GDP cutoff,,,,trn_pass_road,S1S,0.7,2040,10
+SSP3,NAV_act,above GDP cutoff,,,,Walk,S1S,1.7,2040,10
+SSP3,NAV_act,below GDP cutoff,,,,Cycle,S1S,2.5,2040,10
+SSP3,NAV_act,below GDP cutoff,,,,Domestic Aviation,S1S,0.3,2040,10
+SSP3,NAV_act,below GDP cutoff,,,,Domestic Ship,S1S,1,2040,10
+SSP3,NAV_act,below GDP cutoff,,,,Freight Rail,S1S,1,2040,10
+SSP3,NAV_act,below GDP cutoff,,,,HSR,S1S,2.8,2040,10
+SSP3,NAV_act,below GDP cutoff,,,,Passenger Rail,S1S,1.5,2040,10
+SSP3,NAV_act,below GDP cutoff,,,,trn_freight_road,S1S,0.9,2040,10
+SSP3,NAV_act,below GDP cutoff,,,,trn_pass_road,S1S,0.7,2040,10
+SSP3,NAV_act,below GDP cutoff,,,,Walk,S1S,2.5,2040,10
+SSP3,NAV_act,CAZ,,,Bus,trn_pass_road,S2S1,3,2040,10
+SSP3,NAV_act,CAZ,,,trn_pass_road_LDV,trn_pass_road,S2S1,0.7,2040,10
+SSP3,NAV_act,USA,,,Bus,trn_pass_road,S2S1,2,2040,10
+SSP3,NAV_act,USA,,,trn_pass_road_LDV,trn_pass_road,S2S1,0.7,2040,10
+SSP3,NAV_act,above GDP cutoff,,,Bus,trn_pass_road,S2S1,2,2040,10
+SSP3,NAV_act,above GDP cutoff,,,trn_pass_road_LDV,trn_pass_road,S2S1,1,2040,10
+SSP3,NAV_act,below GDP cutoff,,,Bus,trn_pass_road,S2S1,2,2040,10
+SSP3,NAV_act,below GDP cutoff,,,trn_pass_road_LDV,trn_pass_road,S2S1,1,2040,10
+SSP3,NAV_act,CAZ,BEV,Bus,Bus,trn_pass_road,FV,1,2040,10
+SSP3,NAV_act,CAZ,FCEV,Bus,Bus,trn_pass_road,FV,1,2040,10
+SSP3,NAV_act,CAZ,Liquids,Bus,Bus,trn_pass_road,FV,1,2050,10
+SSP3,NAV_act,CAZ,Hydrogen,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SSP3,NAV_act,CAZ,Liquids,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SSP3,NAV_act,CAZ,Liquids,Ship,Domestic Ship_tmp_subsectorL2,Domestic Ship,FV,1,2050,10
+SSP3,NAV_act,CAZ,Electric,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SSP3,NAV_act,CAZ,Liquids,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SSP3,NAV_act,CAZ,Electric,Rail,HSR_tmp_subsectorL2,HSR,FV,1,2050,10
+SSP3,NAV_act,CAZ,Liquids,Aviation,International Aviation_tmp_subsectorL2,International Aviation,FV,1,2050,10
+SSP3,NAV_act,CAZ,Liquids,Ship,International Ship_tmp_subsectorL2,International Ship,FV,1,2050,10
+SSP3,NAV_act,CAZ,BEV,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SSP3,NAV_act,CAZ,Liquids,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SSP3,NAV_act,CAZ,Electric,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SSP3,NAV_act,CAZ,Liquids,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SSP3,NAV_act,CAZ,BEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2040,10
+SSP3,NAV_act,CAZ,FCEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2040,10
+SSP3,NAV_act,CAZ,Liquids,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,10
+SSP3,NAV_act,CAZ,BEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2040,10
+SSP3,NAV_act,CAZ,FCEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2040,10
+SSP3,NAV_act,CAZ,Liquids,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,10
+SSP3,NAV_act,USA,BEV,Bus,Bus,trn_pass_road,FV,1,2035,10
+SSP3,NAV_act,USA,FCEV,Bus,Bus,trn_pass_road,FV,1,2035,10
+SSP3,NAV_act,USA,Liquids,Bus,Bus,trn_pass_road,FV,1,2050,10
+SSP3,NAV_act,USA,Hydrogen,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SSP3,NAV_act,USA,Liquids,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SSP3,NAV_act,USA,Liquids,Ship,Domestic Ship_tmp_subsectorL2,Domestic Ship,FV,1,2050,10
+SSP3,NAV_act,USA,Electric,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SSP3,NAV_act,USA,Liquids,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SSP3,NAV_act,USA,Electric,Rail,HSR_tmp_subsectorL2,HSR,FV,1,2050,10
+SSP3,NAV_act,USA,Liquids,Aviation,International Aviation_tmp_subsectorL2,International Aviation,FV,1,2050,10
+SSP3,NAV_act,USA,Liquids,Ship,International Ship_tmp_subsectorL2,International Ship,FV,1,2050,10
+SSP3,NAV_act,USA,BEV,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SSP3,NAV_act,USA,Liquids,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SSP3,NAV_act,USA,Electric,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SSP3,NAV_act,USA,Liquids,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SSP3,NAV_act,USA,BEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2035,10
+SSP3,NAV_act,USA,FCEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2035,10
+SSP3,NAV_act,USA,Liquids,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,10
+SSP3,NAV_act,USA,BEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2035,10
+SSP3,NAV_act,USA,FCEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2035,10
+SSP3,NAV_act,USA,Liquids,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,10
+SSP3,NAV_act,above GDP cutoff,BEV,Bus,Bus,trn_pass_road,FV,1,2040,10
+SSP3,NAV_act,above GDP cutoff,FCEV,Bus,Bus,trn_pass_road,FV,1,2040,10
+SSP3,NAV_act,above GDP cutoff,Liquids,Bus,Bus,trn_pass_road,FV,1,2050,10
+SSP3,NAV_act,above GDP cutoff,Hydrogen,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SSP3,NAV_act,above GDP cutoff,Liquids,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SSP3,NAV_act,above GDP cutoff,Liquids,Ship,Domestic Ship_tmp_subsectorL2,Domestic Ship,FV,1,2050,10
+SSP3,NAV_act,above GDP cutoff,Electric,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SSP3,NAV_act,above GDP cutoff,Liquids,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SSP3,NAV_act,above GDP cutoff,Electric,Rail,HSR_tmp_subsectorL2,HSR,FV,1,2050,10
+SSP3,NAV_act,above GDP cutoff,Liquids,Aviation,International Aviation_tmp_subsectorL2,International Aviation,FV,1,2050,10
+SSP3,NAV_act,above GDP cutoff,Liquids,Ship,International Ship_tmp_subsectorL2,International Ship,FV,1,2050,10
+SSP3,NAV_act,above GDP cutoff,BEV,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SSP3,NAV_act,above GDP cutoff,Liquids,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SSP3,NAV_act,above GDP cutoff,Electric,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SSP3,NAV_act,above GDP cutoff,Liquids,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SSP3,NAV_act,above GDP cutoff,BEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2040,10
+SSP3,NAV_act,above GDP cutoff,FCEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2040,10
+SSP3,NAV_act,above GDP cutoff,Liquids,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,10
+SSP3,NAV_act,above GDP cutoff,BEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2040,10
+SSP3,NAV_act,above GDP cutoff,FCEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2040,10
+SSP3,NAV_act,above GDP cutoff,Liquids,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,10
+SSP3,NAV_act,below GDP cutoff,BEV,Bus,Bus,trn_pass_road,FV,1,2040,10
+SSP3,NAV_act,below GDP cutoff,FCEV,Bus,Bus,trn_pass_road,FV,1,2040,10
+SSP3,NAV_act,below GDP cutoff,Liquids,Bus,Bus,trn_pass_road,FV,1,2050,10
+SSP3,NAV_act,below GDP cutoff,Hydrogen,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SSP3,NAV_act,below GDP cutoff,Liquids,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SSP3,NAV_act,below GDP cutoff,Liquids,Ship,Domestic Ship_tmp_subsectorL2,Domestic Ship,FV,1,2050,10
+SSP3,NAV_act,below GDP cutoff,Electric,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SSP3,NAV_act,below GDP cutoff,Liquids,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SSP3,NAV_act,below GDP cutoff,Electric,Rail,HSR_tmp_subsectorL2,HSR,FV,1,2050,10
+SSP3,NAV_act,below GDP cutoff,Liquids,Aviation,International Aviation_tmp_subsectorL2,International Aviation,FV,1,2050,10
+SSP3,NAV_act,below GDP cutoff,Liquids,Ship,International Ship_tmp_subsectorL2,International Ship,FV,1,2050,10
+SSP3,NAV_act,below GDP cutoff,BEV,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SSP3,NAV_act,below GDP cutoff,Liquids,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SSP3,NAV_act,below GDP cutoff,Electric,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SSP3,NAV_act,below GDP cutoff,Liquids,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SSP3,NAV_act,below GDP cutoff,BEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2040,10
+SSP3,NAV_act,below GDP cutoff,FCEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2040,10
+SSP3,NAV_act,below GDP cutoff,Liquids,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,10
+SSP3,NAV_act,below GDP cutoff,BEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2040,10
+SSP3,NAV_act,below GDP cutoff,FCEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2040,10
+SSP3,NAV_act,below GDP cutoff,Liquids,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,10
+SSP3,NAV_all,CAZ,,,,Cycle,S1S,2.5,2040,10
+SSP3,NAV_all,CAZ,,,,Domestic Aviation,S1S,0.3,2040,10
+SSP3,NAV_all,CAZ,,,,Domestic Ship,S1S,1,2040,10
+SSP3,NAV_all,CAZ,,,,Freight Rail,S1S,1,2040,10
+SSP3,NAV_all,CAZ,,,,HSR,S1S,1.7,2040,10
+SSP3,NAV_all,CAZ,,,,Passenger Rail,S1S,4,2040,10
+SSP3,NAV_all,CAZ,,,,trn_freight_road,S1S,0.9,2040,10
+SSP3,NAV_all,CAZ,,,,trn_pass_road,S1S,0.6,2040,10
+SSP3,NAV_all,CAZ,,,,Walk,S1S,2.5,2040,10
+SSP3,NAV_all,USA,,,,Cycle,S1S,2.5,2040,10
+SSP3,NAV_all,USA,,,,Domestic Aviation,S1S,0.3,2040,10
+SSP3,NAV_all,USA,,,,Domestic Ship,S1S,1,2040,10
+SSP3,NAV_all,USA,,,,Freight Rail,S1S,1,2040,10
+SSP3,NAV_all,USA,,,,HSR,S1S,1.7,2040,10
+SSP3,NAV_all,USA,,,,Passenger Rail,S1S,4,2040,10
+SSP3,NAV_all,USA,,,,trn_freight_road,S1S,0.9,2040,10
+SSP3,NAV_all,USA,,,,trn_pass_road,S1S,0.6,2040,10
+SSP3,NAV_all,USA,,,,Walk,S1S,2.5,2040,10
+SSP3,NAV_all,above GDP cutoff,,,,Cycle,S1S,1.8,2040,10
+SSP3,NAV_all,above GDP cutoff,,,,Domestic Aviation,S1S,0.3,2040,10
+SSP3,NAV_all,above GDP cutoff,,,,Domestic Ship,S1S,1,2040,10
+SSP3,NAV_all,above GDP cutoff,,,,Freight Rail,S1S,1,2040,10
+SSP3,NAV_all,above GDP cutoff,,,,HSR,S1S,1.7,2040,10
+SSP3,NAV_all,above GDP cutoff,,,,Passenger Rail,S1S,1.6,2040,10
+SSP3,NAV_all,above GDP cutoff,,,,trn_freight_road,S1S,0.9,2040,10
+SSP3,NAV_all,above GDP cutoff,,,,trn_pass_road,S1S,0.7,2040,10
+SSP3,NAV_all,above GDP cutoff,,,,Walk,S1S,1.7,2040,10
+SSP3,NAV_all,below GDP cutoff,,,,Cycle,S1S,2.5,2040,10
+SSP3,NAV_all,below GDP cutoff,,,,Domestic Aviation,S1S,0.3,2040,10
+SSP3,NAV_all,below GDP cutoff,,,,Domestic Ship,S1S,1,2040,10
+SSP3,NAV_all,below GDP cutoff,,,,Freight Rail,S1S,1,2040,10
+SSP3,NAV_all,below GDP cutoff,,,,HSR,S1S,2.8,2040,10
+SSP3,NAV_all,below GDP cutoff,,,,Passenger Rail,S1S,1.5,2040,10
+SSP3,NAV_all,below GDP cutoff,,,,trn_freight_road,S1S,0.9,2040,10
+SSP3,NAV_all,below GDP cutoff,,,,trn_pass_road,S1S,0.7,2040,10
+SSP3,NAV_all,below GDP cutoff,,,,Walk,S1S,2.5,2040,10
+SSP3,NAV_all,CAZ,,,Bus,trn_pass_road,S2S1,3,2040,10
+SSP3,NAV_all,CAZ,,,trn_pass_road_LDV,trn_pass_road,S2S1,0.7,2040,10
+SSP3,NAV_all,USA,,,Bus,trn_pass_road,S2S1,2,2040,10
+SSP3,NAV_all,USA,,,trn_pass_road_LDV,trn_pass_road,S2S1,0.7,2040,10
+SSP3,NAV_all,above GDP cutoff,,,Bus,trn_pass_road,S2S1,2,2040,10
+SSP3,NAV_all,above GDP cutoff,,,trn_pass_road_LDV,trn_pass_road,S2S1,1,2040,10
+SSP3,NAV_all,below GDP cutoff,,,Bus,trn_pass_road,S2S1,2,2040,10
+SSP3,NAV_all,below GDP cutoff,,,trn_pass_road_LDV,trn_pass_road,S2S1,1,2040,10
+SSP3,NAV_all,above GDP cutoff,BEV,Bus,Bus,trn_pass_road,FV,9,2025,10
+SSP3,NAV_all,above GDP cutoff,FCEV,Bus,Bus,trn_pass_road,FV,6,2025,10
+SSP3,NAV_all,above GDP cutoff,Liquids,Bus,Bus,trn_pass_road,FV,0.01,2025,10
+SSP3,NAV_all,above GDP cutoff,Hydrogen,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,10,2045,10
+SSP3,NAV_all,above GDP cutoff,Liquids,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,0.1,2045,10
+SSP3,NAV_all,above GDP cutoff,Liquids,Ship,Domestic Ship_tmp_subsectorL2,Domestic Ship,FV,0.1,2050,10
+SSP3,NAV_all,above GDP cutoff,Electric,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,2,2040,10
+SSP3,NAV_all,above GDP cutoff,Liquids,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,0.1,2040,10
+SSP3,NAV_all,above GDP cutoff,Electric,Rail,HSR_tmp_subsectorL2,HSR,FV,2,2040,10
+SSP3,NAV_all,above GDP cutoff,Liquids,Aviation,International Aviation_tmp_subsectorL2,International Aviation,FV,0.1,2045,10
+SSP3,NAV_all,above GDP cutoff,Liquids,Ship,International Ship_tmp_subsectorL2,International Ship,FV,0.1,2050,10
+SSP3,NAV_all,above GDP cutoff,BEV,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,4,2030,10
+SSP3,NAV_all,above GDP cutoff,Liquids,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,0.05,2030,10
+SSP3,NAV_all,above GDP cutoff,Electric,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,2,2040,10
+SSP3,NAV_all,above GDP cutoff,Liquids,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,0.1,2040,10
+SSP3,NAV_all,above GDP cutoff,BEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,4,2025,10
+SSP3,NAV_all,above GDP cutoff,FCEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,4,2025,10
+SSP3,NAV_all,above GDP cutoff,Liquids,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,0.01,2025,10
+SSP3,NAV_all,above GDP cutoff,BEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,4,2025,10
+SSP3,NAV_all,above GDP cutoff,FCEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,9,2025,10
+SSP3,NAV_all,above GDP cutoff,Liquids,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,0.01,2025,10
+SSP3,NAV_all,below GDP cutoff,BEV,Bus,Bus,trn_pass_road,FV,7,2025,10
+SSP3,NAV_all,below GDP cutoff,FCEV,Bus,Bus,trn_pass_road,FV,5,2025,10
+SSP3,NAV_all,below GDP cutoff,Liquids,Bus,Bus,trn_pass_road,FV,0.01,2025,10
+SSP3,NAV_all,below GDP cutoff,Hydrogen,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,10,2045,10
+SSP3,NAV_all,below GDP cutoff,Liquids,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,0.1,2045,10
+SSP3,NAV_all,below GDP cutoff,Liquids,Ship,Domestic Ship_tmp_subsectorL2,Domestic Ship,FV,0.1,2050,10
+SSP3,NAV_all,below GDP cutoff,Electric,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,2,2040,10
+SSP3,NAV_all,below GDP cutoff,Liquids,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,0.1,2040,10
+SSP3,NAV_all,below GDP cutoff,Electric,Rail,HSR_tmp_subsectorL2,HSR,FV,2,2040,10
+SSP3,NAV_all,below GDP cutoff,Liquids,Aviation,International Aviation_tmp_subsectorL2,International Aviation,FV,0.1,2045,10
+SSP3,NAV_all,below GDP cutoff,Liquids,Ship,International Ship_tmp_subsectorL2,International Ship,FV,0.1,2050,10
+SSP3,NAV_all,below GDP cutoff,BEV,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,4,2030,10
+SSP3,NAV_all,below GDP cutoff,Liquids,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,0.05,2030,10
+SSP3,NAV_all,below GDP cutoff,Electric,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,2,2040,10
+SSP3,NAV_all,below GDP cutoff,Liquids,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,0.1,2040,10
+SSP3,NAV_all,below GDP cutoff,BEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,4,2025,10
+SSP3,NAV_all,below GDP cutoff,FCEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,4,2025,10
+SSP3,NAV_all,below GDP cutoff,Liquids,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,0.01,2025,10
+SSP3,NAV_all,below GDP cutoff,BEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1.5,2025,10
+SSP3,NAV_all,below GDP cutoff,FCEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,9,2025,10
+SSP3,NAV_all,below GDP cutoff,Liquids,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,0.01,2025,10
+SSP3,NAV_ele,above GDP cutoff,,,,Cycle,S1S,1,2040,10
+SSP3,NAV_ele,above GDP cutoff,,,,Domestic Aviation,S1S,1,2040,10
+SSP3,NAV_ele,above GDP cutoff,,,,Domestic Ship,S1S,1,2040,10
+SSP3,NAV_ele,above GDP cutoff,,,,Freight Rail,S1S,1,2040,10
+SSP3,NAV_ele,above GDP cutoff,,,,HSR,S1S,1,2040,10
+SSP3,NAV_ele,above GDP cutoff,,,,Passenger Rail,S1S,1,2040,10
+SSP3,NAV_ele,above GDP cutoff,,,,trn_freight_road,S1S,1,2040,10
+SSP3,NAV_ele,above GDP cutoff,,,,trn_pass_road,S1S,1,2040,10
+SSP3,NAV_ele,above GDP cutoff,,,,Walk,S1S,1,2040,10
+SSP3,NAV_ele,below GDP cutoff,,,,Cycle,S1S,1,2040,10
+SSP3,NAV_ele,below GDP cutoff,,,,Domestic Aviation,S1S,1,2040,10
+SSP3,NAV_ele,below GDP cutoff,,,,Domestic Ship,S1S,1,2040,10
+SSP3,NAV_ele,below GDP cutoff,,,,Freight Rail,S1S,1,2040,10
+SSP3,NAV_ele,below GDP cutoff,,,,HSR,S1S,1,2040,10
+SSP3,NAV_ele,below GDP cutoff,,,,Passenger Rail,S1S,1,2040,10
+SSP3,NAV_ele,below GDP cutoff,,,,trn_freight_road,S1S,1,2040,10
+SSP3,NAV_ele,below GDP cutoff,,,,trn_pass_road,S1S,1,2040,10
+SSP3,NAV_ele,below GDP cutoff,,,,Walk,S1S,1,2040,10
+SSP3,NAV_ele,above GDP cutoff,,,Bus,trn_pass_road,S2S1,1,2040,10
+SSP3,NAV_ele,above GDP cutoff,,,trn_pass_road_LDV,trn_pass_road,S2S1,1,2040,10
+SSP3,NAV_ele,below GDP cutoff,,,Bus,trn_pass_road,S2S1,1,2040,10
+SSP3,NAV_ele,below GDP cutoff,,,trn_pass_road_LDV,trn_pass_road,S2S1,1,2040,10
+SSP3,NAV_ele,above GDP cutoff,BEV,Bus,Bus,trn_pass_road,FV,9,2025,10
+SSP3,NAV_ele,above GDP cutoff,FCEV,Bus,Bus,trn_pass_road,FV,6,2025,10
+SSP3,NAV_ele,above GDP cutoff,Liquids,Bus,Bus,trn_pass_road,FV,0.01,2025,10
+SSP3,NAV_ele,above GDP cutoff,Hydrogen,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,10,2045,10
+SSP3,NAV_ele,above GDP cutoff,Liquids,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,0.1,2045,10
+SSP3,NAV_ele,above GDP cutoff,Liquids,Ship,Domestic Ship_tmp_subsectorL2,Domestic Ship,FV,0.1,2050,10
+SSP3,NAV_ele,above GDP cutoff,Electric,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,2,2040,10
+SSP3,NAV_ele,above GDP cutoff,Liquids,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,0.1,2040,10
+SSP3,NAV_ele,above GDP cutoff,Electric,Rail,HSR_tmp_subsectorL2,HSR,FV,2,2040,10
+SSP3,NAV_ele,above GDP cutoff,Liquids,Aviation,International Aviation_tmp_subsectorL2,International Aviation,FV,0.1,2045,10
+SSP3,NAV_ele,above GDP cutoff,Liquids,Ship,International Ship_tmp_subsectorL2,International Ship,FV,0.1,2050,10
+SSP3,NAV_ele,above GDP cutoff,BEV,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,4,2030,10
+SSP3,NAV_ele,above GDP cutoff,Liquids,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,0.05,2030,10
+SSP3,NAV_ele,above GDP cutoff,Electric,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,2,2040,10
+SSP3,NAV_ele,above GDP cutoff,Liquids,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,0.1,2040,10
+SSP3,NAV_ele,above GDP cutoff,BEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,4,2025,10
+SSP3,NAV_ele,above GDP cutoff,FCEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,4,2025,10
+SSP3,NAV_ele,above GDP cutoff,Liquids,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,0.01,2025,10
+SSP3,NAV_ele,above GDP cutoff,BEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,4,2025,10
+SSP3,NAV_ele,above GDP cutoff,FCEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,9,2025,10
+SSP3,NAV_ele,above GDP cutoff,Liquids,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,0.01,2025,10
+SSP3,NAV_ele,below GDP cutoff,BEV,Bus,Bus,trn_pass_road,FV,7,2025,10
+SSP3,NAV_ele,below GDP cutoff,FCEV,Bus,Bus,trn_pass_road,FV,5,2025,10
+SSP3,NAV_ele,below GDP cutoff,Liquids,Bus,Bus,trn_pass_road,FV,0.01,2025,10
+SSP3,NAV_ele,below GDP cutoff,Hydrogen,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,10,2045,10
+SSP3,NAV_ele,below GDP cutoff,Liquids,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,0.1,2045,10
+SSP3,NAV_ele,below GDP cutoff,Liquids,Ship,Domestic Ship_tmp_subsectorL2,Domestic Ship,FV,0.1,2050,10
+SSP3,NAV_ele,below GDP cutoff,Electric,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,2,2040,10
+SSP3,NAV_ele,below GDP cutoff,Liquids,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,0.1,2040,10
+SSP3,NAV_ele,below GDP cutoff,Electric,Rail,HSR_tmp_subsectorL2,HSR,FV,2,2040,10
+SSP3,NAV_ele,below GDP cutoff,Liquids,Aviation,International Aviation_tmp_subsectorL2,International Aviation,FV,0.1,2045,10
+SSP3,NAV_ele,below GDP cutoff,Liquids,Ship,International Ship_tmp_subsectorL2,International Ship,FV,0.1,2050,10
+SSP3,NAV_ele,below GDP cutoff,BEV,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,4,2030,10
+SSP3,NAV_ele,below GDP cutoff,Liquids,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,0.05,2030,10
+SSP3,NAV_ele,below GDP cutoff,Electric,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,2,2040,10
+SSP3,NAV_ele,below GDP cutoff,Liquids,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,0.1,2040,10
+SSP3,NAV_ele,below GDP cutoff,BEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,4,2025,10
+SSP3,NAV_ele,below GDP cutoff,FCEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,4,2025,10
+SSP3,NAV_ele,below GDP cutoff,Liquids,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,0.01,2025,10
+SSP3,NAV_ele,below GDP cutoff,BEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1.5,2025,10
+SSP3,NAV_ele,below GDP cutoff,FCEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,9,2025,10
+SSP3,NAV_ele,below GDP cutoff,Liquids,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,0.01,2025,10
+SSP3,NAV_lce,CAZ,,,,Cycle,S1S,2.5,2040,10
+SSP3,NAV_lce,CAZ,,,,Domestic Aviation,S1S,0.3,2040,10
+SSP3,NAV_lce,CAZ,,,,Domestic Ship,S1S,1,2040,10
+SSP3,NAV_lce,CAZ,,,,Freight Rail,S1S,1,2040,10
+SSP3,NAV_lce,CAZ,,,,HSR,S1S,1.7,2040,10
+SSP3,NAV_lce,CAZ,,,,Passenger Rail,S1S,4,2040,10
+SSP3,NAV_lce,CAZ,,,,trn_freight_road,S1S,0.9,2040,10
+SSP3,NAV_lce,CAZ,,,,trn_pass_road,S1S,0.6,2040,10
+SSP3,NAV_lce,CAZ,,,,Walk,S1S,2.5,2040,10
+SSP3,NAV_lce,USA,,,,Cycle,S1S,2.5,2040,10
+SSP3,NAV_lce,USA,,,,Domestic Aviation,S1S,0.3,2040,10
+SSP3,NAV_lce,USA,,,,Domestic Ship,S1S,1,2040,10
+SSP3,NAV_lce,USA,,,,Freight Rail,S1S,1,2040,10
+SSP3,NAV_lce,USA,,,,HSR,S1S,1.7,2040,10
+SSP3,NAV_lce,USA,,,,Passenger Rail,S1S,4,2040,10
+SSP3,NAV_lce,USA,,,,trn_freight_road,S1S,0.9,2040,10
+SSP3,NAV_lce,USA,,,,trn_pass_road,S1S,0.6,2040,10
+SSP3,NAV_lce,USA,,,,Walk,S1S,2.5,2040,10
+SSP3,NAV_lce,above GDP cutoff,,,,Cycle,S1S,1.8,2040,10
+SSP3,NAV_lce,above GDP cutoff,,,,Domestic Aviation,S1S,0.3,2040,10
+SSP3,NAV_lce,above GDP cutoff,,,,Domestic Ship,S1S,1,2040,10
+SSP3,NAV_lce,above GDP cutoff,,,,Freight Rail,S1S,1,2040,10
+SSP3,NAV_lce,above GDP cutoff,,,,HSR,S1S,1.7,2040,10
+SSP3,NAV_lce,above GDP cutoff,,,,Passenger Rail,S1S,1.6,2040,10
+SSP3,NAV_lce,above GDP cutoff,,,,trn_freight_road,S1S,0.9,2040,10
+SSP3,NAV_lce,above GDP cutoff,,,,trn_pass_road,S1S,0.7,2040,10
+SSP3,NAV_lce,above GDP cutoff,,,,Walk,S1S,1.7,2040,10
+SSP3,NAV_lce,below GDP cutoff,,,,Cycle,S1S,2.5,2040,10
+SSP3,NAV_lce,below GDP cutoff,,,,Domestic Aviation,S1S,0.3,2040,10
+SSP3,NAV_lce,below GDP cutoff,,,,Domestic Ship,S1S,1,2040,10
+SSP3,NAV_lce,below GDP cutoff,,,,Freight Rail,S1S,1,2040,10
+SSP3,NAV_lce,below GDP cutoff,,,,HSR,S1S,2.8,2040,10
+SSP3,NAV_lce,below GDP cutoff,,,,Passenger Rail,S1S,1.5,2040,10
+SSP3,NAV_lce,below GDP cutoff,,,,trn_freight_road,S1S,0.9,2040,10
+SSP3,NAV_lce,below GDP cutoff,,,,trn_pass_road,S1S,0.7,2040,10
+SSP3,NAV_lce,below GDP cutoff,,,,Walk,S1S,2.5,2040,10
+SSP3,NAV_lce,CAZ,,,Bus,trn_pass_road,S2S1,3,2040,10
+SSP3,NAV_lce,CAZ,,,trn_pass_road_LDV,trn_pass_road,S2S1,0.7,2040,10
+SSP3,NAV_lce,USA,,,Bus,trn_pass_road,S2S1,2,2040,10
+SSP3,NAV_lce,USA,,,trn_pass_road_LDV,trn_pass_road,S2S1,0.7,2040,10
+SSP3,NAV_lce,above GDP cutoff,,,Bus,trn_pass_road,S2S1,2,2040,10
+SSP3,NAV_lce,above GDP cutoff,,,trn_pass_road_LDV,trn_pass_road,S2S1,1,2040,10
+SSP3,NAV_lce,below GDP cutoff,,,Bus,trn_pass_road,S2S1,2,2040,10
+SSP3,NAV_lce,below GDP cutoff,,,trn_pass_road_LDV,trn_pass_road,S2S1,1,2040,10
+SSP3,NAV_lce,CAZ,BEV,Bus,Bus,trn_pass_road,FV,1,2040,10
+SSP3,NAV_lce,CAZ,FCEV,Bus,Bus,trn_pass_road,FV,1,2040,10
+SSP3,NAV_lce,CAZ,Liquids,Bus,Bus,trn_pass_road,FV,1,2050,10
+SSP3,NAV_lce,CAZ,Hydrogen,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SSP3,NAV_lce,CAZ,Liquids,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SSP3,NAV_lce,CAZ,Liquids,Ship,Domestic Ship_tmp_subsectorL2,Domestic Ship,FV,1,2050,10
+SSP3,NAV_lce,CAZ,Electric,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SSP3,NAV_lce,CAZ,Liquids,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SSP3,NAV_lce,CAZ,Electric,Rail,HSR_tmp_subsectorL2,HSR,FV,1,2050,10
+SSP3,NAV_lce,CAZ,Liquids,Aviation,International Aviation_tmp_subsectorL2,International Aviation,FV,1,2050,10
+SSP3,NAV_lce,CAZ,Liquids,Ship,International Ship_tmp_subsectorL2,International Ship,FV,1,2050,10
+SSP3,NAV_lce,CAZ,BEV,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SSP3,NAV_lce,CAZ,Liquids,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SSP3,NAV_lce,CAZ,Electric,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SSP3,NAV_lce,CAZ,Liquids,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SSP3,NAV_lce,CAZ,BEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2040,10
+SSP3,NAV_lce,CAZ,FCEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2040,10
+SSP3,NAV_lce,CAZ,Liquids,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,10
+SSP3,NAV_lce,CAZ,BEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2040,10
+SSP3,NAV_lce,CAZ,FCEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2040,10
+SSP3,NAV_lce,CAZ,Liquids,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,10
+SSP3,NAV_lce,USA,BEV,Bus,Bus,trn_pass_road,FV,1,2035,10
+SSP3,NAV_lce,USA,FCEV,Bus,Bus,trn_pass_road,FV,1,2035,10
+SSP3,NAV_lce,USA,Liquids,Bus,Bus,trn_pass_road,FV,1,2050,10
+SSP3,NAV_lce,USA,Hydrogen,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SSP3,NAV_lce,USA,Liquids,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SSP3,NAV_lce,USA,Liquids,Ship,Domestic Ship_tmp_subsectorL2,Domestic Ship,FV,1,2050,10
+SSP3,NAV_lce,USA,Electric,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SSP3,NAV_lce,USA,Liquids,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SSP3,NAV_lce,USA,Electric,Rail,HSR_tmp_subsectorL2,HSR,FV,1,2050,10
+SSP3,NAV_lce,USA,Liquids,Aviation,International Aviation_tmp_subsectorL2,International Aviation,FV,1,2050,10
+SSP3,NAV_lce,USA,Liquids,Ship,International Ship_tmp_subsectorL2,International Ship,FV,1,2050,10
+SSP3,NAV_lce,USA,BEV,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SSP3,NAV_lce,USA,Liquids,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SSP3,NAV_lce,USA,Electric,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SSP3,NAV_lce,USA,Liquids,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SSP3,NAV_lce,USA,BEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2035,10
+SSP3,NAV_lce,USA,FCEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2035,10
+SSP3,NAV_lce,USA,Liquids,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,10
+SSP3,NAV_lce,USA,BEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2035,10
+SSP3,NAV_lce,USA,FCEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2035,10
+SSP3,NAV_lce,USA,Liquids,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,10
+SSP3,NAV_lce,above GDP cutoff,BEV,Bus,Bus,trn_pass_road,FV,1,2040,10
+SSP3,NAV_lce,above GDP cutoff,FCEV,Bus,Bus,trn_pass_road,FV,1,2040,10
+SSP3,NAV_lce,above GDP cutoff,Liquids,Bus,Bus,trn_pass_road,FV,1,2050,10
+SSP3,NAV_lce,above GDP cutoff,Hydrogen,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SSP3,NAV_lce,above GDP cutoff,Liquids,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SSP3,NAV_lce,above GDP cutoff,Liquids,Ship,Domestic Ship_tmp_subsectorL2,Domestic Ship,FV,1,2050,10
+SSP3,NAV_lce,above GDP cutoff,Electric,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SSP3,NAV_lce,above GDP cutoff,Liquids,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SSP3,NAV_lce,above GDP cutoff,Electric,Rail,HSR_tmp_subsectorL2,HSR,FV,1,2050,10
+SSP3,NAV_lce,above GDP cutoff,Liquids,Aviation,International Aviation_tmp_subsectorL2,International Aviation,FV,1,2050,10
+SSP3,NAV_lce,above GDP cutoff,Liquids,Ship,International Ship_tmp_subsectorL2,International Ship,FV,1,2050,10
+SSP3,NAV_lce,above GDP cutoff,BEV,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SSP3,NAV_lce,above GDP cutoff,Liquids,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SSP3,NAV_lce,above GDP cutoff,Electric,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SSP3,NAV_lce,above GDP cutoff,Liquids,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SSP3,NAV_lce,above GDP cutoff,BEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2040,10
+SSP3,NAV_lce,above GDP cutoff,FCEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2040,10
+SSP3,NAV_lce,above GDP cutoff,Liquids,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,10
+SSP3,NAV_lce,above GDP cutoff,BEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2040,10
+SSP3,NAV_lce,above GDP cutoff,FCEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2040,10
+SSP3,NAV_lce,above GDP cutoff,Liquids,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,10
+SSP3,NAV_lce,below GDP cutoff,BEV,Bus,Bus,trn_pass_road,FV,1,2040,10
+SSP3,NAV_lce,below GDP cutoff,FCEV,Bus,Bus,trn_pass_road,FV,1,2040,10
+SSP3,NAV_lce,below GDP cutoff,Liquids,Bus,Bus,trn_pass_road,FV,1,2050,10
+SSP3,NAV_lce,below GDP cutoff,Hydrogen,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SSP3,NAV_lce,below GDP cutoff,Liquids,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
+SSP3,NAV_lce,below GDP cutoff,Liquids,Ship,Domestic Ship_tmp_subsectorL2,Domestic Ship,FV,1,2050,10
+SSP3,NAV_lce,below GDP cutoff,Electric,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SSP3,NAV_lce,below GDP cutoff,Liquids,Rail,Freight Rail_tmp_subsectorL2,Freight Rail,FV,1,2050,10
+SSP3,NAV_lce,below GDP cutoff,Electric,Rail,HSR_tmp_subsectorL2,HSR,FV,1,2050,10
+SSP3,NAV_lce,below GDP cutoff,Liquids,Aviation,International Aviation_tmp_subsectorL2,International Aviation,FV,1,2050,10
+SSP3,NAV_lce,below GDP cutoff,Liquids,Ship,International Ship_tmp_subsectorL2,International Ship,FV,1,2050,10
+SSP3,NAV_lce,below GDP cutoff,BEV,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SSP3,NAV_lce,below GDP cutoff,Liquids,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
+SSP3,NAV_lce,below GDP cutoff,Electric,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SSP3,NAV_lce,below GDP cutoff,Liquids,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
+SSP3,NAV_lce,below GDP cutoff,BEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2040,10
+SSP3,NAV_lce,below GDP cutoff,FCEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2040,10
+SSP3,NAV_lce,below GDP cutoff,Liquids,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,10
+SSP3,NAV_lce,below GDP cutoff,BEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2040,10
+SSP3,NAV_lce,below GDP cutoff,FCEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2040,10
+SSP3,NAV_lce,below GDP cutoff,Liquids,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,10


### PR DESCRIPTION
## Purpose of this PR
Improve the BEV phase in: Increase speed in CHA, reduce it in developing region. Increase BEV-Sales shares post-2040
I: 
1. lowered the BEV-CAPEX-cost markup in `[mrtransport ](https://github.com/pik-piam/mrtransport/pull/27)`
2. adjusted the start values for the inconvenience costs 
3. adjusted the policy mask for inconvenience costs 
4. adjusted the preference factors for BEV-trucks


* Test runs are here: ```/p/projects/edget/PRchangeLog/20241129_PR310_BEVPhaseIn_Trucks&Cars```


