### PR TITLE
Update annuity parameters

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '43377864'
+ValidationKey: '43398021'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,7 +2,7 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'edgeTransport: Prepare EDGE Transport Data for the REMIND model'
-version: 2.15.2
+version: 2.15.3
 date-released: '2025-03-10'
 abstract: EDGE-T is a fork of the GCAM transport module https://jgcri.github.io/gcam-doc/energy.html#transportation
   with a high level of detail in its representation of technological and modal options.

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: edgeTransport
 Title: Prepare EDGE Transport Data for the REMIND model
-Version: 2.15.2
+Version: 2.15.3
 Authors@R: c(
     person("Johanna", "Hoppe", email = "johanna.hoppe@pik-potsdam.de", role = c("aut", "cre"),
            comment = c(ORCID = "0009-0004-6753-5090")),

--- a/R/toolCalculateFleetComposition.R
+++ b/R/toolCalculateFleetComposition.R
@@ -39,7 +39,7 @@ toolCalculateFleetComposition <- function(ESdemandFVsalesLevel,
 
   # calculate distribution of total demand on construction years -----------------------------------------
   # change to yearly resolution
-  timesteps <- seq(1990, 2100, by = 1)
+  timesteps <- seq(1985, 2100, by = 1)
   fleetESdemand <- approx_dt(fleetESdemand, timesteps, "period", "totalESdemand",
                              c("region", "subsectorL3"),
                              extrapolate = TRUE)
@@ -74,7 +74,6 @@ toolCalculateFleetComposition <- function(ESdemandFVsalesLevel,
 
   # Initialize columns for fleet tracking (to have them in the data.table before the construction year columns)
   fleetESdemand[, c("vintagesDemand", "earlyRetirement", "earlyRetirementRate") := 0]
-
   for (i in constructionYears) {
     for (j in contributionYears) {
       vehDepreciation <- copy(vehDepreciationFactors)[, period := i + indexUsagePeriod][, indexUsagePeriod := NULL]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Prepare EDGE Transport Data for the REMIND model
 
-R package **edgeTransport**, version **2.15.2**
+R package **edgeTransport**, version **2.15.3**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/edgeTransport)](https://cran.r-project.org/package=edgeTransport) [![R build status](https://github.com/pik-piam/edgeTransport/workflows/check/badge.svg)](https://github.com/pik-piam/edgeTransport/actions) [![codecov](https://codecov.io/gh/pik-piam/edgeTransport/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/edgeTransport) [![r-universe](https://pik-piam.r-universe.dev/badges/edgeTransport)](https://pik-piam.r-universe.dev/builds)
 
@@ -46,13 +46,13 @@ In case of questions / problems please contact Johanna Hoppe <johanna.hoppe@pik-
 
 To cite package **edgeTransport** in publications use:
 
-Hoppe J, Dirnaichner A, Rottoli M, Muessel J, Hagen A (2025). "edgeTransport: Prepare EDGE Transport Data for the REMIND model - Version 2.15.2."
+Hoppe J, Dirnaichner A, Rottoli M, Muessel J, Hagen A (2025). "edgeTransport: Prepare EDGE Transport Data for the REMIND model - Version 2.15.3."
 
 A BibTeX entry for LaTeX users is
 
  ```latex
 @Misc{,
-  title = {edgeTransport: Prepare EDGE Transport Data for the REMIND model - Version 2.15.2},
+  title = {edgeTransport: Prepare EDGE Transport Data for the REMIND model - Version 2.15.3},
   author = {Johanna Hoppe and Alois Dirnaichner and Marianna Rottoli and Jarusch Muessel and Alex K. Hagen},
   date = {2025-03-10},
   year = {2025},

--- a/inst/extdata/genParAnnuityCalc.csv
+++ b/inst/extdata/genParAnnuityCalc.csv
@@ -1,5 +1,5 @@
 transportPolScen;FVvehvar;interestRate;serviceLife
-default;LDV|4W;0.05;15
-default;Bus;0.05;7
-default;Truck|light;0.05;7
-default;Truck|heavy;0.05;7
+default;LDV|4W;0.1;20
+default;Bus;0.1;15
+default;Truck|light;0.1;15
+default;Truck|heavy;0.1;15

--- a/inst/extdata/genParAnnuityCalc.csv
+++ b/inst/extdata/genParAnnuityCalc.csv
@@ -1,5 +1,5 @@
 transportPolScen;FVvehvar;interestRate;serviceLife
 default;LDV|4W;0.1;20
-default;Bus;0.1;15
-default;Truck|light;0.1;15
-default;Truck|heavy;0.1;15
+default;Bus;0.05;15
+default;Truck|light;0.05;15
+default;Truck|heavy;0.05;15


### PR DESCRIPTION
## Purpose of this PR
We felt that the lifetime for our vehicles was rather short and the interest rate for (privately owned) LDVs was rather low. We increased the life time and the interest rate for LDVs. 
Changes: 
Lifetime: 15-->20 years (for LDVs), 7-->15 years (for Busses and Trucks) 
Interest rate: 5-->10% (for LDVs), remains at 5% (for Busses and Trucks)

## Checklist:

- [X] I used ./test-standard-runs to compare and archive the changes introduced by this PR in /p/projects/edget/PRchangeLog/

## Further information (optional):

* Test runs are here: 
PR log: ```/p/projects/edget/PRchangeLog/20250310_annuityAdjustments```

