### PR TITLE
Bugfix gdxPath

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '42588540'
+ValidationKey: '42643548'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
@@ -8,3 +8,4 @@ AcceptedNotes: 'Undefined global functions or variables:'
 allowLinterWarnings: yes
 enforceVersionUpdate: no
 skipCoverage: no
+AutocreateCITATION: yes

--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '42643548'
+ValidationKey: '42588540'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
@@ -8,4 +8,3 @@ AcceptedNotes: 'Undefined global functions or variables:'
 allowLinterWarnings: yes
 enforceVersionUpdate: no
 skipCoverage: no
-AutocreateCITATION: yes

--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '42588540'
+ValidationKey: '42623471'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
@@ -8,3 +8,4 @@ AcceptedNotes: 'Undefined global functions or variables:'
 allowLinterWarnings: yes
 enforceVersionUpdate: no
 skipCoverage: no
+AutocreateCITATION: yes

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'edgeTransport: Prepare EDGE Transport Data for the REMIND model'
-version: 2.12.4
-date-released: '2024-12-20'
+version: 2.12.2
+date-released: '2024-12-13'
 abstract: EDGE-T is a fork of the GCAM transport module https://jgcri.github.io/gcam-doc/energy.html#transportation
   with a high level of detail in its representation of technological and modal options.
   It is a partial equilibrium model with a nested multinomial logit structure and

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'edgeTransport: Prepare EDGE Transport Data for the REMIND model'
-version: 2.12.2
-date-released: '2024-12-13'
+version: 2.12.4
+date-released: '2024-12-20'
 abstract: EDGE-T is a fork of the GCAM transport module https://jgcri.github.io/gcam-doc/energy.html#transportation
   with a high level of detail in its representation of technological and modal options.
   It is a partial equilibrium model with a nested multinomial logit structure and

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'edgeTransport: Prepare EDGE Transport Data for the REMIND model'
-version: 2.12.2
-date-released: '2024-12-13'
+version: 2.12.3
+date-released: '2024-12-20'
 abstract: EDGE-T is a fork of the GCAM transport module https://jgcri.github.io/gcam-doc/energy.html#transportation
   with a high level of detail in its representation of technological and modal options.
   It is a partial equilibrium model with a nested multinomial logit structure and

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: edgeTransport
 Title: Prepare EDGE Transport Data for the REMIND model
-Version: 2.12.2
+Version: 2.12.3
 Authors@R: c(
     person("Johanna", "Hoppe", , "johanna.hoppe@pik-potsdam.de", role = c("aut", "cre"),
            comment = c(ORCID = "0009-0004-6753-5090")),
@@ -19,7 +19,7 @@ Encoding: UTF-8
 LazyData: true
 RoxygenNote: 7.3.2
 VignetteBuilder: knitr
-Date: 2024-12-13
+Date: 2024-12-20
 Config/testthat/edition: 3
 Imports:
     rmndt,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: edgeTransport
 Title: Prepare EDGE Transport Data for the REMIND model
-Version: 2.12.2
+Version: 2.12.4
 Authors@R: c(
     person("Johanna", "Hoppe", , "johanna.hoppe@pik-potsdam.de", role = c("aut", "cre"),
            comment = c(ORCID = "0009-0004-6753-5090")),
@@ -19,7 +19,7 @@ Encoding: UTF-8
 LazyData: true
 RoxygenNote: 7.3.2
 VignetteBuilder: knitr
-Date: 2024-12-13
+Date: 2024-12-20
 Config/testthat/edition: 3
 Imports:
     rmndt,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: edgeTransport
 Title: Prepare EDGE Transport Data for the REMIND model
-Version: 2.12.4
+Version: 2.12.2
 Authors@R: c(
     person("Johanna", "Hoppe", , "johanna.hoppe@pik-potsdam.de", role = c("aut", "cre"),
            comment = c(ORCID = "0009-0004-6753-5090")),
@@ -19,7 +19,7 @@ Encoding: UTF-8
 LazyData: true
 RoxygenNote: 7.3.2
 VignetteBuilder: knitr
-Date: 2024-12-20
+Date: 2024-12-13
 Config/testthat/edition: 3
 Imports:
     rmndt,

--- a/R/toolEdgeTransportSA.R
+++ b/R/toolEdgeTransportSA.R
@@ -50,6 +50,9 @@ toolEdgeTransportSA <- function(SSPscen,
   ## Load input data
   ########################################################
   if (is.null(outputFolder) & isStored) stop("Please provide an outputfolder to store your results")
+  if (is.null(gdxPath)) {gdxPath <- file.path(getConfig("sourcefolder"),
+                                             "REMINDinputForTransportStandalone", "v1.2", "fulldata.gdx")}
+  if (!file.exists(gdxPath)) stop("Please provide valid path to REMIND fulldata.gdx as input for fuel costs")
 
   inputs <- toolLoadInputs(SSPscen, transportPolScen, demScen, gdxPath, hybridElecShare)
 

--- a/R/toolEdgeTransportSA.R
+++ b/R/toolEdgeTransportSA.R
@@ -52,6 +52,9 @@ toolEdgeTransportSA <- function(SSPscen,
   if (is.null(outputFolder) & isStored) stop("Please provide an outputfolder to store your results")
 
   inputs <- toolLoadInputs(SSPscen, transportPolScen, demScen, gdxPath, hybridElecShare)
+  if (is.null(gdxPath)) {gdxPath <- file.path(getConfig("sourcefolder"),
+                                              "REMINDinputForTransportStandalone", "v1.2", "fulldata.gdx")}
+  if (!file.exists(gdxPath)) stop("Please provide valid path to REMIND fulldata.gdx as input for fuel costs")
 
   helpers <- inputs$helpers
   genModelPar <- inputs$genModelPar

--- a/R/toolEdgeTransportSA.R
+++ b/R/toolEdgeTransportSA.R
@@ -50,9 +50,6 @@ toolEdgeTransportSA <- function(SSPscen,
   ## Load input data
   ########################################################
   if (is.null(outputFolder) & isStored) stop("Please provide an outputfolder to store your results")
-  if (is.null(gdxPath)) {gdxPath <- file.path(getConfig("sourcefolder"),
-                                             "REMINDinputForTransportStandalone", "v1.2", "fulldata.gdx")}
-  if (!file.exists(gdxPath)) stop("Please provide valid path to REMIND fulldata.gdx as input for fuel costs")
 
   inputs <- toolLoadInputs(SSPscen, transportPolScen, demScen, gdxPath, hybridElecShare)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Prepare EDGE Transport Data for the REMIND model
 
-R package **edgeTransport**, version **2.12.2**
+R package **edgeTransport**, version **2.12.4**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/edgeTransport)](https://cran.r-project.org/package=edgeTransport) [![R build status](https://github.com/pik-piam/edgeTransport/workflows/check/badge.svg)](https://github.com/pik-piam/edgeTransport/actions) [![codecov](https://codecov.io/gh/pik-piam/edgeTransport/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/edgeTransport) [![r-universe](https://pik-piam.r-universe.dev/badges/edgeTransport)](https://pik-piam.r-universe.dev/builds)
 
@@ -46,16 +46,17 @@ In case of questions / problems please contact Johanna Hoppe <johanna.hoppe@pik-
 
 To cite package **edgeTransport** in publications use:
 
-Hoppe J, Dirnaichner A, Rottoli M, Muessel J (2024). _edgeTransport: Prepare EDGE Transport Data for the REMIND model_. R package version 2.12.2, <https://github.com/pik-piam/edgeTransport>.
+Hoppe J, Dirnaichner A, Rottoli M, Muessel J (2024). "edgeTransport: Prepare EDGE Transport Data for the REMIND model." Version: 2.12.4, <https://github.com/pik-piam/edgeTransport>.
 
 A BibTeX entry for LaTeX users is
 
  ```latex
-@Manual{,
+@Misc{,
   title = {edgeTransport: Prepare EDGE Transport Data for the REMIND model},
   author = {Johanna Hoppe and Alois Dirnaichner and Marianna Rottoli and Jarusch Muessel},
+  date = {2024-12-20},
   year = {2024},
-  note = {R package version 2.12.2},
   url = {https://github.com/pik-piam/edgeTransport},
+  note = {Version: 2.12.4},
 }
 ```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Prepare EDGE Transport Data for the REMIND model
 
-R package **edgeTransport**, version **2.12.4**
+R package **edgeTransport**, version **2.12.2**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/edgeTransport)](https://cran.r-project.org/package=edgeTransport) [![R build status](https://github.com/pik-piam/edgeTransport/workflows/check/badge.svg)](https://github.com/pik-piam/edgeTransport/actions) [![codecov](https://codecov.io/gh/pik-piam/edgeTransport/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/edgeTransport) [![r-universe](https://pik-piam.r-universe.dev/badges/edgeTransport)](https://pik-piam.r-universe.dev/builds)
 
@@ -46,17 +46,16 @@ In case of questions / problems please contact Johanna Hoppe <johanna.hoppe@pik-
 
 To cite package **edgeTransport** in publications use:
 
-Hoppe J, Dirnaichner A, Rottoli M, Muessel J (2024). "edgeTransport: Prepare EDGE Transport Data for the REMIND model." Version: 2.12.4, <https://github.com/pik-piam/edgeTransport>.
+Hoppe J, Dirnaichner A, Rottoli M, Muessel J (2024). _edgeTransport: Prepare EDGE Transport Data for the REMIND model_. R package version 2.12.2, <https://github.com/pik-piam/edgeTransport>.
 
 A BibTeX entry for LaTeX users is
 
  ```latex
-@Misc{,
+@Manual{,
   title = {edgeTransport: Prepare EDGE Transport Data for the REMIND model},
   author = {Johanna Hoppe and Alois Dirnaichner and Marianna Rottoli and Jarusch Muessel},
-  date = {2024-12-20},
   year = {2024},
+  note = {R package version 2.12.2},
   url = {https://github.com/pik-piam/edgeTransport},
-  note = {Version: 2.12.4},
 }
 ```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Prepare EDGE Transport Data for the REMIND model
 
-R package **edgeTransport**, version **2.12.2**
+R package **edgeTransport**, version **2.12.3**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/edgeTransport)](https://cran.r-project.org/package=edgeTransport) [![R build status](https://github.com/pik-piam/edgeTransport/workflows/check/badge.svg)](https://github.com/pik-piam/edgeTransport/actions) [![codecov](https://codecov.io/gh/pik-piam/edgeTransport/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/edgeTransport) [![r-universe](https://pik-piam.r-universe.dev/badges/edgeTransport)](https://pik-piam.r-universe.dev/builds)
 
@@ -46,16 +46,17 @@ In case of questions / problems please contact Johanna Hoppe <johanna.hoppe@pik-
 
 To cite package **edgeTransport** in publications use:
 
-Hoppe J, Dirnaichner A, Rottoli M, Muessel J (2024). _edgeTransport: Prepare EDGE Transport Data for the REMIND model_. R package version 2.12.2, <https://github.com/pik-piam/edgeTransport>.
+Hoppe J, Dirnaichner A, Rottoli M, Muessel J (2024). "edgeTransport: Prepare EDGE Transport Data for the REMIND model." Version: 2.12.3, <https://github.com/pik-piam/edgeTransport>.
 
 A BibTeX entry for LaTeX users is
 
  ```latex
-@Manual{,
+@Misc{,
   title = {edgeTransport: Prepare EDGE Transport Data for the REMIND model},
   author = {Johanna Hoppe and Alois Dirnaichner and Marianna Rottoli and Jarusch Muessel},
+  date = {2024-12-20},
   year = {2024},
-  note = {R package version 2.12.2},
   url = {https://github.com/pik-piam/edgeTransport},
+  note = {Version: 2.12.3},
 }
 ```


### PR DESCRIPTION
## Purpose of this PR

gdxPath is set on level of toolEDGETransportSA as it was before.

Maybe this part should be reworked in the future to allow for madrat read in of the gdx as a source in mrtransport.

