### PR TITLE
Correct SSP1 Baseline Trends 

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '43398021'
+ValidationKey: '43420332'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '43444800'
+ValidationKey: '43464960'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'edgeTransport: Prepare EDGE Transport Data for the REMIND model'
-version: 2.15.3
-date-released: '2025-03-10'
+version: 2.15.4
+date-released: '2025-03-11'
 abstract: EDGE-T is a fork of the GCAM transport module https://jgcri.github.io/gcam-doc/energy.html#transportation
   with a high level of detail in its representation of technological and modal options.
   It is a partial equilibrium model with a nested multinomial logit structure and

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,7 +2,7 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'edgeTransport: Prepare EDGE Transport Data for the REMIND model'
-version: 2.15.5
+version: 2.15.6
 date-released: '2025-03-13'
 abstract: EDGE-T is a fork of the GCAM transport module https://jgcri.github.io/gcam-doc/energy.html#transportation
   with a high level of detail in its representation of technological and modal options.

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: edgeTransport
 Title: Prepare EDGE Transport Data for the REMIND model
-Version: 2.15.5
+Version: 2.15.6
 Authors@R: c(
     person("Johanna", "Hoppe", email = "johanna.hoppe@pik-potsdam.de", role = c("aut", "cre"),
            comment = c(ORCID = "0009-0004-6753-5090")),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: edgeTransport
 Title: Prepare EDGE Transport Data for the REMIND model
-Version: 2.15.3
+Version: 2.15.4
 Authors@R: c(
     person("Johanna", "Hoppe", email = "johanna.hoppe@pik-potsdam.de", role = c("aut", "cre"),
            comment = c(ORCID = "0009-0004-6753-5090")),
@@ -20,7 +20,7 @@ Encoding: UTF-8
 LazyData: true
 RoxygenNote: 7.3.2
 VignetteBuilder: knitr
-Date: 2025-03-10
+Date: 2025-03-11
 Config/testthat/edition: 3
 Imports:
     rmndt,

--- a/R/toolCalculateFleetComposition.R
+++ b/R/toolCalculateFleetComposition.R
@@ -39,7 +39,8 @@ toolCalculateFleetComposition <- function(ESdemandFVsalesLevel,
 
   # calculate distribution of total demand on construction years -----------------------------------------
   # change to yearly resolution
-  timesteps <- seq(1985, 2100, by = 1)
+  startY <- 2005 - max(vehDepreciationFactors$serviceLife)
+  timesteps <- seq(startY, 2100, by = 1)
   fleetESdemand <- approx_dt(fleetESdemand, timesteps, "period", "totalESdemand",
                              c("region", "subsectorL3"),
                              extrapolate = TRUE)

--- a/R/toolCalculateFleetComposition.R
+++ b/R/toolCalculateFleetComposition.R
@@ -39,8 +39,7 @@ toolCalculateFleetComposition <- function(ESdemandFVsalesLevel,
 
   # calculate distribution of total demand on construction years -----------------------------------------
   # change to yearly resolution
-  startY <- 2005 - max(vehDepreciationFactors$serviceLife)
-  timesteps <- seq(startY, 2100, by = 1)
+  timesteps <- seq(1990, 2100, by = 1)
   fleetESdemand <- approx_dt(fleetESdemand, timesteps, "period", "totalESdemand",
                              c("region", "subsectorL3"),
                              extrapolate = TRUE)
@@ -75,6 +74,7 @@ toolCalculateFleetComposition <- function(ESdemandFVsalesLevel,
 
   # Initialize columns for fleet tracking (to have them in the data.table before the construction year columns)
   fleetESdemand[, c("vintagesDemand", "earlyRetirement", "earlyRetirementRate") := 0]
+
   for (i in constructionYears) {
     for (j in contributionYears) {
       vehDepreciation <- copy(vehDepreciationFactors)[, period := i + indexUsagePeriod][, indexUsagePeriod := NULL]

--- a/R/toolCalculateFleetComposition.R
+++ b/R/toolCalculateFleetComposition.R
@@ -39,7 +39,7 @@ toolCalculateFleetComposition <- function(ESdemandFVsalesLevel,
 
   # calculate distribution of total demand on construction years -----------------------------------------
   # change to yearly resolution
-  timesteps <- seq(1990, 2100, by = 1)
+  timesteps <- seq(1985, 2100, by = 1)
   fleetESdemand <- approx_dt(fleetESdemand, timesteps, "period", "totalESdemand",
                              c("region", "subsectorL3"),
                              extrapolate = TRUE)

--- a/R/toolCalculateFleetComposition.R
+++ b/R/toolCalculateFleetComposition.R
@@ -74,7 +74,6 @@ toolCalculateFleetComposition <- function(ESdemandFVsalesLevel,
 
   # Initialize columns for fleet tracking (to have them in the data.table before the construction year columns)
   fleetESdemand[, c("vintagesDemand", "earlyRetirement", "earlyRetirementRate") := 0]
-
   for (i in constructionYears) {
     for (j in contributionYears) {
       vehDepreciation <- copy(vehDepreciationFactors)[, period := i + indexUsagePeriod][, indexUsagePeriod := NULL]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Prepare EDGE Transport Data for the REMIND model
 
-R package **edgeTransport**, version **2.15.3**
+R package **edgeTransport**, version **2.15.4**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/edgeTransport)](https://cran.r-project.org/package=edgeTransport) [![R build status](https://github.com/pik-piam/edgeTransport/workflows/check/badge.svg)](https://github.com/pik-piam/edgeTransport/actions) [![codecov](https://codecov.io/gh/pik-piam/edgeTransport/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/edgeTransport) [![r-universe](https://pik-piam.r-universe.dev/badges/edgeTransport)](https://pik-piam.r-universe.dev/builds)
 
@@ -46,15 +46,15 @@ In case of questions / problems please contact Johanna Hoppe <johanna.hoppe@pik-
 
 To cite package **edgeTransport** in publications use:
 
-Hoppe J, Dirnaichner A, Rottoli M, Muessel J, Hagen A (2025). "edgeTransport: Prepare EDGE Transport Data for the REMIND model - Version 2.15.3."
+Hoppe J, Dirnaichner A, Rottoli M, Muessel J, Hagen A (2025). "edgeTransport: Prepare EDGE Transport Data for the REMIND model - Version 2.15.4."
 
 A BibTeX entry for LaTeX users is
 
  ```latex
 @Misc{,
-  title = {edgeTransport: Prepare EDGE Transport Data for the REMIND model - Version 2.15.3},
+  title = {edgeTransport: Prepare EDGE Transport Data for the REMIND model - Version 2.15.4},
   author = {Johanna Hoppe and Alois Dirnaichner and Marianna Rottoli and Jarusch Muessel and Alex K. Hagen},
-  date = {2025-03-10},
+  date = {2025-03-11},
   year = {2025},
 }
 ```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Prepare EDGE Transport Data for the REMIND model
 
-R package **edgeTransport**, version **2.15.5**
+R package **edgeTransport**, version **2.15.6**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/edgeTransport)](https://cran.r-project.org/package=edgeTransport) [![R build status](https://github.com/pik-piam/edgeTransport/workflows/check/badge.svg)](https://github.com/pik-piam/edgeTransport/actions) [![codecov](https://codecov.io/gh/pik-piam/edgeTransport/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/edgeTransport) [![r-universe](https://pik-piam.r-universe.dev/badges/edgeTransport)](https://pik-piam.r-universe.dev/builds)
 
@@ -46,13 +46,13 @@ In case of questions / problems please contact Johanna Hoppe <johanna.hoppe@pik-
 
 To cite package **edgeTransport** in publications use:
 
-Hoppe J, Dirnaichner A, Rottoli M, Muessel J, Hagen A (2025). "edgeTransport: Prepare EDGE Transport Data for the REMIND model - Version 2.15.5."
+Hoppe J, Dirnaichner A, Rottoli M, Muessel J, Hagen A (2025). "edgeTransport: Prepare EDGE Transport Data for the REMIND model - Version 2.15.6."
 
 A BibTeX entry for LaTeX users is
 
  ```latex
 @Misc{,
-  title = {edgeTransport: Prepare EDGE Transport Data for the REMIND model - Version 2.15.5},
+  title = {edgeTransport: Prepare EDGE Transport Data for the REMIND model - Version 2.15.6},
   author = {Johanna Hoppe and Alois Dirnaichner and Marianna Rottoli and Jarusch Muessel and Alex K. Hagen},
   date = {2025-03-13},
   year = {2025},

--- a/inst/extdata/genParBaselinePrefTrends.csv
+++ b/inst/extdata/genParBaselinePrefTrends.csv
@@ -5668,97 +5668,97 @@ SDP_RC;USA;Liquids;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road
 SDP_RC;USA;Liquids;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;0.5382;0.3524;0.3524
 SDP_RC;USA;Liquids;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;0.3588;0.3588
 SSP1;CAZ;;;;;Cycle;trn_pass;S1S;0.01911;0.03822;0.03822;0.07645;0.07645
-SSP1;CAZ;;;;;Domestic Aviation;trn_pass;S1S;0.001432;0.001527;0.001813;0.001909;0.001909
+SSP1;CAZ;;;;;Domestic Aviation;trn_pass;S1S;0.001432;0.001527;0.0004532;0.0004773;0.0004773
 SSP1;CAZ;;;;;Domestic Ship;trn_freight;S1S;0.01583;0.01583;0.01583;0.01583;0.01583
-SSP1;CAZ;;;;;Freight Rail;trn_freight;S1S;0.107;0.107;0.107;0.09633;0.09633
+SSP1;CAZ;;;;;Freight Rail;trn_freight;S1S;0.107;0.107;0.1605;0.1445;0.1445
 SSP1;CAZ;;;;;HSR;trn_pass;S1S;8.79E-08;8.79E-05;0.0002638;0.0002638;0.0002638
 SSP1;CAZ;;;;;International Aviation;trn_aviation_intl;S1S;1;1;1;1;1
 SSP1;CAZ;;;;;International Ship;trn_shipping_intl;S1S;1;1;1;1;1
-SSP1;CAZ;;;;;Passenger Rail;trn_pass;S1S;0.0008785;0.0008785;0.0008785;0.0008785;0.0008785
+SSP1;CAZ;;;;;Passenger Rail;trn_pass;S1S;0.0008785;0.0008785;0.001757;0.001757;0.001757
 SSP1;CAZ;;;;;Walk;trn_pass;S1S;1;1;1;1;1
 SSP1;CAZ;;;;;trn_freight_road;trn_freight;S1S;1;1;1;1;1
-SSP1;CAZ;;;;;trn_pass_road;trn_pass;S1S;0.1509;0.1509;0.1509;0.1509;0.1509
-SSP1;CAZ;;;;Bus;trn_pass_road;trn_pass;S2S1;0.08852;0.08852;0.1107;0.1402;0.1402
+SSP1;CAZ;;;;;trn_pass_road;trn_pass;S1S;0.1509;0.1509;0.06036;0.07545;0.07545
+SSP1;CAZ;;;;Bus;trn_pass_road;trn_pass;S2S1;0.08852;0.08852;0.1661;0.2103;0.2103
 SSP1;CAZ;;;;trn_pass_road_LDV;trn_pass_road;trn_pass;S2S1;1;1;1;1;1
 SSP1;CAZ;;;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;0.999;0.034;0.03;0.02;0.02
 SSP1;CAZ;;;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;1;1;1;1;1
-SSP1;CAZ;;Compact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.1291;0.1291;0.1291;0.1291;0.1291
+SSP1;CAZ;;Compact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.1291;0.1291;0.2582;0.3873;0.3873
 SSP1;CAZ;;Large Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.3264;0.3264;0.3264;0.3264;0.3264
 SSP1;CAZ;;Large Car and SUV;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;6.97E-05;6.97E-05;6.97E-05;6.97E-05;6.97E-05
 SSP1;CAZ;;Midsize Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;1;1;1;1;1
-SSP1;CAZ;;Mini Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;9.88E-09;9.88E-09;9.88E-09;9.88E-09;9.88E-09
+SSP1;CAZ;;Mini Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;9.88E-09;9.88E-09;1.98E-08;2.96E-08;2.96E-08
 SSP1;CAZ;;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.0002867;0.0002867;0.0002867;0.0002867;0.0002867
 SSP1;CAZ;;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.0001994;0.0001994;0.0001994;0.0001994;0.0001994
 SSP1;CAZ;;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;1;1;1;1;1
-SSP1;CAZ;;Subcompact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;6.73E-05;6.73E-05;6.73E-05;6.73E-05;6.73E-05
+SSP1;CAZ;;Subcompact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;6.73E-05;6.73E-05;0.0001346;0.0002018;0.0002018
 SSP1;CAZ;;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;1;1;1;1;1
 SSP1;CAZ;;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.2333;0.2333;0.2333;0.2333;0.2333
 SSP1;CAZ;;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.8337;0.8337;0.8337;0.8337;0.8337
 SSP1;CAZ;;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;3.5E-05;3.5E-05;3.5E-05;3.5E-05;3.5E-05
 SSP1;CAZ;;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.6282;0.6282;0.6282;0.6282;0.6282
 SSP1;CAZ;;Van;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.2082;0.2082;0.2082;0.2082;0.2082
-SSP1;CAZ;BEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.1122;0.4423;0.9735;0.9735
-SSP1;CAZ;BEV;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.044;0.192;0.336;0.336
-SSP1;CAZ;BEV;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.044;0.192;0.336;0.336
-SSP1;CAZ;BEV;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.044;0.192;0.336;0.336
-SSP1;CAZ;BEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1409;0.3311;0.4354;0.4354
-SSP1;CAZ;BEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.05608;0.1781;0.4224;0.4224
-SSP1;CAZ;BEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.05608;0.1781;0.4224;0.4224
-SSP1;CAZ;BEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.05608;0.1781;0.4224;0.4224
-SSP1;CAZ;BEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1409;0.3311;0.4354;0.4354
-SSP1;CAZ;Electric;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;0.09074;0.2044;0.4317;0.8863;0.8863
+SSP1;CAZ;BEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.1122;0.8846;1;1
+SSP1;CAZ;BEV;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.044;0.384;0.672;0.672
+SSP1;CAZ;BEV;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.044;0.384;0.672;0.672
+SSP1;CAZ;BEV;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.044;0.384;0.672;0.672
+SSP1;CAZ;BEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1409;0.6622;0.8708;0.8708
+SSP1;CAZ;BEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.05608;0.3562;0.8448;0.8448
+SSP1;CAZ;BEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.05608;0.3562;0.8448;0.8448
+SSP1;CAZ;BEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.05608;0.3562;0.8448;0.8448
+SSP1;CAZ;BEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1409;0.6622;0.8708;0.8708
+SSP1;CAZ;Electric;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;0.09074;0.2044;0.8634;1;1
 SSP1;CAZ;Electric;HSR_tmp_vehicletype;HSR_tmp_subsectorL3;HSR_tmp_subsectorL2;HSR;trn_pass;FV;1;1;1;1;1
 SSP1;CAZ;Electric;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;1;1;1;1;1
-SSP1;CAZ;FCEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.01462;0.01933;0.07601;0.07601
-SSP1;CAZ;FCEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.03957;0.05608;0.1153;0.1153
-SSP1;CAZ;FCEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.01462;0.02127;0.07883;0.07883
-SSP1;CAZ;FCEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.01462;0.02127;0.07883;0.07883
-SSP1;CAZ;FCEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.01462;0.02127;0.07883;0.07883
-SSP1;CAZ;FCEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.03957;0.05608;0.1153;0.1153
-SSP1;CAZ;Gases;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0.03104;0.05654;0.09776;0.1497;0.1497
+SSP1;CAZ;FCEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.01462;0.01933;0.03904;0.03904
+SSP1;CAZ;FCEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.03957;0.1682;0.3459;0.3459
+SSP1;CAZ;FCEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.01462;0.06381;0.2365;0.2365
+SSP1;CAZ;FCEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.01462;0.06381;0.2365;0.2365
+SSP1;CAZ;FCEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.01462;0.06381;0.2365;0.2365
+SSP1;CAZ;FCEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.03957;0.1682;0.3459;0.3459
+SSP1;CAZ;Gases;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0.03104;0.05654;0.09776;0.07689;0.07689
 SSP1;CAZ;Gases;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02632;0.07895;0.1535;0.1535
 SSP1;CAZ;Gases;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02632;0.07895;0.1535;0.1535
 SSP1;CAZ;Gases;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02632;0.07895;0.1535;0.1535
 SSP1;CAZ;Gases;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02632;0.07895;0.1535;0.1535
 SSP1;CAZ;Gases;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02632;0.07895;0.1535;0.1535
-SSP1;CAZ;Hydrogen;Domestic Aviation_tmp_vehicletype;Domestic Aviation_tmp_subsectorL3;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;trn_pass;FV;0;8.32E-07;4.54E-05;0.1192;0.1192
-SSP1;CAZ;Liquids;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;1;1;1;1;1
+SSP1;CAZ;Hydrogen;Domestic Aviation_tmp_vehicletype;Domestic Aviation_tmp_subsectorL3;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;trn_pass;FV;0;8.32E-07;0.1362;0.3576;0.3576
+SSP1;CAZ;Liquids;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;1;1;1;0.5136;0.5136
 SSP1;CAZ;Liquids;Domestic Aviation_tmp_vehicletype;Domestic Aviation_tmp_subsectorL3;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;trn_pass;FV;1;1;1;1;1
 SSP1;CAZ;Liquids;Domestic Ship_tmp_vehicletype;Domestic Ship_tmp_subsectorL3;Domestic Ship_tmp_subsectorL2;Domestic Ship;trn_freight;FV;1;1;1;1;1
-SSP1;CAZ;Liquids;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;1;1;1;1;1
+SSP1;CAZ;Liquids;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;1;1;1;0.5641;0.5641
 SSP1;CAZ;Liquids;International Aviation_tmp_vehicletype;International Aviation_tmp_subsectorL3;International Aviation_tmp_subsectorL2;International Aviation;trn_aviation_intl;FV;1;1;1;1;1
 SSP1;CAZ;Liquids;International Ship_tmp_vehicletype;International Ship_tmp_subsectorL3;International Ship_tmp_subsectorL2;International Ship;trn_shipping_intl;FV;1;1;1;1;1
 SSP1;CAZ;Liquids;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;1;1;1
 SSP1;CAZ;Liquids;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;1;1;1
 SSP1;CAZ;Liquids;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;1;1;1
-SSP1;CAZ;Liquids;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;0.2746;0.2746;0.2746;0.2746;0.2746
+SSP1;CAZ;Liquids;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;0.2746;0.2746;0.1373;0.09153;0.09153
 SSP1;CAZ;Liquids;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
 SSP1;CAZ;Liquids;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
 SSP1;CAZ;Liquids;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
 SSP1;CAZ;Liquids;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
 SSP1;CAZ;Liquids;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
 SSP1;CHA;;;;;Cycle;trn_pass;S1S;0.09454;0.04412;0.03782;0.04848;0.04848
-SSP1;CHA;;;;;Domestic Aviation;trn_pass;S1S;0.12;0.02712;0.01745;0.003357;0.003357
+SSP1;CHA;;;;;Domestic Aviation;trn_pass;S1S;0.12;0.02712;0.004363;0.0008393;0.0008393
 SSP1;CHA;;;;;Domestic Ship;trn_freight;S1S;0.01847;0.01922;0.02232;0.02232;0.02232
-SSP1;CHA;;;;;Freight Rail;trn_freight;S1S;0.03204;0.0357;0.03795;0.03795;0.03795
+SSP1;CHA;;;;;Freight Rail;trn_freight;S1S;0.03204;0.0357;0.05693;0.05693;0.05693
 SSP1;CHA;;;;;HSR;trn_pass;S1S;0.2402;0.08143;0.01916;0.003695;0.003695
 SSP1;CHA;;;;;International Aviation;trn_aviation_intl;S1S;1;1;1;1;1
 SSP1;CHA;;;;;International Ship;trn_shipping_intl;S1S;1;1;1;1;1
-SSP1;CHA;;;;;Passenger Rail;trn_pass;S1S;0.006222;0.003111;0.001867;0.0009572;0.0009572
+SSP1;CHA;;;;;Passenger Rail;trn_pass;S1S;0.006222;0.003111;0.003734;0.001914;0.001914
 SSP1;CHA;;;;;Walk;trn_pass;S1S;1;1;1;1;1
 SSP1;CHA;;;;;trn_freight_road;trn_freight;S1S;1;1;1;1;1
-SSP1;CHA;;;;;trn_pass_road;trn_pass;S1S;0.6711;0.2684;0.1342;0.04015;0.04015
-SSP1;CHA;;;;Bus;trn_pass_road;trn_pass;S2S1;0.6609;0.2927;0.2084;0.09649;0.09649
+SSP1;CHA;;;;;trn_pass_road;trn_pass;S1S;0.6711;0.2684;0.0671;0.02007;0.02007
+SSP1;CHA;;;;Bus;trn_pass_road;trn_pass;S2S1;0.6609;0.2927;0.4168;0.2895;0.2895
 SSP1;CHA;;;;trn_pass_road_LDV;trn_pass_road;trn_pass;S2S1;1;1;1;1;1
 SSP1;CHA;;;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;0.6;0.4;0.3;0.3;0.3
 SSP1;CHA;;;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;1;1;1;1;1
-SSP1;CHA;;Compact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.8035;0.7232;0.6574;0.5563;0.5563
-SSP1;CHA;;Large Car and SUV;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;1;1;1;1;1
-SSP1;CHA;;Mini Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.01783;0.01605;0.01459;0.01234;0.01234
+SSP1;CHA;;Compact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.8035;0.7232;1;1;1
+SSP1;CHA;;Large Car and SUV;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;1;1;0.7606;0.5992;0.5992
+SSP1;CHA;;Mini Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.01783;0.01605;0.02219;0.02218;0.02218
 SSP1;CHA;;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.04044;0.04044;0.04044;0.04044;0.04044
 SSP1;CHA;;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;1;1;1;1;1
 SSP1;CHA;;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;1;1;1;1;1
-SSP1;CHA;;Subcompact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.08662;0.07795;0.07087;0.05996;0.05996
+SSP1;CHA;;Subcompact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.08662;0.07795;0.1078;0.1078;0.1078
 SSP1;CHA;;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;1;1;1;1;1
 SSP1;CHA;;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.2234;0.2234;0.2234;0.2234;0.2234
 SSP1;CHA;;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.4022;0.3352;0.3016;0.3352;0.3352
@@ -5767,331 +5767,331 @@ SSP1;CHA;;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_sub
 SSP1;CHA;BEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.3019;1;1;1
 SSP1;CHA;BEV;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.6;1;1;1
 SSP1;CHA;BEV;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0.06;0.6;1;1;1
-SSP1;CHA;BEV;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.6;1;1;1
-SSP1;CHA;BEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.04002;0.3725;0.8768;0.8768
-SSP1;CHA;BEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.01592;0.2004;0.8505;0.8505
-SSP1;CHA;BEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.0992;0.3358;0.745;0.8928;0.8928
-SSP1;CHA;BEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.0992;0.3358;0.745;0.8928;0.8928
-SSP1;CHA;BEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.04002;0.3725;0.8768;0.8768
-SSP1;CHA;Electric;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;0.4553;0.5234;0.6595;0.9319;0.9319
+SSP1;CHA;BEV;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.6;0;0;0
+SSP1;CHA;BEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.04002;0.745;1;1
+SSP1;CHA;BEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.01592;0.4008;1;1
+SSP1;CHA;BEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.0992;0.3358;1;1;1
+SSP1;CHA;BEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.0992;0.3358;1;1;1
+SSP1;CHA;BEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.04002;0.745;1;1
+SSP1;CHA;Electric;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;0.4553;0.5234;1;1;1
 SSP1;CHA;Electric;HSR_tmp_vehicletype;HSR_tmp_subsectorL3;HSR_tmp_subsectorL2;HSR;trn_pass;FV;1;1;1;1;1
-SSP1;CHA;Electric;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;0.4158;0.4888;0.6349;0.927;0.927
-SSP1;CHA;FCEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.02024;0.09554;0.06999;0.06999
-SSP1;CHA;FCEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.001124;0.01713;0.145;0.145
-SSP1;CHA;FCEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.0004151;0.006497;0.0992;0.0992
-SSP1;CHA;FCEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.00992;0.1679;0.3612;0.1984;0.1984
-SSP1;CHA;FCEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.00992;0.1679;0.3612;0.1984;0.1984
-SSP1;CHA;FCEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.001124;0.01713;0.145;0.145
-SSP1;CHA;Gases;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0.1421;0.1329;0.1181;0.1055;0.1055
-SSP1;CHA;Gases;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1.71E-05;0.01014;0.03814;0.08376;0.08376
-SSP1;CHA;Gases;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.000714;0.0111;0.03928;0.0847;0.0847
-SSP1;CHA;Gases;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.2727;0.3846;0.4828;0.4545;0.4545
-SSP1;CHA;Gases;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.2727;0.3846;0.4828;0.4545;0.4545
-SSP1;CHA;Gases;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.0003008;0.01053;0.0386;0.08414;0.08414
-SSP1;CHA;Hydrogen;Domestic Aviation_tmp_vehicletype;Domestic Aviation_tmp_subsectorL3;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;trn_pass;FV;0;8.32E-07;4.54E-05;0.1192;0.1192
-SSP1;CHA;Liquids;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;1;1;0.9736;0.3527;0.3527
+SSP1;CHA;Electric;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;0.4158;0.4888;1;1;1
+SSP1;CHA;FCEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.02024;0.04777;0.03499;0.03499
+SSP1;CHA;FCEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.001124;0.05139;0.2481;0.2481
+SSP1;CHA;FCEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.0004151;0.01949;0.175;0.175
+SSP1;CHA;FCEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.00992;0.1679;0.7272;0.3333;0.3333
+SSP1;CHA;FCEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.00992;0.1679;0.7272;0.3333;0.3333
+SSP1;CHA;FCEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.001124;0.05139;0.2481;0.2481
+SSP1;CHA;Gases;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0.1421;0.1329;0.05905;0.05275;0.05275
+SSP1;CHA;Gases;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1.71E-05;0.01014;0.03814;0.04776;0.04776
+SSP1;CHA;Gases;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.000714;0.0111;0.03928;0.04979;0.04979
+SSP1;CHA;Gases;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.2727;0.3846;0.324;0.2545;0.2545
+SSP1;CHA;Gases;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.2727;0.3846;0.324;0.2545;0.2545
+SSP1;CHA;Gases;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.0003008;0.01053;0.0386;0.04798;0.04798
+SSP1;CHA;Hydrogen;Domestic Aviation_tmp_vehicletype;Domestic Aviation_tmp_subsectorL3;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;trn_pass;FV;0;8.32E-07;0.1362;0.3576;0.3576
+SSP1;CHA;Liquids;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;1;1;0.4868;0.1764;0.1764
 SSP1;CHA;Liquids;Domestic Aviation_tmp_vehicletype;Domestic Aviation_tmp_subsectorL3;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;trn_pass;FV;1;1;1;1;1
 SSP1;CHA;Liquids;Domestic Ship_tmp_vehicletype;Domestic Ship_tmp_subsectorL3;Domestic Ship_tmp_subsectorL2;Domestic Ship;trn_freight;FV;1;1;1;1;1
-SSP1;CHA;Liquids;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;1;1;1;1;1
+SSP1;CHA;Liquids;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;1;1;0.7582;0.5365;0.5365
 SSP1;CHA;Liquids;International Aviation_tmp_vehicletype;International Aviation_tmp_subsectorL3;International Aviation_tmp_subsectorL2;International Aviation;trn_aviation_intl;FV;1;1;1;1;1
 SSP1;CHA;Liquids;International Ship_tmp_vehicletype;International Ship_tmp_subsectorL3;International Ship_tmp_subsectorL2;International Ship;trn_shipping_intl;FV;1;1;1;1;1
-SSP1;CHA;Liquids;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;0.8333;0.6803;0.6803
-SSP1;CHA;Liquids;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;0.8333;0.6803;0.6803
-SSP1;CHA;Liquids;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;0.8333;0.6803;0.6803
-SSP1;CHA;Liquids;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;1;1;1;1;1
-SSP1;CHA;Liquids;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
-SSP1;CHA;Liquids;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
-SSP1;CHA;Liquids;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
-SSP1;CHA;Liquids;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
-SSP1;CHA;Liquids;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
-SSP1;DEU;;;;;Cycle;trn_pass;S1S;0.042;0.05;0.07;0.1875;0.1875
-SSP1;DEU;;;;;Domestic Aviation;trn_pass;S1S;6.6E-05;6.2E-05;5.97E-05;5.97E-05;5.97E-05
-SSP1;DEU;;;;;Domestic Ship;trn_freight;S1S;0.004;0.004;0.004;0.004;0.004
-SSP1;DEU;;;;;Freight Rail;trn_freight;S1S;0.032;0.032;0.032;0.032;0.032
-SSP1;DEU;;;;;HSR;trn_pass;S1S;0.00018;0.0002;0.0003;0.0004;0.0004
+SSP1;CHA;Liquids;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;0.4167;0.3402;0.3402
+SSP1;CHA;Liquids;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;0.4167;0.3402;0.3402
+SSP1;CHA;Liquids;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;1;1;1
+SSP1;CHA;Liquids;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;1;1;0.7875;0.3596;0.3596
+SSP1;CHA;Liquids;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;0.5703;0.5703
+SSP1;CHA;Liquids;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;0.5879;0.5879
+SSP1;CHA;Liquids;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;0.6711;0.56;0.56
+SSP1;CHA;Liquids;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;0.6711;0.56;0.56
+SSP1;CHA;Liquids;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;0.5703;0.5703
+SSP1;DEU;;;;;Cycle;trn_pass;S1S;0.042;0.05;0.025;0.1875;0.1875
+SSP1;DEU;;;;;Domestic Aviation;trn_pass;S1S;6.6E-05;6.2E-05;1.49E-05;1.49E-05;1.49E-05
+SSP1;DEU;;;;;Domestic Ship;trn_freight;S1S;0.004;0.004;0.002127;0.002127;0.002127
+SSP1;DEU;;;;;Freight Rail;trn_freight;S1S;0.032;0.032;0.042;0.042;0.042
+SSP1;DEU;;;;;HSR;trn_pass;S1S;0.00018;0.0002;0.000625;0.000625;0.000625
 SSP1;DEU;;;;;International Aviation;trn_aviation_intl;S1S;1;1;1;1;1
 SSP1;DEU;;;;;International Ship;trn_shipping_intl;S1S;1;1;1;1;1
-SSP1;DEU;;;;;Passenger Rail;trn_pass;S1S;0.0032;0.004;0.0042;0.0042;0.0042
+SSP1;DEU;;;;;Passenger Rail;trn_pass;S1S;0.0032;0.004;0.0075;0.0075;0.0075
 SSP1;DEU;;;;;Walk;trn_pass;S1S;1;1;1;1;1
-SSP1;DEU;;;;;trn_freight_road;trn_freight;S1S;0.94;0.94;0.94;0.94;0.94
-SSP1;DEU;;;;;trn_pass_road;trn_pass;S1S;0.0725;0.0725;0.0725;0.0725;0.0725
-SSP1;DEU;;;;Bus;trn_pass_road;trn_pass;S2S1;0.04;0.06;0.07;0.08;0.08
+SSP1;DEU;;;;;trn_freight_road;trn_freight;S1S;0.94;0.94;1;1;1
+SSP1;DEU;;;;;trn_pass_road;trn_pass;S1S;0.0725;0.0725;0.03682;0.03682;0.03682
+SSP1;DEU;;;;Bus;trn_pass_road;trn_pass;S2S1;0.04;0.06;0.1222;0.2292;0.2292
 SSP1;DEU;;;;trn_pass_road_LDV;trn_pass_road;trn_pass;S2S1;1;1;1;1;1
 SSP1;DEU;;;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;0.06;0.06;0.06;0.06;0.06
 SSP1;DEU;;;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;1;1;1;1;1
-SSP1;DEU;;Compact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.5249;0.5249;0.4724;0.4724;0.4724
-SSP1;DEU;;Large Car and SUV;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;1;1;1;1;1
-SSP1;DEU;;Midsize Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.2716;0.2716;0.2716;0.2716;0.2716
+SSP1;DEU;;Compact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.5249;0.5249;0.9448;0.9836;0.9836
+SSP1;DEU;;Large Car and SUV;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;1;1;1;0.694;0.694
+SSP1;DEU;;Midsize Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.2716;0.2716;0.2716;0.1885;0.1885
 SSP1;DEU;;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.2183;0.2183;0.2183;0.2183;0.2183
 SSP1;DEU;;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.00663;0.00663;0.00663;0.00663;0.00663
 SSP1;DEU;;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;1;1;1;1;1
-SSP1;DEU;;Subcompact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.5337;0.5337;0.4803;0.4803;0.4803
+SSP1;DEU;;Subcompact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.5337;0.5337;0.9606;1;1
 SSP1;DEU;;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;1;1;1;1;1
 SSP1;DEU;;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.1873;0.1873;0.1873;0.1873;0.1873
 SSP1;DEU;;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.257;0.257;0.257;0.257;0.257
 SSP1;DEU;;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.8568;0.8568;0.8568;0.8568;0.8568
 SSP1;DEU;;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.4959;0.4959;0.4959;0.4959;0.4959
-SSP1;DEU;BEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.1294;0.3669;0.7798;0.7798
-SSP1;DEU;BEV;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.02;0.25;0.45;0.45
-SSP1;DEU;BEV;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.02;0.25;0.45;0.45
-SSP1;DEU;BEV;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.02;0.25;0.45;0.45
-SSP1;DEU;BEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.3524;0.6784;0.8709;0.8709
-SSP1;DEU;BEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1402;0.3649;0.8448;0.8448
-SSP1;DEU;BEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1402;0.3649;0.8448;0.8448
-SSP1;DEU;BEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1402;0.3649;0.8448;0.8448
-SSP1;DEU;BEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.3524;0.6784;0.8709;0.8709
+SSP1;DEU;BEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.1294;0.7338;1;1
+SSP1;DEU;BEV;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.02;0.5;0.9;0.9
+SSP1;DEU;BEV;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.02;0.5;0.9;0.9
+SSP1;DEU;BEV;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.02;0.5;0.9;0.9
+SSP1;DEU;BEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.3524;1;1;1
+SSP1;DEU;BEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1402;0.7298;1;1
+SSP1;DEU;BEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1402;0.7298;1;1
+SSP1;DEU;BEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1402;0.7298;1;1
+SSP1;DEU;BEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.3524;1;1;1
 SSP1;DEU;Electric;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;1;1;1;1;1
 SSP1;DEU;Electric;HSR_tmp_vehicletype;HSR_tmp_subsectorL3;HSR_tmp_subsectorL2;HSR;trn_pass;FV;1;1;1;1;1
 SSP1;DEU;Electric;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;1;1;1;1;1
-SSP1;DEU;FCEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.002249;0.01636;0.04548;0.04548
-SSP1;DEU;FCEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.09497;0.3925;0.1837;0.1837
-SSP1;DEU;FCEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.03508;0.1489;0.1257;0.1257
-SSP1;DEU;FCEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.03508;0.1489;0.1257;0.1257
-SSP1;DEU;FCEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.03508;0.1489;0.1257;0.1257
-SSP1;DEU;FCEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.09497;0.3925;0.1837;0.1837
-SSP1;DEU;Gases;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0.03948;0.04981;0.0887;0.1332;0.1332
-SSP1;DEU;Gases;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.02615;0.04142;0.103;0.1713;0.1713
-SSP1;DEU;Gases;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02105;0.07895;0.1535;0.1535
-SSP1;DEU;Gases;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02105;0.07895;0.1535;0.1535
-SSP1;DEU;Gases;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02105;0.07895;0.1535;0.1535
-SSP1;DEU;Gases;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02105;0.07895;0.1535;0.1535
-SSP1;DEU;Hydrogen;Domestic Aviation_tmp_vehicletype;Domestic Aviation_tmp_subsectorL3;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;trn_pass;FV;0;8.32E-07;4.54E-05;0.1192;0.1192
-SSP1;DEU;Liquids;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;1;1;1;1;1
+SSP1;DEU;FCEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.002249;0.01636;0.02916;0.02916
+SSP1;DEU;FCEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.09497;0.8679;0.3164;0.3164
+SSP1;DEU;FCEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.03508;0.4467;0.2232;0.2232
+SSP1;DEU;FCEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.03508;0.4467;0.2232;0.2232
+SSP1;DEU;FCEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.03508;0.4467;0.2232;0.2232
+SSP1;DEU;FCEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.09497;0.8679;0.3164;0.3164
+SSP1;DEU;Gases;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0.03948;0.04981;0.0887;0.08541;0.08541
+SSP1;DEU;Gases;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.02615;0.04142;0.07591;0.09835;0.09835
+SSP1;DEU;Gases;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02105;0.07895;0.09085;0.09085
+SSP1;DEU;Gases;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02105;0.07895;0.09085;0.09085
+SSP1;DEU;Gases;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02105;0.07895;0.09085;0.09085
+SSP1;DEU;Gases;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02105;0.05819;0.08813;0.08813
+SSP1;DEU;Hydrogen;Domestic Aviation_tmp_vehicletype;Domestic Aviation_tmp_subsectorL3;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;trn_pass;FV;0;8.32E-07;0.1362;0.3576;0.3576
+SSP1;DEU;Liquids;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;1;1;1;0.6412;0.6412
 SSP1;DEU;Liquids;Domestic Aviation_tmp_vehicletype;Domestic Aviation_tmp_subsectorL3;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;trn_pass;FV;1;1;1;1;1
 SSP1;DEU;Liquids;Domestic Ship_tmp_vehicletype;Domestic Ship_tmp_subsectorL3;Domestic Ship_tmp_subsectorL2;Domestic Ship;trn_freight;FV;1;1;1;1;1
-SSP1;DEU;Liquids;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;0.2523;0.2523;0.2523;0.2523;0.2523
+SSP1;DEU;Liquids;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;0.2523;0.2523;0.1262;0.1262;0.1262
 SSP1;DEU;Liquids;International Aviation_tmp_vehicletype;International Aviation_tmp_subsectorL3;International Aviation_tmp_subsectorL2;International Aviation;trn_aviation_intl;FV;1;1;1;1;1
 SSP1;DEU;Liquids;International Ship_tmp_vehicletype;International Ship_tmp_subsectorL3;International Ship_tmp_subsectorL2;International Ship;trn_shipping_intl;FV;1;1;1;1;1
 SSP1;DEU;Liquids;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;1;1;1
 SSP1;DEU;Liquids;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;1;1;1
 SSP1;DEU;Liquids;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;1;1;1
-SSP1;DEU;Liquids;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;0.05386;0.05386;0.05386;0.05386;0.05386
-SSP1;DEU;Liquids;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
-SSP1;DEU;Liquids;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
-SSP1;DEU;Liquids;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
-SSP1;DEU;Liquids;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
-SSP1;DEU;Liquids;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
+SSP1;DEU;Liquids;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;0.05386;0.05386;0.02693;0.01795;0.01795
+SSP1;DEU;Liquids;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;0.737;0.5741;0.5741
+SSP1;DEU;Liquids;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;0.5919;0.5919
+SSP1;DEU;Liquids;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;0.5919;0.5919
+SSP1;DEU;Liquids;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;0.5919;0.5919
+SSP1;DEU;Liquids;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;0.737;0.5741;0.5741
 SSP1;ECE;;;;;Cycle;trn_pass;S1S;0.01942;0.01942;0.09709;0.1092;0.1092
-SSP1;ECE;;;;;Domestic Aviation;trn_pass;S1S;6.98E-05;6.98E-05;6.98E-05;1.96E-05;1.96E-05
+SSP1;ECE;;;;;Domestic Aviation;trn_pass;S1S;6.98E-05;6.98E-05;1.75E-05;4.91E-06;4.91E-06
 SSP1;ECE;;;;;Domestic Ship;trn_freight;S1S;0.0003966;0.0003966;0.0003966;0.0003966;0.0003966
-SSP1;ECE;;;;;Freight Rail;trn_freight;S1S;0.06019;0.06019;0.05417;0.05417;0.05417
+SSP1;ECE;;;;;Freight Rail;trn_freight;S1S;0.06019;0.06019;0.08125;0.08125;0.08125
 SSP1;ECE;;;;;HSR;trn_pass;S1S;0.0001139;0.0001708;0.0004555;0.0003202;0.0003202
 SSP1;ECE;;;;;International Aviation;trn_aviation_intl;S1S;1;1;1;1;1
 SSP1;ECE;;;;;International Ship;trn_shipping_intl;S1S;1;1;1;1;1
-SSP1;ECE;;;;;Passenger Rail;trn_pass;S1S;0.006799;0.006799;0.009065;0.003824;0.003824
+SSP1;ECE;;;;;Passenger Rail;trn_pass;S1S;0.006799;0.006799;0.01813;0.007648;0.007648
 SSP1;ECE;;;;;Walk;trn_pass;S1S;1;1;1;1;1
 SSP1;ECE;;;;;trn_freight_road;trn_freight;S1S;1;1;1;1;1
-SSP1;ECE;;;;;trn_pass_road;trn_pass;S1S;0.6166;0.6166;0.4933;0.1268;0.1268
-SSP1;ECE;;;;Bus;trn_pass_road;trn_pass;S2S1;0.2712;0.2543;0.1469;0.113;0.113
+SSP1;ECE;;;;;trn_pass_road;trn_pass;S1S;0.6166;0.6166;0.2467;0.0634;0.0634
+SSP1;ECE;;;;Bus;trn_pass_road;trn_pass;S2S1;0.2712;0.2543;0.2203;0.1695;0.1695
 SSP1;ECE;;;;trn_pass_road_LDV;trn_pass_road;trn_pass;S2S1;1;1;1;1;1
 SSP1;ECE;;;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;0.02;0.02;0.02;0.02;0.02
 SSP1;ECE;;;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;1;1;1;1;1
-SSP1;ECE;;Compact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.4706;0.4706;0.4601;0.4314;0.4314
-SSP1;ECE;;Large Car and SUV;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.7825;0.7825;0.7825;0.7825;0.7825
-SSP1;ECE;;Midsize Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;1;1;1;1;1
+SSP1;ECE;;Compact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.4706;0.4706;0.7369;0.7369;0.7369
+SSP1;ECE;;Large Car and SUV;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.7825;0.7825;0.6266;0.4456;0.4456
+SSP1;ECE;;Midsize Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;1;1;0.8008;0.5694;0.5694
 SSP1;ECE;;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.05321;0.05321;0.05321;0.05321;0.05321
 SSP1;ECE;;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.0004728;0.0004728;0.0004728;0.0004728;0.0004728
 SSP1;ECE;;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;1;1;1;1;1
-SSP1;ECE;;Subcompact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.6386;0.6386;0.6244;0.5854;0.5854
+SSP1;ECE;;Subcompact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.6386;0.6386;1;1;1
 SSP1;ECE;;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.6161;0.6161;0.6161;0.6161;0.6161
 SSP1;ECE;;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.1384;0.1384;0.1384;0.1384;0.1384
 SSP1;ECE;;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.137;0.137;0.137;0.137;0.137
 SSP1;ECE;;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.1691;0.1691;0.1691;0.1691;0.1691
 SSP1;ECE;;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;1;1;1;1;1
-SSP1;ECE;BEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.1553;0.5283;1;1
-SSP1;ECE;BEV;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.04;0.19;0.43;0.43
-SSP1;ECE;BEV;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.04;0.19;0.43;0.43
-SSP1;ECE;BEV;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.04;0.19;0.43;0.43
-SSP1;ECE;BEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.06504;0.1455;0.2786;0.2786
-SSP1;ECE;BEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02588;0.07826;0.2703;0.2703
-SSP1;ECE;BEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02588;0.07826;0.2703;0.2703
-SSP1;ECE;BEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02588;0.07826;0.2703;0.2703
-SSP1;ECE;BEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.06504;0.1455;0.2786;0.2786
+SSP1;ECE;BEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.1553;1;1;1
+SSP1;ECE;BEV;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.04;0.38;0.86;0.86
+SSP1;ECE;BEV;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.04;0.38;0.86;0.86
+SSP1;ECE;BEV;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.04;0.38;0.86;0.86
+SSP1;ECE;BEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.06504;0.291;0.5572;0.5572
+SSP1;ECE;BEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02588;0.1565;0.5406;0.5406
+SSP1;ECE;BEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02588;0.1565;0.5406;0.5406
+SSP1;ECE;BEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02588;0.1565;0.5406;0.5406
+SSP1;ECE;BEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.06504;0.291;0.5572;0.5572
 SSP1;ECE;Electric;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;1;1;1;1;1
 SSP1;ECE;Electric;HSR_tmp_vehicletype;HSR_tmp_subsectorL3;HSR_tmp_subsectorL2;HSR;trn_pass;FV;1;1;1;1;1
 SSP1;ECE;Electric;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;1;1;1;1;1
-SSP1;ECE;FCEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.01349;0.01963;0.08748;0.08748
-SSP1;ECE;FCEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.01461;0.0575;0.06382;0.06382
-SSP1;ECE;FCEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.005396;0.02181;0.04365;0.04365
-SSP1;ECE;FCEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.005396;0.02181;0.04365;0.04365
-SSP1;ECE;FCEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.005396;0.02181;0.04365;0.04365
-SSP1;ECE;FCEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.01461;0.0575;0.06382;0.06382
-SSP1;ECE;Gases;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0.01;0.02;0.07;0.09;0.09
+SSP1;ECE;FCEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.01349;0.01858;0.04374;0.04374
+SSP1;ECE;FCEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.01461;0.1725;0.1915;0.1915
+SSP1;ECE;FCEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.005396;0.06543;0.131;0.131
+SSP1;ECE;FCEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.005396;0.06543;0.131;0.131
+SSP1;ECE;FCEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.005396;0.06543;0.131;0.131
+SSP1;ECE;FCEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.01461;0.1725;0.1915;0.1915
+SSP1;ECE;Gases;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0.01;0.02;0.06625;0.045;0.045
 SSP1;ECE;Gases;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.05;0.1111;0.1867;0.1867
 SSP1;ECE;Gases;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.05;0.1111;0.1867;0.1867
 SSP1;ECE;Gases;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.05;0.1111;0.1867;0.1867
 SSP1;ECE;Gases;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0;0;0;0
 SSP1;ECE;Gases;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.05;0.1111;0.1867;0.1867
-SSP1;ECE;Hydrogen;Domestic Aviation_tmp_vehicletype;Domestic Aviation_tmp_subsectorL3;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;trn_pass;FV;0;8.32E-07;4.54E-05;0.1192;0.1192
-SSP1;ECE;Liquids;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;1;1;1;0.8017;0.8017
+SSP1;ECE;Hydrogen;Domestic Aviation_tmp_vehicletype;Domestic Aviation_tmp_subsectorL3;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;trn_pass;FV;0;8.32E-07;0.1362;0.3576;0.3576
+SSP1;ECE;Liquids;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;1;1;0.9464;0.4008;0.4008
 SSP1;ECE;Liquids;Domestic Aviation_tmp_vehicletype;Domestic Aviation_tmp_subsectorL3;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;trn_pass;FV;1;1;1;1;1
 SSP1;ECE;Liquids;Domestic Ship_tmp_vehicletype;Domestic Ship_tmp_subsectorL3;Domestic Ship_tmp_subsectorL2;Domestic Ship;trn_freight;FV;1;1;1;1;1
-SSP1;ECE;Liquids;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;0.587;0.587;0.587;0.587;0.587
+SSP1;ECE;Liquids;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;0.587;0.587;0.2935;0.2935;0.2935
 SSP1;ECE;Liquids;International Aviation_tmp_vehicletype;International Aviation_tmp_subsectorL3;International Aviation_tmp_subsectorL2;International Aviation;trn_aviation_intl;FV;1;1;1;1;1
 SSP1;ECE;Liquids;International Ship_tmp_vehicletype;International Ship_tmp_subsectorL3;International Ship_tmp_subsectorL2;International Ship;trn_shipping_intl;FV;1;1;1;1;1
 SSP1;ECE;Liquids;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;1;1;1
 SSP1;ECE;Liquids;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;1;1;1
 SSP1;ECE;Liquids;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;1;1;1
-SSP1;ECE;Liquids;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;0.1453;0.1453;0.1453;0.1453;0.1453
+SSP1;ECE;Liquids;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;0.1453;0.1453;0.07265;0.04843;0.04843
 SSP1;ECE;Liquids;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
 SSP1;ECE;Liquids;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
 SSP1;ECE;Liquids;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
 SSP1;ECE;Liquids;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
 SSP1;ECE;Liquids;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
 SSP1;ECS;;;;;Cycle;trn_pass;S1S;0.01092;0.03277;0.1311;0.08738;0.08738
-SSP1;ECS;;;;;Domestic Aviation;trn_pass;S1S;0.003717;0.003717;0.003717;0.0003717;0.0003717
+SSP1;ECS;;;;;Domestic Aviation;trn_pass;S1S;0.003717;0.003717;0.0009292;9.29E-05;9.29E-05
 SSP1;ECS;;;;;Domestic Ship;trn_freight;S1S;0.00395;0.00395;0.003591;0.00395;0.00395
-SSP1;ECS;;;;;Freight Rail;trn_freight;S1S;0.05976;0.05976;0.05433;0.05379;0.05379
+SSP1;ECS;;;;;Freight Rail;trn_freight;S1S;0.05976;0.05976;0.08149;0.08069;0.08069
 SSP1;ECS;;;;;HSR;trn_pass;S1S;0.0002969;0.0002969;0.0007917;0.0004;0.0004
 SSP1;ECS;;;;;International Aviation;trn_aviation_intl;S1S;1;1;1;1;1
 SSP1;ECS;;;;;International Ship;trn_shipping_intl;S1S;1;1;1;1;1
-SSP1;ECS;;;;;Passenger Rail;trn_pass;S1S;0.007915;0.01055;0.01319;0.002638;0.002638
+SSP1;ECS;;;;;Passenger Rail;trn_pass;S1S;0.007915;0.01055;0.02638;0.005276;0.005276
 SSP1;ECS;;;;;Walk;trn_pass;S1S;1;1;1;1;1
 SSP1;ECS;;;;;trn_freight_road;trn_freight;S1S;1;1;1;1;1
-SSP1;ECS;;;;;trn_pass_road;trn_pass;S1S;0.7451;0.7451;0.7451;0.08941;0.08941
-SSP1;ECS;;;;Bus;trn_pass_road;trn_pass;S2S1;0.209;0.1742;0.1219;0.1045;0.1045
+SSP1;ECS;;;;;trn_pass_road;trn_pass;S1S;0.7451;0.7451;0.3725;0.04471;0.04471
+SSP1;ECS;;;;Bus;trn_pass_road;trn_pass;S2S1;0.209;0.1742;0.1829;0.1568;0.1568
 SSP1;ECS;;;;trn_pass_road_LDV;trn_pass_road;trn_pass;S2S1;1;1;1;1;1
 SSP1;ECS;;;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;0.01;0.01;0.01;0.01;0.01
 SSP1;ECS;;;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;1;1;1;1;1
-SSP1;ECS;;Compact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.5004;0.5004;0.5004;0.4549;0.4549
-SSP1;ECS;;Large Car and SUV;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;1;1;1;1;1
-SSP1;ECS;;Midsize Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.9609;0.9609;0.9609;0.9609;0.9609
+SSP1;ECS;;Compact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.5004;0.5004;0.5117;0.5116;0.5116
+SSP1;ECS;;Large Car and SUV;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;1;1;0.5112;0.3749;0.3749
+SSP1;ECS;;Midsize Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.9609;0.9609;0.4913;0.3603;0.3603
 SSP1;ECS;;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.1125;0.1125;0.1125;0.1125;0.1125
 SSP1;ECS;;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.03579;0.03579;0.03579;0.03579;0.03579
 SSP1;ECS;;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;1;1;1;1;1
-SSP1;ECS;;Subcompact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.978;0.978;0.978;0.8891;0.8891
+SSP1;ECS;;Subcompact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.978;0.978;1;1;1
 SSP1;ECS;;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;1;1;1;1;1
 SSP1;ECS;;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.2555;0.2555;0.2555;0.2555;0.2555
 SSP1;ECS;;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.3104;0.3104;0.3104;0.3104;0.3104
 SSP1;ECS;;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.1282;0.1282;0.1282;0.1282;0.1282
 SSP1;ECS;;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.4409;0.4409;0.4409;0.4409;0.4409
-SSP1;ECS;BEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.09315;0.3815;0.842;0.842
-SSP1;ECS;BEV;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.032;0.192;0.42;0.42
-SSP1;ECS;BEV;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.032;0.192;0.42;0.42
-SSP1;ECS;BEV;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.032;0.192;0.42;0.42
-SSP1;ECS;BEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1041;0.2182;0.2893;0.2893
-SSP1;ECS;BEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.0414;0.1174;0.2807;0.2807
-SSP1;ECS;BEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.0414;0.1174;0.2807;0.2807
-SSP1;ECS;BEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.0414;0.1174;0.2807;0.2807
-SSP1;ECS;BEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1041;0.2182;0.2893;0.2893
+SSP1;ECS;BEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.09315;0.763;1;1
+SSP1;ECS;BEV;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.032;0.384;0.84;0.84
+SSP1;ECS;BEV;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.032;0.384;0.84;0.84
+SSP1;ECS;BEV;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.032;0.384;0.84;0.84
+SSP1;ECS;BEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1041;0.4364;0.5786;0.5786
+SSP1;ECS;BEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.0414;0.2348;0.5614;0.5614
+SSP1;ECS;BEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.0414;0.2348;0.5614;0.5614
+SSP1;ECS;BEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.0414;0.2348;0.5614;0.5614
+SSP1;ECS;BEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1041;0.4364;0.5786;0.5786
 SSP1;ECS;Electric;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;1;1;1;1;1
 SSP1;ECS;Electric;HSR_tmp_vehicletype;HSR_tmp_subsectorL3;HSR_tmp_subsectorL2;HSR;trn_pass;FV;1;1;1;1;1
 SSP1;ECS;Electric;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;1;1;1;1;1
-SSP1;ECS;FCEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.002698;0.0736;0.1091;0.1091
-SSP1;ECS;FCEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.01461;0.069;0.07977;0.07977
-SSP1;ECS;FCEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.005396;0.02617;0.05456;0.05456
-SSP1;ECS;FCEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.005396;0.02617;0.05456;0.05456
-SSP1;ECS;FCEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.005396;0.02617;0.05456;0.05456
-SSP1;ECS;FCEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.01461;0.069;0.07977;0.07977
-SSP1;ECS;Gases;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0.01;0.02;0.0625;0.1;0.1
+SSP1;ECS;FCEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.002698;0.0736;0.06479;0.06479
+SSP1;ECS;FCEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.01461;0.207;0.2393;0.2393
+SSP1;ECS;FCEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.005396;0.07851;0.1637;0.1637
+SSP1;ECS;FCEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.005396;0.07851;0.1637;0.1637
+SSP1;ECS;FCEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.005396;0.07851;0.1637;0.1637
+SSP1;ECS;FCEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.01461;0.207;0.2393;0.2393
+SSP1;ECS;Gases;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0.01;0.02;0.0625;0.05938;0.05938
 SSP1;ECS;Gases;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1E-05;0.013;0.06667;0.14;0.14
 SSP1;ECS;Gases;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1E-05;0.013;0.06667;0.14;0.14
 SSP1;ECS;Gases;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1E-05;0.013;0.06667;0.14;0.14
 SSP1;ECS;Gases;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1E-05;0.013;0.06667;0.14;0.14
 SSP1;ECS;Gases;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1E-05;0.013;0.06667;0.14;0.14
-SSP1;ECS;Hydrogen;Domestic Aviation_tmp_vehicletype;Domestic Aviation_tmp_subsectorL3;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;trn_pass;FV;0;8.32E-07;4.54E-05;0.1192;0.1192
-SSP1;ECS;Liquids;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;1;1;1;1;1
+SSP1;ECS;Hydrogen;Domestic Aviation_tmp_vehicletype;Domestic Aviation_tmp_subsectorL3;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;trn_pass;FV;0;8.32E-07;0.1362;0.3576;0.3576
+SSP1;ECS;Liquids;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;1;1;1;0.5938;0.5938
 SSP1;ECS;Liquids;Domestic Aviation_tmp_vehicletype;Domestic Aviation_tmp_subsectorL3;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;trn_pass;FV;1;1;1;1;1
 SSP1;ECS;Liquids;Domestic Ship_tmp_vehicletype;Domestic Ship_tmp_subsectorL3;Domestic Ship_tmp_subsectorL2;Domestic Ship;trn_freight;FV;1;1;1;1;1
-SSP1;ECS;Liquids;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;0.6302;0.6302;0.6302;0.6302;0.6302
+SSP1;ECS;Liquids;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;0.6302;0.6302;0.3151;0.3151;0.3151
 SSP1;ECS;Liquids;International Aviation_tmp_vehicletype;International Aviation_tmp_subsectorL3;International Aviation_tmp_subsectorL2;International Aviation;trn_aviation_intl;FV;1;1;1;1;1
 SSP1;ECS;Liquids;International Ship_tmp_vehicletype;International Ship_tmp_subsectorL3;International Ship_tmp_subsectorL2;International Ship;trn_shipping_intl;FV;1;1;1;1;1
 SSP1;ECS;Liquids;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;1;1;1
 SSP1;ECS;Liquids;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;1;1;1
 SSP1;ECS;Liquids;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;1;1;1
-SSP1;ECS;Liquids;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;0.2298;0.2298;0.2298;0.2298;0.2298
+SSP1;ECS;Liquids;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;0.2298;0.2298;0.1149;0.0766;0.0766
 SSP1;ECS;Liquids;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
 SSP1;ECS;Liquids;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
 SSP1;ECS;Liquids;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
 SSP1;ECS;Liquids;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
 SSP1;ECS;Liquids;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
 SSP1;ENC;;;;;Cycle;trn_pass;S1S;0.025;0.025;0.05556;0.1;0.1
-SSP1;ENC;;;;;Domestic Aviation;trn_pass;S1S;5.97E-05;5.97E-05;5.3E-05;2.39E-05;2.39E-05
+SSP1;ENC;;;;;Domestic Aviation;trn_pass;S1S;5.97E-05;5.97E-05;1.33E-05;5.97E-06;5.97E-06
 SSP1;ENC;;;;;Domestic Ship;trn_freight;S1S;0.01246;0.01246;0.01246;0.01246;0.01246
-SSP1;ENC;;;;;Freight Rail;trn_freight;S1S;0.02928;0.02928;0.02928;0.02928;0.02928
+SSP1;ENC;;;;;Freight Rail;trn_freight;S1S;0.02928;0.02928;0.04392;0.04392;0.04392
 SSP1;ENC;;;;;HSR;trn_pass;S1S;0.000125;0.00025;0.0002222;0.0002;0.0002
 SSP1;ENC;;;;;International Aviation;trn_aviation_intl;S1S;1;1;1;1;1
 SSP1;ENC;;;;;International Ship;trn_shipping_intl;S1S;1;1;1;1;1
-SSP1;ENC;;;;;Passenger Rail;trn_pass;S1S;0.003125;0.003125;0.003333;0.002;0.002
+SSP1;ENC;;;;;Passenger Rail;trn_pass;S1S;0.003125;0.003125;0.006666;0.004;0.004
 SSP1;ENC;;;;;Walk;trn_pass;S1S;1;1;1;1;1
 SSP1;ENC;;;;;trn_freight_road;trn_freight;S1S;1;1;1;1;1
-SSP1;ENC;;;;;trn_pass_road;trn_pass;S1S;0.07363;0.07363;0.06545;0.02945;0.02945
-SSP1;ENC;;;;Bus;trn_pass_road;trn_pass;S2S1;0.2037;0.1528;0.1528;0.1528;0.1528
+SSP1;ENC;;;;;trn_pass_road;trn_pass;S1S;0.07363;0.07363;0.03272;0.01473;0.01473
+SSP1;ENC;;;;Bus;trn_pass_road;trn_pass;S2S1;0.2037;0.1528;0.2292;0.2292;0.2292
 SSP1;ENC;;;;trn_pass_road_LDV;trn_pass_road;trn_pass;S2S1;1;1;1;1;1
 SSP1;ENC;;;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;0.06;0.06;0.06;0.06;0.06
 SSP1;ENC;;;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;1;1;1;1;1
-SSP1;ENC;;Compact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.3955;0.3955;0.3955;0.3559;0.3559
-SSP1;ENC;;Large Car and SUV;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;1;1;1;1;1
-SSP1;ENC;;Midsize Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.196;0.196;0.196;0.196;0.196
-SSP1;ENC;;Mini Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;2.62E-07;2.62E-07;2.62E-07;2.36E-07;2.36E-07
+SSP1;ENC;;Compact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.3955;0.3955;0.791;1;1
+SSP1;ENC;;Large Car and SUV;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;1;1;1;0.9366;0.9366
+SSP1;ENC;;Midsize Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.196;0.196;0.196;0.1836;0.1836
+SSP1;ENC;;Mini Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;2.62E-07;2.62E-07;5.24E-07;6.62E-07;6.62E-07
 SSP1;ENC;;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.1576;0.1576;0.1576;0.1576;0.1576
 SSP1;ENC;;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.03751;0.03751;0.03751;0.03751;0.03751
 SSP1;ENC;;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;1;1;1;1;1
-SSP1;ENC;;Subcompact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.2181;0.2181;0.2181;0.1963;0.1963
+SSP1;ENC;;Subcompact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.2181;0.2181;0.4362;0.5516;0.5516
 SSP1;ENC;;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;1;1;1;1;1
 SSP1;ENC;;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.1002;0.1002;0.1002;0.1002;0.1002
 SSP1;ENC;;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.3593;0.3593;0.3593;0.3593;0.3593
 SSP1;ENC;;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.4374;0.4374;0.4374;0.4374;0.4374
 SSP1;ENC;;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.4946;0.4946;0.4946;0.4946;0.4946
-SSP1;ENC;;Van;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.001049;0.001049;0.001049;0.001049;0.001049
-SSP1;ENC;BEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.2157;0.7227;1;1
-SSP1;ENC;BEV;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.05;0.23;0.5;0.5
-SSP1;ENC;BEV;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.05;0.23;0.5;0.5
-SSP1;ENC;BEV;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.05;0.23;0.5;0.5
-SSP1;ENC;BEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.3101;0.6386;0.9289;0.9289
-SSP1;ENC;BEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1234;0.3434;0.9011;0.9011
-SSP1;ENC;BEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1234;0.3434;0.9011;0.9011
-SSP1;ENC;BEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1234;0.3434;0.9011;0.9011
-SSP1;ENC;BEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.3101;0.6386;0.9289;0.9289
+SSP1;ENC;;Van;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.001049;0.001049;0.001049;0.0009825;0.0009825
+SSP1;ENC;BEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.2157;1;1;1
+SSP1;ENC;BEV;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.05;0.46;1;1
+SSP1;ENC;BEV;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.05;0.46;1;1
+SSP1;ENC;BEV;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.05;0.46;1;1
+SSP1;ENC;BEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.3101;1;1;1
+SSP1;ENC;BEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1234;0.6868;1;1
+SSP1;ENC;BEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1234;0.6868;1;1
+SSP1;ENC;BEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1234;0.6868;1;1
+SSP1;ENC;BEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.3101;1;1;1
 SSP1;ENC;Electric;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;1;1;1;1;1
 SSP1;ENC;Electric;HSR_tmp_vehicletype;HSR_tmp_subsectorL3;HSR_tmp_subsectorL2;HSR;trn_pass;FV;1;1;1;1;1
 SSP1;ENC;Electric;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;1;1;1;1;1
-SSP1;ENC;FCEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.01124;0.058;0.1021;0.1021
-SSP1;ENC;FCEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.07914;0.2804;0.1729;0.1729
-SSP1;ENC;FCEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02924;0.1063;0.1183;0.1183
-SSP1;ENC;FCEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02924;0.1063;0.1183;0.1183
-SSP1;ENC;FCEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02924;0.1063;0.1183;0.1183
-SSP1;ENC;FCEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.07914;0.2804;0.1729;0.1729
-SSP1;ENC;Gases;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0.02533;0.03921;0.09298;0.1011;0.1011
-SSP1;ENC;Gases;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02632;0.07895;0.1842;0.1842
-SSP1;ENC;Gases;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02632;0.07895;0.1842;0.1842
-SSP1;ENC;Gases;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02632;0.07895;0.1842;0.1842
-SSP1;ENC;Gases;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02632;0.07895;0.1842;0.1842
-SSP1;ENC;Gases;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02632;0.07895;0.1842;0.1842
-SSP1;ENC;Hydrogen;Domestic Aviation_tmp_vehicletype;Domestic Aviation_tmp_subsectorL3;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;trn_pass;FV;0;8.32E-07;4.54E-05;0.1192;0.1192
-SSP1;ENC;Liquids;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;1;1;1;0.5426;0.5426
+SSP1;ENC;FCEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.01124;0.04013;0.05105;0.05105
+SSP1;ENC;FCEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.07914;0.6586;0.2792;0.2792
+SSP1;ENC;FCEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02924;0.3189;0.1969;0.1969
+SSP1;ENC;FCEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02924;0.3189;0.1969;0.1969
+SSP1;ENC;FCEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02924;0.3189;0.1969;0.1969
+SSP1;ENC;FCEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.07914;0.6586;0.2792;0.2792
+SSP1;ENC;Gases;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0.02533;0.03921;0.06433;0.05055;0.05055
+SSP1;ENC;Gases;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02632;0.06181;0.09915;0.09915
+SSP1;ENC;Gases;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02632;0.07895;0.1022;0.1022
+SSP1;ENC;Gases;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02632;0.07895;0.1022;0.1022
+SSP1;ENC;Gases;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02632;0.07895;0.1022;0.1022
+SSP1;ENC;Gases;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02632;0.06181;0.09915;0.09915
+SSP1;ENC;Hydrogen;Domestic Aviation_tmp_vehicletype;Domestic Aviation_tmp_subsectorL3;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;trn_pass;FV;0;8.32E-07;0.1362;0.3576;0.3576
+SSP1;ENC;Liquids;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;1;1;0.6919;0.2713;0.2713
 SSP1;ENC;Liquids;Domestic Aviation_tmp_vehicletype;Domestic Aviation_tmp_subsectorL3;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;trn_pass;FV;1;1;1;1;1
 SSP1;ENC;Liquids;Domestic Ship_tmp_vehicletype;Domestic Ship_tmp_subsectorL3;Domestic Ship_tmp_subsectorL2;Domestic Ship;trn_freight;FV;1;1;1;1;1
-SSP1;ENC;Liquids;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;0.1341;0.1341;0.1341;0.1341;0.1341
+SSP1;ENC;Liquids;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;0.1341;0.1341;0.06705;0.06705;0.06705
 SSP1;ENC;Liquids;International Aviation_tmp_vehicletype;International Aviation_tmp_subsectorL3;International Aviation_tmp_subsectorL2;International Aviation;trn_aviation_intl;FV;1;1;1;1;1
 SSP1;ENC;Liquids;International Ship_tmp_vehicletype;International Ship_tmp_subsectorL3;International Ship_tmp_subsectorL2;International Ship;trn_shipping_intl;FV;1;1;1;1;1
 SSP1;ENC;Liquids;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;1;1;1
 SSP1;ENC;Liquids;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;1;1;1
 SSP1;ENC;Liquids;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;1;1;1
-SSP1;ENC;Liquids;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;0.1258;0.1258;0.1258;0.1258;0.1258
-SSP1;ENC;Liquids;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
-SSP1;ENC;Liquids;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
-SSP1;ENC;Liquids;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
-SSP1;ENC;Liquids;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
-SSP1;ENC;Liquids;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
+SSP1;ENC;Liquids;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;0.1258;0.1258;0.0629;0.04193;0.04193
+SSP1;ENC;Liquids;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;0.783;0.5383;0.5383
+SSP1;ENC;Liquids;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;0.5549;0.5549
+SSP1;ENC;Liquids;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;0.5549;0.5549
+SSP1;ENC;Liquids;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;0.5549;0.5549
+SSP1;ENC;Liquids;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;0.783;0.5383;0.5383
 SSP1;ESC;;;;;Cycle;trn_pass;S1S;0.01942;0.02184;0.04369;0.1638;0.1638
-SSP1;ESC;;;;;Domestic Aviation;trn_pass;S1S;0.0001286;3.62E-05;3.62E-05;7.23E-05;7.23E-05
+SSP1;ESC;;;;;Domestic Aviation;trn_pass;S1S;0.0001286;3.62E-05;9.04E-06;1.81E-05;1.81E-05
 SSP1;ESC;;;;;Domestic Ship;trn_freight;S1S;0.01209;0.01209;0.01209;0.01209;0.01209
-SSP1;ESC;;;;;Freight Rail;trn_freight;S1S;0.004094;0.004094;0.004094;0.004094;0.004094
+SSP1;ESC;;;;;Freight Rail;trn_freight;S1S;0.004094;0.004094;0.006141;0.006141;0.006141
 SSP1;ESC;;;;;HSR;trn_pass;S1S;0.0006613;0.000186;0.00062;0.00062;0.00062
 SSP1;ESC;;;;;International Aviation;trn_aviation_intl;S1S;1;1;1;1;1
 SSP1;ESC;;;;;International Ship;trn_shipping_intl;S1S;1;1;1;1;1
-SSP1;ESC;;;;;Passenger Rail;trn_pass;S1S;0.003195;0.002696;0.002696;0.004044;0.004044
+SSP1;ESC;;;;;Passenger Rail;trn_pass;S1S;0.003195;0.002696;0.005392;0.008088;0.008088
 SSP1;ESC;;;;;Walk;trn_pass;S1S;1;1;1;1;1
 SSP1;ESC;;;;;trn_freight_road;trn_freight;S1S;1;1;1;1;1
-SSP1;ESC;;;;;trn_pass_road;trn_pass;S1S;0.1798;0.1011;0.08092;0.06473;0.06473
-SSP1;ESC;;;;Bus;trn_pass_road;trn_pass;S2S1;0.06714;0.06714;0.06714;0.1007;0.1007
+SSP1;ESC;;;;;trn_pass_road;trn_pass;S1S;0.1798;0.1011;0.04046;0.03236;0.03236
+SSP1;ESC;;;;Bus;trn_pass_road;trn_pass;S2S1;0.06714;0.06714;0.1007;0.151;0.151
 SSP1;ESC;;;;trn_pass_road_LDV;trn_pass_road;trn_pass;S2S1;1;1;1;1;1
 SSP1;ESC;;;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;0.4;0.4;0.4;0.4;0.4
 SSP1;ESC;;;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;1;1;1;1;1
 SSP1;ESC;;Compact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.3942;0.3942;0.3942;0.3942;0.3942
-SSP1;ESC;;Large Car and SUV;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.8712;0.784;0.8712;0.8712;0.8712
-SSP1;ESC;;Midsize Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.2323;0.2091;0.2323;0.2323;0.2323
+SSP1;ESC;;Large Car and SUV;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.8712;0.784;0.4356;0.2904;0.2904
+SSP1;ESC;;Midsize Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.2323;0.2091;0.1162;0.07743;0.07743
 SSP1;ESC;;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.1009;0.1009;0.1009;0.1009;0.1009
 SSP1;ESC;;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.06375;0.06375;0.06375;0.06375;0.06375
 SSP1;ESC;;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;1;1;1;1;1
@@ -6101,259 +6101,259 @@ SSP1;ESC;;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subs
 SSP1;ESC;;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.2234;0.2234;0.2234;0.2234;0.2234
 SSP1;ESC;;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.2172;0.2172;0.2172;0.2172;0.2172
 SSP1;ESC;;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;1;1;1;1;1
-SSP1;ESC;BEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.1359;0.3816;0.8448;0.8448
-SSP1;ESC;BEV;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.04;0.22;0.42;0.42
-SSP1;ESC;BEV;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.04;0.22;0.42;0.42
-SSP1;ESC;BEV;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.04;0.22;0.42;0.42
-SSP1;ESC;BEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.2819;0.5321;0.7741;0.7741
-SSP1;ESC;BEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1122;0.2862;0.7509;0.7509
-SSP1;ESC;BEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1122;0.2862;0.7509;0.7509
-SSP1;ESC;BEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1122;0.2862;0.7509;0.7509
-SSP1;ESC;BEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.2819;0.5321;0.7741;0.7741
+SSP1;ESC;BEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.1359;0.7632;1;1
+SSP1;ESC;BEV;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.04;0.44;0.84;0.84
+SSP1;ESC;BEV;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.04;0.44;0.84;0.84
+SSP1;ESC;BEV;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.04;0.44;0.84;0.84
+SSP1;ESC;BEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.2819;1;1;1
+SSP1;ESC;BEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1122;0.5724;1;1
+SSP1;ESC;BEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1122;0.5724;1;1
+SSP1;ESC;BEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1122;0.5724;1;1
+SSP1;ESC;BEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.2819;1;1;1
 SSP1;ESC;Electric;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;1;1;1;1;1
 SSP1;ESC;Electric;HSR_tmp_vehicletype;HSR_tmp_subsectorL3;HSR_tmp_subsectorL2;HSR;trn_pass;FV;1;1;1;1;1
 SSP1;ESC;Electric;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;1;1;1;1;1
-SSP1;ESC;FCEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.01124;0.0638;0.07883;0.07883
-SSP1;ESC;FCEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.07914;0.05608;0.1441;0.1441
-SSP1;ESC;FCEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02924;0.02127;0.09854;0.09854
-SSP1;ESC;FCEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02924;0.02127;0.09854;0.09854
-SSP1;ESC;FCEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02924;0.02127;0.09854;0.09854
-SSP1;ESC;FCEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.07914;0.05608;0.1441;0.1441
-SSP1;ESC;Gases;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0.02742;0.04078;0.1042;0.1721;0.1721
-SSP1;ESC;Gases;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02632;0.07895;0.1535;0.1535
-SSP1;ESC;Gases;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02632;0.07895;0.1535;0.1535
-SSP1;ESC;Gases;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02632;0.07895;0.1535;0.1535
-SSP1;ESC;Gases;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02632;0.07895;0.1535;0.1535
-SSP1;ESC;Gases;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02632;0.07895;0.1535;0.1535
-SSP1;ESC;Hydrogen;Domestic Aviation_tmp_vehicletype;Domestic Aviation_tmp_subsectorL3;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;trn_pass;FV;0;8.32E-07;4.54E-05;0.1192;0.1192
-SSP1;ESC;Liquids;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;1;1;1;1;1
+SSP1;ESC;FCEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.01124;0.0638;0.04666;0.04666
+SSP1;ESC;FCEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.07914;0.1581;0.2792;0.2792
+SSP1;ESC;FCEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02924;0.06381;0.1968;0.1968
+SSP1;ESC;FCEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02924;0.06381;0.1968;0.1968
+SSP1;ESC;FCEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02924;0.06381;0.1968;0.1968
+SSP1;ESC;FCEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.07914;0.1581;0.2792;0.2792
+SSP1;ESC;Gases;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0.02742;0.04078;0.1042;0.1019;0.1019
+SSP1;ESC;Gases;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02632;0.07419;0.09915;0.09915
+SSP1;ESC;Gases;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02632;0.07895;0.1022;0.1022
+SSP1;ESC;Gases;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02632;0.07895;0.1022;0.1022
+SSP1;ESC;Gases;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02632;0.07895;0.1022;0.1022
+SSP1;ESC;Gases;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02632;0.07419;0.09915;0.09915
+SSP1;ESC;Hydrogen;Domestic Aviation_tmp_vehicletype;Domestic Aviation_tmp_subsectorL3;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;trn_pass;FV;0;8.32E-07;0.1362;0.3576;0.3576
+SSP1;ESC;Liquids;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;1;1;1;0.5919;0.5919
 SSP1;ESC;Liquids;Domestic Aviation_tmp_vehicletype;Domestic Aviation_tmp_subsectorL3;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;trn_pass;FV;1;1;1;1;1
 SSP1;ESC;Liquids;Domestic Ship_tmp_vehicletype;Domestic Ship_tmp_subsectorL3;Domestic Ship_tmp_subsectorL2;Domestic Ship;trn_freight;FV;1;1;1;1;1
-SSP1;ESC;Liquids;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;0.1241;0.1241;0.1241;0.1241;0.1241
+SSP1;ESC;Liquids;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;0.1241;0.1241;0.06205;0.06205;0.06205
 SSP1;ESC;Liquids;International Aviation_tmp_vehicletype;International Aviation_tmp_subsectorL3;International Aviation_tmp_subsectorL2;International Aviation;trn_aviation_intl;FV;1;1;1;1;1
 SSP1;ESC;Liquids;International Ship_tmp_vehicletype;International Ship_tmp_subsectorL3;International Ship_tmp_subsectorL2;International Ship;trn_shipping_intl;FV;1;1;1;1;1
 SSP1;ESC;Liquids;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;1;1;1
 SSP1;ESC;Liquids;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;1;1;1
 SSP1;ESC;Liquids;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;1;1;1
-SSP1;ESC;Liquids;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;0.07003;0.07003;0.07003;0.07003;0.07003
-SSP1;ESC;Liquids;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
-SSP1;ESC;Liquids;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
-SSP1;ESC;Liquids;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
-SSP1;ESC;Liquids;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
-SSP1;ESC;Liquids;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
+SSP1;ESC;Liquids;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;0.07003;0.07003;0.03501;0.02334;0.02334
+SSP1;ESC;Liquids;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;0.9397;0.6459;0.6459
+SSP1;ESC;Liquids;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;0.6659;0.6659
+SSP1;ESC;Liquids;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;0.6659;0.6659
+SSP1;ESC;Liquids;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;0.6659;0.6659
+SSP1;ESC;Liquids;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;0.9397;0.6459;0.6459
 SSP1;ESW;;;;;Cycle;trn_pass;S1S;0.01942;0.03884;0.05825;0.1019;0.1019
-SSP1;ESW;;;;;Domestic Aviation;trn_pass;S1S;0.0006852;0.0006852;0.0005482;0.0001285;0.0001285
+SSP1;ESW;;;;;Domestic Aviation;trn_pass;S1S;0.0006852;0.0006852;0.000137;3.21E-05;3.21E-05
 SSP1;ESW;;;;;Domestic Ship;trn_freight;S1S;0.00613;0.00613;0.00613;0.00613;0.00613
-SSP1;ESW;;;;;Freight Rail;trn_freight;S1S;0.0142;0.0142;0.0142;0.0142;0.0142
+SSP1;ESW;;;;;Freight Rail;trn_freight;S1S;0.0142;0.0142;0.0213;0.0213;0.0213
 SSP1;ESW;;;;;HSR;trn_pass;S1S;0.0009579;0.0009579;0.0009579;0.0003592;0.0003592
 SSP1;ESW;;;;;International Aviation;trn_aviation_intl;S1S;1;1;1;1;1
 SSP1;ESW;;;;;International Ship;trn_shipping_intl;S1S;1;1;1;1;1
-SSP1;ESW;;;;;Passenger Rail;trn_pass;S1S;0.003621;0.003621;0.005432;0.002037;0.002037
+SSP1;ESW;;;;;Passenger Rail;trn_pass;S1S;0.003621;0.003621;0.01086;0.004074;0.004074
 SSP1;ESW;;;;;Walk;trn_pass;S1S;1;1;1;1;1
 SSP1;ESW;;;;;trn_freight_road;trn_freight;S1S;1;1;1;1;1
-SSP1;ESW;;;;;trn_pass_road;trn_pass;S1S;0.1385;0.1108;0.1108;0.03117;0.03117
-SSP1;ESW;;;;Bus;trn_pass_road;trn_pass;S2S1;0.05772;0.05772;0.07215;0.1082;0.1082
+SSP1;ESW;;;;;trn_pass_road;trn_pass;S1S;0.1385;0.1108;0.0554;0.01558;0.01558
+SSP1;ESW;;;;Bus;trn_pass_road;trn_pass;S2S1;0.05772;0.05772;0.1082;0.1623;0.1623
 SSP1;ESW;;;;trn_pass_road_LDV;trn_pass_road;trn_pass;S2S1;1;1;1;1;1
 SSP1;ESW;;;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;0.2;0.2;0.2;0.2;0.2
 SSP1;ESW;;;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;1;1;1;1;1
-SSP1;ESW;;Compact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.5725;0.5725;0.5725;0.5725;0.5725
-SSP1;ESW;;Large Car and SUV;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;1;1;1;1;1
-SSP1;ESW;;Midsize Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.2963;0.2963;0.2963;0.2963;0.2963
+SSP1;ESW;;Compact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.5725;0.5725;1;1;1
+SSP1;ESW;;Large Car and SUV;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;1;1;0.8734;0.5822;0.5822
+SSP1;ESW;;Midsize Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.2963;0.2963;0.2588;0.1725;0.1725
 SSP1;ESW;;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.09741;0.09741;0.09741;0.09741;0.09741
 SSP1;ESW;;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.1669;0.1669;0.1669;0.1669;0.1669
 SSP1;ESW;;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;1;1;1;1;1
-SSP1;ESW;;Subcompact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.4448;0.4448;0.4448;0.4448;0.4448
+SSP1;ESW;;Subcompact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.4448;0.4448;0.7769;0.7769;0.7769
 SSP1;ESW;;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.285;0.285;0.285;0.285;0.285
 SSP1;ESW;;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.06043;0.06043;0.06043;0.06043;0.06043
 SSP1;ESW;;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.08424;0.08424;0.08424;0.08424;0.08424
 SSP1;ESW;;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.4041;0.4041;0.4041;0.4041;0.4041
 SSP1;ESW;;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;1;1;1;1;1
-SSP1;ESW;BEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0.01078;0.1164;0.2935;0.6237;0.6237
-SSP1;ESW;BEV;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.048;0.216;0.42;0.42
-SSP1;ESW;BEV;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.048;0.216;0.42;0.42
-SSP1;ESW;BEV;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.048;0.216;0.42;0.42
-SSP1;ESW;BEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.3902;0.6875;1;1
-SSP1;ESW;BEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1553;0.3698;1;1
-SSP1;ESW;BEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1553;0.3698;1;1
-SSP1;ESW;BEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1553;0.3698;1;1
-SSP1;ESW;BEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.3902;0.6875;1;1
-SSP1;ESW;Electric;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;0.7295;0.7633;0.8309;0.9662;0.9662
+SSP1;ESW;BEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0.01078;0.1164;0.587;1;1
+SSP1;ESW;BEV;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.048;0.432;0.84;0.84
+SSP1;ESW;BEV;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.048;0.432;0.84;0.84
+SSP1;ESW;BEV;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.048;0.432;0.84;0.84
+SSP1;ESW;BEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.3902;1;1;1
+SSP1;ESW;BEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1553;0.7396;1;1
+SSP1;ESW;BEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1553;0.7396;1;1
+SSP1;ESW;BEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1553;0.7396;1;1
+SSP1;ESW;BEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.3902;1;1;1
+SSP1;ESW;Electric;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;0.7295;0.7633;1;1;1
 SSP1;ESW;Electric;HSR_tmp_vehicletype;HSR_tmp_subsectorL3;HSR_tmp_subsectorL2;HSR;trn_pass;FV;1;1;1;1;1
 SSP1;ESW;Electric;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;1;1;1;1;1
-SSP1;ESW;FCEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0.002248;0.002698;0.01963;0.05846;0.05846
-SSP1;ESW;FCEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.07303;0.2588;0.1489;0.1489
-SSP1;ESW;FCEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02698;0.09813;0.105;0.105
-SSP1;ESW;FCEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02698;0.09813;0.105;0.105
-SSP1;ESW;FCEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02698;0.09813;0.105;0.105
-SSP1;ESW;FCEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.07303;0.2588;0.1489;0.1489
-SSP1;ESW;Gases;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0.01754;0.02632;0.07895;0.1316;0.1316
-SSP1;ESW;Gases;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02632;0.07895;0.1719;0.1719
-SSP1;ESW;Gases;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02632;0.07895;0.1772;0.1772
-SSP1;ESW;Gases;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02632;0.07895;0.1772;0.1772
-SSP1;ESW;Gases;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02632;0.07895;0.1772;0.1772
-SSP1;ESW;Gases;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02632;0.07895;0.1719;0.1719
-SSP1;ESW;Hydrogen;Domestic Aviation_tmp_vehicletype;Domestic Aviation_tmp_subsectorL3;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;trn_pass;FV;0;8.32E-07;4.54E-05;0.1192;0.1192
-SSP1;ESW;Liquids;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;1;1;1;1;1
+SSP1;ESW;FCEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0.002248;0.002698;0.01963;0.04687;0.04687
+SSP1;ESW;FCEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.07303;0.5647;0.2233;0.2233
+SSP1;ESW;FCEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02698;0.2944;0.1575;0.1575
+SSP1;ESW;FCEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02698;0.2944;0.1575;0.1575
+SSP1;ESW;FCEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02698;0.2944;0.1575;0.1575
+SSP1;ESW;FCEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.07303;0.5647;0.2233;0.2233
+SSP1;ESW;Gases;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0.01754;0.02632;0.07895;0.1055;0.1055
+SSP1;ESW;Gases;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02632;0.05742;0.08595;0.08595
+SSP1;ESW;Gases;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02632;0.07895;0.0886;0.0886
+SSP1;ESW;Gases;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02632;0.07895;0.0886;0.0886
+SSP1;ESW;Gases;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02632;0.07895;0.0886;0.0886
+SSP1;ESW;Gases;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02632;0.05742;0.08595;0.08595
+SSP1;ESW;Hydrogen;Domestic Aviation_tmp_vehicletype;Domestic Aviation_tmp_subsectorL3;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;trn_pass;FV;0;8.32E-07;0.1362;0.3576;0.3576
+SSP1;ESW;Liquids;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;1;1;1;0.8017;0.8017
 SSP1;ESW;Liquids;Domestic Aviation_tmp_vehicletype;Domestic Aviation_tmp_subsectorL3;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;trn_pass;FV;1;1;1;1;1
 SSP1;ESW;Liquids;Domestic Ship_tmp_vehicletype;Domestic Ship_tmp_subsectorL3;Domestic Ship_tmp_subsectorL2;Domestic Ship;trn_freight;FV;1;1;1;1;1
-SSP1;ESW;Liquids;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;1;1;1;1;1
+SSP1;ESW;Liquids;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;1;1;0.6018;0.5175;0.5175
 SSP1;ESW;Liquids;International Aviation_tmp_vehicletype;International Aviation_tmp_subsectorL3;International Aviation_tmp_subsectorL2;International Aviation;trn_aviation_intl;FV;1;1;1;1;1
 SSP1;ESW;Liquids;International Ship_tmp_vehicletype;International Ship_tmp_subsectorL3;International Ship_tmp_subsectorL2;International Ship;trn_shipping_intl;FV;1;1;1;1;1
 SSP1;ESW;Liquids;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;1;1;1
 SSP1;ESW;Liquids;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;1;1;1
 SSP1;ESW;Liquids;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;1;1;1
-SSP1;ESW;Liquids;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;0.5162;0.5162;0.5162;0.5162;0.5162
-SSP1;ESW;Liquids;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;0.9332;0.9332
-SSP1;ESW;Liquids;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;0.962;0.962
-SSP1;ESW;Liquids;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;0.962;0.962
-SSP1;ESW;Liquids;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;0.962;0.962
-SSP1;ESW;Liquids;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;0.9332;0.9332
+SSP1;ESW;Liquids;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;0.5162;0.5162;0.2581;0.1721;0.1721
+SSP1;ESW;Liquids;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;0.7273;0.4666;0.4666
+SSP1;ESW;Liquids;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;0.481;0.481
+SSP1;ESW;Liquids;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;0.481;0.481
+SSP1;ESW;Liquids;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;0.481;0.481
+SSP1;ESW;Liquids;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;0.7273;0.4666;0.4666
 SSP1;EWN;;;;;Cycle;trn_pass;S1S;0.01;0.01;0.05;0.1;0.1
-SSP1;EWN;;;;;Domestic Aviation;trn_pass;S1S;4.77E-05;4.77E-05;4.77E-05;4.77E-06;4.77E-06
+SSP1;EWN;;;;;Domestic Aviation;trn_pass;S1S;4.77E-05;4.77E-05;1.19E-05;1.19E-06;1.19E-06
 SSP1;EWN;;;;;Domestic Ship;trn_freight;S1S;0.006261;0.006957;0.006261;0.006261;0.006261
-SSP1;EWN;;;;;Freight Rail;trn_freight;S1S;0.0127;0.01411;0.0127;0.0127;0.0127
+SSP1;EWN;;;;;Freight Rail;trn_freight;S1S;0.0127;0.01411;0.01905;0.01905;0.01905
 SSP1;EWN;;;;;HSR;trn_pass;S1S;0.0001;0.0001;0.0004;0.0002;0.0002
 SSP1;EWN;;;;;International Aviation;trn_aviation_intl;S1S;1;1;1;1;1
 SSP1;EWN;;;;;International Ship;trn_shipping_intl;S1S;1;1;1;1;1
-SSP1;EWN;;;;;Passenger Rail;trn_pass;S1S;0.002;0.003;0.003;0.002;0.002
+SSP1;EWN;;;;;Passenger Rail;trn_pass;S1S;0.002;0.003;0.006;0.004;0.004
 SSP1;EWN;;;;;Walk;trn_pass;S1S;1;1;1;1;1
 SSP1;EWN;;;;;trn_freight_road;trn_freight;S1S;1;1;1;1;1
-SSP1;EWN;;;;;trn_pass_road;trn_pass;S1S;0.05891;0.05891;0.05891;0.02945;0.02945
-SSP1;EWN;;;;Bus;trn_pass_road;trn_pass;S2S1;0.1019;0.1019;0.1019;0.1528;0.1528
+SSP1;EWN;;;;;trn_pass_road;trn_pass;S1S;0.05891;0.05891;0.02945;0.01473;0.01473
+SSP1;EWN;;;;Bus;trn_pass_road;trn_pass;S2S1;0.1019;0.1019;0.1529;0.2292;0.2292
 SSP1;EWN;;;;trn_pass_road_LDV;trn_pass_road;trn_pass;S2S1;1;1;1;1;1
 SSP1;EWN;;;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;0.1;0.1;0.1;0.1;0.1
 SSP1;EWN;;;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;1;1;1;1;1
-SSP1;EWN;;Compact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.4317;0.4317;0.3886;0.3886;0.3886
-SSP1;EWN;;Large Car and SUV;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;1;1;1;1;1
-SSP1;EWN;;Midsize Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.2283;0.2283;0.2283;0.2283;0.2283
+SSP1;EWN;;Compact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.4317;0.4317;0.7772;0.8878;0.8878
+SSP1;EWN;;Large Car and SUV;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;1;1;1;0.7616;0.7616
+SSP1;EWN;;Midsize Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.2283;0.2283;0.2283;0.1739;0.1739
 SSP1;EWN;;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.1183;0.1183;0.1183;0.1183;0.1183
 SSP1;EWN;;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.04339;0.04339;0.04339;0.04339;0.04339
 SSP1;EWN;;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;1;1;1;1;1
-SSP1;EWN;;Subcompact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.4864;0.4864;0.4377;0.4377;0.4377
+SSP1;EWN;;Subcompact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.4864;0.4864;0.8754;1;1
 SSP1;EWN;;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;1;1;1;1;1
 SSP1;EWN;;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.1164;0.1164;0.1164;0.1164;0.1164
 SSP1;EWN;;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.5225;0.5225;0.5225;0.5225;0.5225
 SSP1;EWN;;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.4061;0.4061;0.4061;0.4061;0.4061
 SSP1;EWN;;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.5651;0.5651;0.5651;0.5651;0.5651
-SSP1;EWN;BEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.08794;0.2197;0.5006;0.5006
-SSP1;EWN;BEV;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0.001;0.06;0.245;0.45;0.45
-SSP1;EWN;BEV;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0.001;0.06;0.245;0.45;0.45
-SSP1;EWN;BEV;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0.001;0.06;0.245;0.45;0.45
-SSP1;EWN;BEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.3436;0.6405;0.9031;0.9031
-SSP1;EWN;BEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1367;0.3445;0.876;0.876
-SSP1;EWN;BEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1367;0.3445;0.876;0.876
-SSP1;EWN;BEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1367;0.3445;0.876;0.876
-SSP1;EWN;BEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.3436;0.6405;0.9031;0.9031
+SSP1;EWN;BEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.08794;0.4394;1;1
+SSP1;EWN;BEV;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0.001;0.06;0.49;0.9;0.9
+SSP1;EWN;BEV;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0.001;0.06;0.49;0.9;0.9
+SSP1;EWN;BEV;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0.001;0.06;0.49;0.9;0.9
+SSP1;EWN;BEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.3436;1;1;1
+SSP1;EWN;BEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1367;0.689;1;1
+SSP1;EWN;BEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1367;0.689;1;1
+SSP1;EWN;BEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1367;0.689;1;1
+SSP1;EWN;BEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.3436;1;1;1
 SSP1;EWN;Electric;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;1;1;1;1;1
 SSP1;EWN;Electric;HSR_tmp_vehicletype;HSR_tmp_subsectorL3;HSR_tmp_subsectorL2;HSR;trn_pass;FV;1;1;1;1;1
 SSP1;EWN;Electric;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;1;1;1;1;1
-SSP1;EWN;FCEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.001861;0.007734;0.0219;0.0219
-SSP1;EWN;FCEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.01385;0.1059;0.06003;0.06003
-SSP1;EWN;FCEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.005116;0.04017;0.04106;0.04106
-SSP1;EWN;FCEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.005116;0.04017;0.04106;0.04106
-SSP1;EWN;FCEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.005116;0.04017;0.04106;0.04106
-SSP1;EWN;FCEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.01385;0.1059;0.06003;0.06003
-SSP1;EWN;Gases;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0.00807;0.03107;0.06282;0.09716;0.09716
-SSP1;EWN;Gases;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.0008171;0.03389;0.08856;0.1284;0.1284
-SSP1;EWN;Gases;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.03289;0.08772;0.1279;0.1279
-SSP1;EWN;Gases;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.03289;0.08772;0.1279;0.1279
-SSP1;EWN;Gases;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.03289;0.08772;0.1279;0.1279
-SSP1;EWN;Gases;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.03289;0.08772;0.1279;0.1279
-SSP1;EWN;Hydrogen;Domestic Aviation_tmp_vehicletype;Domestic Aviation_tmp_subsectorL3;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;trn_pass;FV;0;8.32E-07;4.54E-05;0.1192;0.1192
-SSP1;EWN;Liquids;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;1;1;1;1;1
+SSP1;EWN;FCEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.001861;0.007734;0.02187;0.02187
+SSP1;EWN;FCEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.01385;0.248;0.09971;0.09971
+SSP1;EWN;FCEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.005116;0.1205;0.07031;0.07031
+SSP1;EWN;FCEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.005116;0.1205;0.07031;0.07031
+SSP1;EWN;FCEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.005116;0.1205;0.07031;0.07031
+SSP1;EWN;FCEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.01385;0.248;0.09971;0.09971
+SSP1;EWN;Gases;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0.00807;0.03107;0.06282;0.09704;0.09704
+SSP1;EWN;Gases;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.0008171;0.03389;0.06913;0.07109;0.07109
+SSP1;EWN;Gases;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.03289;0.08772;0.073;0.073
+SSP1;EWN;Gases;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.03289;0.08772;0.073;0.073
+SSP1;EWN;Gases;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.03289;0.08772;0.073;0.073
+SSP1;EWN;Gases;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.03289;0.06848;0.07081;0.07081
+SSP1;EWN;Hydrogen;Domestic Aviation_tmp_vehicletype;Domestic Aviation_tmp_subsectorL3;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;trn_pass;FV;0;8.32E-07;0.1362;0.3576;0.3576
+SSP1;EWN;Liquids;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;1;1;1;0.9988;0.9988
 SSP1;EWN;Liquids;Domestic Aviation_tmp_vehicletype;Domestic Aviation_tmp_subsectorL3;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;trn_pass;FV;1;1;1;1;1
 SSP1;EWN;Liquids;Domestic Ship_tmp_vehicletype;Domestic Ship_tmp_subsectorL3;Domestic Ship_tmp_subsectorL2;Domestic Ship;trn_freight;FV;1;1;1;1;1
-SSP1;EWN;Liquids;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;0.3943;0.3943;0.3943;0.3943;0.3943
+SSP1;EWN;Liquids;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;0.3943;0.3943;0.1971;0.1971;0.1971
 SSP1;EWN;Liquids;International Aviation_tmp_vehicletype;International Aviation_tmp_subsectorL3;International Aviation_tmp_subsectorL2;International Aviation;trn_aviation_intl;FV;1;1;1;1;1
 SSP1;EWN;Liquids;International Ship_tmp_vehicletype;International Ship_tmp_subsectorL3;International Ship_tmp_subsectorL2;International Ship;trn_shipping_intl;FV;1;1;1;1;1
 SSP1;EWN;Liquids;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;1;1;1
 SSP1;EWN;Liquids;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;1;1;1
 SSP1;EWN;Liquids;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;1;1;1
-SSP1;EWN;Liquids;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;0.03824;0.03824;0.03824;0.03824;0.03824
-SSP1;EWN;Liquids;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
-SSP1;EWN;Liquids;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
-SSP1;EWN;Liquids;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
-SSP1;EWN;Liquids;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
-SSP1;EWN;Liquids;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
+SSP1;EWN;Liquids;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;0.03824;0.03824;0.01912;0.01275;0.01275
+SSP1;EWN;Liquids;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;0.7806;0.5536;0.5536
+SSP1;EWN;Liquids;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;0.5708;0.5708
+SSP1;EWN;Liquids;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;0.5708;0.5708
+SSP1;EWN;Liquids;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;0.5708;0.5708
+SSP1;EWN;Liquids;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;0.7806;0.5536;0.5536
 SSP1;FRA;;;;;Cycle;trn_pass;S1S;0.01942;0.02184;0.03641;0.1019;0.1019
-SSP1;FRA;;;;;Domestic Aviation;trn_pass;S1S;0.0001169;6.58E-05;4.39E-05;2.19E-05;2.19E-05
+SSP1;FRA;;;;;Domestic Aviation;trn_pass;S1S;0.0001169;6.58E-05;1.1E-05;5.48E-06;5.48E-06
 SSP1;FRA;;;;;Domestic Ship;trn_freight;S1S;0.003419;0.003419;0.003419;0.003419;0.003419
-SSP1;FRA;;;;;Freight Rail;trn_freight;S1S;0.01799;0.01799;0.01799;0.01799;0.01799
+SSP1;FRA;;;;;Freight Rail;trn_freight;S1S;0.01799;0.01799;0.02698;0.02698;0.02698
 SSP1;FRA;;;;;HSR;trn_pass;S1S;0.0003359;0.0002267;0.0002015;0.0002015;0.0002015
 SSP1;FRA;;;;;International Aviation;trn_aviation_intl;S1S;1;1;1;1;1
 SSP1;FRA;;;;;International Ship;trn_shipping_intl;S1S;1;1;1;1;1
-SSP1;FRA;;;;;Passenger Rail;trn_pass;S1S;0.003972;0.002979;0.001986;0.001986;0.001986
+SSP1;FRA;;;;;Passenger Rail;trn_pass;S1S;0.003972;0.002979;0.003972;0.003972;0.003972
 SSP1;FRA;;;;;Walk;trn_pass;S1S;1;1;1;1;1
 SSP1;FRA;;;;;trn_freight_road;trn_freight;S1S;1;1;1;1;1
-SSP1;FRA;;;;;trn_pass_road;trn_pass;S1S;0.09055;0.05094;0.03396;0.02717;0.02717
-SSP1;FRA;;;;Bus;trn_pass_road;trn_pass;S2S1;0.07932;0.08726;0.09519;0.1428;0.1428
+SSP1;FRA;;;;;trn_pass_road;trn_pass;S1S;0.09055;0.05094;0.01698;0.01358;0.01358
+SSP1;FRA;;;;Bus;trn_pass_road;trn_pass;S2S1;0.07932;0.08726;0.1428;0.2142;0.2142
 SSP1;FRA;;;;trn_pass_road_LDV;trn_pass_road;trn_pass;S2S1;1;1;1;1;1
 SSP1;FRA;;;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;0.2;0.2;0.2;0.2;0.2
 SSP1;FRA;;;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;1;1;1;1;1
-SSP1;FRA;;Compact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.6352;0.6352;0.6352;0.6352;0.6352
-SSP1;FRA;;Large Car and SUV;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;1;1;1;1;1
-SSP1;FRA;;Midsize Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.3632;0.3632;0.3632;0.3632;0.3632
+SSP1;FRA;;Compact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.6352;0.6352;0.7912;0.7912;0.7912
+SSP1;FRA;;Large Car and SUV;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;1;1;0.6228;0.4152;0.4152
+SSP1;FRA;;Midsize Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.3632;0.3632;0.2262;0.1508;0.1508
 SSP1;FRA;;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.092;0.092;0.092;0.092;0.092
 SSP1;FRA;;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.06774;0.06774;0.06774;0.06774;0.06774
 SSP1;FRA;;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;1;1;1;1;1
-SSP1;FRA;;Subcompact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.8028;0.8028;0.8028;0.8028;0.8028
+SSP1;FRA;;Subcompact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.8028;0.8028;1;1;1
 SSP1;FRA;;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;1;1;1;1;1
 SSP1;FRA;;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.1408;0.1408;0.1408;0.1408;0.1408
 SSP1;FRA;;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.1602;0.1602;0.1602;0.1602;0.1602
 SSP1;FRA;;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.4011;0.4011;0.4011;0.4011;0.4011
 SSP1;FRA;;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.3755;0.3755;0.3755;0.3755;0.3755
-SSP1;FRA;BEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0.01402;0.1682;0.4579;0.9531;0.9531
-SSP1;FRA;BEV;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.04;0.24;0.42;0.42
-SSP1;FRA;BEV;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.04;0.24;0.42;0.42
-SSP1;FRA;BEV;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.04;0.24;0.42;0.42
-SSP1;FRA;BEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.3171;0.6651;0.9087;0.9087
-SSP1;FRA;BEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1262;0.3578;0.8815;0.8815
-SSP1;FRA;BEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1262;0.3578;0.8815;0.8815
-SSP1;FRA;BEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1262;0.3578;0.8815;0.8815
-SSP1;FRA;BEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.3171;0.6651;0.9087;0.9087
+SSP1;FRA;BEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0.01402;0.1682;0.9158;1;1
+SSP1;FRA;BEV;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.04;0.48;0.84;0.84
+SSP1;FRA;BEV;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.04;0.48;0.84;0.84
+SSP1;FRA;BEV;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.04;0.48;0.84;0.84
+SSP1;FRA;BEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.3171;1;1;1
+SSP1;FRA;BEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1262;0.7156;1;1
+SSP1;FRA;BEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1262;0.7156;1;1
+SSP1;FRA;BEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1262;0.7156;1;1
+SSP1;FRA;BEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.3171;1;1;1
 SSP1;FRA;Electric;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;1;1;1;1;1
 SSP1;FRA;Electric;HSR_tmp_vehicletype;HSR_tmp_subsectorL3;HSR_tmp_subsectorL2;HSR;trn_pass;FV;1;1;1;1;1
 SSP1;FRA;Electric;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;1;1;1;1;1
-SSP1;FRA;FCEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0.01218;0.01462;0.02127;0.08186;0.08186
-SSP1;FRA;FCEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.07914;0.2337;0.1503;0.1503
-SSP1;FRA;FCEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02924;0.08861;0.1028;0.1028
-SSP1;FRA;FCEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02924;0.08861;0.1028;0.1028
-SSP1;FRA;FCEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02924;0.08861;0.1028;0.1028
-SSP1;FRA;FCEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.07914;0.2337;0.1503;0.1503
-SSP1;FRA;Gases;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0.01535;0.02632;0.07895;0.1417;0.1417
-SSP1;FRA;Gases;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02632;0.06579;0.1602;0.1602
-SSP1;FRA;Gases;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02632;0.06579;0.1602;0.1602
-SSP1;FRA;Gases;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02632;0.06579;0.1602;0.1602
-SSP1;FRA;Gases;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02632;0.06579;0.1602;0.1602
-SSP1;FRA;Gases;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02632;0.06579;0.1602;0.1602
-SSP1;FRA;Hydrogen;Domestic Aviation_tmp_vehicletype;Domestic Aviation_tmp_subsectorL3;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;trn_pass;FV;0;8.32E-07;4.54E-05;0.1192;0.1192
-SSP1;FRA;Liquids;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;1;1;1;1;1
+SSP1;FRA;FCEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0.01218;0.01462;0.02127;0.04294;0.04294
+SSP1;FRA;FCEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.07914;0.5271;0.2481;0.2481
+SSP1;FRA;FCEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02924;0.2658;0.1749;0.1749
+SSP1;FRA;FCEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02924;0.2658;0.1749;0.1749
+SSP1;FRA;FCEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02924;0.2658;0.1749;0.1749
+SSP1;FRA;FCEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.07914;0.5271;0.2481;0.2481
+SSP1;FRA;Gases;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0.01535;0.02632;0.07895;0.07434;0.07434
+SSP1;FRA;Gases;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02632;0.04946;0.08815;0.08815
+SSP1;FRA;Gases;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02632;0.06579;0.09087;0.09087
+SSP1;FRA;Gases;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02632;0.06579;0.09087;0.09087
+SSP1;FRA;Gases;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02632;0.06579;0.09087;0.09087
+SSP1;FRA;Gases;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02632;0.04946;0.08815;0.08815
+SSP1;FRA;Hydrogen;Domestic Aviation_tmp_vehicletype;Domestic Aviation_tmp_subsectorL3;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;trn_pass;FV;0;8.32E-07;0.1362;0.3576;0.3576
+SSP1;FRA;Liquids;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;1;1;1;0.5246;0.5246
 SSP1;FRA;Liquids;Domestic Aviation_tmp_vehicletype;Domestic Aviation_tmp_subsectorL3;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;trn_pass;FV;1;1;1;1;1
 SSP1;FRA;Liquids;Domestic Ship_tmp_vehicletype;Domestic Ship_tmp_subsectorL3;Domestic Ship_tmp_subsectorL2;Domestic Ship;trn_freight;FV;1;1;1;1;1
-SSP1;FRA;Liquids;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;0.1608;0.1608;0.1608;0.1608;0.1608
+SSP1;FRA;Liquids;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;0.1608;0.1608;0.0804;0.0804;0.0804
 SSP1;FRA;Liquids;International Aviation_tmp_vehicletype;International Aviation_tmp_subsectorL3;International Aviation_tmp_subsectorL2;International Aviation;trn_aviation_intl;FV;1;1;1;1;1
 SSP1;FRA;Liquids;International Ship_tmp_vehicletype;International Ship_tmp_subsectorL3;International Ship_tmp_subsectorL2;International Ship;trn_shipping_intl;FV;1;1;1;1;1
 SSP1;FRA;Liquids;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;1;1;1
 SSP1;FRA;Liquids;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;1;1;1
 SSP1;FRA;Liquids;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;1;1;1
-SSP1;FRA;Liquids;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;0.05395;0.05395;0.05395;0.05395;0.05395
-SSP1;FRA;Liquids;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
-SSP1;FRA;Liquids;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
-SSP1;FRA;Liquids;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
-SSP1;FRA;Liquids;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
-SSP1;FRA;Liquids;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
-SSP1;IND;;;;;Cycle;trn_pass;S1S;0.01915;0.03175;0.0463;0.1;0.1
-SSP1;IND;;;;;Domestic Aviation;trn_pass;S1S;1.4;0.7575;0.4861;0.1909;0.1909
+SSP1;FRA;Liquids;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;0.05395;0.05395;0.02697;0.01798;0.01798
+SSP1;FRA;Liquids;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;0.7518;0.5502;0.5502
+SSP1;FRA;Liquids;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;0.5672;0.5672
+SSP1;FRA;Liquids;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;0.5672;0.5672
+SSP1;FRA;Liquids;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;0.5672;0.5672
+SSP1;FRA;Liquids;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;0.7518;0.5502;0.5502
+SSP1;IND;;;;;Cycle;trn_pass;S1S;0.01915;0.03175;0.075;0.2;0.2
+SSP1;IND;;;;;Domestic Aviation;trn_pass;S1S;1.4;0.7575;0.1312;0.04772;0.04772
 SSP1;IND;;;;;Domestic Ship;trn_freight;S1S;0.001202;0.001202;0.001092;0.0009244;0.0009244
-SSP1;IND;;;;;Freight Rail;trn_freight;S1S;0.1924;0.1924;0.1574;0.1332;0.1332
-SSP1;IND;;;;;HSR;trn_pass;S1S;0;0.0003175;0.0005093;0.0003;0.0003
+SSP1;IND;;;;;Freight Rail;trn_freight;S1S;0.1924;0.1924;0.2361;0.1998;0.1998
+SSP1;IND;;;;;HSR;trn_pass;S1S;0;0.0003175;0.00055;0.0003;0.0003
 SSP1;IND;;;;;International Aviation;trn_aviation_intl;S1S;1;1;1;1;1
 SSP1;IND;;;;;International Ship;trn_shipping_intl;S1S;1;1;1;1;1
-SSP1;IND;;;;;Passenger Rail;trn_pass;S1S;0.004978;0.00582;0.005556;0.004;0.004
-SSP1;IND;;;;;Walk;trn_pass;S1S;1.053;0.6879;0.926;1;1
+SSP1;IND;;;;;Passenger Rail;trn_pass;S1S;0.004978;0.00582;0.012;0.008;0.008
+SSP1;IND;;;;;Walk;trn_pass;S1S;1.053;0.6879;1;1;1
 SSP1;IND;;;;;trn_freight_road;trn_freight;S1S;1;1;1;1;1
-SSP1;IND;;;;;trn_pass_road;trn_pass;S1S;1;1;1;0.2945;0.2945
-SSP1;IND;;;;Bus;trn_pass_road;trn_pass;S2S1;1;0.3638;0.1645;0.09872;0.09872
+SSP1;IND;;;;;trn_pass_road;trn_pass;S1S;1;1;0.54;0.1472;0.1472
+SSP1;IND;;;;Bus;trn_pass_road;trn_pass;S2S1;1;0.3638;0.3948;0.3949;0.3949
 SSP1;IND;;;;trn_pass_road_LDV;trn_pass_road;trn_pass;S2S1;0.7344;1;1;1;1
 SSP1;IND;;;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;0.072;0.06;0.05108;0.05108;0.05108
 SSP1;IND;;;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;1;1;1;1;1
@@ -6369,132 +6369,132 @@ SSP1;IND;;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subs
 SSP1;IND;;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0;0.05;0.1987;0.1987;0.1987
 SSP1;IND;;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0;0.05;0.1987;0.1987;0.1987
 SSP1;IND;;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;1;1;1;1;1
-SSP1;IND;BEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.05175;0.2935;0.6653;0.6653
-SSP1;IND;BEV;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.2;0.36;0.378;0.378
-SSP1;IND;BEV;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.2;0.36;0.378;0.378
-SSP1;IND;BEV;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.2;0.36;0.378;0.378
-SSP1;IND;BEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02787;0.06365;0.0643;0.0643
-SSP1;IND;BEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.01109;0.03424;0.06237;0.06237
-SSP1;IND;BEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;0.2338;0.1273;0.06547;0.06547
-SSP1;IND;BEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;0.2338;0.1273;0.06547;0.06547
-SSP1;IND;BEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02787;0.06365;0.0643;0.0643
+SSP1;IND;BEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.05175;0.587;1;1
+SSP1;IND;BEV;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.2;0.72;0.756;0.756
+SSP1;IND;BEV;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.2;0.72;0.756;0.756
+SSP1;IND;BEV;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.2;0;0;0
+SSP1;IND;BEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02787;0.1273;0.1286;0.1286
+SSP1;IND;BEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.01109;0.06848;0.1247;0.1247
+SSP1;IND;BEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;0.2338;0.2546;0.1309;0.1309
+SSP1;IND;BEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;0.2338;0.2546;0.1309;0.1309
+SSP1;IND;BEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02787;0.1273;0.1286;0.1286
 SSP1;IND;Electric;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;1;1;1;1;1
 SSP1;IND;Electric;HSR_tmp_vehicletype;HSR_tmp_subsectorL3;HSR_tmp_subsectorL2;HSR;trn_pass;FV;1;1;1;1;1
-SSP1;IND;Electric;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;0.834;0.8547;0.8962;0.9792;0.9792
-SSP1;IND;FCEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.002698;0.01963;0.05456;0.05456
-SSP1;IND;FCEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.005217;0.008625;0.001595;0.001595
-SSP1;IND;FCEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.001927;0.003271;0.001091;0.001091
-SSP1;IND;FCEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;0.7794;0.1819;0.002182;0.002182
-SSP1;IND;FCEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;0.7794;0.1819;0.002182;0.002182
-SSP1;IND;FCEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.005217;0.008625;0.001595;0.001595
-SSP1;IND;Gases;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0.2408;0.2086;0.2105;0.1903;0.1903
+SSP1;IND;Electric;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;0.834;0.8547;1;1;1
+SSP1;IND;FCEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.002698;0.01963;0.041;0.041
+SSP1;IND;FCEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.005217;0.02587;0.004785;0.004785
+SSP1;IND;FCEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.001927;0.009813;0.003273;0.003273
+SSP1;IND;FCEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;0.7794;0.5457;0.006546;0.006546
+SSP1;IND;FCEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;0.7794;0.5457;0.006546;0.006546
+SSP1;IND;FCEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.005217;0.02587;0.004785;0.004785
+SSP1;IND;Gases;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0.2408;0.2086;0.2105;0.143;0.143
 SSP1;IND;Gases;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.08768;0.07978;0.06655;0.02557;0.02557
 SSP1;IND;Gases;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.0188;0.03289;0.01842;0.01842
 SSP1;IND;Gases;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.9164;0.7143;0.4167;0.1;0.1
 SSP1;IND;Gases;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.9164;0.7143;0.4167;0.1;0.1
 SSP1;IND;Gases;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.0188;0.03289;0.01842;0.01842
-SSP1;IND;Hydrogen;Domestic Aviation_tmp_vehicletype;Domestic Aviation_tmp_subsectorL3;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;trn_pass;FV;0;8.32E-07;4.54E-05;0.1192;0.1192
-SSP1;IND;Liquids;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;1;1;1;1;1
+SSP1;IND;Hydrogen;Domestic Aviation_tmp_vehicletype;Domestic Aviation_tmp_subsectorL3;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;trn_pass;FV;0;8.32E-07;0.1362;0.3576;0.3576
+SSP1;IND;Liquids;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;1;1;1;0.7515;0.7515
 SSP1;IND;Liquids;Domestic Aviation_tmp_vehicletype;Domestic Aviation_tmp_subsectorL3;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;trn_pass;FV;1;1;1;1;1
 SSP1;IND;Liquids;Domestic Ship_tmp_vehicletype;Domestic Ship_tmp_subsectorL3;Domestic Ship_tmp_subsectorL2;Domestic Ship;trn_freight;FV;1;1;1;1;1
-SSP1;IND;Liquids;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;0.9342;0.9342;0.9342;0.9342;0.9342
+SSP1;IND;Liquids;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;0.9342;0.9342;0.4671;0.4671;0.4671
 SSP1;IND;Liquids;International Aviation_tmp_vehicletype;International Aviation_tmp_subsectorL3;International Aviation_tmp_subsectorL2;International Aviation;trn_aviation_intl;FV;1;1;1;1;1
 SSP1;IND;Liquids;International Ship_tmp_vehicletype;International Ship_tmp_subsectorL3;International Ship_tmp_subsectorL2;International Ship;trn_shipping_intl;FV;1;1;1;1;1
 SSP1;IND;Liquids;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;1;1;1
 SSP1;IND;Liquids;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;1;1;1
 SSP1;IND;Liquids;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;1;1;1
-SSP1;IND;Liquids;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;1;1;1;1;1
+SSP1;IND;Liquids;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;1;1;0.5579;0.3404;0.3404
 SSP1;IND;Liquids;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
 SSP1;IND;Liquids;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
 SSP1;IND;Liquids;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.9164;1;1;1;1
 SSP1;IND;Liquids;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.9164;1;1;1;1
 SSP1;IND;Liquids;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
 SSP1;JPN;;;;;Cycle;trn_pass;S1S;0.01743;0.01743;0.03486;0.01961;0.01961
-SSP1;JPN;;;;;Domestic Aviation;trn_pass;S1S;0.0001729;0.0002075;0.0003112;8.75E-05;8.75E-05
+SSP1;JPN;;;;;Domestic Aviation;trn_pass;S1S;0.0001729;0.0002075;0.0002334;6.57E-05;6.57E-05
 SSP1;JPN;;;;;Domestic Ship;trn_freight;S1S;0.01167;0.01111;0.01167;0.01167;0.01167
-SSP1;JPN;;;;;Freight Rail;trn_freight;S1S;0.002833;0.002698;0.002833;0.002833;0.002833
-SSP1;JPN;;;;;HSR;trn_pass;S1S;0.0004081;0.0004081;0.0004591;0.0001291;0.0001291
+SSP1;JPN;;;;;Freight Rail;trn_freight;S1S;0.002833;0.002698;0.004249;0.004249;0.004249
+SSP1;JPN;;;;;HSR;trn_pass;S1S;0.0004081;0.0004081;0.0003673;0.0001033;0.0001033
 SSP1;JPN;;;;;International Aviation;trn_aviation_intl;S1S;1;1;1;1;1
 SSP1;JPN;;;;;International Ship;trn_shipping_intl;S1S;1;1;1;1;1
-SSP1;JPN;;;;;Passenger Rail;trn_pass;S1S;0.006084;0.006084;0.007;0.002281;0.002281
+SSP1;JPN;;;;;Passenger Rail;trn_pass;S1S;0.006084;0.006084;0.0084;0.00365;0.00365
 SSP1;JPN;;;;;Walk;trn_pass;S1S;1;1;1;1;1
 SSP1;JPN;;;;;trn_freight_road;trn_freight;S1S;1;1;1;1;1
-SSP1;JPN;;;;;trn_pass_road;trn_pass;S1S;0.07113;0.07629;0.07629;0.02146;0.02146
-SSP1;JPN;;;;Bus;trn_pass_road;trn_pass;S2S1;0.06081;0.06081;0.06081;0.06081;0.06081
+SSP1;JPN;;;;;trn_pass_road;trn_pass;S1S;0.07113;0.07629;0.04195;0.0118;0.0118
+SSP1;JPN;;;;Bus;trn_pass_road;trn_pass;S2S1;0.06081;0.06081;0.09122;0.09122;0.09122
 SSP1;JPN;;;;trn_pass_road_LDV;trn_pass_road;trn_pass;S2S1;1;1;1;1;1
 SSP1;JPN;;;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;0.07;0.06;0.05491;0.05491;0.05491
 SSP1;JPN;;;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;1;1;1;1;1
-SSP1;JPN;;Compact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.1662;0.1662;0.1662;0.1662;0.1662
+SSP1;JPN;;Compact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.1662;0.1662;0.3324;0.4986;0.4986
 SSP1;JPN;;Large Car and SUV;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;1;1;1;1;1
-SSP1;JPN;;Mini Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.0484;0.0484;0.0484;0.0484;0.0484
+SSP1;JPN;;Mini Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.0484;0.0484;0.0968;0.1452;0.1452
 SSP1;JPN;;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;1;1;1;1;1
 SSP1;JPN;;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.6255;0.6255;0.6255;0.6255;0.6255
 SSP1;JPN;;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.5153;0.5153;0.5153;0.5153;0.5153
-SSP1;JPN;;Subcompact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.1286;0.1286;0.1286;0.1286;0.1286
+SSP1;JPN;;Subcompact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.1286;0.1286;0.2572;0.3858;0.3858
 SSP1;JPN;;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;1;1;1;1;1
 SSP1;JPN;;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0;0;0;0;0
 SSP1;JPN;;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0;0;0;0;0
 SSP1;JPN;;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0;0;0;0;0
 SSP1;JPN;;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.5896;0.5896;0.5896;0.5896;0.5896
-SSP1;JPN;BEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.09673;0.1794;0.3754;0.3754
-SSP1;JPN;BEV;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.16;0.528;1;1
-SSP1;JPN;BEV;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.16;0.528;1;1
-SSP1;JPN;BEV;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.16;0.528;1;1
-SSP1;JPN;BEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1332;0.3414;0.887;0.887
-SSP1;JPN;BEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;0.05727;0.12;0.9032;0.9032
-SSP1;JPN;BEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;0.05727;0.12;0.9032;0.9032
-SSP1;JPN;BEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;0.05727;0.12;0.9032;0.9032
-SSP1;JPN;BEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1332;0.3414;0.887;0.887
+SSP1;JPN;BEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.09673;0.3588;0.7508;0.7508
+SSP1;JPN;BEV;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.16;1;1;1
+SSP1;JPN;BEV;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.16;1;1;1
+SSP1;JPN;BEV;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.16;1;1;1
+SSP1;JPN;BEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1332;0.6828;1;1
+SSP1;JPN;BEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;0.05727;0.08;1;1
+SSP1;JPN;BEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;0.05727;0.08;1;1
+SSP1;JPN;BEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;0.05727;0.08;1;1
+SSP1;JPN;BEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1332;0.6828;1;1
 SSP1;JPN;Electric;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;1;1;1;1;1
 SSP1;JPN;Electric;HSR_tmp_vehicletype;HSR_tmp_subsectorL3;HSR_tmp_subsectorL2;HSR;trn_pass;FV;1;1;1;1;1
 SSP1;JPN;Electric;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;1;1;1;1;1
 SSP1;JPN;FCEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.06091;0.12;0.09854;0.09854
-SSP1;JPN;FCEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1306;0.2699;0.2701;0.2701
-SSP1;JPN;FCEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;0.3695;0.3695
-SSP1;JPN;FCEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;0.3695;0.3695
-SSP1;JPN;FCEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;0.3695;0.3695
-SSP1;JPN;FCEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1306;0.2699;0.2701;0.2701
+SSP1;JPN;FCEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1306;0.8097;0.4568;0.4568
+SSP1;JPN;FCEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;0.6137;0.6137
+SSP1;JPN;FCEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;0.6137;0.6137
+SSP1;JPN;FCEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;0.6137;0.6137
+SSP1;JPN;FCEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1306;0.8097;0.4568;0.4568
 SSP1;JPN;Gases;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.006579;0.01215;0.01919;0.01919
-SSP1;JPN;Gases;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.01316;0.04222;0.03838;0.03838
-SSP1;JPN;Gases;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.8457;0.02563;0.09397;0.2083;0.2083
-SSP1;JPN;Gases;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.8457;0.02563;0.09397;0.2083;0.2083
-SSP1;JPN;Gases;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.8457;0.02563;0.09397;0.2083;0.2083
-SSP1;JPN;Gases;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.01316;0.04222;0.03838;0.03838
-SSP1;JPN;Hydrogen;Domestic Aviation_tmp_vehicletype;Domestic Aviation_tmp_subsectorL3;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;trn_pass;FV;0;8.32E-07;4.54E-05;0.1192;0.1192
+SSP1;JPN;Gases;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.01316;0.04222;0.02163;0.02163
+SSP1;JPN;Gases;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.8457;0.02563;0.03132;0.1153;0.1153
+SSP1;JPN;Gases;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.8457;0.02563;0.03132;0.1153;0.1153
+SSP1;JPN;Gases;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.8457;0.02563;0.03132;0.1153;0.1153
+SSP1;JPN;Gases;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.01316;0.04222;0.02163;0.02163
+SSP1;JPN;Hydrogen;Domestic Aviation_tmp_vehicletype;Domestic Aviation_tmp_subsectorL3;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;trn_pass;FV;0;8.32E-07;0.1362;0.3576;0.3576
 SSP1;JPN;Liquids;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;1;1;1;1;1
 SSP1;JPN;Liquids;Domestic Aviation_tmp_vehicletype;Domestic Aviation_tmp_subsectorL3;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;trn_pass;FV;1;1;1;1;1
 SSP1;JPN;Liquids;Domestic Ship_tmp_vehicletype;Domestic Ship_tmp_subsectorL3;Domestic Ship_tmp_subsectorL2;Domestic Ship;trn_freight;FV;1;1;1;1;1
-SSP1;JPN;Liquids;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;0.8837;0.8837;0.8837;0.8837;0.8837
+SSP1;JPN;Liquids;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;0.8837;0.8837;0.4419;0.4419;0.4419
 SSP1;JPN;Liquids;International Aviation_tmp_vehicletype;International Aviation_tmp_subsectorL3;International Aviation_tmp_subsectorL2;International Aviation;trn_aviation_intl;FV;1;1;1;1;1
 SSP1;JPN;Liquids;International Ship_tmp_vehicletype;International Ship_tmp_subsectorL3;International Ship_tmp_subsectorL2;International Ship;trn_shipping_intl;FV;1;1;1;1;1
-SSP1;JPN;Liquids;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;1;0.9921;0.9921
-SSP1;JPN;Liquids;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;1;0.9921;0.9921
-SSP1;JPN;Liquids;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;1;0.9921;0.9921
-SSP1;JPN;Liquids;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;0.03433;0.03433;0.03433;0.03433;0.03433
-SSP1;JPN;Liquids;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
-SSP1;JPN;Liquids;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.8457;0.05126;0.1757;1;1
-SSP1;JPN;Liquids;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.8457;0.05126;0.1757;1;1
-SSP1;JPN;Liquids;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.8457;0.05126;0.1757;1;1
-SSP1;JPN;Liquids;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
+SSP1;JPN;Liquids;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;0.947;0.496;0.496
+SSP1;JPN;Liquids;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;0.947;0.496;0.496
+SSP1;JPN;Liquids;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;0.947;0.496;0.496
+SSP1;JPN;Liquids;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;0.03433;0.03433;0.01716;0.01144;0.01144
+SSP1;JPN;Liquids;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;0.5637;0.5637
+SSP1;JPN;Liquids;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.8457;0.05126;0.05857;0.5536;0.5536
+SSP1;JPN;Liquids;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.8457;0.05126;0.05857;0.5536;0.5536
+SSP1;JPN;Liquids;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.8457;0.05126;0.05857;0.5536;0.5536
+SSP1;JPN;Liquids;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;0.5637;0.5637
 SSP1;LAM;;;;;Cycle;trn_pass;S1S;0.01091;0.02182;0.05455;0.2728;0.2728
-SSP1;LAM;;;;;Domestic Aviation;trn_pass;S1S;0.008921;0.0119;0.02974;0.0223;0.0223
+SSP1;LAM;;;;;Domestic Aviation;trn_pass;S1S;0.008921;0.0119;0.007435;0.005575;0.005575
 SSP1;LAM;;;;;Domestic Ship;trn_freight;S1S;0.0097;0.0097;0.008908;0.006736;0.006736
-SSP1;LAM;;;;;Freight Rail;trn_freight;S1S;0.04782;0.04782;0.04391;0.03985;0.03985
+SSP1;LAM;;;;;Freight Rail;trn_freight;S1S;0.04782;0.04782;0.06587;0.05978;0.05978
 SSP1;LAM;;;;;HSR;trn_pass;S1S;0.005236;0.2905;0.2905;0.2905;0.2905
 SSP1;LAM;;;;;International Aviation;trn_aviation_intl;S1S;1;1;1;1;1
 SSP1;LAM;;;;;International Ship;trn_shipping_intl;S1S;1;1;1;1;1
-SSP1;LAM;;;;;Passenger Rail;trn_pass;S1S;0.1499;0.1499;0.1499;0.09996;0.09996
+SSP1;LAM;;;;;Passenger Rail;trn_pass;S1S;0.1499;0.1499;0.2998;0.1999;0.1999
 SSP1;LAM;;;;;Walk;trn_pass;S1S;1;1;1;1;1
 SSP1;LAM;;;;;trn_freight_road;trn_freight;S1S;1;1;1;1;1
-SSP1;LAM;;;;;trn_pass_road;trn_pass;S1S;0.655;0.6942;0.6942;0.8099;0.8099
-SSP1;LAM;;;;Bus;trn_pass_road;trn_pass;S2S1;0.2647;0.1654;0.1323;0.1323;0.1323
+SSP1;LAM;;;;;trn_pass_road;trn_pass;S1S;0.655;0.6942;0.3471;0.4049;0.4049
+SSP1;LAM;;;;Bus;trn_pass_road;trn_pass;S2S1;0.2647;0.1654;0.1984;0.1984;0.1984
 SSP1;LAM;;;;trn_pass_road_LDV;trn_pass_road;trn_pass;S2S1;0.8;1;1;1;1
 SSP1;LAM;;;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;0.35;0.3;0.25;0.25;0.25
 SSP1;LAM;;;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;1;1;1;1;1
 SSP1;LAM;;Compact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;1;1;1;1;1
-SSP1;LAM;;Large Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.03279;0.03935;0.04099;0.04372;0.04372
-SSP1;LAM;;Large Car and SUV;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.3624;0.4348;0.4529;0.4831;0.4831
-SSP1;LAM;;Midsize Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.04788;0.05745;0.05984;0.06383;0.06383
+SSP1;LAM;;Large Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.03279;0.03935;0.02049;0.01457;0.01457
+SSP1;LAM;;Large Car and SUV;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.3624;0.4348;0.2265;0.161;0.161
+SSP1;LAM;;Midsize Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.04788;0.05745;0.02992;0.02128;0.02128
 SSP1;LAM;;Mini Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.01226;0.01226;0.01226;0.01226;0.01226
 SSP1;LAM;;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.000458;0.000458;0.000458;0.000458;0.000458
 SSP1;LAM;;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;1;1;1;1;1
@@ -6505,404 +6505,404 @@ SSP1;LAM;;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subs
 SSP1;LAM;;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;1;1;1;1;1
 SSP1;LAM;;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.0005079;0.0005079;0.0005079;0.0005079;0.0005079
 SSP1;LAM;;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.1892;0.1892;0.1892;0.1892;0.1892
-SSP1;LAM;;Van;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.001473;0.001768;0.001842;0.001964;0.001964
-SSP1;LAM;BEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.1294;0.5869;1;1
-SSP1;LAM;BEV;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.056;0.216;0.504;0.504
-SSP1;LAM;BEV;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.056;0.216;0.504;0.504
-SSP1;LAM;BEV;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.056;0.216;0.504;0.504
-SSP1;LAM;BEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1041;0.1964;0.2357;0.2357
-SSP1;LAM;BEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.0414;0.1057;0.2287;0.2287
-SSP1;LAM;BEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.0414;0.1057;0.2287;0.2287
-SSP1;LAM;BEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.0414;0.1057;0.2287;0.2287
-SSP1;LAM;BEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1041;0.1964;0.2357;0.2357
-SSP1;LAM;Electric;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;0.0681;0.1846;0.4176;0.8835;0.8835
+SSP1;LAM;;Van;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.001473;0.001768;0.000921;0.0006547;0.0006547
+SSP1;LAM;BEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.1294;1;1;1
+SSP1;LAM;BEV;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.056;0.432;1;1
+SSP1;LAM;BEV;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.056;0.432;1;1
+SSP1;LAM;BEV;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.056;0.432;1;1
+SSP1;LAM;BEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1041;0.3928;0.4714;0.4714
+SSP1;LAM;BEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.0414;0.2114;0.4574;0.4574
+SSP1;LAM;BEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.0414;0.2114;0.4574;0.4574
+SSP1;LAM;BEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.0414;0.2114;0.4574;0.4574
+SSP1;LAM;BEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1041;0.3928;0.4714;0.4714
+SSP1;LAM;Electric;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;0.0681;0.1846;0.8352;1;1
 SSP1;LAM;Electric;HSR_tmp_vehicletype;HSR_tmp_subsectorL3;HSR_tmp_subsectorL2;HSR;trn_pass;FV;1;1;1;1;1
 SSP1;LAM;Electric;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;1;1;1;1;1
-SSP1;LAM;FCEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.002698;0.01963;0.06561;0.06561
-SSP1;LAM;FCEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.009738;0.0621;0.08864;0.08864
-SSP1;LAM;FCEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.003598;0.02355;0.06062;0.06062
-SSP1;LAM;FCEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.003598;0.02355;0.06062;0.06062
-SSP1;LAM;FCEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.003598;0.02355;0.06062;0.06062
-SSP1;LAM;FCEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.009738;0.0621;0.08864;0.08864
-SSP1;LAM;Gases;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0.02689;0.04725;0.1037;0.124;0.124
+SSP1;LAM;FCEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.002698;0.01672;0.03281;0.03281
+SSP1;LAM;FCEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.009738;0.1863;0.2659;0.2659
+SSP1;LAM;FCEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.003598;0.07065;0.1819;0.1819
+SSP1;LAM;FCEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.003598;0.07065;0.1819;0.1819
+SSP1;LAM;FCEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.003598;0.07065;0.1819;0.1819
+SSP1;LAM;FCEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.009738;0.1863;0.2659;0.2659
+SSP1;LAM;Gases;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0.02689;0.04725;0.08835;0.062;0.062
 SSP1;LAM;Gases;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.01754;0.03158;0.0614;0.0614
 SSP1;LAM;Gases;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.01754;0.03158;0.0614;0.0614
 SSP1;LAM;Gases;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.01754;0.03158;0.0614;0.0614
 SSP1;LAM;Gases;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.01754;0.03158;0.0614;0.0614
 SSP1;LAM;Gases;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.01754;0.03158;0.0614;0.0614
-SSP1;LAM;Hydrogen;Domestic Aviation_tmp_vehicletype;Domestic Aviation_tmp_subsectorL3;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;trn_pass;FV;0;8.32E-07;4.54E-05;0.1192;0.1192
-SSP1;LAM;Liquids;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;1;1;1;0.7275;0.7275
+SSP1;LAM;Hydrogen;Domestic Aviation_tmp_vehicletype;Domestic Aviation_tmp_subsectorL3;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;trn_pass;FV;0;8.32E-07;0.1362;0.3576;0.3576
+SSP1;LAM;Liquids;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;1;1;0.8519;0.3638;0.3638
 SSP1;LAM;Liquids;Domestic Aviation_tmp_vehicletype;Domestic Aviation_tmp_subsectorL3;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;trn_pass;FV;1;1;1;1;1
 SSP1;LAM;Liquids;Domestic Ship_tmp_vehicletype;Domestic Ship_tmp_subsectorL3;Domestic Ship_tmp_subsectorL2;Domestic Ship;trn_freight;FV;1;1;1;1;1
-SSP1;LAM;Liquids;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;1;1;1;1;1
+SSP1;LAM;Liquids;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;1;1;1;0.5659;0.5659
 SSP1;LAM;Liquids;International Aviation_tmp_vehicletype;International Aviation_tmp_subsectorL3;International Aviation_tmp_subsectorL2;International Aviation;trn_aviation_intl;FV;1;1;1;1;1
 SSP1;LAM;Liquids;International Ship_tmp_vehicletype;International Ship_tmp_subsectorL3;International Ship_tmp_subsectorL2;International Ship;trn_shipping_intl;FV;1;1;1;1;1
-SSP1;LAM;Liquids;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;1;1;1
-SSP1;LAM;Liquids;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;1;1;1
-SSP1;LAM;Liquids;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;1;1;1
-SSP1;LAM;Liquids;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;0.6477;0.6477;0.6477;0.6477;0.6477
+SSP1;LAM;Liquids;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;1;0.9921;0.9921
+SSP1;LAM;Liquids;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;1;0.9921;0.9921
+SSP1;LAM;Liquids;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;1;0.9921;0.9921
+SSP1;LAM;Liquids;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;0.6477;0.6477;0.3239;0.2159;0.2159
 SSP1;LAM;Liquids;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
 SSP1;LAM;Liquids;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
 SSP1;LAM;Liquids;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
 SSP1;LAM;Liquids;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
 SSP1;LAM;Liquids;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
 SSP1;MEA;;;;;Cycle;trn_pass;S1S;0.0166;0.0166;0.0166;0.04149;0.04149
-SSP1;MEA;;;;;Domestic Aviation;trn_pass;S1S;0.008522;0.005681;0.01704;0.025;0.025
+SSP1;MEA;;;;;Domestic Aviation;trn_pass;S1S;0.008522;0.005681;0.00426;0.00625;0.00625
 SSP1;MEA;;;;;Domestic Ship;trn_freight;S1S;0.00206;0.00206;0.00206;0.00206;0.00206
-SSP1;MEA;;;;;Freight Rail;trn_freight;S1S;0.003202;0.003202;0.003202;0.003202;0.003202
+SSP1;MEA;;;;;Freight Rail;trn_freight;S1S;0.003202;0.003202;0.004803;0.004803;0.004803
 SSP1;MEA;;;;;HSR;trn_pass;S1S;0;0.01667;0.01667;0.01667;0.01667
 SSP1;MEA;;;;;International Aviation;trn_aviation_intl;S1S;1;1;1;1;1
 SSP1;MEA;;;;;International Ship;trn_shipping_intl;S1S;1;1;1;1;1
-SSP1;MEA;;;;;Passenger Rail;trn_pass;S1S;0.0005567;0.001113;0.001113;0.001856;0.001856
+SSP1;MEA;;;;;Passenger Rail;trn_pass;S1S;0.0005567;0.001113;0.002226;0.003712;0.003712
 SSP1;MEA;;;;;Walk;trn_pass;S1S;1;1;1;1;1
 SSP1;MEA;;;;;trn_freight_road;trn_freight;S1S;1;1;1;1;1
-SSP1;MEA;;;;;trn_pass_road;trn_pass;S1S;0.3767;0.4239;0.3815;0.3815;0.3815
-SSP1;MEA;;;;Bus;trn_pass_road;trn_pass;S2S1;0.2676;0.1873;0.09367;0.07493;0.07493
+SSP1;MEA;;;;;trn_pass_road;trn_pass;S1S;0.3767;0.4239;0.1908;0.1908;0.1908
+SSP1;MEA;;;;Bus;trn_pass_road;trn_pass;S2S1;0.2676;0.1873;0.1405;0.1124;0.1124
 SSP1;MEA;;;;trn_pass_road_LDV;trn_pass_road;trn_pass;S2S1;1;1;1;1;1
 SSP1;MEA;;;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;0.01502;0.01502;0.01502;0.01502;0.01502
 SSP1;MEA;;;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;1;1;1;1;1
-SSP1;MEA;;Compact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.5257;0.4732;0.4337;0.3943;0.3943
-SSP1;MEA;;Large Car and SUV;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;1;1;1;1;1
-SSP1;MEA;;Mini Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.04395;0.03955;0.03626;0.03296;0.03296
+SSP1;MEA;;Compact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.5257;0.4732;0.8674;1;1
+SSP1;MEA;;Large Car and SUV;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;1;1;1;0.8454;0.8454
+SSP1;MEA;;Mini Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.04395;0.03955;0.07252;0.08359;0.08359
 SSP1;MEA;;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;1;1;1;1;1
 SSP1;MEA;;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.001;0.001;0.001;0.001;0.001
-SSP1;MEA;;Subcompact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.2071;0.1864;0.1709;0.1553;0.1553
+SSP1;MEA;;Subcompact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.2071;0.1864;0.3418;0.3939;0.3939
 SSP1;MEA;;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.1304;0.1304;0.1304;0.1304;0.1304
 SSP1;MEA;;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.2013;0.2013;0.2013;0.2013;0.2013
 SSP1;MEA;;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0;0;0;0;0
 SSP1;MEA;;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0;0;0;0;0
 SSP1;MEA;;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;1;1;1;1;1
-SSP1;MEA;BEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.05175;0.2935;0.6497;0.6497
-SSP1;MEA;BEV;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.12;0.216;0.21;0.21
-SSP1;MEA;BEV;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.12;0.216;0.21;0.21
-SSP1;MEA;BEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.06504;0.1091;0.1392;0.1392
-SSP1;MEA;BEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02588;0.05869;0.135;0.135
-SSP1;MEA;BEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;0.1559;0.2182;0.1417;0.1417
-SSP1;MEA;BEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;0.1559;0.2182;0.1417;0.1417
-SSP1;MEA;BEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.06504;0.1091;0.1392;0.1392
-SSP1;MEA;Electric;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;0.4021;0.4768;0.6263;0.9253;0.9253
+SSP1;MEA;BEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.05175;0.587;1;1
+SSP1;MEA;BEV;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.12;0.432;0.42;0.42
+SSP1;MEA;BEV;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.12;0;0;0
+SSP1;MEA;BEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.06504;0.2182;0.2784;0.2784
+SSP1;MEA;BEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02588;0.1174;0.27;0.27
+SSP1;MEA;BEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;0.1559;0.4364;0.2834;0.2834
+SSP1;MEA;BEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;0.1559;0.4364;0.2834;0.2834
+SSP1;MEA;BEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.06504;0.2182;0.2784;0.2784
+SSP1;MEA;Electric;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;0.4021;0.4768;1;1;1
 SSP1;MEA;Electric;HSR_tmp_vehicletype;HSR_tmp_subsectorL3;HSR_tmp_subsectorL2;HSR;trn_pass;FV;1;1;1;1;1
 SSP1;MEA;Electric;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;1;1;1;1;1
-SSP1;MEA;FCEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.002698;0.01784;0.0558;0.0558
-SSP1;MEA;FCEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.003652;0.01035;0.0004144;0.0004144
-SSP1;MEA;FCEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.001349;0.003925;0.0002834;0.0002834
-SSP1;MEA;FCEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;0.1559;0.2182;0.0005669;0.0005669
-SSP1;MEA;FCEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;0.1559;0.2182;0.0005669;0.0005669
-SSP1;MEA;FCEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.003652;0.01035;0.0004144;0.0004144
-SSP1;MEA;Gases;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0.01342;0.03938;0.083;0.1109;0.1109
+SSP1;MEA;FCEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.002698;0.01784;0.04294;0.04294
+SSP1;MEA;FCEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.003652;0.03105;0.001243;0.001243
+SSP1;MEA;FCEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.001349;0.01178;0.0008502;0.0008502
+SSP1;MEA;FCEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;0.1559;0.6546;0.001701;0.001701
+SSP1;MEA;FCEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;0.1559;0.6546;0.001701;0.001701
+SSP1;MEA;FCEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.003652;0.03105;0.001243;0.001243
+SSP1;MEA;Gases;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0.01342;0.03938;0.083;0.08535;0.08535
 SSP1;MEA;Gases;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.0009283;0.09527;0.04788;0.04804;0.04804
 SSP1;MEA;Gases;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.09211;0.04737;0.04785;0.04785
 SSP1;MEA;Gases;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.9164;1;0.6;0.2597;0.2597
 SSP1;MEA;Gases;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.9164;1;0.6;0.2597;0.2597
 SSP1;MEA;Gases;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.09211;0.04737;0.04785;0.04785
-SSP1;MEA;Hydrogen;Domestic Aviation_tmp_vehicletype;Domestic Aviation_tmp_subsectorL3;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;trn_pass;FV;0;8.32E-07;4.54E-05;0.1192;0.1192
-SSP1;MEA;Liquids;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;1;1;1;1;1
+SSP1;MEA;Hydrogen;Domestic Aviation_tmp_vehicletype;Domestic Aviation_tmp_subsectorL3;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;trn_pass;FV;0;8.32E-07;0.1362;0.3576;0.3576
+SSP1;MEA;Liquids;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;1;1;1;0.7696;0.7696
 SSP1;MEA;Liquids;Domestic Aviation_tmp_vehicletype;Domestic Aviation_tmp_subsectorL3;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;trn_pass;FV;1;1;1;1;1
 SSP1;MEA;Liquids;Domestic Ship_tmp_vehicletype;Domestic Ship_tmp_subsectorL3;Domestic Ship_tmp_subsectorL2;Domestic Ship;trn_freight;FV;1;1;1;1;1
-SSP1;MEA;Liquids;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;1;1;1;1;1
+SSP1;MEA;Liquids;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;1;1;0.7983;0.5404;0.5404
 SSP1;MEA;Liquids;International Aviation_tmp_vehicletype;International Aviation_tmp_subsectorL3;International Aviation_tmp_subsectorL2;International Aviation;trn_aviation_intl;FV;1;1;1;1;1
 SSP1;MEA;Liquids;International Ship_tmp_vehicletype;International Ship_tmp_subsectorL3;International Ship_tmp_subsectorL2;International Ship;trn_shipping_intl;FV;1;1;1;1;1
 SSP1;MEA;Liquids;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;1;1;1
 SSP1;MEA;Liquids;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;1;1;1
-SSP1;MEA;Liquids;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;0.07852;0.07852;0.07852;0.07852;0.07852
+SSP1;MEA;Liquids;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;0.07852;0.07852;0.03926;0.02617;0.02617
 SSP1;MEA;Liquids;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
 SSP1;MEA;Liquids;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
 SSP1;MEA;Liquids;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.9164;0.2857;1;1;1
 SSP1;MEA;Liquids;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.9164;0.2857;1;1;1
 SSP1;MEA;Liquids;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
 SSP1;NEN;;;;;Cycle;trn_pass;S1S;0.003033;0.003024;0.002621;0.0182;0.0182
-SSP1;NEN;;;;;Domestic Aviation;trn_pass;S1S;7.5E-06;7.54E-06;2.45E-06;1.43E-06;1.43E-06
+SSP1;NEN;;;;;Domestic Aviation;trn_pass;S1S;7.5E-06;7.54E-06;6.12E-07;3.57E-07;3.57E-07
 SSP1;NEN;;;;;Domestic Ship;trn_freight;S1S;0.03175;0.03175;0.03175;0.03175;0.03175
-SSP1;NEN;;;;;Freight Rail;trn_freight;S1S;0.01925;0.01925;0.01925;0.01925;0.01925
+SSP1;NEN;;;;;Freight Rail;trn_freight;S1S;0.01925;0.01925;0.02888;0.02888;0.02888
 SSP1;NEN;;;;;HSR;trn_pass;S1S;2E-05;4.53E-05;7.36E-06;5.52E-06;5.52E-06
 SSP1;NEN;;;;;International Aviation;trn_aviation_intl;S1S;1;1;1;1;1
 SSP1;NEN;;;;;International Ship;trn_shipping_intl;S1S;1;1;1;1;1
-SSP1;NEN;;;;;Passenger Rail;trn_pass;S1S;3E-06;2.97E-06;6.75E-07;3.22E-07;3.22E-07
+SSP1;NEN;;;;;Passenger Rail;trn_pass;S1S;3E-06;2.97E-06;1.35E-06;6.43E-07;6.43E-07
 SSP1;NEN;;;;;Walk;trn_pass;S1S;1;1;1;1;1
 SSP1;NEN;;;;;trn_freight_road;trn_freight;S1S;1;1;1;1;1
-SSP1;NEN;;;;;trn_pass_road;trn_pass;S1S;0.0496;0.06868;0.0279;0.02325;0.02325
-SSP1;NEN;;;;Bus;trn_pass_road;trn_pass;S2S1;0.01287;0.008044;0.004022;0.002011;0.002011
+SSP1;NEN;;;;;trn_pass_road;trn_pass;S1S;0.0496;0.06868;0.01395;0.01162;0.01162
+SSP1;NEN;;;;Bus;trn_pass_road;trn_pass;S2S1;0.01287;0.008044;0.006033;0.003017;0.003017
 SSP1;NEN;;;;trn_pass_road_LDV;trn_pass_road;trn_pass;S2S1;1;1;1;1;1
 SSP1;NEN;;;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;0.09;0.09;0.09;0.09;0.09
 SSP1;NEN;;;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;1;1;1;1;1
-SSP1;NEN;;Compact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.4624;0.4624;0.4624;0.4624;0.4624
-SSP1;NEN;;Large Car and SUV;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;1;1;1;1;1
-SSP1;NEN;;Midsize Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.3307;0.3307;0.3307;0.3307;0.3307
-SSP1;NEN;;Mini Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;6.43E-08;6.43E-08;6.43E-08;6.43E-08;6.43E-08
+SSP1;NEN;;Compact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.4624;0.4624;0.9248;1;1
+SSP1;NEN;;Large Car and SUV;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;1;1;1;0.7209;0.7209
+SSP1;NEN;;Midsize Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.3307;0.3307;0.3307;0.2384;0.2384
+SSP1;NEN;;Mini Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;6.43E-08;6.43E-08;1.29E-07;1.39E-07;1.39E-07
 SSP1;NEN;;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.3331;0.3331;0.3331;0.3331;0.3331
 SSP1;NEN;;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.1369;0.1369;0.1369;0.1369;0.1369
 SSP1;NEN;;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;1;1;1;1;1
-SSP1;NEN;;Subcompact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.3388;0.3388;0.3388;0.3388;0.3388
+SSP1;NEN;;Subcompact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.3388;0.3388;0.6776;0.7327;0.7327
 SSP1;NEN;;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;1;1;1;1;1
 SSP1;NEN;;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.143;0.143;0.143;0.143;0.143
 SSP1;NEN;;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.2745;0.2745;0.2745;0.2745;0.2745
 SSP1;NEN;;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.06397;0.06397;0.06397;0.06397;0.06397
 SSP1;NEN;;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.3433;0.3433;0.3433;0.3433;0.3433
-SSP1;NEN;;Van;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.00735;0.00735;0.00735;0.00735;0.00735
-SSP1;NEN;BEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0.05608;0.1402;0.4134;0.9856;0.9856
-SSP1;NEN;BEV;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.04;0.168;0.294;0.294
-SSP1;NEN;BEV;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.04;0.168;0.294;0.294
-SSP1;NEN;BEV;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.04;0.168;0.294;0.294
-SSP1;NEN;BEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.2537;0.5912;0.8932;0.8932
-SSP1;NEN;BEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1009;0.318;0.8664;0.8664
-SSP1;NEN;BEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1009;0.318;0.8664;0.8664
-SSP1;NEN;BEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1009;0.318;0.8664;0.8664
-SSP1;NEN;BEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.2537;0.5912;0.8932;0.8932
+SSP1;NEN;;Van;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.00735;0.00735;0.00735;0.005298;0.005298
+SSP1;NEN;BEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0.05608;0.1402;0.8268;1;1
+SSP1;NEN;BEV;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.04;0.336;0.588;0.588
+SSP1;NEN;BEV;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.04;0.336;0.588;0.588
+SSP1;NEN;BEV;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.04;0.336;0.588;0.588
+SSP1;NEN;BEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.2537;1;1;1
+SSP1;NEN;BEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1009;0.636;1;1
+SSP1;NEN;BEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1009;0.636;1;1
+SSP1;NEN;BEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1009;0.636;1;1
+SSP1;NEN;BEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.2537;1;1;1
 SSP1;NEN;Electric;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;1;1;1;1;1
 SSP1;NEN;Electric;HSR_tmp_vehicletype;HSR_tmp_subsectorL3;HSR_tmp_subsectorL2;HSR;trn_pass;FV;1;1;1;1;1
 SSP1;NEN;Electric;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;1;1;1;1;1
-SSP1;NEN;FCEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.002924;0.02127;0.05543;0.05543
-SSP1;NEN;FCEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.007914;0.1682;0.09974;0.09974
-SSP1;NEN;FCEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.002924;0.0638;0.06822;0.06822
-SSP1;NEN;FCEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.002924;0.0638;0.06822;0.06822
-SSP1;NEN;FCEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.002924;0.0638;0.06822;0.06822
-SSP1;NEN;FCEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.007914;0.1682;0.09974;0.09974
-SSP1;NEN;Gases;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0.02362;0.03778;0.09872;0.1261;0.1261
-SSP1;NEN;Gases;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.006427;0.03257;0.08487;0.1457;0.1457
-SSP1;NEN;Gases;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02632;0.07895;0.1417;0.1417
-SSP1;NEN;Gases;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02632;0.07895;0.1417;0.1417
-SSP1;NEN;Gases;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02632;0.07895;0.1417;0.1417
-SSP1;NEN;Gases;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02632;0.07895;0.1417;0.1417
-SSP1;NEN;Hydrogen;Domestic Aviation_tmp_vehicletype;Domestic Aviation_tmp_subsectorL3;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;trn_pass;FV;0;8.32E-07;4.54E-05;0.1192;0.1192
-SSP1;NEN;Liquids;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;1;1;1;1;1
+SSP1;NEN;FCEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.002924;0.02127;0.02812;0.02812
+SSP1;NEN;FCEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.007914;0.4268;0.1675;0.1675
+SSP1;NEN;FCEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.002924;0.1914;0.1181;0.1181
+SSP1;NEN;FCEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.002924;0.1914;0.1181;0.1181
+SSP1;NEN;FCEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.002924;0.1914;0.1181;0.1181
+SSP1;NEN;FCEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.007914;0.4268;0.1675;0.1675
+SSP1;NEN;Gases;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0.02362;0.03778;0.09872;0.06397;0.06397
+SSP1;NEN;Gases;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.006427;0.03257;0.07178;0.08156;0.08156
+SSP1;NEN;Gases;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02632;0.07895;0.08178;0.08178
+SSP1;NEN;Gases;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02632;0.07895;0.08178;0.08178
+SSP1;NEN;Gases;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02632;0.07895;0.08178;0.08178
+SSP1;NEN;Gases;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02632;0.06677;0.07932;0.07932
+SSP1;NEN;Hydrogen;Domestic Aviation_tmp_vehicletype;Domestic Aviation_tmp_subsectorL3;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;trn_pass;FV;0;8.32E-07;0.1362;0.3576;0.3576
+SSP1;NEN;Liquids;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;1;1;1;0.5073;0.5073
 SSP1;NEN;Liquids;Domestic Aviation_tmp_vehicletype;Domestic Aviation_tmp_subsectorL3;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;trn_pass;FV;1;1;1;1;1
 SSP1;NEN;Liquids;Domestic Ship_tmp_vehicletype;Domestic Ship_tmp_subsectorL3;Domestic Ship_tmp_subsectorL2;Domestic Ship;trn_freight;FV;1;1;1;1;1
-SSP1;NEN;Liquids;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;0.1317;0.1317;0.1317;0.1317;0.1317
+SSP1;NEN;Liquids;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;0.1317;0.1317;0.06585;0.06585;0.06585
 SSP1;NEN;Liquids;International Aviation_tmp_vehicletype;International Aviation_tmp_subsectorL3;International Aviation_tmp_subsectorL2;International Aviation;trn_aviation_intl;FV;1;1;1;1;1
 SSP1;NEN;Liquids;International Ship_tmp_vehicletype;International Ship_tmp_subsectorL3;International Ship_tmp_subsectorL2;International Ship;trn_shipping_intl;FV;1;1;1;1;1
 SSP1;NEN;Liquids;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;1;1;1
 SSP1;NEN;Liquids;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;1;1;1
 SSP1;NEN;Liquids;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;1;1;1
-SSP1;NEN;Liquids;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;0.0154;0.0154;0.0154;0.0154;0.0154
-SSP1;NEN;Liquids;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
-SSP1;NEN;Liquids;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
-SSP1;NEN;Liquids;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
-SSP1;NEN;Liquids;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
-SSP1;NEN;Liquids;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
+SSP1;NEN;Liquids;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;0.0154;0.0154;0.0077;0.005133;0.005133
+SSP1;NEN;Liquids;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;0.8457;0.5598;0.5598
+SSP1;NEN;Liquids;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;0.5771;0.5771
+SSP1;NEN;Liquids;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;0.5771;0.5771
+SSP1;NEN;Liquids;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;0.5771;0.5771
+SSP1;NEN;Liquids;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;0.8457;0.5598;0.5598
 SSP1;NES;;;;;Cycle;trn_pass;S1S;0.008738;0.007802;0.009929;0.01365;0.01365
-SSP1;NES;;;;;Domestic Aviation;trn_pass;S1S;0.004721;0.003372;0.001431;0.0003935;0.0003935
+SSP1;NES;;;;;Domestic Aviation;trn_pass;S1S;0.004721;0.003372;0.0003577;9.84E-05;9.84E-05
 SSP1;NES;;;;;Domestic Ship;trn_freight;S1S;0.01468;0.01468;0.01468;0.01322;0.01322
-SSP1;NES;;;;;Freight Rail;trn_freight;S1S;0.01697;0.01697;0.01697;0.01697;0.01697
+SSP1;NES;;;;;Freight Rail;trn_freight;S1S;0.01697;0.01697;0.02545;0.02545;0.02545
 SSP1;NES;;;;;HSR;trn_pass;S1S;0.0005085;0.0003632;0.0002311;0.0001271;0.0001271
 SSP1;NES;;;;;International Aviation;trn_aviation_intl;S1S;1;1;1;1;1
 SSP1;NES;;;;;International Ship;trn_shipping_intl;S1S;1;1;1;1;1
-SSP1;NES;;;;;Passenger Rail;trn_pass;S1S;0.001607;0.001148;0.0007303;0.0004017;0.0004017
+SSP1;NES;;;;;Passenger Rail;trn_pass;S1S;0.001607;0.001148;0.001461;0.0008034;0.0008034
 SSP1;NES;;;;;Walk;trn_pass;S1S;1;1;1;1;1
 SSP1;NES;;;;;trn_freight_road;trn_freight;S1S;1;1;1;1;1
-SSP1;NES;;;;;trn_pass_road;trn_pass;S1S;0.2727;0.2818;0.2242;0.1233;0.1233
-SSP1;NES;;;;Bus;trn_pass_road;trn_pass;S2S1;0.08401;0.03734;0.0224;0.0224;0.0224
+SSP1;NES;;;;;trn_pass_road;trn_pass;S1S;0.2727;0.2818;0.1121;0.06165;0.06165
+SSP1;NES;;;;Bus;trn_pass_road;trn_pass;S2S1;0.08401;0.03734;0.0336;0.0336;0.0336
 SSP1;NES;;;;trn_pass_road_LDV;trn_pass_road;trn_pass;S2S1;1;1;1;1;1
 SSP1;NES;;;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;0.02;0.02;0.02;0.02;0.02
 SSP1;NES;;;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;1;1;1;1;1
-SSP1;NES;;Compact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.576;0.576;0.6144;0.6144;0.6144
-SSP1;NES;;Large Car and SUV;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;1;1;1;1;1
-SSP1;NES;;Midsize Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.2352;0.2352;0.2352;0.2352;0.2352
-SSP1;NES;;Mini Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.001886;0.001886;0.002012;0.002012;0.002012
+SSP1;NES;;Compact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.576;0.576;1;1;1
+SSP1;NES;;Large Car and SUV;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;1;1;0.8138;0.5425;0.5425
+SSP1;NES;;Midsize Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.2352;0.2352;0.1914;0.1276;0.1276
+SSP1;NES;;Mini Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.001886;0.001886;0.003275;0.003275;0.003275
 SSP1;NES;;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.01148;0.01148;0.01148;0.01148;0.01148
 SSP1;NES;;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.1337;0.1337;0.1337;0.1337;0.1337
 SSP1;NES;;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;1;1;1;1;1
-SSP1;NES;;Subcompact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.09325;0.09325;0.09946;0.09946;0.09946
+SSP1;NES;;Subcompact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.09325;0.09325;0.1619;0.1619;0.1619
 SSP1;NES;;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;1;1;1;1;1
 SSP1;NES;;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.06299;0.06299;0.06299;0.06299;0.06299
 SSP1;NES;;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.3651;0.3651;0.3651;0.3651;0.3651
 SSP1;NES;;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.5704;0.5704;0.5704;0.5704;0.5704
 SSP1;NES;;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.4799;0.4799;0.4799;0.4799;0.4799
-SSP1;NES;;Van;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.00288;0.00288;0.00288;0.00288;0.00288
-SSP1;NES;BEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.05175;0.1739;0.3465;0.3465
-SSP1;NES;BEV;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.04;0.168;0.336;0.336
-SSP1;NES;BEV;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.04;0.168;0.336;0.336
-SSP1;NES;BEV;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.04;0.168;0.336;0.336
-SSP1;NES;BEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1138;0.2182;0.3215;0.3215
-SSP1;NES;BEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.04528;0.1174;0.3118;0.3118
-SSP1;NES;BEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.04528;0.1174;0.3118;0.3118
-SSP1;NES;BEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.04528;0.1174;0.3118;0.3118
-SSP1;NES;BEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1138;0.2182;0.3215;0.3215
-SSP1;NES;Electric;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;0.2081;0.3071;0.505;0.901;0.901
+SSP1;NES;;Van;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.00288;0.00288;0.002344;0.001563;0.001563
+SSP1;NES;BEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.05175;0.3478;0.693;0.693
+SSP1;NES;BEV;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.04;0.336;0.672;0.672
+SSP1;NES;BEV;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.04;0.336;0.672;0.672
+SSP1;NES;BEV;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.04;0.336;0.672;0.672
+SSP1;NES;BEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1138;0.4364;0.643;0.643
+SSP1;NES;BEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.04528;0.2348;0.6236;0.6236
+SSP1;NES;BEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.04528;0.2348;0.6236;0.6236
+SSP1;NES;BEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.04528;0.2348;0.6236;0.6236
+SSP1;NES;BEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1138;0.4364;0.643;0.643
+SSP1;NES;Electric;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;0.2081;0.3071;1;1;1
 SSP1;NES;Electric;HSR_tmp_vehicletype;HSR_tmp_subsectorL3;HSR_tmp_subsectorL2;HSR;trn_pass;FV;1;1;1;1;1
 SSP1;NES;Electric;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;1;1;1;1;1
 SSP1;NES;FCEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.002698;0.01454;0.03637;0.03637
-SSP1;NES;FCEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.009129;0.03833;0.08376;0.08376
-SSP1;NES;FCEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.003373;0.01454;0.05729;0.05729
-SSP1;NES;FCEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.003373;0.01454;0.05729;0.05729
-SSP1;NES;FCEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.003373;0.01454;0.05729;0.05729
-SSP1;NES;FCEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.009129;0.03833;0.08376;0.08376
+SSP1;NES;FCEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.009129;0.115;0.2513;0.2513
+SSP1;NES;FCEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.003373;0.04362;0.1719;0.1719
+SSP1;NES;FCEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.003373;0.04362;0.1719;0.1719
+SSP1;NES;FCEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.003373;0.04362;0.1719;0.1719
+SSP1;NES;FCEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.009129;0.115;0.2513;0.2513
 SSP1;NES;Gases;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0.003476;0.0297;0.06085;0.07482;0.07482
 SSP1;NES;Gases;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.03289;0.08772;0.1289;0.1289
 SSP1;NES;Gases;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.03289;0.08772;0.1289;0.1289
 SSP1;NES;Gases;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.03289;0.08772;0.1289;0.1289
 SSP1;NES;Gases;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.03289;0.08772;0.1289;0.1289
 SSP1;NES;Gases;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.03289;0.08772;0.1289;0.1289
-SSP1;NES;Hydrogen;Domestic Aviation_tmp_vehicletype;Domestic Aviation_tmp_subsectorL3;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;trn_pass;FV;0;8.32E-07;4.54E-05;0.1192;0.1192
+SSP1;NES;Hydrogen;Domestic Aviation_tmp_vehicletype;Domestic Aviation_tmp_subsectorL3;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;trn_pass;FV;0;8.32E-07;0.1362;0.3576;0.3576
 SSP1;NES;Liquids;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;1;1;1;1;1
 SSP1;NES;Liquids;Domestic Aviation_tmp_vehicletype;Domestic Aviation_tmp_subsectorL3;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;trn_pass;FV;1;1;1;1;1
 SSP1;NES;Liquids;Domestic Ship_tmp_vehicletype;Domestic Ship_tmp_subsectorL3;Domestic Ship_tmp_subsectorL2;Domestic Ship;trn_freight;FV;1;1;1;1;1
-SSP1;NES;Liquids;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;1;1;1;1;1
+SSP1;NES;Liquids;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;1;1;0.9901;0.5549;0.5549
 SSP1;NES;Liquids;International Aviation_tmp_vehicletype;International Aviation_tmp_subsectorL3;International Aviation_tmp_subsectorL2;International Aviation;trn_aviation_intl;FV;1;1;1;1;1
 SSP1;NES;Liquids;International Ship_tmp_vehicletype;International Ship_tmp_subsectorL3;International Ship_tmp_subsectorL2;International Ship;trn_shipping_intl;FV;1;1;1;1;1
 SSP1;NES;Liquids;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;1;1;1
 SSP1;NES;Liquids;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;1;1;1
 SSP1;NES;Liquids;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;1;1;1
-SSP1;NES;Liquids;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;0.4782;0.4782;0.4782;0.4782;0.4782
+SSP1;NES;Liquids;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;0.4782;0.4782;0.2391;0.1594;0.1594
 SSP1;NES;Liquids;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
 SSP1;NES;Liquids;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
 SSP1;NES;Liquids;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
 SSP1;NES;Liquids;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
 SSP1;NES;Liquids;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
 SSP1;OAS;;;;;Cycle;trn_pass;S1S;0.01256;0.03616;0.04821;0.1205;0.1205
-SSP1;OAS;;;;;Domestic Aviation;trn_pass;S1S;0.02456;0.03684;0.05158;0.1326;0.1326
+SSP1;OAS;;;;;Domestic Aviation;trn_pass;S1S;0.02456;0.03684;0.0129;0.03315;0.03315
 SSP1;OAS;;;;;Domestic Ship;trn_freight;S1S;0.03712;0.03375;0.02856;0.027;0.027
-SSP1;OAS;;;;;Freight Rail;trn_freight;S1S;0.04736;0.04305;0.03643;0.03444;0.03444
+SSP1;OAS;;;;;Freight Rail;trn_freight;S1S;0.04736;0.04305;0.05464;0.05166;0.05166
 SSP1;OAS;;;;;HSR;trn_pass;S1S;0.000966;0.004347;0.004347;0.005796;0.005796
 SSP1;OAS;;;;;International Aviation;trn_aviation_intl;S1S;1;1;1;1;1
 SSP1;OAS;;;;;International Ship;trn_shipping_intl;S1S;1;1;1;1;1
-SSP1;OAS;;;;;Passenger Rail;trn_pass;S1S;0.0007701;0.001155;0.001733;0.00231;0.00231
+SSP1;OAS;;;;;Passenger Rail;trn_pass;S1S;0.0007701;0.001155;0.003466;0.00462;0.00462
 SSP1;OAS;;;;;Walk;trn_pass;S1S;1;1;1;1;1
 SSP1;OAS;;;;;trn_freight_road;trn_freight;S1S;1;1;1;1;1
-SSP1;OAS;;;;;trn_pass_road;trn_pass;S1S;0.4452;0.5697;0.5697;0.7121;0.7121
-SSP1;OAS;;;;Bus;trn_pass_road;trn_pass;S2S1;0.4352;0.2571;0.1122;0.0962;0.0962
+SSP1;OAS;;;;;trn_pass_road;trn_pass;S1S;0.4452;0.5697;0.2848;0.356;0.356
+SSP1;OAS;;;;Bus;trn_pass_road;trn_pass;S2S1;0.4352;0.2571;0.1683;0.1443;0.1443
 SSP1;OAS;;;;trn_pass_road_LDV;trn_pass_road;trn_pass;S2S1;1.2;1;1;1;1
 SSP1;OAS;;;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;0.8;0.5;0.3;0.2;0.2
 SSP1;OAS;;;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;1;1;1;1;1
-SSP1;OAS;;Compact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.002698;0.002811;0.004216;0.005621;0.005621
+SSP1;OAS;;Compact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.002698;0.002811;0.008432;0.01686;0.01686
 SSP1;OAS;;Large Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.3018;0.3018;0.3018;0.3018;0.3018
 SSP1;OAS;;Large Car and SUV;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.0006459;0.0006459;0.0006459;0.0006459;0.0006459
 SSP1;OAS;;Midsize Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.00025;0.00025;0.00025;0.00025;0.00025
-SSP1;OAS;;Mini Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;2.78E-05;2.89E-05;4.34E-05;5.78E-05;5.78E-05
+SSP1;OAS;;Mini Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;2.78E-05;2.89E-05;8.67E-05;0.0001735;0.0001735
 SSP1;OAS;;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.007762;0.007762;0.007762;0.007762;0.007762
 SSP1;OAS;;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;1;1;1;1;1
 SSP1;OAS;;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.006391;0.006391;0.006391;0.006391;0.006391
-SSP1;OAS;;Subcompact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.003403;0.003545;0.005318;0.00709;0.00709
+SSP1;OAS;;Subcompact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.003403;0.003545;0.01064;0.02127;0.02127
 SSP1;OAS;;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.3765;0.3765;0.3765;0.3765;0.3765
 SSP1;OAS;;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.4784;0.4784;0.4784;0.4784;0.4784
 SSP1;OAS;;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.001365;0.001365;0.001365;0.001365;0.001365
 SSP1;OAS;;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.0007361;0.0007361;0.0007361;0.0007361;0.0007361
 SSP1;OAS;;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;1;1;1;1;1
 SSP1;OAS;;Van;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;1.03E-05;1.03E-05;1.03E-05;1.03E-05;1.03E-05
-SSP1;OAS;BEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.1411;0.667;1;1
-SSP1;OAS;BEV;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.044;0.168;0.294;0.294
-SSP1;OAS;BEV;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.044;0.168;0.294;0.294
-SSP1;OAS;BEV;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.044;0.168;0.294;0.294
-SSP1;OAS;BEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.03469;0.05456;0.07144;0.07144
-SSP1;OAS;BEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.0138;0.02935;0.0693;0.0693
-SSP1;OAS;BEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.0138;0.02935;0.0693;0.0693
-SSP1;OAS;BEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.0138;0.02935;0.0693;0.0693
-SSP1;OAS;BEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.03469;0.05456;0.07144;0.07144
-SSP1;OAS;Electric;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;0.1733;0.2767;0.4833;0.8967;0.8967
+SSP1;OAS;BEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.1411;1;1;1
+SSP1;OAS;BEV;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.044;0.336;0.588;0.588
+SSP1;OAS;BEV;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.044;0.336;0.588;0.588
+SSP1;OAS;BEV;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.044;0.336;0.588;0.588
+SSP1;OAS;BEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.03469;0.1091;0.1429;0.1429
+SSP1;OAS;BEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.0138;0.0587;0.1386;0.1386
+SSP1;OAS;BEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.0138;0.0587;0.1386;0.1386
+SSP1;OAS;BEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.0138;0.0587;0.1386;0.1386
+SSP1;OAS;BEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.03469;0.1091;0.1429;0.1429
+SSP1;OAS;Electric;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;0.1733;0.2767;0.9666;1;1
 SSP1;OAS;Electric;HSR_tmp_vehicletype;HSR_tmp_subsectorL3;HSR_tmp_subsectorL2;HSR;trn_pass;FV;1;1;1;1;1
-SSP1;OAS;Electric;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;0.353;0.4338;0.5956;0.9191;0.9191
-SSP1;OAS;FCEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.002453;0.01784;0.0729;0.0729
-SSP1;OAS;FCEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.01217;0.01294;0.02127;0.02127
-SSP1;OAS;FCEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.004497;0.004907;0.01455;0.01455
-SSP1;OAS;FCEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.004497;0.004907;0.01455;0.01455
-SSP1;OAS;FCEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.004497;0.004907;0.01455;0.01455
-SSP1;OAS;FCEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.01217;0.01294;0.02127;0.02127
-SSP1;OAS;Gases;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0.1967;0.198;0.2365;0.2303;0.2303
+SSP1;OAS;Electric;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;0.353;0.4338;1;1;1
+SSP1;OAS;FCEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.002453;0.01337;0.03645;0.03645
+SSP1;OAS;FCEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.01217;0.03882;0.06381;0.06381
+SSP1;OAS;FCEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.004497;0.01472;0.04365;0.04365
+SSP1;OAS;FCEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.004497;0.01472;0.04365;0.04365
+SSP1;OAS;FCEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.004497;0.01472;0.04365;0.04365
+SSP1;OAS;FCEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.01217;0.03882;0.06381;0.06381
+SSP1;OAS;Gases;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0.1967;0.198;0.1773;0.1152;0.1152
 SSP1;OAS;Gases;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.0004535;0.008919;0.03968;0.06153;0.06153
 SSP1;OAS;Gases;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.008772;0.03947;0.0614;0.0614
 SSP1;OAS;Gases;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.1395;0.05404;0.1037;0.09933;0.09933
 SSP1;OAS;Gases;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.2466;0.08882;0.1531;0.1285;0.1285
 SSP1;OAS;Gases;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.008772;0.03947;0.0614;0.0614
-SSP1;OAS;Hydrogen;Domestic Aviation_tmp_vehicletype;Domestic Aviation_tmp_subsectorL3;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;trn_pass;FV;0;8.32E-07;4.54E-05;0.1192;0.1192
-SSP1;OAS;Liquids;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;1;1;1;0.6681;0.6681
+SSP1;OAS;Hydrogen;Domestic Aviation_tmp_vehicletype;Domestic Aviation_tmp_subsectorL3;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;trn_pass;FV;0;8.32E-07;0.1362;0.3576;0.3576
+SSP1;OAS;Liquids;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;1;1;0.7496;0.3341;0.3341
 SSP1;OAS;Liquids;Domestic Aviation_tmp_vehicletype;Domestic Aviation_tmp_subsectorL3;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;trn_pass;FV;1;1;1;1;1
 SSP1;OAS;Liquids;Domestic Ship_tmp_vehicletype;Domestic Ship_tmp_subsectorL3;Domestic Ship_tmp_subsectorL2;Domestic Ship;trn_freight;FV;1;1;1;1;1
-SSP1;OAS;Liquids;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;1;1;1;1;1
+SSP1;OAS;Liquids;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;1;1;1;0.5576;0.5576
 SSP1;OAS;Liquids;International Aviation_tmp_vehicletype;International Aviation_tmp_subsectorL3;International Aviation_tmp_subsectorL2;International Aviation;trn_aviation_intl;FV;1;1;1;1;1
 SSP1;OAS;Liquids;International Ship_tmp_vehicletype;International Ship_tmp_subsectorL3;International Ship_tmp_subsectorL2;International Ship;trn_shipping_intl;FV;1;1;1;1;1
 SSP1;OAS;Liquids;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;1;1;1
 SSP1;OAS;Liquids;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;1;1;1
 SSP1;OAS;Liquids;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;1;1;1
-SSP1;OAS;Liquids;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;1;1;1;1;1
+SSP1;OAS;Liquids;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;1;1;0.8395;0.3627;0.3627
 SSP1;OAS;Liquids;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
 SSP1;OAS;Liquids;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
 SSP1;OAS;Liquids;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
 SSP1;OAS;Liquids;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
 SSP1;OAS;Liquids;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
-SSP1;REF;;;;;Cycle;trn_pass;S1S;0.01379;0.01206;0.06031;0.07824;0.07824
-SSP1;REF;;;;;Domestic Aviation;trn_pass;S1S;0.03574;0.02995;0.03743;0.01387;0.01387
+SSP1;REF;;;;;Cycle;trn_pass;S1S;0.01379;0.01206;0.0745;0.07824;0.07824
+SSP1;REF;;;;;Domestic Aviation;trn_pass;S1S;0.03574;0.02995;0.01156;0.003468;0.003468
 SSP1;REF;;;;;Domestic Ship;trn_freight;S1S;0.007227;0.007227;0.007227;0.007227;0.007227
-SSP1;REF;;;;;Freight Rail;trn_freight;S1S;0.1296;0.1296;0.1296;0.1296;0.1296
-SSP1;REF;;;;;HSR;trn_pass;S1S;0;0.002037;0.002037;0.000755;0.000755
+SSP1;REF;;;;;Freight Rail;trn_freight;S1S;0.1296;0.1296;0.1944;0.1944;0.1944
+SSP1;REF;;;;;HSR;trn_pass;S1S;0;0.002037;0.002516;0.000755;0.000755
 SSP1;REF;;;;;International Aviation;trn_aviation_intl;S1S;1;1;1;1;1
 SSP1;REF;;;;;International Ship;trn_shipping_intl;S1S;1;1;1;1;1
-SSP1;REF;;;;;Passenger Rail;trn_pass;S1S;0.006884;0.01205;0.01506;0.01116;0.01116
-SSP1;REF;;;;;Walk;trn_pass;S1S;0.9251;0.8095;0.8095;1;1
+SSP1;REF;;;;;Passenger Rail;trn_pass;S1S;0.006884;0.01205;0.03721;0.02232;0.02232
+SSP1;REF;;;;;Walk;trn_pass;S1S;0.9251;0.8095;1;1;1
 SSP1;REF;;;;;trn_freight_road;trn_freight;S1S;1;1;1;1;1
-SSP1;REF;;;;;trn_pass_road;trn_pass;S1S;1;1;1;0.4633;0.4633
-SSP1;REF;;;;Bus;trn_pass_road;trn_pass;S2S1;0.2684;0.1864;0.1553;0.1242;0.1242
+SSP1;REF;;;;;trn_pass_road;trn_pass;S1S;1;1;0.6177;0.2316;0.2316
+SSP1;REF;;;;Bus;trn_pass_road;trn_pass;S2S1;0.2684;0.1864;0.2329;0.1863;0.1863
 SSP1;REF;;;;trn_pass_road_LDV;trn_pass_road;trn_pass;S2S1;1;1;1;1;1
 SSP1;REF;;;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;0.8;0.7;0.5;0.5;0.5
 SSP1;REF;;;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;1;1;1;1;1
-SSP1;REF;;Compact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.4455;0.4176;0.4176;0.3818;0.3818
-SSP1;REF;;Large Car and SUV;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;1;1;1;1;1
-SSP1;REF;;Midsize Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.1842;0.1842;0.1842;0.1842;0.1842
-SSP1;REF;;Mini Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.0001425;0.0001336;0.0001336;0.0001222;0.0001222
+SSP1;REF;;Compact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.4455;0.4176;0.8352;1;1
+SSP1;REF;;Large Car and SUV;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;1;1;1;0.8731;0.8731
+SSP1;REF;;Midsize Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.1842;0.1842;0.1842;0.1608;0.1608
+SSP1;REF;;Mini Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.0001425;0.0001336;0.0002672;0.0003201;0.0003201
 SSP1;REF;;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.003376;0.003376;0.003376;0.003376;0.003376
 SSP1;REF;;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;1;1;1;1;1
 SSP1;REF;;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.4141;0.4141;0.4141;0.4141;0.4141
-SSP1;REF;;Subcompact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.02508;0.02351;0.02351;0.0215;0.0215
+SSP1;REF;;Subcompact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.02508;0.02351;0.04702;0.05631;0.05631
 SSP1;REF;;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;1;1;1;1;1
 SSP1;REF;;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.005081;0.005081;0.005081;0.005081;0.005081
 SSP1;REF;;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.5837;0.5837;0.5837;0.5837;0.5837
 SSP1;REF;;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.1888;0.1888;0.1888;0.1888;0.1888
 SSP1;REF;;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.01676;0.01676;0.01676;0.01676;0.01676
-SSP1;REF;BEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.07245;0.3202;0.7425;0.7425
-SSP1;REF;BEV;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.04;0.168;0.336;0.336
-SSP1;REF;BEV;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.04;0.168;0.336;0.336
-SSP1;REF;BEV;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.04;0.168;0.336;0.336
-SSP1;REF;BEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1183;0.2678;0.3957;0.3957
-SSP1;REF;BEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.04705;0.1441;0.3838;0.3838
-SSP1;REF;BEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.04705;0.1441;0.3838;0.3838
-SSP1;REF;BEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.04705;0.1441;0.3838;0.3838
-SSP1;REF;BEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1183;0.2678;0.3957;0.3957
+SSP1;REF;BEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.07245;0.6404;1;1
+SSP1;REF;BEV;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.04;0.336;0.672;0.672
+SSP1;REF;BEV;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.04;0.336;0.672;0.672
+SSP1;REF;BEV;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.04;0.336;0.672;0.672
+SSP1;REF;BEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1183;0.5356;0.7914;0.7914
+SSP1;REF;BEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.04705;0.2882;0.7676;0.7676
+SSP1;REF;BEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.04705;0.2882;0.7676;0.7676
+SSP1;REF;BEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.04705;0.2882;0.7676;0.7676
+SSP1;REF;BEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1183;0.5356;0.7914;0.7914
 SSP1;REF;Electric;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;1;1;1;1;1
 SSP1;REF;Electric;HSR_tmp_vehicletype;HSR_tmp_subsectorL3;HSR_tmp_subsectorL2;HSR;trn_pass;FV;1;1;1;1;1
 SSP1;REF;Electric;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;1;1;1;1;1
-SSP1;REF;FCEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.002698;0.03569;0.06236;0.06236
-SSP1;REF;FCEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.05975;0.04705;0.05523;0.05523
-SSP1;REF;FCEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02208;0.01784;0.03777;0.03777
-SSP1;REF;FCEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02208;0.01784;0.03777;0.03777
-SSP1;REF;FCEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02208;0.01784;0.03777;0.03777
-SSP1;REF;FCEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.05975;0.04705;0.05523;0.05523
-SSP1;REF;Gases;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0.014;0.03195;0.06011;0.07825;0.07825
+SSP1;REF;FCEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.002698;0.03569;0.04199;0.04199
+SSP1;REF;FCEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.05975;0.1411;0.1657;0.1657
+SSP1;REF;FCEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02208;0.05352;0.1133;0.1133
+SSP1;REF;FCEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02208;0.05352;0.1133;0.1133
+SSP1;REF;FCEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02208;0.05352;0.1133;0.1133
+SSP1;REF;FCEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.05975;0.1411;0.1657;0.1657
+SSP1;REF;Gases;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0.014;0.03195;0.06011;0.05269;0.05269
 SSP1;REF;Gases;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.03465;0.06073;0.09593;0.1342;0.1342
 SSP1;REF;Gases;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02392;0.06459;0.1134;0.1134
 SSP1;REF;Gases;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.05259;0.07979;0.1122;0.145;0.145
 SSP1;REF;Gases;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.0254;0.0509;0.08756;0.1287;0.1287
 SSP1;REF;Gases;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02392;0.06459;0.1134;0.1134
-SSP1;REF;Hydrogen;Domestic Aviation_tmp_vehicletype;Domestic Aviation_tmp_subsectorL3;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;trn_pass;FV;0;8.32E-07;4.54E-05;0.1192;0.1192
-SSP1;REF;Liquids;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;1;1;1;1;1
+SSP1;REF;Hydrogen;Domestic Aviation_tmp_vehicletype;Domestic Aviation_tmp_subsectorL3;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;trn_pass;FV;0;8.32E-07;0.1362;0.3576;0.3576
+SSP1;REF;Liquids;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;1;1;1;0.6734;0.6734
 SSP1;REF;Liquids;Domestic Aviation_tmp_vehicletype;Domestic Aviation_tmp_subsectorL3;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;trn_pass;FV;1;1;1;1;1
 SSP1;REF;Liquids;Domestic Ship_tmp_vehicletype;Domestic Ship_tmp_subsectorL3;Domestic Ship_tmp_subsectorL2;Domestic Ship;trn_freight;FV;1;1;1;1;1
-SSP1;REF;Liquids;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;0.4599;0.4599;0.4599;0.4599;0.4599
+SSP1;REF;Liquids;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;0.4599;0.4599;0.2299;0.2299;0.2299
 SSP1;REF;Liquids;International Aviation_tmp_vehicletype;International Aviation_tmp_subsectorL3;International Aviation_tmp_subsectorL2;International Aviation;trn_aviation_intl;FV;1;1;1;1;1
 SSP1;REF;Liquids;International Ship_tmp_vehicletype;International Ship_tmp_subsectorL3;International Ship_tmp_subsectorL2;International Ship;trn_shipping_intl;FV;1;1;1;1;1
 SSP1;REF;Liquids;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;1;1;1
 SSP1;REF;Liquids;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;1;1;1
 SSP1;REF;Liquids;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;1;1;1
-SSP1;REF;Liquids;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;0.2359;0.2359;0.2359;0.2359;0.2359
+SSP1;REF;Liquids;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;0.2359;0.2359;0.1179;0.07863;0.07863
 SSP1;REF;Liquids;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
 SSP1;REF;Liquids;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
 SSP1;REF;Liquids;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
 SSP1;REF;Liquids;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
 SSP1;REF;Liquids;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
 SSP1;SSA;;;;;Cycle;trn_pass;S1S;0.01388;0.01987;0.02915;0.03279;0.03279
-SSP1;SSA;;;;;Domestic Aviation;trn_pass;S1S;0.033;0.05387;0.03951;0.005926;0.005926
+SSP1;SSA;;;;;Domestic Aviation;trn_pass;S1S;0.033;0.05387;0.009878;0.001481;0.001481
 SSP1;SSA;;;;;Domestic Ship;trn_freight;S1S;0.001495;0.001495;0.001495;0.001495;0.001495
-SSP1;SSA;;;;;Freight Rail;trn_freight;S1S;0.01665;0.01665;0.01665;0.01498;0.01498
+SSP1;SSA;;;;;Freight Rail;trn_freight;S1S;0.01665;0.01665;0.02498;0.02247;0.02247
 SSP1;SSA;;;;;HSR;trn_pass;S1S;1.48E-05;2.22E-05;0.06504;0.009756;0.009756
 SSP1;SSA;;;;;International Aviation;trn_aviation_intl;S1S;1;1;1;1;1
 SSP1;SSA;;;;;International Ship;trn_shipping_intl;S1S;1;1;1;1;1
-SSP1;SSA;;;;;Passenger Rail;trn_pass;S1S;0.0006024;0.001725;0.00253;0.0005693;0.0005693
+SSP1;SSA;;;;;Passenger Rail;trn_pass;S1S;0.0006024;0.001725;0.00506;0.001139;0.001139
 SSP1;SSA;;;;;Walk;trn_pass;S1S;1;1;1;1;1
 SSP1;SSA;;;;;trn_freight_road;trn_freight;S1S;1;1;1;1;1
-SSP1;SSA;;;;;trn_pass_road;trn_pass;S1S;0.2622;0.326;0.2869;0.04781;0.04781
-SSP1;SSA;;;;Bus;trn_pass_road;trn_pass;S2S1;0.7568;0.3234;0.1493;0.09703;0.09703
+SSP1;SSA;;;;;trn_pass_road;trn_pass;S1S;0.2622;0.326;0.1434;0.0239;0.0239
+SSP1;SSA;;;;Bus;trn_pass_road;trn_pass;S2S1;0.7568;0.3234;0.224;0.1455;0.1455
 SSP1;SSA;;;;trn_pass_road_LDV;trn_pass_road;trn_pass;S2S1;1;1;1;1;1
 SSP1;SSA;;;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;0.02619;0.02619;0.02619;0.03928;0.03928
 SSP1;SSA;;;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;1;1;1;1;1
 SSP1;SSA;;Compact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;1;1;1;1;1
-SSP1;SSA;;Large Car and SUV;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.003022;0.003022;0.003022;0.003022;0.003022
+SSP1;SSA;;Large Car and SUV;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.003022;0.003022;0.001511;0.001007;0.001007
 SSP1;SSA;;Mini Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.02706;0.02706;0.02706;0.02706;0.02706
 SSP1;SSA;;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.3828;0.3828;0.3828;0.3828;0.3828
 SSP1;SSA;;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;1;1;1;1;1
@@ -6913,177 +6913,177 @@ SSP1;SSA;;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subs
 SSP1;SSA;;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;5.61E-06;5.61E-06;5.61E-06;5.61E-06;5.61E-06
 SSP1;SSA;;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;4.21E-06;4.21E-06;4.21E-06;4.21E-06;4.21E-06
 SSP1;SSA;;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;1;1;1;1;1
-SSP1;SSA;;Van;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;7.57E-05;7.57E-05;7.57E-05;7.57E-05;7.57E-05
-SSP1;SSA;BEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.0621;0.3962;0.847;0.847
-SSP1;SSA;BEV;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.1;0.216;0.336;0.336
-SSP1;SSA;BEV;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.1;0.216;0.336;0.336
-SSP1;SSA;BEV;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.1;0.216;0.336;0.336
-SSP1;SSA;BEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02602;0.1007;0.1511;0.1511
-SSP1;SSA;BEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.01035;0.05418;0.1466;0.1466
-SSP1;SSA;BEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.01035;0.05418;0.1466;0.1466
-SSP1;SSA;BEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.01035;0.05418;0.1466;0.1466
-SSP1;SSA;BEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02602;0.1007;0.1511;0.1511
+SSP1;SSA;;Van;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;7.57E-05;7.57E-05;3.79E-05;2.52E-05;2.52E-05
+SSP1;SSA;BEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.0621;0.7924;1;1
+SSP1;SSA;BEV;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.1;0.432;0.672;0.672
+SSP1;SSA;BEV;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.1;0.432;0.672;0.672
+SSP1;SSA;BEV;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.1;0.432;0.672;0.672
+SSP1;SSA;BEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02602;0.2014;0.3022;0.3022
+SSP1;SSA;BEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.01035;0.1084;0.2932;0.2932
+SSP1;SSA;BEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.01035;0.1084;0.2932;0.2932
+SSP1;SSA;BEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.01035;0.1084;0.2932;0.2932
+SSP1;SSA;BEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02602;0.2014;0.3022;0.3022
 SSP1;SSA;Electric;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;1;1;1;1;1
 SSP1;SSA;Electric;HSR_tmp_vehicletype;HSR_tmp_subsectorL3;HSR_tmp_subsectorL2;HSR;trn_pass;FV;1;1;1;1;1
 SSP1;SSA;Electric;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;1;1;1;1;1
-SSP1;SSA;FCEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.002698;0.01963;0.0485;0.0485
-SSP1;SSA;FCEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.007303;0.01194;0.02045;0.02045
-SSP1;SSA;FCEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.002698;0.004529;0.01399;0.01399
-SSP1;SSA;FCEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.002698;0.004529;0.01399;0.01399
-SSP1;SSA;FCEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.002698;0.004529;0.01399;0.01399
-SSP1;SSA;FCEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.007303;0.01194;0.02045;0.02045
-SSP1;SSA;Gases;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0.0003981;0.0267;0.04997;0.06835;0.06835
+SSP1;SSA;FCEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.002698;0.01963;0.02863;0.02863
+SSP1;SSA;FCEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.007303;0.03582;0.06135;0.06135
+SSP1;SSA;FCEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.002698;0.01359;0.04197;0.04197
+SSP1;SSA;FCEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.002698;0.01359;0.04197;0.04197
+SSP1;SSA;FCEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.002698;0.01359;0.04197;0.04197
+SSP1;SSA;FCEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.007303;0.03582;0.06135;0.06135
+SSP1;SSA;Gases;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0.0003981;0.0267;0.04997;0.04035;0.04035
 SSP1;SSA;Gases;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02632;0.04251;0.05904;0.05904
 SSP1;SSA;Gases;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02632;0.04251;0.05904;0.05904
 SSP1;SSA;Gases;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02632;0.04251;0.05904;0.05904
 SSP1;SSA;Gases;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02632;0.04251;0.05904;0.05904
 SSP1;SSA;Gases;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02632;0.04251;0.05904;0.05904
-SSP1;SSA;Hydrogen;Domestic Aviation_tmp_vehicletype;Domestic Aviation_tmp_subsectorL3;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;trn_pass;FV;0;8.32E-07;4.54E-05;0.1192;0.1192
-SSP1;SSA;Liquids;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;1;1;1;1;1
+SSP1;SSA;Hydrogen;Domestic Aviation_tmp_vehicletype;Domestic Aviation_tmp_subsectorL3;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;trn_pass;FV;0;8.32E-07;0.1362;0.3576;0.3576
+SSP1;SSA;Liquids;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;1;1;1;0.5903;0.5903
 SSP1;SSA;Liquids;Domestic Aviation_tmp_vehicletype;Domestic Aviation_tmp_subsectorL3;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;trn_pass;FV;1;1;1;1;1
 SSP1;SSA;Liquids;Domestic Ship_tmp_vehicletype;Domestic Ship_tmp_subsectorL3;Domestic Ship_tmp_subsectorL2;Domestic Ship;trn_freight;FV;1;1;1;1;1
-SSP1;SSA;Liquids;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;0.6248;0.6248;0.6248;0.6248;0.6248
+SSP1;SSA;Liquids;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;0.6248;0.6248;0.3124;0.3124;0.3124
 SSP1;SSA;Liquids;International Aviation_tmp_vehicletype;International Aviation_tmp_subsectorL3;International Aviation_tmp_subsectorL2;International Aviation;trn_aviation_intl;FV;1;1;1;1;1
 SSP1;SSA;Liquids;International Ship_tmp_vehicletype;International Ship_tmp_subsectorL3;International Ship_tmp_subsectorL2;International Ship;trn_shipping_intl;FV;1;1;1;1;1
 SSP1;SSA;Liquids;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;1;1;1
 SSP1;SSA;Liquids;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;1;1;1
 SSP1;SSA;Liquids;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;1;1;1
-SSP1;SSA;Liquids;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;0.07561;0.07561;0.07561;0.07561;0.07561
+SSP1;SSA;Liquids;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;0.07561;0.07561;0.0378;0.0252;0.0252
 SSP1;SSA;Liquids;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
 SSP1;SSA;Liquids;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
 SSP1;SSA;Liquids;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
 SSP1;SSA;Liquids;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
 SSP1;SSA;Liquids;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
 SSP1;UKI;;;;;Cycle;trn_pass;S1S;0.025;0.01092;0.03277;0.06553;0.06553
-SSP1;UKI;;;;;Domestic Aviation;trn_pass;S1S;5.97E-05;8.94E-06;8.94E-06;8.94E-06;8.94E-06
+SSP1;UKI;;;;;Domestic Aviation;trn_pass;S1S;5.97E-05;8.94E-06;2.23E-06;2.23E-06;2.23E-06
 SSP1;UKI;;;;;Domestic Ship;trn_freight;S1S;0.00867;0.00867;0.00867;0.00867;0.00867
-SSP1;UKI;;;;;Freight Rail;trn_freight;S1S;0.00618;0.00618;0.00618;0.00618;0.00618
+SSP1;UKI;;;;;Freight Rail;trn_freight;S1S;0.00618;0.00618;0.00927;0.00927;0.00927
 SSP1;UKI;;;;;HSR;trn_pass;S1S;0.000125;0.0001334;0.0001779;0.0002224;0.0002224
 SSP1;UKI;;;;;International Aviation;trn_aviation_intl;S1S;1;1;1;1;1
 SSP1;UKI;;;;;International Ship;trn_shipping_intl;S1S;1;1;1;1;1
-SSP1;UKI;;;;;Passenger Rail;trn_pass;S1S;0.003125;0.002502;0.001876;0.001876;0.001876
+SSP1;UKI;;;;;Passenger Rail;trn_pass;S1S;0.003125;0.002502;0.003752;0.003752;0.003752
 SSP1;UKI;;;;;Walk;trn_pass;S1S;1;1;1;1;1
 SSP1;UKI;;;;;trn_freight_road;trn_freight;S1S;1;1;1;1;1
-SSP1;UKI;;;;;trn_pass_road;trn_pass;S1S;0.07363;0.05228;0.03346;0.03346;0.03346
-SSP1;UKI;;;;Bus;trn_pass_road;trn_pass;S2S1;0.2546;0.2048;0.1877;0.1706;0.1706
+SSP1;UKI;;;;;trn_pass_road;trn_pass;S1S;0.07363;0.05228;0.01673;0.01673;0.01673
+SSP1;UKI;;;;Bus;trn_pass_road;trn_pass;S2S1;0.2546;0.2048;0.2816;0.2559;0.2559
 SSP1;UKI;;;;trn_pass_road_LDV;trn_pass_road;trn_pass;S2S1;1;1;1;1;1
 SSP1;UKI;;;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;0.1;0.1;0.1;0.1;0.1
 SSP1;UKI;;;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;1;1;1;1;1
-SSP1;UKI;;Compact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.5404;0.5404;0.4864;0.4864;0.4864
-SSP1;UKI;;Large Car and SUV;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;1;1;1;1;1
-SSP1;UKI;;Midsize Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.2616;0.2616;0.2616;0.2616;0.2616
-SSP1;UKI;;Mini Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;5.28E-07;5.28E-07;4.75E-07;4.75E-07;4.75E-07
+SSP1;UKI;;Compact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.5404;0.5404;0.9502;0.9502;0.9502
+SSP1;UKI;;Large Car and SUV;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;1;1;0.9768;0.6512;0.6512
+SSP1;UKI;;Midsize Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.2616;0.2616;0.2555;0.1703;0.1703
+SSP1;UKI;;Mini Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;5.28E-07;5.28E-07;9.28E-07;9.28E-07;9.28E-07
 SSP1;UKI;;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.02088;0.02088;0.02088;0.02088;0.02088
 SSP1;UKI;;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.003798;0.003798;0.003798;0.003798;0.003798
 SSP1;UKI;;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;1;1;1;1;1
-SSP1;UKI;;Subcompact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.5688;0.5688;0.5119;0.5119;0.5119
+SSP1;UKI;;Subcompact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.5688;0.5688;1;1;1
 SSP1;UKI;;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;1;1;1;1;1
 SSP1;UKI;;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.04528;0.04528;0.04528;0.04528;0.04528
 SSP1;UKI;;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.09437;0.09437;0.09437;0.09437;0.09437
 SSP1;UKI;;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.5696;0.5696;0.5696;0.5696;0.5696
 SSP1;UKI;;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.7765;0.7765;0.7765;0.7765;0.7765
-SSP1;UKI;;Van;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.002681;0.002681;0.002681;0.002681;0.002681
-SSP1;UKI;BEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0.025;0.1168;0.3434;0.7434;0.7434
-SSP1;UKI;BEV;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.05;0.2;0.37;0.37
-SSP1;UKI;BEV;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.05;0.2;0.37;0.37
-SSP1;UKI;BEV;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.05;0.2;0.37;0.37
-SSP1;UKI;BEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.2819;0.5853;0.836;0.836
-SSP1;UKI;BEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1122;0.3148;0.811;0.811
-SSP1;UKI;BEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1122;0.3148;0.811;0.811
-SSP1;UKI;BEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1122;0.3148;0.811;0.811
-SSP1;UKI;BEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.2819;0.5853;0.836;0.836
-SSP1;UKI;Electric;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;0.826;0.8478;0.8913;0.9783;0.9783
+SSP1;UKI;;Van;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.002681;0.002681;0.002619;0.001746;0.001746
+SSP1;UKI;BEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0.025;0.1168;0.6868;1;1
+SSP1;UKI;BEV;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.05;0.4;0.74;0.74
+SSP1;UKI;BEV;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.05;0.4;0.74;0.74
+SSP1;UKI;BEV;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.05;0.4;0.74;0.74
+SSP1;UKI;BEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.2819;1;1;1
+SSP1;UKI;BEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1122;0.6296;1;1
+SSP1;UKI;BEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1122;0.6296;1;1
+SSP1;UKI;BEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1122;0.6296;1;1
+SSP1;UKI;BEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.2819;1;1;1
+SSP1;UKI;Electric;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;0.826;0.8478;1;1;1
 SSP1;UKI;Electric;HSR_tmp_vehicletype;HSR_tmp_subsectorL3;HSR_tmp_subsectorL2;HSR;trn_pass;FV;1;1;1;1;1
 SSP1;UKI;Electric;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;1;1;1;1;1
-SSP1;UKI;FCEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;2.5E-05;0.01218;0.02127;0.07883;0.07883
-SSP1;UKI;FCEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.07914;0.2243;0.1729;0.1729
-SSP1;UKI;FCEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02924;0.08507;0.1182;0.1182
-SSP1;UKI;FCEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02924;0.08507;0.1182;0.1182
-SSP1;UKI;FCEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02924;0.08507;0.1182;0.1182
-SSP1;UKI;FCEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.07914;0.2243;0.1729;0.1729
-SSP1;UKI;Gases;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0.000904;0.02222;0.07928;0.123;0.123
-SSP1;UKI;Gases;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02632;0.07895;0.1842;0.1842
-SSP1;UKI;Gases;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02632;0.07895;0.1842;0.1842
-SSP1;UKI;Gases;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02632;0.07895;0.1842;0.1842
-SSP1;UKI;Gases;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02632;0.07895;0.1842;0.1842
-SSP1;UKI;Gases;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02632;0.07895;0.1842;0.1842
-SSP1;UKI;Hydrogen;Domestic Aviation_tmp_vehicletype;Domestic Aviation_tmp_subsectorL3;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;trn_pass;FV;0;8.32E-07;4.54E-05;0.1192;0.1192
-SSP1;UKI;Liquids;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;1;1;1;1;1
+SSP1;UKI;FCEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;2.5E-05;0.01218;0.02127;0.05302;0.05302
+SSP1;UKI;FCEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.07914;0.5748;0.3102;0.3102
+SSP1;UKI;FCEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02924;0.2552;0.2186;0.2186
+SSP1;UKI;FCEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02924;0.2552;0.2186;0.2186
+SSP1;UKI;FCEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02924;0.2552;0.2186;0.2186
+SSP1;UKI;FCEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.07914;0.5748;0.3102;0.3102
+SSP1;UKI;Gases;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0.000904;0.02222;0.07928;0.08273;0.08273
+SSP1;UKI;Gases;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02632;0.06744;0.1102;0.1102
+SSP1;UKI;Gases;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02632;0.07895;0.1136;0.1136
+SSP1;UKI;Gases;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02632;0.07895;0.1136;0.1136
+SSP1;UKI;Gases;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02632;0.07895;0.1136;0.1136
+SSP1;UKI;Gases;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02632;0.06744;0.1102;0.1102
+SSP1;UKI;Hydrogen;Domestic Aviation_tmp_vehicletype;Domestic Aviation_tmp_subsectorL3;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;trn_pass;FV;0;8.32E-07;0.1362;0.3576;0.3576
+SSP1;UKI;Liquids;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;1;1;1;0.6726;0.6726
 SSP1;UKI;Liquids;Domestic Aviation_tmp_vehicletype;Domestic Aviation_tmp_subsectorL3;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;trn_pass;FV;1;1;1;1;1
 SSP1;UKI;Liquids;Domestic Ship_tmp_vehicletype;Domestic Ship_tmp_subsectorL3;Domestic Ship_tmp_subsectorL2;Domestic Ship;trn_freight;FV;1;1;1;1;1
-SSP1;UKI;Liquids;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;1;1;1;1;1
+SSP1;UKI;Liquids;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;1;1;0.561;0.5111;0.5111
 SSP1;UKI;Liquids;International Aviation_tmp_vehicletype;International Aviation_tmp_subsectorL3;International Aviation_tmp_subsectorL2;International Aviation;trn_aviation_intl;FV;1;1;1;1;1
 SSP1;UKI;Liquids;International Ship_tmp_vehicletype;International Ship_tmp_subsectorL3;International Ship_tmp_subsectorL2;International Ship;trn_shipping_intl;FV;1;1;1;1;1
 SSP1;UKI;Liquids;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;1;1;1
 SSP1;UKI;Liquids;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;1;1;1
 SSP1;UKI;Liquids;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;1;1;1
-SSP1;UKI;Liquids;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;0.5355;0.5355;0.5355;0.5355;0.5355
-SSP1;UKI;Liquids;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
-SSP1;UKI;Liquids;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
-SSP1;UKI;Liquids;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
-SSP1;UKI;Liquids;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
-SSP1;UKI;Liquids;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
+SSP1;UKI;Liquids;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;0.5355;0.5355;0.2677;0.1785;0.1785
+SSP1;UKI;Liquids;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;0.8543;0.5981;0.5981
+SSP1;UKI;Liquids;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;0.6165;0.6165
+SSP1;UKI;Liquids;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;0.6165;0.6165
+SSP1;UKI;Liquids;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;0.6165;0.6165
+SSP1;UKI;Liquids;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;0.8543;0.5981;0.5981
 SSP1;USA;;;;;Cycle;trn_pass;S1S;0.008197;0.008197;0.008197;0.04098;0.04098
-SSP1;USA;;;;;Domestic Aviation;trn_pass;S1S;0.001009;0.001527;0.001718;0.00105;0.00105
+SSP1;USA;;;;;Domestic Aviation;trn_pass;S1S;0.001009;0.001527;0.0004295;0.0002625;0.0002625
 SSP1;USA;;;;;Domestic Ship;trn_freight;S1S;0.003267;0.003267;0.003267;0.003267;0.003267
-SSP1;USA;;;;;Freight Rail;trn_freight;S1S;0.03427;0.03427;0.03427;0.03427;0.03427
+SSP1;USA;;;;;Freight Rail;trn_freight;S1S;0.03427;0.03427;0.0514;0.0514;0.0514
 SSP1;USA;;;;;HSR;trn_pass;S1S;4.53E-06;4.53E-06;4.53E-06;0.0002265;0.0002265
 SSP1;USA;;;;;International Aviation;trn_aviation_intl;S1S;1;1;1;1;1
 SSP1;USA;;;;;International Ship;trn_shipping_intl;S1S;1;1;1;1;1
-SSP1;USA;;;;;Passenger Rail;trn_pass;S1S;0.001933;0.001933;0.001933;0.0009665;0.0009665
+SSP1;USA;;;;;Passenger Rail;trn_pass;S1S;0.001933;0.001933;0.003866;0.001933;0.001933
 SSP1;USA;;;;;Walk;trn_pass;S1S;1;1;1;1;1
 SSP1;USA;;;;;trn_freight_road;trn_freight;S1S;1;1;1;1;1
-SSP1;USA;;;;;trn_pass_road;trn_pass;S1S;0.1305;0.1436;0.1253;0.06526;0.06526
-SSP1;USA;;;;Bus;trn_pass_road;trn_pass;S2S1;0.0872;0.109;0.109;0.1235;0.1235
+SSP1;USA;;;;;trn_pass_road;trn_pass;S1S;0.1305;0.1436;0.06265;0.03263;0.03263
+SSP1;USA;;;;Bus;trn_pass_road;trn_pass;S2S1;0.0872;0.109;0.1635;0.1852;0.1852
 SSP1;USA;;;;trn_pass_road_LDV;trn_pass_road;trn_pass;S2S1;1;1;1;1;1
 SSP1;USA;;;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;0.06;0.06;0.06;0.05;0.05
 SSP1;USA;;;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;1;1;1;1;1
-SSP1;USA;;Compact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.3784;0.3784;0.3784;0.3784;0.3784
-SSP1;USA;;Large Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.2661;0.2661;0.2661;0.2661;0.2661
-SSP1;USA;;Large Car and SUV;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;1;1;1;1;1
-SSP1;USA;;Midsize Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.3745;0.3745;0.3745;0.3745;0.3745
+SSP1;USA;;Compact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.3784;0.3784;0.7568;1;1
+SSP1;USA;;Large Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.2661;0.2661;0.2661;0.2344;0.2344
+SSP1;USA;;Large Car and SUV;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;1;1;1;0.8809;0.8809
+SSP1;USA;;Midsize Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.3745;0.3745;0.3745;0.3299;0.3299
 SSP1;USA;;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;1;1;1;1;1
 SSP1;USA;;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.7057;0.7057;0.7057;0.7057;0.7057
 SSP1;USA;;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;1;1;1;1;1
 SSP1;USA;;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.9;1;1;1;1
 SSP1;USA;;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.9;1;1;1;1
 SSP1;USA;;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.6263;0.6263;0.6263;0.6263;0.6263
-SSP1;USA;BEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.1122;0.5382;1;1
-SSP1;USA;BEV;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.044;0.216;0.378;0.378
-SSP1;USA;BEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.01626;0.2323;0.6967;0.6967
-SSP1;USA;BEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.00647;0.1249;0.6758;0.6758
-SSP1;USA;BEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.03547;0.1364;0.4645;0.7095;0.7095
-SSP1;USA;BEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.03547;0.1364;0.4645;0.7095;0.7095
-SSP1;USA;BEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.01626;0.2323;0.6967;0.6967
-SSP1;USA;Electric;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;0;0.125;0.375;0.875;0.875
+SSP1;USA;BEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.1122;1;1;1
+SSP1;USA;BEV;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.044;0.432;0.756;0.756
+SSP1;USA;BEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.01626;0.4646;1;1
+SSP1;USA;BEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.00647;0.2498;1;1
+SSP1;USA;BEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.03547;0.1364;0.929;1;1
+SSP1;USA;BEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.03547;0.1364;0.929;1;1
+SSP1;USA;BEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.01626;0.4646;1;1
+SSP1;USA;Electric;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;0;0.125;0.75;1;1
 SSP1;USA;Electric;HSR_tmp_vehicletype;HSR_tmp_subsectorL3;HSR_tmp_subsectorL2;HSR;trn_pass;FV;1;1;1;1;1
 SSP1;USA;Electric;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;1;1;1;1;1
-SSP1;USA;FCEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.02436;0.01636;0.07776;0.07776
-SSP1;USA;FCEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.001218;0.01202;0.1008;0.1008
-SSP1;USA;FCEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.0004498;0.004557;0.06897;0.06897
-SSP1;USA;FCEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.05912;0.1819;0.2534;0.1379;0.1379
-SSP1;USA;FCEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.05912;0.1819;0.2534;0.1379;0.1379
-SSP1;USA;FCEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.001218;0.01202;0.1008;0.1008
-SSP1;USA;Gases;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0.08478;0.09072;0.1208;0.1666;0.1666
-SSP1;USA;Gases;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.004049;0.02256;0.0614;0.0614
-SSP1;USA;Gases;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.004049;0.02256;0.0614;0.0614
-SSP1;USA;Gases;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.005;0.1538;0.2857;0.3333;0.3333
-SSP1;USA;Gases;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.005;0.1538;0.2857;0.3333;0.3333
-SSP1;USA;Gases;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.004049;0.02256;0.0614;0.0614
-SSP1;USA;Hydrogen;Domestic Aviation_tmp_vehicletype;Domestic Aviation_tmp_subsectorL3;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;trn_pass;FV;0;8.32E-07;4.54E-05;0.1192;0.1192
-SSP1;USA;Liquids;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;1;1;1;0.7892;0.7892
+SSP1;USA;FCEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.02436;0.0152;0.03888;0.03888
+SSP1;USA;FCEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.001218;0.03606;0.217;0.217
+SSP1;USA;FCEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.0004498;0.01367;0.1531;0.1531
+SSP1;USA;FCEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.05912;0.1819;0.7602;0.2915;0.2915
+SSP1;USA;FCEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.05912;0.1819;0.7602;0.2915;0.2915
+SSP1;USA;FCEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.001218;0.03606;0.217;0.217
+SSP1;USA;Gases;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0.08478;0.09072;0.1122;0.0833;0.0833
+SSP1;USA;Gases;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.004049;0.02256;0.04406;0.04406
+SSP1;USA;Gases;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.004049;0.02256;0.04543;0.04543
+SSP1;USA;Gases;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.005;0.1538;0.2857;0.2349;0.2349
+SSP1;USA;Gases;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.005;0.1538;0.2857;0.2349;0.2349
+SSP1;USA;Gases;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.004049;0.02256;0.04406;0.04406
+SSP1;USA;Hydrogen;Domestic Aviation_tmp_vehicletype;Domestic Aviation_tmp_subsectorL3;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;trn_pass;FV;0;8.32E-07;0.1362;0.3576;0.3576
+SSP1;USA;Liquids;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;1;1;0.929;0.3946;0.3946
 SSP1;USA;Liquids;Domestic Aviation_tmp_vehicletype;Domestic Aviation_tmp_subsectorL3;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;trn_pass;FV;1;1;1;1;1
 SSP1;USA;Liquids;Domestic Ship_tmp_vehicletype;Domestic Ship_tmp_subsectorL3;Domestic Ship_tmp_subsectorL2;Domestic Ship;trn_freight;FV;1;1;1;1;1
-SSP1;USA;Liquids;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;1;1;1;1;1
+SSP1;USA;Liquids;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;1;1;1;0.5714;0.5714
 SSP1;USA;Liquids;International Aviation_tmp_vehicletype;International Aviation_tmp_subsectorL3;International Aviation_tmp_subsectorL2;International Aviation;trn_aviation_intl;FV;1;1;1;1;1
 SSP1;USA;Liquids;International Ship_tmp_vehicletype;International Ship_tmp_subsectorL3;International Ship_tmp_subsectorL2;International Ship;trn_shipping_intl;FV;1;1;1;1;1
 SSP1;USA;Liquids;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;1;1;1
-SSP1;USA;Liquids;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;0.4393;0.4393;0.4393;0.4393;0.4393
-SSP1;USA;Liquids;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
-SSP1;USA;Liquids;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
-SSP1;USA;Liquids;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
-SSP1;USA;Liquids;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
-SSP1;USA;Liquids;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
+SSP1;USA;Liquids;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;0.4393;0.4393;0.2197;0.1464;0.1464
+SSP1;USA;Liquids;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;0.7177;0.7177
+SSP1;USA;Liquids;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;0.7399;0.7399
+SSP1;USA;Liquids;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;0.7047;0.7047
+SSP1;USA;Liquids;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;0.7047;0.7047
+SSP1;USA;Liquids;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;0.7177;0.7177
 SSP2;CAZ;;;;;Cycle;trn_pass;S1S;0.01911;0.03822;0.03822;0.07645;0.07645
 SSP2;CAZ;;;;;Domestic Aviation;trn_pass;S1S;0.001432;0.001527;0.001813;0.001909;0.001909
 SSP2;CAZ;;;;;Domestic Ship;trn_freight;S1S;0.01583;0.01583;0.01583;0.01583;0.01583

--- a/inst/extdata/genParBaselinePrefTrends.csv
+++ b/inst/extdata/genParBaselinePrefTrends.csv
@@ -5668,53 +5668,53 @@ SDP_RC;USA;Liquids;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road
 SDP_RC;USA;Liquids;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;0.5382;0.3524;0.3524
 SDP_RC;USA;Liquids;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;0.3588;0.3588
 SSP1;CAZ;;;;;Cycle;trn_pass;S1S;0.01911;0.03822;0.03822;0.07645;0.07645
-SSP1;CAZ;;;;;Domestic Aviation;trn_pass;S1S;0.001432;0.001527;0.0004532;0.0004773;0.0004773
+SSP1;CAZ;;;;;Domestic Aviation;trn_pass;S1S;0.001432;0.001145;0.0004532;0.0004773;0.0004773
 SSP1;CAZ;;;;;Domestic Ship;trn_freight;S1S;0.01583;0.01583;0.01583;0.01583;0.01583
-SSP1;CAZ;;;;;Freight Rail;trn_freight;S1S;0.107;0.107;0.1605;0.1445;0.1445
+SSP1;CAZ;;;;;Freight Rail;trn_freight;S1S;0.107;0.1605;0.1605;0.1445;0.1445
 SSP1;CAZ;;;;;HSR;trn_pass;S1S;8.79E-08;8.79E-05;0.0002638;0.0002638;0.0002638
 SSP1;CAZ;;;;;International Aviation;trn_aviation_intl;S1S;1;1;1;1;1
 SSP1;CAZ;;;;;International Ship;trn_shipping_intl;S1S;1;1;1;1;1
-SSP1;CAZ;;;;;Passenger Rail;trn_pass;S1S;0.0008785;0.0008785;0.001757;0.001757;0.001757
-SSP1;CAZ;;;;;Walk;trn_pass;S1S;1;1;1;1;1
+SSP1;CAZ;;;;;Passenger Rail;trn_pass;S1S;0.0008785;0.001757;0.001757;0.001757;0.001757
+SSP1;CAZ;;;;;Walk;trn_pass;S1S;1;0.8;1;1;1
 SSP1;CAZ;;;;;trn_freight_road;trn_freight;S1S;1;1;1;1;1
-SSP1;CAZ;;;;;trn_pass_road;trn_pass;S1S;0.1509;0.1509;0.06036;0.07545;0.07545
-SSP1;CAZ;;;;Bus;trn_pass_road;trn_pass;S2S1;0.08852;0.08852;0.1661;0.2103;0.2103
-SSP1;CAZ;;;;trn_pass_road_LDV;trn_pass_road;trn_pass;S2S1;1;1;1;1;1
-SSP1;CAZ;;;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;0.999;0.034;0.03;0.02;0.02
+SSP1;CAZ;;;;;trn_pass_road;trn_pass;S1S;0.1509;0.1056;0.06036;0.07545;0.07545
+SSP1;CAZ;;;;Bus;trn_pass_road;trn_pass;S2S1;0.08852;0.1328;0.1661;0.2103;0.2103
+SSP1;CAZ;;;;trn_pass_road_LDV;trn_pass_road;trn_pass;S2S1;1;1.2;1;1;1
+SSP1;CAZ;;;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;0.04;0.034;0.03;0.02;0.02
 SSP1;CAZ;;;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;1;1;1;1;1
-SSP1;CAZ;;Compact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.1291;0.1291;0.2582;0.3873;0.3873
+SSP1;CAZ;;Compact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.1291;0.1936;0.2582;0.3873;0.3873
 SSP1;CAZ;;Large Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.3264;0.3264;0.3264;0.3264;0.3264
 SSP1;CAZ;;Large Car and SUV;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;6.97E-05;6.97E-05;6.97E-05;6.97E-05;6.97E-05
 SSP1;CAZ;;Midsize Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;1;1;1;1;1
-SSP1;CAZ;;Mini Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;9.88E-09;9.88E-09;1.98E-08;2.96E-08;2.96E-08
+SSP1;CAZ;;Mini Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;9.88E-09;1.48E-08;1.98E-08;2.96E-08;2.96E-08
 SSP1;CAZ;;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.0002867;0.0002867;0.0002867;0.0002867;0.0002867
 SSP1;CAZ;;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.0001994;0.0001994;0.0001994;0.0001994;0.0001994
 SSP1;CAZ;;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;1;1;1;1;1
-SSP1;CAZ;;Subcompact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;6.73E-05;6.73E-05;0.0001346;0.0002018;0.0002018
+SSP1;CAZ;;Subcompact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;6.73E-05;0.0001009;0.0001346;0.0002018;0.0002018
 SSP1;CAZ;;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;1;1;1;1;1
 SSP1;CAZ;;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.2333;0.2333;0.2333;0.2333;0.2333
 SSP1;CAZ;;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.8337;0.8337;0.8337;0.8337;0.8337
 SSP1;CAZ;;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;3.5E-05;3.5E-05;3.5E-05;3.5E-05;3.5E-05
 SSP1;CAZ;;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.6282;0.6282;0.6282;0.6282;0.6282
 SSP1;CAZ;;Van;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.2082;0.2082;0.2082;0.2082;0.2082
-SSP1;CAZ;BEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.1122;0.8846;1;1
-SSP1;CAZ;BEV;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.044;0.384;0.672;0.672
-SSP1;CAZ;BEV;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.044;0.384;0.672;0.672
-SSP1;CAZ;BEV;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.044;0.384;0.672;0.672
-SSP1;CAZ;BEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1409;0.6622;0.8708;0.8708
-SSP1;CAZ;BEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.05608;0.3562;0.8448;0.8448
-SSP1;CAZ;BEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.05608;0.3562;0.8448;0.8448
-SSP1;CAZ;BEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.05608;0.3562;0.8448;0.8448
-SSP1;CAZ;BEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1409;0.6622;0.8708;0.8708
-SSP1;CAZ;Electric;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;0.09074;0.2044;0.8634;1;1
+SSP1;CAZ;BEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.2244;0.8846;1;1
+SSP1;CAZ;BEV;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.088;0.384;0.672;0.672
+SSP1;CAZ;BEV;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.088;0.384;0.672;0.672
+SSP1;CAZ;BEV;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.088;0.384;0.672;0.672
+SSP1;CAZ;BEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.2818;0.6622;0.8708;0.8708
+SSP1;CAZ;BEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1122;0.3562;0.8448;0.8448
+SSP1;CAZ;BEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1122;0.3562;0.8448;0.8448
+SSP1;CAZ;BEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1122;0.3562;0.8448;0.8448
+SSP1;CAZ;BEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.2818;0.6622;0.8708;0.8708
+SSP1;CAZ;Electric;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;0.09074;0.4088;0.8634;1;1
 SSP1;CAZ;Electric;HSR_tmp_vehicletype;HSR_tmp_subsectorL3;HSR_tmp_subsectorL2;HSR;trn_pass;FV;1;1;1;1;1
 SSP1;CAZ;Electric;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;1;1;1;1;1
 SSP1;CAZ;FCEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.01462;0.01933;0.03904;0.03904
-SSP1;CAZ;FCEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.03957;0.1682;0.3459;0.3459
-SSP1;CAZ;FCEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.01462;0.06381;0.2365;0.2365
-SSP1;CAZ;FCEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.01462;0.06381;0.2365;0.2365
-SSP1;CAZ;FCEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.01462;0.06381;0.2365;0.2365
-SSP1;CAZ;FCEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.03957;0.1682;0.3459;0.3459
+SSP1;CAZ;FCEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1187;0.1682;0.3459;0.3459
+SSP1;CAZ;FCEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.04386;0.06381;0.2365;0.2365
+SSP1;CAZ;FCEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.04386;0.06381;0.2365;0.2365
+SSP1;CAZ;FCEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.04386;0.06381;0.2365;0.2365
+SSP1;CAZ;FCEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1187;0.1682;0.3459;0.3459
 SSP1;CAZ;Gases;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0.03104;0.05654;0.09776;0.07689;0.07689
 SSP1;CAZ;Gases;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02632;0.07895;0.1535;0.1535
 SSP1;CAZ;Gases;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02632;0.07895;0.1535;0.1535
@@ -5731,57 +5731,57 @@ SSP1;CAZ;Liquids;International Ship_tmp_vehicletype;International Ship_tmp_subse
 SSP1;CAZ;Liquids;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;1;1;1
 SSP1;CAZ;Liquids;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;1;1;1
 SSP1;CAZ;Liquids;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;1;1;1
-SSP1;CAZ;Liquids;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;0.2746;0.2746;0.1373;0.09153;0.09153
+SSP1;CAZ;Liquids;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;0.2746;0.1831;0.1373;0.09153;0.09153
 SSP1;CAZ;Liquids;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
 SSP1;CAZ;Liquids;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
 SSP1;CAZ;Liquids;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
 SSP1;CAZ;Liquids;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
 SSP1;CAZ;Liquids;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
 SSP1;CHA;;;;;Cycle;trn_pass;S1S;0.09454;0.04412;0.03782;0.04848;0.04848
-SSP1;CHA;;;;;Domestic Aviation;trn_pass;S1S;0.12;0.02712;0.004363;0.0008393;0.0008393
+SSP1;CHA;;;;;Domestic Aviation;trn_pass;S1S;0.12;0.01;0.004363;0.0008393;0.0008393
 SSP1;CHA;;;;;Domestic Ship;trn_freight;S1S;0.01847;0.01922;0.02232;0.02232;0.02232
-SSP1;CHA;;;;;Freight Rail;trn_freight;S1S;0.03204;0.0357;0.05693;0.05693;0.05693
+SSP1;CHA;;;;;Freight Rail;trn_freight;S1S;0.03204;0.05355;0.05693;0.05693;0.05693
 SSP1;CHA;;;;;HSR;trn_pass;S1S;0.2402;0.08143;0.01916;0.003695;0.003695
 SSP1;CHA;;;;;International Aviation;trn_aviation_intl;S1S;1;1;1;1;1
 SSP1;CHA;;;;;International Ship;trn_shipping_intl;S1S;1;1;1;1;1
-SSP1;CHA;;;;;Passenger Rail;trn_pass;S1S;0.006222;0.003111;0.003734;0.001914;0.001914
-SSP1;CHA;;;;;Walk;trn_pass;S1S;1;1;1;1;1
+SSP1;CHA;;;;;Passenger Rail;trn_pass;S1S;0.006222;0.006222;0.003734;0.001914;0.001914
+SSP1;CHA;;;;;Walk;trn_pass;S1S;1;0.8;1;1;1
 SSP1;CHA;;;;;trn_freight_road;trn_freight;S1S;1;1;1;1;1
-SSP1;CHA;;;;;trn_pass_road;trn_pass;S1S;0.6711;0.2684;0.0671;0.02007;0.02007
-SSP1;CHA;;;;Bus;trn_pass_road;trn_pass;S2S1;0.6609;0.2927;0.4168;0.2895;0.2895
+SSP1;CHA;;;;;trn_pass_road;trn_pass;S1S;0.6711;0.1342;0.0671;0.02007;0.02007
+SSP1;CHA;;;;Bus;trn_pass_road;trn_pass;S2S1;0.6609;0.439;0.4168;0.2895;0.2895
 SSP1;CHA;;;;trn_pass_road_LDV;trn_pass_road;trn_pass;S2S1;1;1;1;1;1
 SSP1;CHA;;;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;0.6;0.4;0.3;0.3;0.3
 SSP1;CHA;;;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;1;1;1;1;1
-SSP1;CHA;;Compact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.8035;0.7232;1;1;1
-SSP1;CHA;;Large Car and SUV;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;1;1;0.7606;0.5992;0.5992
-SSP1;CHA;;Mini Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.01783;0.01605;0.02219;0.02218;0.02218
+SSP1;CHA;;Compact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.8035;1;1;1;1
+SSP1;CHA;;Large Car and SUV;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;1;0.9218;0.7606;0.5992;0.5992
+SSP1;CHA;;Mini Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.01783;0.02219;0.02219;0.02218;0.02218
 SSP1;CHA;;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.04044;0.04044;0.04044;0.04044;0.04044
 SSP1;CHA;;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;1;1;1;1;1
 SSP1;CHA;;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;1;1;1;1;1
-SSP1;CHA;;Subcompact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.08662;0.07795;0.1078;0.1078;0.1078
+SSP1;CHA;;Subcompact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.08662;0.1078;0.1078;0.1078;0.1078
 SSP1;CHA;;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;1;1;1;1;1
 SSP1;CHA;;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.2234;0.2234;0.2234;0.2234;0.2234
 SSP1;CHA;;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.4022;0.3352;0.3016;0.3352;0.3352
 SSP1;CHA;;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.4022;0.3352;0.3016;0.3352;0.3352
 SSP1;CHA;;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.1657;0.1657;0.1657;0.1657;0.1657
-SSP1;CHA;BEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.3019;1;1;1
-SSP1;CHA;BEV;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.6;1;1;1
-SSP1;CHA;BEV;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0.06;0.6;1;1;1
-SSP1;CHA;BEV;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.6;0;0;0
-SSP1;CHA;BEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.04002;0.745;1;1
-SSP1;CHA;BEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.01592;0.4008;1;1
-SSP1;CHA;BEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.0992;0.3358;1;1;1
-SSP1;CHA;BEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.0992;0.3358;1;1;1
-SSP1;CHA;BEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.04002;0.745;1;1
-SSP1;CHA;Electric;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;0.4553;0.5234;1;1;1
+SSP1;CHA;BEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.6038;1;1;1
+SSP1;CHA;BEV;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;1;1;1;1
+SSP1;CHA;BEV;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0.06;1;1;1;1
+SSP1;CHA;BEV;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0;0;0;0
+SSP1;CHA;BEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.08004;0.745;1;1
+SSP1;CHA;BEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.03184;0.4008;1;1
+SSP1;CHA;BEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.0992;0.6716;1;1;1
+SSP1;CHA;BEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.0992;0.6716;1;1;1
+SSP1;CHA;BEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.08004;0.745;1;1
+SSP1;CHA;Electric;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;0.4553;1;1;1;1
 SSP1;CHA;Electric;HSR_tmp_vehicletype;HSR_tmp_subsectorL3;HSR_tmp_subsectorL2;HSR;trn_pass;FV;1;1;1;1;1
-SSP1;CHA;Electric;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;0.4158;0.4888;1;1;1
+SSP1;CHA;Electric;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;0.4158;0.7332;1;1;1
 SSP1;CHA;FCEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.02024;0.04777;0.03499;0.03499
-SSP1;CHA;FCEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.001124;0.05139;0.2481;0.2481
-SSP1;CHA;FCEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.0004151;0.01949;0.175;0.175
-SSP1;CHA;FCEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.00992;0.1679;0.7272;0.3333;0.3333
-SSP1;CHA;FCEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.00992;0.1679;0.7272;0.3333;0.3333
-SSP1;CHA;FCEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.001124;0.05139;0.2481;0.2481
+SSP1;CHA;FCEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.003372;0.05139;0.2481;0.2481
+SSP1;CHA;FCEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.001245;0.01949;0.175;0.175
+SSP1;CHA;FCEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.00992;0.5037;0.7272;0.3333;0.3333
+SSP1;CHA;FCEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.00992;0.5037;0.7272;0.3333;0.3333
+SSP1;CHA;FCEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.003372;0.05139;0.2481;0.2481
 SSP1;CHA;Gases;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0.1421;0.1329;0.05905;0.05275;0.05275
 SSP1;CHA;Gases;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1.71E-05;0.01014;0.03814;0.04776;0.04776
 SSP1;CHA;Gases;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.000714;0.0111;0.03928;0.04979;0.04979
@@ -5792,11 +5792,11 @@ SSP1;CHA;Hydrogen;Domestic Aviation_tmp_vehicletype;Domestic Aviation_tmp_subsec
 SSP1;CHA;Liquids;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;1;1;0.4868;0.1764;0.1764
 SSP1;CHA;Liquids;Domestic Aviation_tmp_vehicletype;Domestic Aviation_tmp_subsectorL3;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;trn_pass;FV;1;1;1;1;1
 SSP1;CHA;Liquids;Domestic Ship_tmp_vehicletype;Domestic Ship_tmp_subsectorL3;Domestic Ship_tmp_subsectorL2;Domestic Ship;trn_freight;FV;1;1;1;1;1
-SSP1;CHA;Liquids;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;1;1;0.7582;0.5365;0.5365
+SSP1;CHA;Liquids;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;1;0.9553;0.7582;0.5365;0.5365
 SSP1;CHA;Liquids;International Aviation_tmp_vehicletype;International Aviation_tmp_subsectorL3;International Aviation_tmp_subsectorL2;International Aviation;trn_aviation_intl;FV;1;1;1;1;1
 SSP1;CHA;Liquids;International Ship_tmp_vehicletype;International Ship_tmp_subsectorL3;International Ship_tmp_subsectorL2;International Ship;trn_shipping_intl;FV;1;1;1;1;1
-SSP1;CHA;Liquids;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;0.4167;0.3402;0.3402
-SSP1;CHA;Liquids;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;0.4167;0.3402;0.3402
+SSP1;CHA;Liquids;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;0.8333;0.4167;0.3402;0.3402
+SSP1;CHA;Liquids;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;0.8333;0.4167;0.3402;0.3402
 SSP1;CHA;Liquids;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;1;1;1
 SSP1;CHA;Liquids;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;1;1;0.7875;0.3596;0.3596
 SSP1;CHA;Liquids;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;0.5703;0.5703
@@ -5804,51 +5804,51 @@ SSP1;CHA;Liquids;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_t
 SSP1;CHA;Liquids;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;0.6711;0.56;0.56
 SSP1;CHA;Liquids;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;0.6711;0.56;0.56
 SSP1;CHA;Liquids;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;0.5703;0.5703
-SSP1;DEU;;;;;Cycle;trn_pass;S1S;0.042;0.05;0.025;0.1875;0.1875
-SSP1;DEU;;;;;Domestic Aviation;trn_pass;S1S;6.6E-05;6.2E-05;1.49E-05;1.49E-05;1.49E-05
-SSP1;DEU;;;;;Domestic Ship;trn_freight;S1S;0.004;0.004;0.002127;0.002127;0.002127
-SSP1;DEU;;;;;Freight Rail;trn_freight;S1S;0.032;0.032;0.042;0.042;0.042
-SSP1;DEU;;;;;HSR;trn_pass;S1S;0.00018;0.0002;0.000625;0.000625;0.000625
+SSP1;DEU;;;;;Cycle;trn_pass;S1S;0.042;0.025;0.025;0.1875;0.1875
+SSP1;DEU;;;;;Domestic Aviation;trn_pass;S1S;6.6E-05;2E-05;1.49E-05;1.49E-05;1.49E-05
+SSP1;DEU;;;;;Domestic Ship;trn_freight;S1S;0.004;0.002127;0.002127;0.002127;0.002127
+SSP1;DEU;;;;;Freight Rail;trn_freight;S1S;0.032;0.042;0.042;0.042;0.042
+SSP1;DEU;;;;;HSR;trn_pass;S1S;0.00018;0.00025;0.000625;0.000625;0.000625
 SSP1;DEU;;;;;International Aviation;trn_aviation_intl;S1S;1;1;1;1;1
 SSP1;DEU;;;;;International Ship;trn_shipping_intl;S1S;1;1;1;1;1
-SSP1;DEU;;;;;Passenger Rail;trn_pass;S1S;0.0032;0.004;0.0075;0.0075;0.0075
-SSP1;DEU;;;;;Walk;trn_pass;S1S;1;1;1;1;1
-SSP1;DEU;;;;;trn_freight_road;trn_freight;S1S;0.94;0.94;1;1;1
-SSP1;DEU;;;;;trn_pass_road;trn_pass;S1S;0.0725;0.0725;0.03682;0.03682;0.03682
-SSP1;DEU;;;;Bus;trn_pass_road;trn_pass;S2S1;0.04;0.06;0.1222;0.2292;0.2292
+SSP1;DEU;;;;;Passenger Rail;trn_pass;S1S;0.0032;0.0075;0.0075;0.0075;0.0075
+SSP1;DEU;;;;;Walk;trn_pass;S1S;1;0.8;1;1;1
+SSP1;DEU;;;;;trn_freight_road;trn_freight;S1S;0.94;1;1;1;1
+SSP1;DEU;;;;;trn_pass_road;trn_pass;S1S;0.0725;0.03682;0.03682;0.03682;0.03682
+SSP1;DEU;;;;Bus;trn_pass_road;trn_pass;S2S1;0.04;0.1222;0.1222;0.2292;0.2292
 SSP1;DEU;;;;trn_pass_road_LDV;trn_pass_road;trn_pass;S2S1;1;1;1;1;1
 SSP1;DEU;;;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;0.06;0.06;0.06;0.06;0.06
 SSP1;DEU;;;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;1;1;1;1;1
-SSP1;DEU;;Compact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.5249;0.5249;0.9448;0.9836;0.9836
+SSP1;DEU;;Compact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.5249;0.7873;0.9448;0.9836;0.9836
 SSP1;DEU;;Large Car and SUV;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;1;1;1;0.694;0.694
 SSP1;DEU;;Midsize Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.2716;0.2716;0.2716;0.1885;0.1885
 SSP1;DEU;;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.2183;0.2183;0.2183;0.2183;0.2183
 SSP1;DEU;;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.00663;0.00663;0.00663;0.00663;0.00663
 SSP1;DEU;;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;1;1;1;1;1
-SSP1;DEU;;Subcompact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.5337;0.5337;0.9606;1;1
+SSP1;DEU;;Subcompact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.5337;0.8005;0.9606;1;1
 SSP1;DEU;;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;1;1;1;1;1
 SSP1;DEU;;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.1873;0.1873;0.1873;0.1873;0.1873
 SSP1;DEU;;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.257;0.257;0.257;0.257;0.257
 SSP1;DEU;;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.8568;0.8568;0.8568;0.8568;0.8568
 SSP1;DEU;;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.4959;0.4959;0.4959;0.4959;0.4959
-SSP1;DEU;BEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.1294;0.7338;1;1
-SSP1;DEU;BEV;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.02;0.5;0.9;0.9
-SSP1;DEU;BEV;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.02;0.5;0.9;0.9
-SSP1;DEU;BEV;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.02;0.5;0.9;0.9
-SSP1;DEU;BEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.3524;1;1;1
-SSP1;DEU;BEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1402;0.7298;1;1
-SSP1;DEU;BEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1402;0.7298;1;1
-SSP1;DEU;BEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1402;0.7298;1;1
-SSP1;DEU;BEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.3524;1;1;1
+SSP1;DEU;BEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.2588;0.7338;1;1
+SSP1;DEU;BEV;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.04;0.5;0.9;0.9
+SSP1;DEU;BEV;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.04;0.5;0.9;0.9
+SSP1;DEU;BEV;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.04;0.5;0.9;0.9
+SSP1;DEU;BEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.7048;1;1;1
+SSP1;DEU;BEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.2804;0.7298;1;1
+SSP1;DEU;BEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.2804;0.7298;1;1
+SSP1;DEU;BEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.2804;0.7298;1;1
+SSP1;DEU;BEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.7048;1;1;1
 SSP1;DEU;Electric;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;1;1;1;1;1
 SSP1;DEU;Electric;HSR_tmp_vehicletype;HSR_tmp_subsectorL3;HSR_tmp_subsectorL2;HSR;trn_pass;FV;1;1;1;1;1
 SSP1;DEU;Electric;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;1;1;1;1;1
 SSP1;DEU;FCEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.002249;0.01636;0.02916;0.02916
-SSP1;DEU;FCEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.09497;0.8679;0.3164;0.3164
-SSP1;DEU;FCEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.03508;0.4467;0.2232;0.2232
-SSP1;DEU;FCEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.03508;0.4467;0.2232;0.2232
-SSP1;DEU;FCEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.03508;0.4467;0.2232;0.2232
-SSP1;DEU;FCEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.09497;0.8679;0.3164;0.3164
+SSP1;DEU;FCEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.2849;0.8679;0.3164;0.3164
+SSP1;DEU;FCEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1052;0.4467;0.2232;0.2232
+SSP1;DEU;FCEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1052;0.4467;0.2232;0.2232
+SSP1;DEU;FCEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1052;0.4467;0.2232;0.2232
+SSP1;DEU;FCEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.2849;0.8679;0.3164;0.3164
 SSP1;DEU;Gases;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0.03948;0.04981;0.0887;0.08541;0.08541
 SSP1;DEU;Gases;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.02615;0.04142;0.07591;0.09835;0.09835
 SSP1;DEU;Gases;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02105;0.07895;0.09085;0.09085
@@ -5859,63 +5859,63 @@ SSP1;DEU;Hydrogen;Domestic Aviation_tmp_vehicletype;Domestic Aviation_tmp_subsec
 SSP1;DEU;Liquids;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;1;1;1;0.6412;0.6412
 SSP1;DEU;Liquids;Domestic Aviation_tmp_vehicletype;Domestic Aviation_tmp_subsectorL3;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;trn_pass;FV;1;1;1;1;1
 SSP1;DEU;Liquids;Domestic Ship_tmp_vehicletype;Domestic Ship_tmp_subsectorL3;Domestic Ship_tmp_subsectorL2;Domestic Ship;trn_freight;FV;1;1;1;1;1
-SSP1;DEU;Liquids;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;0.2523;0.2523;0.1262;0.1262;0.1262
+SSP1;DEU;Liquids;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;0.2523;0.1262;0.1262;0.1262;0.1262
 SSP1;DEU;Liquids;International Aviation_tmp_vehicletype;International Aviation_tmp_subsectorL3;International Aviation_tmp_subsectorL2;International Aviation;trn_aviation_intl;FV;1;1;1;1;1
 SSP1;DEU;Liquids;International Ship_tmp_vehicletype;International Ship_tmp_subsectorL3;International Ship_tmp_subsectorL2;International Ship;trn_shipping_intl;FV;1;1;1;1;1
 SSP1;DEU;Liquids;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;1;1;1
 SSP1;DEU;Liquids;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;1;1;1
 SSP1;DEU;Liquids;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;1;1;1
-SSP1;DEU;Liquids;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;0.05386;0.05386;0.02693;0.01795;0.01795
+SSP1;DEU;Liquids;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;0.05386;0.03591;0.02693;0.01795;0.01795
 SSP1;DEU;Liquids;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;0.737;0.5741;0.5741
 SSP1;DEU;Liquids;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;0.5919;0.5919
 SSP1;DEU;Liquids;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;0.5919;0.5919
 SSP1;DEU;Liquids;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;0.5919;0.5919
 SSP1;DEU;Liquids;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;0.737;0.5741;0.5741
 SSP1;ECE;;;;;Cycle;trn_pass;S1S;0.01942;0.01942;0.09709;0.1092;0.1092
-SSP1;ECE;;;;;Domestic Aviation;trn_pass;S1S;6.98E-05;6.98E-05;1.75E-05;4.91E-06;4.91E-06
+SSP1;ECE;;;;;Domestic Aviation;trn_pass;S1S;6.98E-05;1.75E-05;1.75E-05;4.91E-06;4.91E-06
 SSP1;ECE;;;;;Domestic Ship;trn_freight;S1S;0.0003966;0.0003966;0.0003966;0.0003966;0.0003966
-SSP1;ECE;;;;;Freight Rail;trn_freight;S1S;0.06019;0.06019;0.08125;0.08125;0.08125
+SSP1;ECE;;;;;Freight Rail;trn_freight;S1S;0.06019;0.09029;0.08125;0.08125;0.08125
 SSP1;ECE;;;;;HSR;trn_pass;S1S;0.0001139;0.0001708;0.0004555;0.0003202;0.0003202
 SSP1;ECE;;;;;International Aviation;trn_aviation_intl;S1S;1;1;1;1;1
 SSP1;ECE;;;;;International Ship;trn_shipping_intl;S1S;1;1;1;1;1
-SSP1;ECE;;;;;Passenger Rail;trn_pass;S1S;0.006799;0.006799;0.01813;0.007648;0.007648
-SSP1;ECE;;;;;Walk;trn_pass;S1S;1;1;1;1;1
+SSP1;ECE;;;;;Passenger Rail;trn_pass;S1S;0.006799;0.0136;0.01813;0.007648;0.007648
+SSP1;ECE;;;;;Walk;trn_pass;S1S;1;0.8;1;1;1
 SSP1;ECE;;;;;trn_freight_road;trn_freight;S1S;1;1;1;1;1
-SSP1;ECE;;;;;trn_pass_road;trn_pass;S1S;0.6166;0.6166;0.2467;0.0634;0.0634
-SSP1;ECE;;;;Bus;trn_pass_road;trn_pass;S2S1;0.2712;0.2543;0.2203;0.1695;0.1695
+SSP1;ECE;;;;;trn_pass_road;trn_pass;S1S;0.6166;0.3083;0.2467;0.0634;0.0634
+SSP1;ECE;;;;Bus;trn_pass_road;trn_pass;S2S1;0.2712;0.3815;0.2203;0.1695;0.1695
 SSP1;ECE;;;;trn_pass_road_LDV;trn_pass_road;trn_pass;S2S1;1;1;1;1;1
 SSP1;ECE;;;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;0.02;0.02;0.02;0.02;0.02
 SSP1;ECE;;;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;1;1;1;1;1
-SSP1;ECE;;Compact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.4706;0.4706;0.7369;0.7369;0.7369
+SSP1;ECE;;Compact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.4706;0.7059;0.7369;0.7369;0.7369
 SSP1;ECE;;Large Car and SUV;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.7825;0.7825;0.6266;0.4456;0.4456
 SSP1;ECE;;Midsize Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;1;1;0.8008;0.5694;0.5694
 SSP1;ECE;;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.05321;0.05321;0.05321;0.05321;0.05321
 SSP1;ECE;;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.0004728;0.0004728;0.0004728;0.0004728;0.0004728
 SSP1;ECE;;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;1;1;1;1;1
-SSP1;ECE;;Subcompact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.6386;0.6386;1;1;1
+SSP1;ECE;;Subcompact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.6386;0.9579;1;1;1
 SSP1;ECE;;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.6161;0.6161;0.6161;0.6161;0.6161
 SSP1;ECE;;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.1384;0.1384;0.1384;0.1384;0.1384
 SSP1;ECE;;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.137;0.137;0.137;0.137;0.137
 SSP1;ECE;;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.1691;0.1691;0.1691;0.1691;0.1691
 SSP1;ECE;;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;1;1;1;1;1
-SSP1;ECE;BEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.1553;1;1;1
-SSP1;ECE;BEV;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.04;0.38;0.86;0.86
-SSP1;ECE;BEV;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.04;0.38;0.86;0.86
-SSP1;ECE;BEV;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.04;0.38;0.86;0.86
-SSP1;ECE;BEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.06504;0.291;0.5572;0.5572
-SSP1;ECE;BEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02588;0.1565;0.5406;0.5406
-SSP1;ECE;BEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02588;0.1565;0.5406;0.5406
-SSP1;ECE;BEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02588;0.1565;0.5406;0.5406
-SSP1;ECE;BEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.06504;0.291;0.5572;0.5572
+SSP1;ECE;BEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.3106;1;1;1
+SSP1;ECE;BEV;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.08;0.38;0.86;0.86
+SSP1;ECE;BEV;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.08;0.38;0.86;0.86
+SSP1;ECE;BEV;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.08;0.38;0.86;0.86
+SSP1;ECE;BEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1301;0.291;0.5572;0.5572
+SSP1;ECE;BEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.05176;0.1565;0.5406;0.5406
+SSP1;ECE;BEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.05176;0.1565;0.5406;0.5406
+SSP1;ECE;BEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.05176;0.1565;0.5406;0.5406
+SSP1;ECE;BEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1301;0.291;0.5572;0.5572
 SSP1;ECE;Electric;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;1;1;1;1;1
 SSP1;ECE;Electric;HSR_tmp_vehicletype;HSR_tmp_subsectorL3;HSR_tmp_subsectorL2;HSR;trn_pass;FV;1;1;1;1;1
 SSP1;ECE;Electric;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;1;1;1;1;1
 SSP1;ECE;FCEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.01349;0.01858;0.04374;0.04374
-SSP1;ECE;FCEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.01461;0.1725;0.1915;0.1915
-SSP1;ECE;FCEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.005396;0.06543;0.131;0.131
-SSP1;ECE;FCEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.005396;0.06543;0.131;0.131
-SSP1;ECE;FCEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.005396;0.06543;0.131;0.131
-SSP1;ECE;FCEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.01461;0.1725;0.1915;0.1915
+SSP1;ECE;FCEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.04383;0.1725;0.1915;0.1915
+SSP1;ECE;FCEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.01619;0.06543;0.131;0.131
+SSP1;ECE;FCEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.01619;0.06543;0.131;0.131
+SSP1;ECE;FCEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.01619;0.06543;0.131;0.131
+SSP1;ECE;FCEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.04383;0.1725;0.1915;0.1915
 SSP1;ECE;Gases;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0.01;0.02;0.06625;0.045;0.045
 SSP1;ECE;Gases;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.05;0.1111;0.1867;0.1867
 SSP1;ECE;Gases;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.05;0.1111;0.1867;0.1867
@@ -5926,63 +5926,63 @@ SSP1;ECE;Hydrogen;Domestic Aviation_tmp_vehicletype;Domestic Aviation_tmp_subsec
 SSP1;ECE;Liquids;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;1;1;0.9464;0.4008;0.4008
 SSP1;ECE;Liquids;Domestic Aviation_tmp_vehicletype;Domestic Aviation_tmp_subsectorL3;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;trn_pass;FV;1;1;1;1;1
 SSP1;ECE;Liquids;Domestic Ship_tmp_vehicletype;Domestic Ship_tmp_subsectorL3;Domestic Ship_tmp_subsectorL2;Domestic Ship;trn_freight;FV;1;1;1;1;1
-SSP1;ECE;Liquids;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;0.587;0.587;0.2935;0.2935;0.2935
+SSP1;ECE;Liquids;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;0.587;0.2935;0.2935;0.2935;0.2935
 SSP1;ECE;Liquids;International Aviation_tmp_vehicletype;International Aviation_tmp_subsectorL3;International Aviation_tmp_subsectorL2;International Aviation;trn_aviation_intl;FV;1;1;1;1;1
 SSP1;ECE;Liquids;International Ship_tmp_vehicletype;International Ship_tmp_subsectorL3;International Ship_tmp_subsectorL2;International Ship;trn_shipping_intl;FV;1;1;1;1;1
 SSP1;ECE;Liquids;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;1;1;1
 SSP1;ECE;Liquids;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;1;1;1
 SSP1;ECE;Liquids;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;1;1;1
-SSP1;ECE;Liquids;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;0.1453;0.1453;0.07265;0.04843;0.04843
+SSP1;ECE;Liquids;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;0.1453;0.09687;0.07265;0.04843;0.04843
 SSP1;ECE;Liquids;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
 SSP1;ECE;Liquids;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
 SSP1;ECE;Liquids;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
 SSP1;ECE;Liquids;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
 SSP1;ECE;Liquids;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
 SSP1;ECS;;;;;Cycle;trn_pass;S1S;0.01092;0.03277;0.1311;0.08738;0.08738
-SSP1;ECS;;;;;Domestic Aviation;trn_pass;S1S;0.003717;0.003717;0.0009292;9.29E-05;9.29E-05
+SSP1;ECS;;;;;Domestic Aviation;trn_pass;S1S;0.003717;0.0009292;0.0009292;9.29E-05;9.29E-05
 SSP1;ECS;;;;;Domestic Ship;trn_freight;S1S;0.00395;0.00395;0.003591;0.00395;0.00395
-SSP1;ECS;;;;;Freight Rail;trn_freight;S1S;0.05976;0.05976;0.08149;0.08069;0.08069
+SSP1;ECS;;;;;Freight Rail;trn_freight;S1S;0.05976;0.08964;0.08149;0.08069;0.08069
 SSP1;ECS;;;;;HSR;trn_pass;S1S;0.0002969;0.0002969;0.0007917;0.0004;0.0004
 SSP1;ECS;;;;;International Aviation;trn_aviation_intl;S1S;1;1;1;1;1
 SSP1;ECS;;;;;International Ship;trn_shipping_intl;S1S;1;1;1;1;1
-SSP1;ECS;;;;;Passenger Rail;trn_pass;S1S;0.007915;0.01055;0.02638;0.005276;0.005276
-SSP1;ECS;;;;;Walk;trn_pass;S1S;1;1;1;1;1
+SSP1;ECS;;;;;Passenger Rail;trn_pass;S1S;0.007915;0.0211;0.02638;0.005276;0.005276
+SSP1;ECS;;;;;Walk;trn_pass;S1S;1;0.8;1;1;1
 SSP1;ECS;;;;;trn_freight_road;trn_freight;S1S;1;1;1;1;1
-SSP1;ECS;;;;;trn_pass_road;trn_pass;S1S;0.7451;0.7451;0.3725;0.04471;0.04471
-SSP1;ECS;;;;Bus;trn_pass_road;trn_pass;S2S1;0.209;0.1742;0.1829;0.1568;0.1568
+SSP1;ECS;;;;;trn_pass_road;trn_pass;S1S;0.7451;0.3725;0.3725;0.04471;0.04471
+SSP1;ECS;;;;Bus;trn_pass_road;trn_pass;S2S1;0.209;0.2613;0.1829;0.1568;0.1568
 SSP1;ECS;;;;trn_pass_road_LDV;trn_pass_road;trn_pass;S2S1;1;1;1;1;1
 SSP1;ECS;;;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;0.01;0.01;0.01;0.01;0.01
 SSP1;ECS;;;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;1;1;1;1;1
-SSP1;ECS;;Compact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.5004;0.5004;0.5117;0.5116;0.5116
-SSP1;ECS;;Large Car and SUV;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;1;1;0.5112;0.3749;0.3749
-SSP1;ECS;;Midsize Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.9609;0.9609;0.4913;0.3603;0.3603
+SSP1;ECS;;Compact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.5004;0.5117;0.5117;0.5116;0.5116
+SSP1;ECS;;Large Car and SUV;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;1;0.6817;0.5112;0.3749;0.3749
+SSP1;ECS;;Midsize Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.9609;0.655;0.4913;0.3603;0.3603
 SSP1;ECS;;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.1125;0.1125;0.1125;0.1125;0.1125
 SSP1;ECS;;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.03579;0.03579;0.03579;0.03579;0.03579
 SSP1;ECS;;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;1;1;1;1;1
-SSP1;ECS;;Subcompact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.978;0.978;1;1;1
+SSP1;ECS;;Subcompact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.978;1;1;1;1
 SSP1;ECS;;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;1;1;1;1;1
 SSP1;ECS;;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.2555;0.2555;0.2555;0.2555;0.2555
 SSP1;ECS;;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.3104;0.3104;0.3104;0.3104;0.3104
 SSP1;ECS;;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.1282;0.1282;0.1282;0.1282;0.1282
 SSP1;ECS;;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.4409;0.4409;0.4409;0.4409;0.4409
-SSP1;ECS;BEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.09315;0.763;1;1
-SSP1;ECS;BEV;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.032;0.384;0.84;0.84
-SSP1;ECS;BEV;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.032;0.384;0.84;0.84
-SSP1;ECS;BEV;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.032;0.384;0.84;0.84
-SSP1;ECS;BEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1041;0.4364;0.5786;0.5786
-SSP1;ECS;BEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.0414;0.2348;0.5614;0.5614
-SSP1;ECS;BEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.0414;0.2348;0.5614;0.5614
-SSP1;ECS;BEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.0414;0.2348;0.5614;0.5614
-SSP1;ECS;BEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1041;0.4364;0.5786;0.5786
+SSP1;ECS;BEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.1863;0.763;1;1
+SSP1;ECS;BEV;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.064;0.384;0.84;0.84
+SSP1;ECS;BEV;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.064;0.384;0.84;0.84
+SSP1;ECS;BEV;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.064;0.384;0.84;0.84
+SSP1;ECS;BEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.2082;0.4364;0.5786;0.5786
+SSP1;ECS;BEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.0828;0.2348;0.5614;0.5614
+SSP1;ECS;BEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.0828;0.2348;0.5614;0.5614
+SSP1;ECS;BEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.0828;0.2348;0.5614;0.5614
+SSP1;ECS;BEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.2082;0.4364;0.5786;0.5786
 SSP1;ECS;Electric;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;1;1;1;1;1
 SSP1;ECS;Electric;HSR_tmp_vehicletype;HSR_tmp_subsectorL3;HSR_tmp_subsectorL2;HSR;trn_pass;FV;1;1;1;1;1
 SSP1;ECS;Electric;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;1;1;1;1;1
 SSP1;ECS;FCEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.002698;0.0736;0.06479;0.06479
-SSP1;ECS;FCEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.01461;0.207;0.2393;0.2393
-SSP1;ECS;FCEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.005396;0.07851;0.1637;0.1637
-SSP1;ECS;FCEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.005396;0.07851;0.1637;0.1637
-SSP1;ECS;FCEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.005396;0.07851;0.1637;0.1637
-SSP1;ECS;FCEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.01461;0.207;0.2393;0.2393
+SSP1;ECS;FCEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.04383;0.207;0.2393;0.2393
+SSP1;ECS;FCEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.01619;0.07851;0.1637;0.1637
+SSP1;ECS;FCEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.01619;0.07851;0.1637;0.1637
+SSP1;ECS;FCEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.01619;0.07851;0.1637;0.1637
+SSP1;ECS;FCEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.04383;0.207;0.2393;0.2393
 SSP1;ECS;Gases;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0.01;0.02;0.0625;0.05938;0.05938
 SSP1;ECS;Gases;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1E-05;0.013;0.06667;0.14;0.14
 SSP1;ECS;Gases;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1E-05;0.013;0.06667;0.14;0.14
@@ -5993,65 +5993,65 @@ SSP1;ECS;Hydrogen;Domestic Aviation_tmp_vehicletype;Domestic Aviation_tmp_subsec
 SSP1;ECS;Liquids;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;1;1;1;0.5938;0.5938
 SSP1;ECS;Liquids;Domestic Aviation_tmp_vehicletype;Domestic Aviation_tmp_subsectorL3;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;trn_pass;FV;1;1;1;1;1
 SSP1;ECS;Liquids;Domestic Ship_tmp_vehicletype;Domestic Ship_tmp_subsectorL3;Domestic Ship_tmp_subsectorL2;Domestic Ship;trn_freight;FV;1;1;1;1;1
-SSP1;ECS;Liquids;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;0.6302;0.6302;0.3151;0.3151;0.3151
+SSP1;ECS;Liquids;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;0.6302;0.3151;0.3151;0.3151;0.3151
 SSP1;ECS;Liquids;International Aviation_tmp_vehicletype;International Aviation_tmp_subsectorL3;International Aviation_tmp_subsectorL2;International Aviation;trn_aviation_intl;FV;1;1;1;1;1
 SSP1;ECS;Liquids;International Ship_tmp_vehicletype;International Ship_tmp_subsectorL3;International Ship_tmp_subsectorL2;International Ship;trn_shipping_intl;FV;1;1;1;1;1
 SSP1;ECS;Liquids;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;1;1;1
 SSP1;ECS;Liquids;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;1;1;1
 SSP1;ECS;Liquids;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;1;1;1
-SSP1;ECS;Liquids;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;0.2298;0.2298;0.1149;0.0766;0.0766
+SSP1;ECS;Liquids;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;0.2298;0.1532;0.1149;0.0766;0.0766
 SSP1;ECS;Liquids;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
 SSP1;ECS;Liquids;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
 SSP1;ECS;Liquids;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
 SSP1;ECS;Liquids;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
 SSP1;ECS;Liquids;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
 SSP1;ENC;;;;;Cycle;trn_pass;S1S;0.025;0.025;0.05556;0.1;0.1
-SSP1;ENC;;;;;Domestic Aviation;trn_pass;S1S;5.97E-05;5.97E-05;1.33E-05;5.97E-06;5.97E-06
+SSP1;ENC;;;;;Domestic Aviation;trn_pass;S1S;5.97E-05;2E-05;1.33E-05;5.97E-06;5.97E-06
 SSP1;ENC;;;;;Domestic Ship;trn_freight;S1S;0.01246;0.01246;0.01246;0.01246;0.01246
-SSP1;ENC;;;;;Freight Rail;trn_freight;S1S;0.02928;0.02928;0.04392;0.04392;0.04392
+SSP1;ENC;;;;;Freight Rail;trn_freight;S1S;0.02928;0.04392;0.04392;0.04392;0.04392
 SSP1;ENC;;;;;HSR;trn_pass;S1S;0.000125;0.00025;0.0002222;0.0002;0.0002
 SSP1;ENC;;;;;International Aviation;trn_aviation_intl;S1S;1;1;1;1;1
 SSP1;ENC;;;;;International Ship;trn_shipping_intl;S1S;1;1;1;1;1
-SSP1;ENC;;;;;Passenger Rail;trn_pass;S1S;0.003125;0.003125;0.006666;0.004;0.004
-SSP1;ENC;;;;;Walk;trn_pass;S1S;1;1;1;1;1
+SSP1;ENC;;;;;Passenger Rail;trn_pass;S1S;0.003125;0.00625;0.006666;0.004;0.004
+SSP1;ENC;;;;;Walk;trn_pass;S1S;1;0.8;1;1;1
 SSP1;ENC;;;;;trn_freight_road;trn_freight;S1S;1;1;1;1;1
-SSP1;ENC;;;;;trn_pass_road;trn_pass;S1S;0.07363;0.07363;0.03272;0.01473;0.01473
-SSP1;ENC;;;;Bus;trn_pass_road;trn_pass;S2S1;0.2037;0.1528;0.2292;0.2292;0.2292
+SSP1;ENC;;;;;trn_pass_road;trn_pass;S1S;0.07363;0.03682;0.03272;0.01473;0.01473
+SSP1;ENC;;;;Bus;trn_pass_road;trn_pass;S2S1;0.2037;0.2292;0.2292;0.2292;0.2292
 SSP1;ENC;;;;trn_pass_road_LDV;trn_pass_road;trn_pass;S2S1;1;1;1;1;1
 SSP1;ENC;;;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;0.06;0.06;0.06;0.06;0.06
 SSP1;ENC;;;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;1;1;1;1;1
-SSP1;ENC;;Compact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.3955;0.3955;0.791;1;1
+SSP1;ENC;;Compact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.3955;0.5933;0.791;1;1
 SSP1;ENC;;Large Car and SUV;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;1;1;1;0.9366;0.9366
 SSP1;ENC;;Midsize Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.196;0.196;0.196;0.1836;0.1836
-SSP1;ENC;;Mini Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;2.62E-07;2.62E-07;5.24E-07;6.62E-07;6.62E-07
+SSP1;ENC;;Mini Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;2.62E-07;3.93E-07;5.24E-07;6.62E-07;6.62E-07
 SSP1;ENC;;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.1576;0.1576;0.1576;0.1576;0.1576
 SSP1;ENC;;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.03751;0.03751;0.03751;0.03751;0.03751
 SSP1;ENC;;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;1;1;1;1;1
-SSP1;ENC;;Subcompact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.2181;0.2181;0.4362;0.5516;0.5516
+SSP1;ENC;;Subcompact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.2181;0.3271;0.4362;0.5516;0.5516
 SSP1;ENC;;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;1;1;1;1;1
 SSP1;ENC;;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.1002;0.1002;0.1002;0.1002;0.1002
 SSP1;ENC;;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.3593;0.3593;0.3593;0.3593;0.3593
 SSP1;ENC;;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.4374;0.4374;0.4374;0.4374;0.4374
 SSP1;ENC;;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.4946;0.4946;0.4946;0.4946;0.4946
 SSP1;ENC;;Van;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.001049;0.001049;0.001049;0.0009825;0.0009825
-SSP1;ENC;BEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.2157;1;1;1
-SSP1;ENC;BEV;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.05;0.46;1;1
-SSP1;ENC;BEV;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.05;0.46;1;1
-SSP1;ENC;BEV;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.05;0.46;1;1
-SSP1;ENC;BEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.3101;1;1;1
-SSP1;ENC;BEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1234;0.6868;1;1
-SSP1;ENC;BEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1234;0.6868;1;1
-SSP1;ENC;BEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1234;0.6868;1;1
-SSP1;ENC;BEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.3101;1;1;1
+SSP1;ENC;BEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.4314;1;1;1
+SSP1;ENC;BEV;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.1;0.46;1;1
+SSP1;ENC;BEV;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.1;0.46;1;1
+SSP1;ENC;BEV;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.1;0.46;1;1
+SSP1;ENC;BEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.6202;1;1;1
+SSP1;ENC;BEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.2468;0.6868;1;1
+SSP1;ENC;BEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.2468;0.6868;1;1
+SSP1;ENC;BEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.2468;0.6868;1;1
+SSP1;ENC;BEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.6202;1;1;1
 SSP1;ENC;Electric;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;1;1;1;1;1
 SSP1;ENC;Electric;HSR_tmp_vehicletype;HSR_tmp_subsectorL3;HSR_tmp_subsectorL2;HSR;trn_pass;FV;1;1;1;1;1
 SSP1;ENC;Electric;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;1;1;1;1;1
 SSP1;ENC;FCEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.01124;0.04013;0.05105;0.05105
-SSP1;ENC;FCEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.07914;0.6586;0.2792;0.2792
-SSP1;ENC;FCEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02924;0.3189;0.1969;0.1969
-SSP1;ENC;FCEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02924;0.3189;0.1969;0.1969
-SSP1;ENC;FCEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02924;0.3189;0.1969;0.1969
-SSP1;ENC;FCEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.07914;0.6586;0.2792;0.2792
+SSP1;ENC;FCEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.2374;0.6586;0.2792;0.2792
+SSP1;ENC;FCEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.08772;0.3189;0.1969;0.1969
+SSP1;ENC;FCEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.08772;0.3189;0.1969;0.1969
+SSP1;ENC;FCEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.08772;0.3189;0.1969;0.1969
+SSP1;ENC;FCEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.2374;0.6586;0.2792;0.2792
 SSP1;ENC;Gases;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0.02533;0.03921;0.06433;0.05055;0.05055
 SSP1;ENC;Gases;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02632;0.06181;0.09915;0.09915
 SSP1;ENC;Gases;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02632;0.07895;0.1022;0.1022
@@ -6062,36 +6062,36 @@ SSP1;ENC;Hydrogen;Domestic Aviation_tmp_vehicletype;Domestic Aviation_tmp_subsec
 SSP1;ENC;Liquids;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;1;1;0.6919;0.2713;0.2713
 SSP1;ENC;Liquids;Domestic Aviation_tmp_vehicletype;Domestic Aviation_tmp_subsectorL3;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;trn_pass;FV;1;1;1;1;1
 SSP1;ENC;Liquids;Domestic Ship_tmp_vehicletype;Domestic Ship_tmp_subsectorL3;Domestic Ship_tmp_subsectorL2;Domestic Ship;trn_freight;FV;1;1;1;1;1
-SSP1;ENC;Liquids;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;0.1341;0.1341;0.06705;0.06705;0.06705
+SSP1;ENC;Liquids;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;0.1341;0.06705;0.06705;0.06705;0.06705
 SSP1;ENC;Liquids;International Aviation_tmp_vehicletype;International Aviation_tmp_subsectorL3;International Aviation_tmp_subsectorL2;International Aviation;trn_aviation_intl;FV;1;1;1;1;1
 SSP1;ENC;Liquids;International Ship_tmp_vehicletype;International Ship_tmp_subsectorL3;International Ship_tmp_subsectorL2;International Ship;trn_shipping_intl;FV;1;1;1;1;1
 SSP1;ENC;Liquids;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;1;1;1
 SSP1;ENC;Liquids;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;1;1;1
 SSP1;ENC;Liquids;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;1;1;1
-SSP1;ENC;Liquids;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;0.1258;0.1258;0.0629;0.04193;0.04193
+SSP1;ENC;Liquids;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;0.1258;0.08387;0.0629;0.04193;0.04193
 SSP1;ENC;Liquids;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;0.783;0.5383;0.5383
 SSP1;ENC;Liquids;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;0.5549;0.5549
 SSP1;ENC;Liquids;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;0.5549;0.5549
 SSP1;ENC;Liquids;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;0.5549;0.5549
 SSP1;ENC;Liquids;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;0.783;0.5383;0.5383
 SSP1;ESC;;;;;Cycle;trn_pass;S1S;0.01942;0.02184;0.04369;0.1638;0.1638
-SSP1;ESC;;;;;Domestic Aviation;trn_pass;S1S;0.0001286;3.62E-05;9.04E-06;1.81E-05;1.81E-05
+SSP1;ESC;;;;;Domestic Aviation;trn_pass;S1S;0.0001286;7.04E-06;9.04E-06;1.81E-05;1.81E-05
 SSP1;ESC;;;;;Domestic Ship;trn_freight;S1S;0.01209;0.01209;0.01209;0.01209;0.01209
-SSP1;ESC;;;;;Freight Rail;trn_freight;S1S;0.004094;0.004094;0.006141;0.006141;0.006141
+SSP1;ESC;;;;;Freight Rail;trn_freight;S1S;0.004094;0.006141;0.006141;0.006141;0.006141
 SSP1;ESC;;;;;HSR;trn_pass;S1S;0.0006613;0.000186;0.00062;0.00062;0.00062
 SSP1;ESC;;;;;International Aviation;trn_aviation_intl;S1S;1;1;1;1;1
 SSP1;ESC;;;;;International Ship;trn_shipping_intl;S1S;1;1;1;1;1
-SSP1;ESC;;;;;Passenger Rail;trn_pass;S1S;0.003195;0.002696;0.005392;0.008088;0.008088
-SSP1;ESC;;;;;Walk;trn_pass;S1S;1;1;1;1;1
+SSP1;ESC;;;;;Passenger Rail;trn_pass;S1S;0.003195;0.005392;0.005392;0.008088;0.008088
+SSP1;ESC;;;;;Walk;trn_pass;S1S;1;0.8;1;1;1
 SSP1;ESC;;;;;trn_freight_road;trn_freight;S1S;1;1;1;1;1
-SSP1;ESC;;;;;trn_pass_road;trn_pass;S1S;0.1798;0.1011;0.04046;0.03236;0.03236
-SSP1;ESC;;;;Bus;trn_pass_road;trn_pass;S2S1;0.06714;0.06714;0.1007;0.151;0.151
+SSP1;ESC;;;;;trn_pass_road;trn_pass;S1S;0.1798;0.05055;0.04046;0.03236;0.03236
+SSP1;ESC;;;;Bus;trn_pass_road;trn_pass;S2S1;0.06714;0.1007;0.1007;0.151;0.151
 SSP1;ESC;;;;trn_pass_road_LDV;trn_pass_road;trn_pass;S2S1;1;1;1;1;1
 SSP1;ESC;;;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;0.4;0.4;0.4;0.4;0.4
 SSP1;ESC;;;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;1;1;1;1;1
 SSP1;ESC;;Compact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.3942;0.3942;0.3942;0.3942;0.3942
-SSP1;ESC;;Large Car and SUV;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.8712;0.784;0.4356;0.2904;0.2904
-SSP1;ESC;;Midsize Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.2323;0.2091;0.1162;0.07743;0.07743
+SSP1;ESC;;Large Car and SUV;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.8712;0.5227;0.4356;0.2904;0.2904
+SSP1;ESC;;Midsize Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.2323;0.1394;0.1162;0.07743;0.07743
 SSP1;ESC;;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.1009;0.1009;0.1009;0.1009;0.1009
 SSP1;ESC;;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.06375;0.06375;0.06375;0.06375;0.06375
 SSP1;ESC;;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;1;1;1;1;1
@@ -6101,24 +6101,24 @@ SSP1;ESC;;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subs
 SSP1;ESC;;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.2234;0.2234;0.2234;0.2234;0.2234
 SSP1;ESC;;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.2172;0.2172;0.2172;0.2172;0.2172
 SSP1;ESC;;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;1;1;1;1;1
-SSP1;ESC;BEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.1359;0.7632;1;1
-SSP1;ESC;BEV;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.04;0.44;0.84;0.84
-SSP1;ESC;BEV;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.04;0.44;0.84;0.84
-SSP1;ESC;BEV;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.04;0.44;0.84;0.84
-SSP1;ESC;BEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.2819;1;1;1
-SSP1;ESC;BEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1122;0.5724;1;1
-SSP1;ESC;BEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1122;0.5724;1;1
-SSP1;ESC;BEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1122;0.5724;1;1
-SSP1;ESC;BEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.2819;1;1;1
+SSP1;ESC;BEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.2718;0.7632;1;1
+SSP1;ESC;BEV;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.08;0.44;0.84;0.84
+SSP1;ESC;BEV;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.08;0.44;0.84;0.84
+SSP1;ESC;BEV;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.08;0.44;0.84;0.84
+SSP1;ESC;BEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.5638;1;1;1
+SSP1;ESC;BEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.2244;0.5724;1;1
+SSP1;ESC;BEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.2244;0.5724;1;1
+SSP1;ESC;BEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.2244;0.5724;1;1
+SSP1;ESC;BEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.5638;1;1;1
 SSP1;ESC;Electric;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;1;1;1;1;1
 SSP1;ESC;Electric;HSR_tmp_vehicletype;HSR_tmp_subsectorL3;HSR_tmp_subsectorL2;HSR;trn_pass;FV;1;1;1;1;1
 SSP1;ESC;Electric;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;1;1;1;1;1
 SSP1;ESC;FCEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.01124;0.0638;0.04666;0.04666
-SSP1;ESC;FCEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.07914;0.1581;0.2792;0.2792
-SSP1;ESC;FCEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02924;0.06381;0.1968;0.1968
-SSP1;ESC;FCEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02924;0.06381;0.1968;0.1968
-SSP1;ESC;FCEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02924;0.06381;0.1968;0.1968
-SSP1;ESC;FCEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.07914;0.1581;0.2792;0.2792
+SSP1;ESC;FCEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.2374;0.1581;0.2792;0.2792
+SSP1;ESC;FCEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.08772;0.06381;0.1968;0.1968
+SSP1;ESC;FCEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.08772;0.06381;0.1968;0.1968
+SSP1;ESC;FCEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.08772;0.06381;0.1968;0.1968
+SSP1;ESC;FCEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.2374;0.1581;0.2792;0.2792
 SSP1;ESC;Gases;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0.02742;0.04078;0.1042;0.1019;0.1019
 SSP1;ESC;Gases;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02632;0.07419;0.09915;0.09915
 SSP1;ESC;Gases;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02632;0.07895;0.1022;0.1022
@@ -6129,63 +6129,63 @@ SSP1;ESC;Hydrogen;Domestic Aviation_tmp_vehicletype;Domestic Aviation_tmp_subsec
 SSP1;ESC;Liquids;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;1;1;1;0.5919;0.5919
 SSP1;ESC;Liquids;Domestic Aviation_tmp_vehicletype;Domestic Aviation_tmp_subsectorL3;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;trn_pass;FV;1;1;1;1;1
 SSP1;ESC;Liquids;Domestic Ship_tmp_vehicletype;Domestic Ship_tmp_subsectorL3;Domestic Ship_tmp_subsectorL2;Domestic Ship;trn_freight;FV;1;1;1;1;1
-SSP1;ESC;Liquids;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;0.1241;0.1241;0.06205;0.06205;0.06205
+SSP1;ESC;Liquids;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;0.1241;0.06205;0.06205;0.06205;0.06205
 SSP1;ESC;Liquids;International Aviation_tmp_vehicletype;International Aviation_tmp_subsectorL3;International Aviation_tmp_subsectorL2;International Aviation;trn_aviation_intl;FV;1;1;1;1;1
 SSP1;ESC;Liquids;International Ship_tmp_vehicletype;International Ship_tmp_subsectorL3;International Ship_tmp_subsectorL2;International Ship;trn_shipping_intl;FV;1;1;1;1;1
 SSP1;ESC;Liquids;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;1;1;1
 SSP1;ESC;Liquids;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;1;1;1
 SSP1;ESC;Liquids;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;1;1;1
-SSP1;ESC;Liquids;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;0.07003;0.07003;0.03501;0.02334;0.02334
+SSP1;ESC;Liquids;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;0.07003;0.04669;0.03501;0.02334;0.02334
 SSP1;ESC;Liquids;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;0.9397;0.6459;0.6459
 SSP1;ESC;Liquids;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;0.6659;0.6659
 SSP1;ESC;Liquids;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;0.6659;0.6659
 SSP1;ESC;Liquids;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;0.6659;0.6659
 SSP1;ESC;Liquids;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;0.9397;0.6459;0.6459
 SSP1;ESW;;;;;Cycle;trn_pass;S1S;0.01942;0.03884;0.05825;0.1019;0.1019
-SSP1;ESW;;;;;Domestic Aviation;trn_pass;S1S;0.0006852;0.0006852;0.000137;3.21E-05;3.21E-05
+SSP1;ESW;;;;;Domestic Aviation;trn_pass;S1S;0.0006852;0.0001713;0.000137;3.21E-05;3.21E-05
 SSP1;ESW;;;;;Domestic Ship;trn_freight;S1S;0.00613;0.00613;0.00613;0.00613;0.00613
-SSP1;ESW;;;;;Freight Rail;trn_freight;S1S;0.0142;0.0142;0.0213;0.0213;0.0213
+SSP1;ESW;;;;;Freight Rail;trn_freight;S1S;0.0142;0.0213;0.0213;0.0213;0.0213
 SSP1;ESW;;;;;HSR;trn_pass;S1S;0.0009579;0.0009579;0.0009579;0.0003592;0.0003592
 SSP1;ESW;;;;;International Aviation;trn_aviation_intl;S1S;1;1;1;1;1
 SSP1;ESW;;;;;International Ship;trn_shipping_intl;S1S;1;1;1;1;1
-SSP1;ESW;;;;;Passenger Rail;trn_pass;S1S;0.003621;0.003621;0.01086;0.004074;0.004074
-SSP1;ESW;;;;;Walk;trn_pass;S1S;1;1;1;1;1
+SSP1;ESW;;;;;Passenger Rail;trn_pass;S1S;0.003621;0.007242;0.01086;0.004074;0.004074
+SSP1;ESW;;;;;Walk;trn_pass;S1S;1;0.8;1;1;1
 SSP1;ESW;;;;;trn_freight_road;trn_freight;S1S;1;1;1;1;1
-SSP1;ESW;;;;;trn_pass_road;trn_pass;S1S;0.1385;0.1108;0.0554;0.01558;0.01558
-SSP1;ESW;;;;Bus;trn_pass_road;trn_pass;S2S1;0.05772;0.05772;0.1082;0.1623;0.1623
+SSP1;ESW;;;;;trn_pass_road;trn_pass;S1S;0.1385;0.0554;0.0554;0.01558;0.01558
+SSP1;ESW;;;;Bus;trn_pass_road;trn_pass;S2S1;0.05772;0.08658;0.1082;0.1623;0.1623
 SSP1;ESW;;;;trn_pass_road_LDV;trn_pass_road;trn_pass;S2S1;1;1;1;1;1
 SSP1;ESW;;;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;0.2;0.2;0.2;0.2;0.2
 SSP1;ESW;;;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;1;1;1;1;1
-SSP1;ESW;;Compact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.5725;0.5725;1;1;1
+SSP1;ESW;;Compact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.5725;0.8588;1;1;1
 SSP1;ESW;;Large Car and SUV;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;1;1;0.8734;0.5822;0.5822
 SSP1;ESW;;Midsize Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.2963;0.2963;0.2588;0.1725;0.1725
 SSP1;ESW;;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.09741;0.09741;0.09741;0.09741;0.09741
 SSP1;ESW;;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.1669;0.1669;0.1669;0.1669;0.1669
 SSP1;ESW;;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;1;1;1;1;1
-SSP1;ESW;;Subcompact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.4448;0.4448;0.7769;0.7769;0.7769
+SSP1;ESW;;Subcompact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.4448;0.6672;0.7769;0.7769;0.7769
 SSP1;ESW;;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.285;0.285;0.285;0.285;0.285
 SSP1;ESW;;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.06043;0.06043;0.06043;0.06043;0.06043
 SSP1;ESW;;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.08424;0.08424;0.08424;0.08424;0.08424
 SSP1;ESW;;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.4041;0.4041;0.4041;0.4041;0.4041
 SSP1;ESW;;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;1;1;1;1;1
-SSP1;ESW;BEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0.01078;0.1164;0.587;1;1
-SSP1;ESW;BEV;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.048;0.432;0.84;0.84
-SSP1;ESW;BEV;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.048;0.432;0.84;0.84
-SSP1;ESW;BEV;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.048;0.432;0.84;0.84
-SSP1;ESW;BEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.3902;1;1;1
-SSP1;ESW;BEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1553;0.7396;1;1
-SSP1;ESW;BEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1553;0.7396;1;1
-SSP1;ESW;BEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1553;0.7396;1;1
-SSP1;ESW;BEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.3902;1;1;1
-SSP1;ESW;Electric;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;0.7295;0.7633;1;1;1
+SSP1;ESW;BEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0.01078;0.2328;0.587;1;1
+SSP1;ESW;BEV;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.096;0.432;0.84;0.84
+SSP1;ESW;BEV;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.096;0.432;0.84;0.84
+SSP1;ESW;BEV;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.096;0.432;0.84;0.84
+SSP1;ESW;BEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.7804;1;1;1
+SSP1;ESW;BEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.3106;0.7396;1;1
+SSP1;ESW;BEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.3106;0.7396;1;1
+SSP1;ESW;BEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.3106;0.7396;1;1
+SSP1;ESW;BEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.7804;1;1;1
+SSP1;ESW;Electric;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;0.7295;1;1;1;1
 SSP1;ESW;Electric;HSR_tmp_vehicletype;HSR_tmp_subsectorL3;HSR_tmp_subsectorL2;HSR;trn_pass;FV;1;1;1;1;1
 SSP1;ESW;Electric;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;1;1;1;1;1
 SSP1;ESW;FCEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0.002248;0.002698;0.01963;0.04687;0.04687
-SSP1;ESW;FCEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.07303;0.5647;0.2233;0.2233
-SSP1;ESW;FCEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02698;0.2944;0.1575;0.1575
-SSP1;ESW;FCEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02698;0.2944;0.1575;0.1575
-SSP1;ESW;FCEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02698;0.2944;0.1575;0.1575
-SSP1;ESW;FCEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.07303;0.5647;0.2233;0.2233
+SSP1;ESW;FCEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.2191;0.5647;0.2233;0.2233
+SSP1;ESW;FCEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.08094;0.2944;0.1575;0.1575
+SSP1;ESW;FCEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.08094;0.2944;0.1575;0.1575
+SSP1;ESW;FCEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.08094;0.2944;0.1575;0.1575
+SSP1;ESW;FCEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.2191;0.5647;0.2233;0.2233
 SSP1;ESW;Gases;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0.01754;0.02632;0.07895;0.1055;0.1055
 SSP1;ESW;Gases;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02632;0.05742;0.08595;0.08595
 SSP1;ESW;Gases;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02632;0.07895;0.0886;0.0886
@@ -6196,63 +6196,63 @@ SSP1;ESW;Hydrogen;Domestic Aviation_tmp_vehicletype;Domestic Aviation_tmp_subsec
 SSP1;ESW;Liquids;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;1;1;1;0.8017;0.8017
 SSP1;ESW;Liquids;Domestic Aviation_tmp_vehicletype;Domestic Aviation_tmp_subsectorL3;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;trn_pass;FV;1;1;1;1;1
 SSP1;ESW;Liquids;Domestic Ship_tmp_vehicletype;Domestic Ship_tmp_subsectorL3;Domestic Ship_tmp_subsectorL2;Domestic Ship;trn_freight;FV;1;1;1;1;1
-SSP1;ESW;Liquids;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;1;1;0.6018;0.5175;0.5175
+SSP1;ESW;Liquids;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;1;0.6551;0.6018;0.5175;0.5175
 SSP1;ESW;Liquids;International Aviation_tmp_vehicletype;International Aviation_tmp_subsectorL3;International Aviation_tmp_subsectorL2;International Aviation;trn_aviation_intl;FV;1;1;1;1;1
 SSP1;ESW;Liquids;International Ship_tmp_vehicletype;International Ship_tmp_subsectorL3;International Ship_tmp_subsectorL2;International Ship;trn_shipping_intl;FV;1;1;1;1;1
 SSP1;ESW;Liquids;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;1;1;1
 SSP1;ESW;Liquids;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;1;1;1
 SSP1;ESW;Liquids;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;1;1;1
-SSP1;ESW;Liquids;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;0.5162;0.5162;0.2581;0.1721;0.1721
+SSP1;ESW;Liquids;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;0.5162;0.3441;0.2581;0.1721;0.1721
 SSP1;ESW;Liquids;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;0.7273;0.4666;0.4666
 SSP1;ESW;Liquids;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;0.481;0.481
 SSP1;ESW;Liquids;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;0.481;0.481
 SSP1;ESW;Liquids;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;0.481;0.481
 SSP1;ESW;Liquids;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;0.7273;0.4666;0.4666
 SSP1;EWN;;;;;Cycle;trn_pass;S1S;0.01;0.01;0.05;0.1;0.1
-SSP1;EWN;;;;;Domestic Aviation;trn_pass;S1S;4.77E-05;4.77E-05;1.19E-05;1.19E-06;1.19E-06
+SSP1;EWN;;;;;Domestic Aviation;trn_pass;S1S;4.77E-05;2.19E-05;1.19E-05;1.19E-06;1.19E-06
 SSP1;EWN;;;;;Domestic Ship;trn_freight;S1S;0.006261;0.006957;0.006261;0.006261;0.006261
-SSP1;EWN;;;;;Freight Rail;trn_freight;S1S;0.0127;0.01411;0.01905;0.01905;0.01905
+SSP1;EWN;;;;;Freight Rail;trn_freight;S1S;0.0127;0.02116;0.01905;0.01905;0.01905
 SSP1;EWN;;;;;HSR;trn_pass;S1S;0.0001;0.0001;0.0004;0.0002;0.0002
 SSP1;EWN;;;;;International Aviation;trn_aviation_intl;S1S;1;1;1;1;1
 SSP1;EWN;;;;;International Ship;trn_shipping_intl;S1S;1;1;1;1;1
-SSP1;EWN;;;;;Passenger Rail;trn_pass;S1S;0.002;0.003;0.006;0.004;0.004
-SSP1;EWN;;;;;Walk;trn_pass;S1S;1;1;1;1;1
+SSP1;EWN;;;;;Passenger Rail;trn_pass;S1S;0.002;0.006;0.006;0.004;0.004
+SSP1;EWN;;;;;Walk;trn_pass;S1S;1;0.8;1;1;1
 SSP1;EWN;;;;;trn_freight_road;trn_freight;S1S;1;1;1;1;1
-SSP1;EWN;;;;;trn_pass_road;trn_pass;S1S;0.05891;0.05891;0.02945;0.01473;0.01473
-SSP1;EWN;;;;Bus;trn_pass_road;trn_pass;S2S1;0.1019;0.1019;0.1529;0.2292;0.2292
+SSP1;EWN;;;;;trn_pass_road;trn_pass;S1S;0.05891;0.02945;0.02945;0.01473;0.01473
+SSP1;EWN;;;;Bus;trn_pass_road;trn_pass;S2S1;0.1019;0.1529;0.1529;0.2292;0.2292
 SSP1;EWN;;;;trn_pass_road_LDV;trn_pass_road;trn_pass;S2S1;1;1;1;1;1
 SSP1;EWN;;;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;0.1;0.1;0.1;0.1;0.1
 SSP1;EWN;;;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;1;1;1;1;1
-SSP1;EWN;;Compact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.4317;0.4317;0.7772;0.8878;0.8878
+SSP1;EWN;;Compact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.4317;0.6475;0.7772;0.8878;0.8878
 SSP1;EWN;;Large Car and SUV;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;1;1;1;0.7616;0.7616
 SSP1;EWN;;Midsize Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.2283;0.2283;0.2283;0.1739;0.1739
 SSP1;EWN;;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.1183;0.1183;0.1183;0.1183;0.1183
 SSP1;EWN;;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.04339;0.04339;0.04339;0.04339;0.04339
 SSP1;EWN;;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;1;1;1;1;1
-SSP1;EWN;;Subcompact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.4864;0.4864;0.8754;1;1
+SSP1;EWN;;Subcompact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.4864;0.7296;0.8754;1;1
 SSP1;EWN;;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;1;1;1;1;1
 SSP1;EWN;;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.1164;0.1164;0.1164;0.1164;0.1164
 SSP1;EWN;;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.5225;0.5225;0.5225;0.5225;0.5225
 SSP1;EWN;;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.4061;0.4061;0.4061;0.4061;0.4061
 SSP1;EWN;;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.5651;0.5651;0.5651;0.5651;0.5651
-SSP1;EWN;BEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.08794;0.4394;1;1
-SSP1;EWN;BEV;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0.001;0.06;0.49;0.9;0.9
-SSP1;EWN;BEV;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0.001;0.06;0.49;0.9;0.9
-SSP1;EWN;BEV;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0.001;0.06;0.49;0.9;0.9
-SSP1;EWN;BEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.3436;1;1;1
-SSP1;EWN;BEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1367;0.689;1;1
-SSP1;EWN;BEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1367;0.689;1;1
-SSP1;EWN;BEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1367;0.689;1;1
-SSP1;EWN;BEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.3436;1;1;1
+SSP1;EWN;BEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.1759;0.4394;1;1
+SSP1;EWN;BEV;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0.001;0.12;0.49;0.9;0.9
+SSP1;EWN;BEV;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0.001;0.12;0.49;0.9;0.9
+SSP1;EWN;BEV;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0.001;0.12;0.49;0.9;0.9
+SSP1;EWN;BEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.6872;1;1;1
+SSP1;EWN;BEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.2734;0.689;1;1
+SSP1;EWN;BEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.2734;0.689;1;1
+SSP1;EWN;BEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.2734;0.689;1;1
+SSP1;EWN;BEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.6872;1;1;1
 SSP1;EWN;Electric;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;1;1;1;1;1
 SSP1;EWN;Electric;HSR_tmp_vehicletype;HSR_tmp_subsectorL3;HSR_tmp_subsectorL2;HSR;trn_pass;FV;1;1;1;1;1
 SSP1;EWN;Electric;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;1;1;1;1;1
 SSP1;EWN;FCEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.001861;0.007734;0.02187;0.02187
-SSP1;EWN;FCEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.01385;0.248;0.09971;0.09971
-SSP1;EWN;FCEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.005116;0.1205;0.07031;0.07031
-SSP1;EWN;FCEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.005116;0.1205;0.07031;0.07031
-SSP1;EWN;FCEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.005116;0.1205;0.07031;0.07031
-SSP1;EWN;FCEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.01385;0.248;0.09971;0.09971
+SSP1;EWN;FCEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.04155;0.248;0.09971;0.09971
+SSP1;EWN;FCEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.01535;0.1205;0.07031;0.07031
+SSP1;EWN;FCEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.01535;0.1205;0.07031;0.07031
+SSP1;EWN;FCEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.01535;0.1205;0.07031;0.07031
+SSP1;EWN;FCEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.04155;0.248;0.09971;0.09971
 SSP1;EWN;Gases;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0.00807;0.03107;0.06282;0.09704;0.09704
 SSP1;EWN;Gases;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.0008171;0.03389;0.06913;0.07109;0.07109
 SSP1;EWN;Gases;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.03289;0.08772;0.073;0.073
@@ -6263,63 +6263,63 @@ SSP1;EWN;Hydrogen;Domestic Aviation_tmp_vehicletype;Domestic Aviation_tmp_subsec
 SSP1;EWN;Liquids;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;1;1;1;0.9988;0.9988
 SSP1;EWN;Liquids;Domestic Aviation_tmp_vehicletype;Domestic Aviation_tmp_subsectorL3;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;trn_pass;FV;1;1;1;1;1
 SSP1;EWN;Liquids;Domestic Ship_tmp_vehicletype;Domestic Ship_tmp_subsectorL3;Domestic Ship_tmp_subsectorL2;Domestic Ship;trn_freight;FV;1;1;1;1;1
-SSP1;EWN;Liquids;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;0.3943;0.3943;0.1971;0.1971;0.1971
+SSP1;EWN;Liquids;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;0.3943;0.1971;0.1971;0.1971;0.1971
 SSP1;EWN;Liquids;International Aviation_tmp_vehicletype;International Aviation_tmp_subsectorL3;International Aviation_tmp_subsectorL2;International Aviation;trn_aviation_intl;FV;1;1;1;1;1
 SSP1;EWN;Liquids;International Ship_tmp_vehicletype;International Ship_tmp_subsectorL3;International Ship_tmp_subsectorL2;International Ship;trn_shipping_intl;FV;1;1;1;1;1
 SSP1;EWN;Liquids;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;1;1;1
 SSP1;EWN;Liquids;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;1;1;1
 SSP1;EWN;Liquids;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;1;1;1
-SSP1;EWN;Liquids;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;0.03824;0.03824;0.01912;0.01275;0.01275
+SSP1;EWN;Liquids;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;0.03824;0.02549;0.01912;0.01275;0.01275
 SSP1;EWN;Liquids;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;0.7806;0.5536;0.5536
 SSP1;EWN;Liquids;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;0.5708;0.5708
 SSP1;EWN;Liquids;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;0.5708;0.5708
 SSP1;EWN;Liquids;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;0.5708;0.5708
 SSP1;EWN;Liquids;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;0.7806;0.5536;0.5536
 SSP1;FRA;;;;;Cycle;trn_pass;S1S;0.01942;0.02184;0.03641;0.1019;0.1019
-SSP1;FRA;;;;;Domestic Aviation;trn_pass;S1S;0.0001169;6.58E-05;1.1E-05;5.48E-06;5.48E-06
+SSP1;FRA;;;;;Domestic Aviation;trn_pass;S1S;0.0001169;3E-05;1.1E-05;5.48E-06;5.48E-06
 SSP1;FRA;;;;;Domestic Ship;trn_freight;S1S;0.003419;0.003419;0.003419;0.003419;0.003419
-SSP1;FRA;;;;;Freight Rail;trn_freight;S1S;0.01799;0.01799;0.02698;0.02698;0.02698
+SSP1;FRA;;;;;Freight Rail;trn_freight;S1S;0.01799;0.02698;0.02698;0.02698;0.02698
 SSP1;FRA;;;;;HSR;trn_pass;S1S;0.0003359;0.0002267;0.0002015;0.0002015;0.0002015
 SSP1;FRA;;;;;International Aviation;trn_aviation_intl;S1S;1;1;1;1;1
 SSP1;FRA;;;;;International Ship;trn_shipping_intl;S1S;1;1;1;1;1
-SSP1;FRA;;;;;Passenger Rail;trn_pass;S1S;0.003972;0.002979;0.003972;0.003972;0.003972
-SSP1;FRA;;;;;Walk;trn_pass;S1S;1;1;1;1;1
+SSP1;FRA;;;;;Passenger Rail;trn_pass;S1S;0.003972;0.005958;0.003972;0.003972;0.003972
+SSP1;FRA;;;;;Walk;trn_pass;S1S;1;0.8;1;1;1
 SSP1;FRA;;;;;trn_freight_road;trn_freight;S1S;1;1;1;1;1
-SSP1;FRA;;;;;trn_pass_road;trn_pass;S1S;0.09055;0.05094;0.01698;0.01358;0.01358
-SSP1;FRA;;;;Bus;trn_pass_road;trn_pass;S2S1;0.07932;0.08726;0.1428;0.2142;0.2142
+SSP1;FRA;;;;;trn_pass_road;trn_pass;S1S;0.09055;0.02547;0.01698;0.01358;0.01358
+SSP1;FRA;;;;Bus;trn_pass_road;trn_pass;S2S1;0.07932;0.1309;0.1428;0.2142;0.2142
 SSP1;FRA;;;;trn_pass_road_LDV;trn_pass_road;trn_pass;S2S1;1;1;1;1;1
 SSP1;FRA;;;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;0.2;0.2;0.2;0.2;0.2
 SSP1;FRA;;;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;1;1;1;1;1
-SSP1;FRA;;Compact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.6352;0.6352;0.7912;0.7912;0.7912
-SSP1;FRA;;Large Car and SUV;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;1;1;0.6228;0.4152;0.4152
-SSP1;FRA;;Midsize Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.3632;0.3632;0.2262;0.1508;0.1508
+SSP1;FRA;;Compact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.6352;0.7912;0.7912;0.7912;0.7912
+SSP1;FRA;;Large Car and SUV;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;1;0.8304;0.6228;0.4152;0.4152
+SSP1;FRA;;Midsize Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.3632;0.3016;0.2262;0.1508;0.1508
 SSP1;FRA;;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.092;0.092;0.092;0.092;0.092
 SSP1;FRA;;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.06774;0.06774;0.06774;0.06774;0.06774
 SSP1;FRA;;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;1;1;1;1;1
-SSP1;FRA;;Subcompact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.8028;0.8028;1;1;1
+SSP1;FRA;;Subcompact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.8028;1;1;1;1
 SSP1;FRA;;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;1;1;1;1;1
 SSP1;FRA;;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.1408;0.1408;0.1408;0.1408;0.1408
 SSP1;FRA;;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.1602;0.1602;0.1602;0.1602;0.1602
 SSP1;FRA;;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.4011;0.4011;0.4011;0.4011;0.4011
 SSP1;FRA;;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.3755;0.3755;0.3755;0.3755;0.3755
-SSP1;FRA;BEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0.01402;0.1682;0.9158;1;1
-SSP1;FRA;BEV;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.04;0.48;0.84;0.84
-SSP1;FRA;BEV;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.04;0.48;0.84;0.84
-SSP1;FRA;BEV;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.04;0.48;0.84;0.84
-SSP1;FRA;BEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.3171;1;1;1
-SSP1;FRA;BEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1262;0.7156;1;1
-SSP1;FRA;BEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1262;0.7156;1;1
-SSP1;FRA;BEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1262;0.7156;1;1
-SSP1;FRA;BEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.3171;1;1;1
+SSP1;FRA;BEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0.01402;0.3364;0.9158;1;1
+SSP1;FRA;BEV;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.08;0.48;0.84;0.84
+SSP1;FRA;BEV;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.08;0.48;0.84;0.84
+SSP1;FRA;BEV;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.08;0.48;0.84;0.84
+SSP1;FRA;BEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.6342;1;1;1
+SSP1;FRA;BEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.2524;0.7156;1;1
+SSP1;FRA;BEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.2524;0.7156;1;1
+SSP1;FRA;BEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.2524;0.7156;1;1
+SSP1;FRA;BEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.6342;1;1;1
 SSP1;FRA;Electric;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;1;1;1;1;1
 SSP1;FRA;Electric;HSR_tmp_vehicletype;HSR_tmp_subsectorL3;HSR_tmp_subsectorL2;HSR;trn_pass;FV;1;1;1;1;1
 SSP1;FRA;Electric;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;1;1;1;1;1
 SSP1;FRA;FCEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0.01218;0.01462;0.02127;0.04294;0.04294
-SSP1;FRA;FCEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.07914;0.5271;0.2481;0.2481
-SSP1;FRA;FCEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02924;0.2658;0.1749;0.1749
-SSP1;FRA;FCEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02924;0.2658;0.1749;0.1749
-SSP1;FRA;FCEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02924;0.2658;0.1749;0.1749
-SSP1;FRA;FCEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.07914;0.5271;0.2481;0.2481
+SSP1;FRA;FCEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.2374;0.5271;0.2481;0.2481
+SSP1;FRA;FCEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.08772;0.2658;0.1749;0.1749
+SSP1;FRA;FCEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.08772;0.2658;0.1749;0.1749
+SSP1;FRA;FCEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.08772;0.2658;0.1749;0.1749
+SSP1;FRA;FCEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.2374;0.5271;0.2481;0.2481
 SSP1;FRA;Gases;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0.01535;0.02632;0.07895;0.07434;0.07434
 SSP1;FRA;Gases;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02632;0.04946;0.08815;0.08815
 SSP1;FRA;Gases;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02632;0.06579;0.09087;0.09087
@@ -6330,32 +6330,32 @@ SSP1;FRA;Hydrogen;Domestic Aviation_tmp_vehicletype;Domestic Aviation_tmp_subsec
 SSP1;FRA;Liquids;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;1;1;1;0.5246;0.5246
 SSP1;FRA;Liquids;Domestic Aviation_tmp_vehicletype;Domestic Aviation_tmp_subsectorL3;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;trn_pass;FV;1;1;1;1;1
 SSP1;FRA;Liquids;Domestic Ship_tmp_vehicletype;Domestic Ship_tmp_subsectorL3;Domestic Ship_tmp_subsectorL2;Domestic Ship;trn_freight;FV;1;1;1;1;1
-SSP1;FRA;Liquids;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;0.1608;0.1608;0.0804;0.0804;0.0804
+SSP1;FRA;Liquids;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;0.1608;0.0804;0.0804;0.0804;0.0804
 SSP1;FRA;Liquids;International Aviation_tmp_vehicletype;International Aviation_tmp_subsectorL3;International Aviation_tmp_subsectorL2;International Aviation;trn_aviation_intl;FV;1;1;1;1;1
 SSP1;FRA;Liquids;International Ship_tmp_vehicletype;International Ship_tmp_subsectorL3;International Ship_tmp_subsectorL2;International Ship;trn_shipping_intl;FV;1;1;1;1;1
 SSP1;FRA;Liquids;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;1;1;1
 SSP1;FRA;Liquids;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;1;1;1
 SSP1;FRA;Liquids;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;1;1;1
-SSP1;FRA;Liquids;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;0.05395;0.05395;0.02697;0.01798;0.01798
+SSP1;FRA;Liquids;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;0.05395;0.03597;0.02697;0.01798;0.01798
 SSP1;FRA;Liquids;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;0.7518;0.5502;0.5502
 SSP1;FRA;Liquids;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;0.5672;0.5672
 SSP1;FRA;Liquids;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;0.5672;0.5672
 SSP1;FRA;Liquids;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;0.5672;0.5672
 SSP1;FRA;Liquids;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;0.7518;0.5502;0.5502
-SSP1;IND;;;;;Cycle;trn_pass;S1S;0.01915;0.03175;0.075;0.2;0.2
-SSP1;IND;;;;;Domestic Aviation;trn_pass;S1S;1.4;0.7575;0.1312;0.04772;0.04772
+SSP1;IND;;;;;Cycle;trn_pass;S1S;0.01915;0.04615;0.075;0.2;0.2
+SSP1;IND;;;;;Domestic Aviation;trn_pass;S1S;0.6659;0.2753;0.1312;0.04772;0.04772
 SSP1;IND;;;;;Domestic Ship;trn_freight;S1S;0.001202;0.001202;0.001092;0.0009244;0.0009244
-SSP1;IND;;;;;Freight Rail;trn_freight;S1S;0.1924;0.1924;0.2361;0.1998;0.1998
-SSP1;IND;;;;;HSR;trn_pass;S1S;0;0.0003175;0.00055;0.0003;0.0003
+SSP1;IND;;;;;Freight Rail;trn_freight;S1S;0.1924;0.2886;0.2361;0.1998;0.1998
+SSP1;IND;;;;;HSR;trn_pass;S1S;0;0.0004615;0.00055;0.0003;0.0003
 SSP1;IND;;;;;International Aviation;trn_aviation_intl;S1S;1;1;1;1;1
 SSP1;IND;;;;;International Ship;trn_shipping_intl;S1S;1;1;1;1;1
-SSP1;IND;;;;;Passenger Rail;trn_pass;S1S;0.004978;0.00582;0.012;0.008;0.008
-SSP1;IND;;;;;Walk;trn_pass;S1S;1.053;0.6879;1;1;1
+SSP1;IND;;;;;Passenger Rail;trn_pass;S1S;0.004978;0.01354;0.012;0.008;0.008
+SSP1;IND;;;;;Walk;trn_pass;S1S;0.9573;0.8;1;1;1
 SSP1;IND;;;;;trn_freight_road;trn_freight;S1S;1;1;1;1;1
-SSP1;IND;;;;;trn_pass_road;trn_pass;S1S;1;1;0.54;0.1472;0.1472
-SSP1;IND;;;;Bus;trn_pass_road;trn_pass;S2S1;1;0.3638;0.3948;0.3949;0.3949
-SSP1;IND;;;;trn_pass_road_LDV;trn_pass_road;trn_pass;S2S1;0.7344;1;1;1;1
-SSP1;IND;;;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;0.072;0.06;0.05108;0.05108;0.05108
+SSP1;IND;;;;;trn_pass_road;trn_pass;S1S;1;1.09;0.54;0.1472;0.1472
+SSP1;IND;;;;Bus;trn_pass_road;trn_pass;S2S1;1;0.5457;0.3948;0.3949;0.3949
+SSP1;IND;;;;trn_pass_road_LDV;trn_pass_road;trn_pass;S2S1;0.918;1;1;1;1
+SSP1;IND;;;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;0.09;0.06;0.05108;0.05108;0.05108
 SSP1;IND;;;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;1;1;1;1;1
 SSP1;IND;;Compact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;1;1;1;1;1
 SSP1;IND;;Large Car and SUV;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;1;1;1;1;1
@@ -6369,132 +6369,132 @@ SSP1;IND;;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subs
 SSP1;IND;;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0;0.05;0.1987;0.1987;0.1987
 SSP1;IND;;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0;0.05;0.1987;0.1987;0.1987
 SSP1;IND;;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;1;1;1;1;1
-SSP1;IND;BEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.05175;0.587;1;1
-SSP1;IND;BEV;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.2;0.72;0.756;0.756
-SSP1;IND;BEV;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.2;0.72;0.756;0.756
-SSP1;IND;BEV;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.2;0;0;0
-SSP1;IND;BEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02787;0.1273;0.1286;0.1286
-SSP1;IND;BEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.01109;0.06848;0.1247;0.1247
-SSP1;IND;BEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;0.2338;0.2546;0.1309;0.1309
-SSP1;IND;BEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;0.2338;0.2546;0.1309;0.1309
-SSP1;IND;BEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02787;0.1273;0.1286;0.1286
+SSP1;IND;BEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.1035;0.587;1;1
+SSP1;IND;BEV;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.4;0.72;0.756;0.756
+SSP1;IND;BEV;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.4;0.72;0.756;0.756
+SSP1;IND;BEV;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0;0;0;0
+SSP1;IND;BEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.05574;0.1273;0.1286;0.1286
+SSP1;IND;BEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02218;0.06848;0.1247;0.1247
+SSP1;IND;BEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;0.2;0.2546;0.1309;0.1309
+SSP1;IND;BEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;0.2;0.2546;0.1309;0.1309
+SSP1;IND;BEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.05574;0.1273;0.1286;0.1286
 SSP1;IND;Electric;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;1;1;1;1;1
 SSP1;IND;Electric;HSR_tmp_vehicletype;HSR_tmp_subsectorL3;HSR_tmp_subsectorL2;HSR;trn_pass;FV;1;1;1;1;1
-SSP1;IND;Electric;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;0.834;0.8547;1;1;1
+SSP1;IND;Electric;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;0.834;1;1;1;1
 SSP1;IND;FCEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.002698;0.01963;0.041;0.041
-SSP1;IND;FCEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.005217;0.02587;0.004785;0.004785
-SSP1;IND;FCEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.001927;0.009813;0.003273;0.003273
-SSP1;IND;FCEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;0.7794;0.5457;0.006546;0.006546
-SSP1;IND;FCEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;0.7794;0.5457;0.006546;0.006546
-SSP1;IND;FCEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.005217;0.02587;0.004785;0.004785
+SSP1;IND;FCEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.01565;0.02587;0.004785;0.004785
+SSP1;IND;FCEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.005781;0.009813;0.003273;0.003273
+SSP1;IND;FCEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;0.5457;0.006546;0.006546
+SSP1;IND;FCEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;0.5457;0.006546;0.006546
+SSP1;IND;FCEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.01565;0.02587;0.004785;0.004785
 SSP1;IND;Gases;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0.2408;0.2086;0.2105;0.143;0.143
 SSP1;IND;Gases;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.08768;0.07978;0.06655;0.02557;0.02557
 SSP1;IND;Gases;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.0188;0.03289;0.01842;0.01842
-SSP1;IND;Gases;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.9164;0.7143;0.4167;0.1;0.1
-SSP1;IND;Gases;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.9164;0.7143;0.4167;0.1;0.1
+SSP1;IND;Gases;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.9164;0.3055;0.4167;0.1;0.1
+SSP1;IND;Gases;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.9164;0.3055;0.4167;0.1;0.1
 SSP1;IND;Gases;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.0188;0.03289;0.01842;0.01842
 SSP1;IND;Hydrogen;Domestic Aviation_tmp_vehicletype;Domestic Aviation_tmp_subsectorL3;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;trn_pass;FV;0;8.32E-07;0.1362;0.3576;0.3576
 SSP1;IND;Liquids;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;1;1;1;0.7515;0.7515
 SSP1;IND;Liquids;Domestic Aviation_tmp_vehicletype;Domestic Aviation_tmp_subsectorL3;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;trn_pass;FV;1;1;1;1;1
 SSP1;IND;Liquids;Domestic Ship_tmp_vehicletype;Domestic Ship_tmp_subsectorL3;Domestic Ship_tmp_subsectorL2;Domestic Ship;trn_freight;FV;1;1;1;1;1
-SSP1;IND;Liquids;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;0.9342;0.9342;0.4671;0.4671;0.4671
+SSP1;IND;Liquids;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;0.9342;0.4671;0.4671;0.4671;0.4671
 SSP1;IND;Liquids;International Aviation_tmp_vehicletype;International Aviation_tmp_subsectorL3;International Aviation_tmp_subsectorL2;International Aviation;trn_aviation_intl;FV;1;1;1;1;1
 SSP1;IND;Liquids;International Ship_tmp_vehicletype;International Ship_tmp_subsectorL3;International Ship_tmp_subsectorL2;International Ship;trn_shipping_intl;FV;1;1;1;1;1
 SSP1;IND;Liquids;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;1;1;1
 SSP1;IND;Liquids;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;1;1;1
 SSP1;IND;Liquids;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;1;1;1
-SSP1;IND;Liquids;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;1;1;0.5579;0.3404;0.3404
+SSP1;IND;Liquids;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;1;0.78;0.5579;0.3404;0.3404
 SSP1;IND;Liquids;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
 SSP1;IND;Liquids;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
-SSP1;IND;Liquids;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.9164;1;1;1;1
-SSP1;IND;Liquids;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.9164;1;1;1;1
+SSP1;IND;Liquids;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.9164;0.4277;1;1;1
+SSP1;IND;Liquids;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.9164;0.4277;1;1;1
 SSP1;IND;Liquids;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
 SSP1;JPN;;;;;Cycle;trn_pass;S1S;0.01743;0.01743;0.03486;0.01961;0.01961
-SSP1;JPN;;;;;Domestic Aviation;trn_pass;S1S;0.0001729;0.0002075;0.0002334;6.57E-05;6.57E-05
+SSP1;JPN;;;;;Domestic Aviation;trn_pass;S1S;0.0001729;0.0001623;0.0002334;6.57E-05;6.57E-05
 SSP1;JPN;;;;;Domestic Ship;trn_freight;S1S;0.01167;0.01111;0.01167;0.01167;0.01167
-SSP1;JPN;;;;;Freight Rail;trn_freight;S1S;0.002833;0.002698;0.004249;0.004249;0.004249
-SSP1;JPN;;;;;HSR;trn_pass;S1S;0.0004081;0.0004081;0.0003673;0.0001033;0.0001033
+SSP1;JPN;;;;;Freight Rail;trn_freight;S1S;0.002833;0.004047;0.004249;0.004249;0.004249
+SSP1;JPN;;;;;HSR;trn_pass;S1S;0.0004081;0.0002857;0.0003673;0.0001033;0.0001033
 SSP1;JPN;;;;;International Aviation;trn_aviation_intl;S1S;1;1;1;1;1
 SSP1;JPN;;;;;International Ship;trn_shipping_intl;S1S;1;1;1;1;1
-SSP1;JPN;;;;;Passenger Rail;trn_pass;S1S;0.006084;0.006084;0.0084;0.00365;0.00365
-SSP1;JPN;;;;;Walk;trn_pass;S1S;1;1;1;1;1
+SSP1;JPN;;;;;Passenger Rail;trn_pass;S1S;0.006084;0.006085;0.0084;0.00365;0.00365
+SSP1;JPN;;;;;Walk;trn_pass;S1S;1;0.5;1;1;1
 SSP1;JPN;;;;;trn_freight_road;trn_freight;S1S;1;1;1;1;1
-SSP1;JPN;;;;;trn_pass_road;trn_pass;S1S;0.07113;0.07629;0.04195;0.0118;0.0118
-SSP1;JPN;;;;Bus;trn_pass_road;trn_pass;S2S1;0.06081;0.06081;0.09122;0.09122;0.09122
+SSP1;JPN;;;;;trn_pass_road;trn_pass;S1S;0.07113;0.04195;0.04195;0.0118;0.0118
+SSP1;JPN;;;;Bus;trn_pass_road;trn_pass;S2S1;0.06081;0.09122;0.09122;0.09122;0.09122
 SSP1;JPN;;;;trn_pass_road_LDV;trn_pass_road;trn_pass;S2S1;1;1;1;1;1
 SSP1;JPN;;;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;0.07;0.06;0.05491;0.05491;0.05491
 SSP1;JPN;;;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;1;1;1;1;1
-SSP1;JPN;;Compact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.1662;0.1662;0.3324;0.4986;0.4986
+SSP1;JPN;;Compact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.1662;0.2493;0.3324;0.4986;0.4986
 SSP1;JPN;;Large Car and SUV;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;1;1;1;1;1
-SSP1;JPN;;Mini Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.0484;0.0484;0.0968;0.1452;0.1452
+SSP1;JPN;;Mini Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.0484;0.0726;0.0968;0.1452;0.1452
 SSP1;JPN;;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;1;1;1;1;1
 SSP1;JPN;;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.6255;0.6255;0.6255;0.6255;0.6255
 SSP1;JPN;;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.5153;0.5153;0.5153;0.5153;0.5153
-SSP1;JPN;;Subcompact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.1286;0.1286;0.2572;0.3858;0.3858
+SSP1;JPN;;Subcompact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.1286;0.1929;0.2572;0.3858;0.3858
 SSP1;JPN;;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;1;1;1;1;1
 SSP1;JPN;;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0;0;0;0;0
 SSP1;JPN;;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0;0;0;0;0
 SSP1;JPN;;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0;0;0;0;0
 SSP1;JPN;;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.5896;0.5896;0.5896;0.5896;0.5896
-SSP1;JPN;BEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.09673;0.3588;0.7508;0.7508
-SSP1;JPN;BEV;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.16;1;1;1
-SSP1;JPN;BEV;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.16;1;1;1
-SSP1;JPN;BEV;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.16;1;1;1
-SSP1;JPN;BEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1332;0.6828;1;1
-SSP1;JPN;BEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;0.05727;0.08;1;1
-SSP1;JPN;BEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;0.05727;0.08;1;1
-SSP1;JPN;BEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;0.05727;0.08;1;1
-SSP1;JPN;BEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1332;0.6828;1;1
+SSP1;JPN;BEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.1935;0.3588;0.7508;0.7508
+SSP1;JPN;BEV;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.32;1;1;1
+SSP1;JPN;BEV;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.32;1;1;1
+SSP1;JPN;BEV;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.32;1;1;1
+SSP1;JPN;BEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.2664;0.6828;1;1
+SSP1;JPN;BEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;0.03818;0.08;1;1
+SSP1;JPN;BEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;0.03818;0.08;1;1
+SSP1;JPN;BEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;0.03818;0.08;1;1
+SSP1;JPN;BEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.2664;0.6828;1;1
 SSP1;JPN;Electric;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;1;1;1;1;1
 SSP1;JPN;Electric;HSR_tmp_vehicletype;HSR_tmp_subsectorL3;HSR_tmp_subsectorL2;HSR;trn_pass;FV;1;1;1;1;1
 SSP1;JPN;Electric;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;1;1;1;1;1
 SSP1;JPN;FCEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.06091;0.12;0.09854;0.09854
-SSP1;JPN;FCEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1306;0.8097;0.4568;0.4568
+SSP1;JPN;FCEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.3918;0.8097;0.4568;0.4568
 SSP1;JPN;FCEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;0.6137;0.6137
 SSP1;JPN;FCEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;0.6137;0.6137
 SSP1;JPN;FCEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;0.6137;0.6137
-SSP1;JPN;FCEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1306;0.8097;0.4568;0.4568
+SSP1;JPN;FCEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.3918;0.8097;0.4568;0.4568
 SSP1;JPN;Gases;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.006579;0.01215;0.01919;0.01919
 SSP1;JPN;Gases;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.01316;0.04222;0.02163;0.02163
-SSP1;JPN;Gases;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.8457;0.02563;0.03132;0.1153;0.1153
-SSP1;JPN;Gases;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.8457;0.02563;0.03132;0.1153;0.1153
-SSP1;JPN;Gases;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.8457;0.02563;0.03132;0.1153;0.1153
+SSP1;JPN;Gases;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.8457;0.008543;0.03132;0.1153;0.1153
+SSP1;JPN;Gases;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.8457;0.008543;0.03132;0.1153;0.1153
+SSP1;JPN;Gases;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.8457;0.008543;0.03132;0.1153;0.1153
 SSP1;JPN;Gases;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.01316;0.04222;0.02163;0.02163
 SSP1;JPN;Hydrogen;Domestic Aviation_tmp_vehicletype;Domestic Aviation_tmp_subsectorL3;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;trn_pass;FV;0;8.32E-07;0.1362;0.3576;0.3576
 SSP1;JPN;Liquids;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;1;1;1;1;1
 SSP1;JPN;Liquids;Domestic Aviation_tmp_vehicletype;Domestic Aviation_tmp_subsectorL3;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;trn_pass;FV;1;1;1;1;1
 SSP1;JPN;Liquids;Domestic Ship_tmp_vehicletype;Domestic Ship_tmp_subsectorL3;Domestic Ship_tmp_subsectorL2;Domestic Ship;trn_freight;FV;1;1;1;1;1
-SSP1;JPN;Liquids;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;0.8837;0.8837;0.4419;0.4419;0.4419
+SSP1;JPN;Liquids;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;0.8837;0.4419;0.4419;0.4419;0.4419
 SSP1;JPN;Liquids;International Aviation_tmp_vehicletype;International Aviation_tmp_subsectorL3;International Aviation_tmp_subsectorL2;International Aviation;trn_aviation_intl;FV;1;1;1;1;1
 SSP1;JPN;Liquids;International Ship_tmp_vehicletype;International Ship_tmp_subsectorL3;International Ship_tmp_subsectorL2;International Ship;trn_shipping_intl;FV;1;1;1;1;1
 SSP1;JPN;Liquids;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;0.947;0.496;0.496
 SSP1;JPN;Liquids;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;0.947;0.496;0.496
 SSP1;JPN;Liquids;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;0.947;0.496;0.496
-SSP1;JPN;Liquids;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;0.03433;0.03433;0.01716;0.01144;0.01144
+SSP1;JPN;Liquids;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;0.03433;0.02289;0.01716;0.01144;0.01144
 SSP1;JPN;Liquids;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;0.5637;0.5637
-SSP1;JPN;Liquids;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.8457;0.05126;0.05857;0.5536;0.5536
-SSP1;JPN;Liquids;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.8457;0.05126;0.05857;0.5536;0.5536
-SSP1;JPN;Liquids;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.8457;0.05126;0.05857;0.5536;0.5536
+SSP1;JPN;Liquids;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.8457;0.01709;0.05857;0.5536;0.5536
+SSP1;JPN;Liquids;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.8457;0.01709;0.05857;0.5536;0.5536
+SSP1;JPN;Liquids;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.8457;0.01709;0.05857;0.5536;0.5536
 SSP1;JPN;Liquids;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;0.5637;0.5637
 SSP1;LAM;;;;;Cycle;trn_pass;S1S;0.01091;0.02182;0.05455;0.2728;0.2728
-SSP1;LAM;;;;;Domestic Aviation;trn_pass;S1S;0.008921;0.0119;0.007435;0.005575;0.005575
+SSP1;LAM;;;;;Domestic Aviation;trn_pass;S1S;0.008921;0.002975;0.007435;0.005575;0.005575
 SSP1;LAM;;;;;Domestic Ship;trn_freight;S1S;0.0097;0.0097;0.008908;0.006736;0.006736
-SSP1;LAM;;;;;Freight Rail;trn_freight;S1S;0.04782;0.04782;0.06587;0.05978;0.05978
+SSP1;LAM;;;;;Freight Rail;trn_freight;S1S;0.04782;0.07173;0.06587;0.05978;0.05978
 SSP1;LAM;;;;;HSR;trn_pass;S1S;0.005236;0.2905;0.2905;0.2905;0.2905
 SSP1;LAM;;;;;International Aviation;trn_aviation_intl;S1S;1;1;1;1;1
 SSP1;LAM;;;;;International Ship;trn_shipping_intl;S1S;1;1;1;1;1
-SSP1;LAM;;;;;Passenger Rail;trn_pass;S1S;0.1499;0.1499;0.2998;0.1999;0.1999
-SSP1;LAM;;;;;Walk;trn_pass;S1S;1;1;1;1;1
+SSP1;LAM;;;;;Passenger Rail;trn_pass;S1S;0.1499;0.2998;0.2998;0.1999;0.1999
+SSP1;LAM;;;;;Walk;trn_pass;S1S;1;0.8;1;1;1
 SSP1;LAM;;;;;trn_freight_road;trn_freight;S1S;1;1;1;1;1
-SSP1;LAM;;;;;trn_pass_road;trn_pass;S1S;0.655;0.6942;0.3471;0.4049;0.4049
-SSP1;LAM;;;;Bus;trn_pass_road;trn_pass;S2S1;0.2647;0.1654;0.1984;0.1984;0.1984
-SSP1;LAM;;;;trn_pass_road_LDV;trn_pass_road;trn_pass;S2S1;0.8;1;1;1;1
+SSP1;LAM;;;;;trn_pass_road;trn_pass;S1S;0.655;0.3471;0.3471;0.4049;0.4049
+SSP1;LAM;;;;Bus;trn_pass_road;trn_pass;S2S1;0.2647;0.2481;0.1984;0.1984;0.1984
+SSP1;LAM;;;;trn_pass_road_LDV;trn_pass_road;trn_pass;S2S1;1;1;1;1;1
 SSP1;LAM;;;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;0.35;0.3;0.25;0.25;0.25
 SSP1;LAM;;;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;1;1;1;1;1
 SSP1;LAM;;Compact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;1;1;1;1;1
-SSP1;LAM;;Large Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.03279;0.03935;0.02049;0.01457;0.01457
-SSP1;LAM;;Large Car and SUV;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.3624;0.4348;0.2265;0.161;0.161
-SSP1;LAM;;Midsize Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.04788;0.05745;0.02992;0.02128;0.02128
+SSP1;LAM;;Large Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.03279;0.02623;0.02049;0.01457;0.01457
+SSP1;LAM;;Large Car and SUV;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.3624;0.2899;0.2265;0.161;0.161
+SSP1;LAM;;Midsize Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.04788;0.0383;0.02992;0.02128;0.02128
 SSP1;LAM;;Mini Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.01226;0.01226;0.01226;0.01226;0.01226
 SSP1;LAM;;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.000458;0.000458;0.000458;0.000458;0.000458
 SSP1;LAM;;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;1;1;1;1;1
@@ -6505,25 +6505,25 @@ SSP1;LAM;;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subs
 SSP1;LAM;;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;1;1;1;1;1
 SSP1;LAM;;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.0005079;0.0005079;0.0005079;0.0005079;0.0005079
 SSP1;LAM;;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.1892;0.1892;0.1892;0.1892;0.1892
-SSP1;LAM;;Van;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.001473;0.001768;0.000921;0.0006547;0.0006547
-SSP1;LAM;BEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.1294;1;1;1
-SSP1;LAM;BEV;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.056;0.432;1;1
-SSP1;LAM;BEV;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.056;0.432;1;1
-SSP1;LAM;BEV;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.056;0.432;1;1
-SSP1;LAM;BEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1041;0.3928;0.4714;0.4714
-SSP1;LAM;BEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.0414;0.2114;0.4574;0.4574
-SSP1;LAM;BEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.0414;0.2114;0.4574;0.4574
-SSP1;LAM;BEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.0414;0.2114;0.4574;0.4574
-SSP1;LAM;BEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1041;0.3928;0.4714;0.4714
-SSP1;LAM;Electric;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;0.0681;0.1846;0.8352;1;1
+SSP1;LAM;;Van;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.001473;0.001179;0.000921;0.0006547;0.0006547
+SSP1;LAM;BEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.2588;1;1;1
+SSP1;LAM;BEV;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.112;0.432;1;1
+SSP1;LAM;BEV;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.112;0.432;1;1
+SSP1;LAM;BEV;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.112;0.432;1;1
+SSP1;LAM;BEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.2082;0.3928;0.4714;0.4714
+SSP1;LAM;BEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.0828;0.2114;0.4574;0.4574
+SSP1;LAM;BEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.0828;0.2114;0.4574;0.4574
+SSP1;LAM;BEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.0828;0.2114;0.4574;0.4574
+SSP1;LAM;BEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.2082;0.3928;0.4714;0.4714
+SSP1;LAM;Electric;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;0.0681;0.3692;0.8352;1;1
 SSP1;LAM;Electric;HSR_tmp_vehicletype;HSR_tmp_subsectorL3;HSR_tmp_subsectorL2;HSR;trn_pass;FV;1;1;1;1;1
 SSP1;LAM;Electric;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;1;1;1;1;1
 SSP1;LAM;FCEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.002698;0.01672;0.03281;0.03281
-SSP1;LAM;FCEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.009738;0.1863;0.2659;0.2659
-SSP1;LAM;FCEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.003598;0.07065;0.1819;0.1819
-SSP1;LAM;FCEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.003598;0.07065;0.1819;0.1819
-SSP1;LAM;FCEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.003598;0.07065;0.1819;0.1819
-SSP1;LAM;FCEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.009738;0.1863;0.2659;0.2659
+SSP1;LAM;FCEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02921;0.1863;0.2659;0.2659
+SSP1;LAM;FCEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.01079;0.07065;0.1819;0.1819
+SSP1;LAM;FCEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.01079;0.07065;0.1819;0.1819
+SSP1;LAM;FCEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.01079;0.07065;0.1819;0.1819
+SSP1;LAM;FCEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02921;0.1863;0.2659;0.2659
 SSP1;LAM;Gases;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0.02689;0.04725;0.08835;0.062;0.062
 SSP1;LAM;Gases;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.01754;0.03158;0.0614;0.0614
 SSP1;LAM;Gases;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.01754;0.03158;0.0614;0.0614
@@ -6540,55 +6540,55 @@ SSP1;LAM;Liquids;International Ship_tmp_vehicletype;International Ship_tmp_subse
 SSP1;LAM;Liquids;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;1;0.9921;0.9921
 SSP1;LAM;Liquids;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;1;0.9921;0.9921
 SSP1;LAM;Liquids;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;1;0.9921;0.9921
-SSP1;LAM;Liquids;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;0.6477;0.6477;0.3239;0.2159;0.2159
+SSP1;LAM;Liquids;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;0.6477;0.4318;0.3239;0.2159;0.2159
 SSP1;LAM;Liquids;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
 SSP1;LAM;Liquids;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
 SSP1;LAM;Liquids;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
 SSP1;LAM;Liquids;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
 SSP1;LAM;Liquids;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
 SSP1;MEA;;;;;Cycle;trn_pass;S1S;0.0166;0.0166;0.0166;0.04149;0.04149
-SSP1;MEA;;;;;Domestic Aviation;trn_pass;S1S;0.008522;0.005681;0.00426;0.00625;0.00625
+SSP1;MEA;;;;;Domestic Aviation;trn_pass;S1S;0.008522;0.00282;0.00426;0.00625;0.00625
 SSP1;MEA;;;;;Domestic Ship;trn_freight;S1S;0.00206;0.00206;0.00206;0.00206;0.00206
-SSP1;MEA;;;;;Freight Rail;trn_freight;S1S;0.003202;0.003202;0.004803;0.004803;0.004803
+SSP1;MEA;;;;;Freight Rail;trn_freight;S1S;0.003202;0.004803;0.004803;0.004803;0.004803
 SSP1;MEA;;;;;HSR;trn_pass;S1S;0;0.01667;0.01667;0.01667;0.01667
 SSP1;MEA;;;;;International Aviation;trn_aviation_intl;S1S;1;1;1;1;1
 SSP1;MEA;;;;;International Ship;trn_shipping_intl;S1S;1;1;1;1;1
-SSP1;MEA;;;;;Passenger Rail;trn_pass;S1S;0.0005567;0.001113;0.002226;0.003712;0.003712
-SSP1;MEA;;;;;Walk;trn_pass;S1S;1;1;1;1;1
+SSP1;MEA;;;;;Passenger Rail;trn_pass;S1S;0.0005567;0.002226;0.002226;0.003712;0.003712
+SSP1;MEA;;;;;Walk;trn_pass;S1S;1;0.8;1;1;1
 SSP1;MEA;;;;;trn_freight_road;trn_freight;S1S;1;1;1;1;1
-SSP1;MEA;;;;;trn_pass_road;trn_pass;S1S;0.3767;0.4239;0.1908;0.1908;0.1908
-SSP1;MEA;;;;Bus;trn_pass_road;trn_pass;S2S1;0.2676;0.1873;0.1405;0.1124;0.1124
+SSP1;MEA;;;;;trn_pass_road;trn_pass;S1S;0.3767;0.2119;0.1908;0.1908;0.1908
+SSP1;MEA;;;;Bus;trn_pass_road;trn_pass;S2S1;0.2676;0.2809;0.1405;0.1124;0.1124
 SSP1;MEA;;;;trn_pass_road_LDV;trn_pass_road;trn_pass;S2S1;1;1;1;1;1
 SSP1;MEA;;;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;0.01502;0.01502;0.01502;0.01502;0.01502
 SSP1;MEA;;;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;1;1;1;1;1
-SSP1;MEA;;Compact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.5257;0.4732;0.8674;1;1
+SSP1;MEA;;Compact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.5257;0.7098;0.8674;1;1
 SSP1;MEA;;Large Car and SUV;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;1;1;1;0.8454;0.8454
-SSP1;MEA;;Mini Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.04395;0.03955;0.07252;0.08359;0.08359
+SSP1;MEA;;Mini Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.04395;0.05933;0.07252;0.08359;0.08359
 SSP1;MEA;;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;1;1;1;1;1
 SSP1;MEA;;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.001;0.001;0.001;0.001;0.001
-SSP1;MEA;;Subcompact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.2071;0.1864;0.3418;0.3939;0.3939
+SSP1;MEA;;Subcompact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.2071;0.2796;0.3418;0.3939;0.3939
 SSP1;MEA;;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.1304;0.1304;0.1304;0.1304;0.1304
 SSP1;MEA;;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.2013;0.2013;0.2013;0.2013;0.2013
 SSP1;MEA;;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0;0;0;0;0
 SSP1;MEA;;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0;0;0;0;0
 SSP1;MEA;;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;1;1;1;1;1
-SSP1;MEA;BEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.05175;0.587;1;1
-SSP1;MEA;BEV;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.12;0.432;0.42;0.42
-SSP1;MEA;BEV;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.12;0;0;0
-SSP1;MEA;BEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.06504;0.2182;0.2784;0.2784
-SSP1;MEA;BEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02588;0.1174;0.27;0.27
-SSP1;MEA;BEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;0.1559;0.4364;0.2834;0.2834
-SSP1;MEA;BEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;0.1559;0.4364;0.2834;0.2834
-SSP1;MEA;BEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.06504;0.2182;0.2784;0.2784
-SSP1;MEA;Electric;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;0.4021;0.4768;1;1;1
+SSP1;MEA;BEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.1035;0.587;1;1
+SSP1;MEA;BEV;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.24;0.432;0.42;0.42
+SSP1;MEA;BEV;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0;0;0;0
+SSP1;MEA;BEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1301;0.2182;0.2784;0.2784
+SSP1;MEA;BEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.05176;0.1174;0.27;0.27
+SSP1;MEA;BEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;0.3118;0.4364;0.2834;0.2834
+SSP1;MEA;BEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;0.3118;0.4364;0.2834;0.2834
+SSP1;MEA;BEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1301;0.2182;0.2784;0.2784
+SSP1;MEA;Electric;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;0.4021;0.9536;1;1;1
 SSP1;MEA;Electric;HSR_tmp_vehicletype;HSR_tmp_subsectorL3;HSR_tmp_subsectorL2;HSR;trn_pass;FV;1;1;1;1;1
 SSP1;MEA;Electric;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;1;1;1;1;1
 SSP1;MEA;FCEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.002698;0.01784;0.04294;0.04294
-SSP1;MEA;FCEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.003652;0.03105;0.001243;0.001243
-SSP1;MEA;FCEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.001349;0.01178;0.0008502;0.0008502
-SSP1;MEA;FCEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;0.1559;0.6546;0.001701;0.001701
-SSP1;MEA;FCEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;0.1559;0.6546;0.001701;0.001701
-SSP1;MEA;FCEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.003652;0.03105;0.001243;0.001243
+SSP1;MEA;FCEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.01096;0.03105;0.001243;0.001243
+SSP1;MEA;FCEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.004047;0.01178;0.0008502;0.0008502
+SSP1;MEA;FCEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;0.4677;0.6546;0.001701;0.001701
+SSP1;MEA;FCEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;0.4677;0.6546;0.001701;0.001701
+SSP1;MEA;FCEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.01096;0.03105;0.001243;0.001243
 SSP1;MEA;Gases;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0.01342;0.03938;0.083;0.08535;0.08535
 SSP1;MEA;Gases;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.0009283;0.09527;0.04788;0.04804;0.04804
 SSP1;MEA;Gases;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.09211;0.04737;0.04785;0.04785
@@ -6604,59 +6604,59 @@ SSP1;MEA;Liquids;International Aviation_tmp_vehicletype;International Aviation_t
 SSP1;MEA;Liquids;International Ship_tmp_vehicletype;International Ship_tmp_subsectorL3;International Ship_tmp_subsectorL2;International Ship;trn_shipping_intl;FV;1;1;1;1;1
 SSP1;MEA;Liquids;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;1;1;1
 SSP1;MEA;Liquids;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;1;1;1
-SSP1;MEA;Liquids;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;0.07852;0.07852;0.03926;0.02617;0.02617
+SSP1;MEA;Liquids;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;0.07852;0.05235;0.03926;0.02617;0.02617
 SSP1;MEA;Liquids;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
 SSP1;MEA;Liquids;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
 SSP1;MEA;Liquids;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.9164;0.2857;1;1;1
 SSP1;MEA;Liquids;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.9164;0.2857;1;1;1
 SSP1;MEA;Liquids;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
 SSP1;NEN;;;;;Cycle;trn_pass;S1S;0.003033;0.003024;0.002621;0.0182;0.0182
-SSP1;NEN;;;;;Domestic Aviation;trn_pass;S1S;7.5E-06;7.54E-06;6.12E-07;3.57E-07;3.57E-07
+SSP1;NEN;;;;;Domestic Aviation;trn_pass;S1S;7.21E-06;1.4E-06;6.12E-07;3.57E-07;3.57E-07
 SSP1;NEN;;;;;Domestic Ship;trn_freight;S1S;0.03175;0.03175;0.03175;0.03175;0.03175
-SSP1;NEN;;;;;Freight Rail;trn_freight;S1S;0.01925;0.01925;0.02888;0.02888;0.02888
+SSP1;NEN;;;;;Freight Rail;trn_freight;S1S;0.01925;0.02888;0.02888;0.02888;0.02888
 SSP1;NEN;;;;;HSR;trn_pass;S1S;2E-05;4.53E-05;7.36E-06;5.52E-06;5.52E-06
 SSP1;NEN;;;;;International Aviation;trn_aviation_intl;S1S;1;1;1;1;1
 SSP1;NEN;;;;;International Ship;trn_shipping_intl;S1S;1;1;1;1;1
-SSP1;NEN;;;;;Passenger Rail;trn_pass;S1S;3E-06;2.97E-06;1.35E-06;6.43E-07;6.43E-07
-SSP1;NEN;;;;;Walk;trn_pass;S1S;1;1;1;1;1
+SSP1;NEN;;;;;Passenger Rail;trn_pass;S1S;3E-06;5.93E-06;1.35E-06;6.43E-07;6.43E-07
+SSP1;NEN;;;;;Walk;trn_pass;S1S;1;0.8;1;1;1
 SSP1;NEN;;;;;trn_freight_road;trn_freight;S1S;1;1;1;1;1
-SSP1;NEN;;;;;trn_pass_road;trn_pass;S1S;0.0496;0.06868;0.01395;0.01162;0.01162
-SSP1;NEN;;;;Bus;trn_pass_road;trn_pass;S2S1;0.01287;0.008044;0.006033;0.003017;0.003017
+SSP1;NEN;;;;;trn_pass_road;trn_pass;S1S;0.0496;0.03434;0.01395;0.01162;0.01162
+SSP1;NEN;;;;Bus;trn_pass_road;trn_pass;S2S1;0.01287;0.01207;0.006033;0.003017;0.003017
 SSP1;NEN;;;;trn_pass_road_LDV;trn_pass_road;trn_pass;S2S1;1;1;1;1;1
 SSP1;NEN;;;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;0.09;0.09;0.09;0.09;0.09
 SSP1;NEN;;;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;1;1;1;1;1
-SSP1;NEN;;Compact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.4624;0.4624;0.9248;1;1
+SSP1;NEN;;Compact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.4624;0.6936;0.9248;1;1
 SSP1;NEN;;Large Car and SUV;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;1;1;1;0.7209;0.7209
 SSP1;NEN;;Midsize Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.3307;0.3307;0.3307;0.2384;0.2384
-SSP1;NEN;;Mini Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;6.43E-08;6.43E-08;1.29E-07;1.39E-07;1.39E-07
+SSP1;NEN;;Mini Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;6.43E-08;9.65E-08;1.29E-07;1.39E-07;1.39E-07
 SSP1;NEN;;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.3331;0.3331;0.3331;0.3331;0.3331
 SSP1;NEN;;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.1369;0.1369;0.1369;0.1369;0.1369
 SSP1;NEN;;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;1;1;1;1;1
-SSP1;NEN;;Subcompact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.3388;0.3388;0.6776;0.7327;0.7327
+SSP1;NEN;;Subcompact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.3388;0.5082;0.6776;0.7327;0.7327
 SSP1;NEN;;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;1;1;1;1;1
 SSP1;NEN;;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.143;0.143;0.143;0.143;0.143
 SSP1;NEN;;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.2745;0.2745;0.2745;0.2745;0.2745
 SSP1;NEN;;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.06397;0.06397;0.06397;0.06397;0.06397
 SSP1;NEN;;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.3433;0.3433;0.3433;0.3433;0.3433
 SSP1;NEN;;Van;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.00735;0.00735;0.00735;0.005298;0.005298
-SSP1;NEN;BEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0.05608;0.1402;0.8268;1;1
-SSP1;NEN;BEV;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.04;0.336;0.588;0.588
-SSP1;NEN;BEV;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.04;0.336;0.588;0.588
-SSP1;NEN;BEV;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.04;0.336;0.588;0.588
-SSP1;NEN;BEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.2537;1;1;1
-SSP1;NEN;BEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1009;0.636;1;1
-SSP1;NEN;BEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1009;0.636;1;1
-SSP1;NEN;BEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1009;0.636;1;1
-SSP1;NEN;BEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.2537;1;1;1
+SSP1;NEN;BEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0.05608;0.2804;0.8268;1;1
+SSP1;NEN;BEV;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.08;0.336;0.588;0.588
+SSP1;NEN;BEV;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.08;0.336;0.588;0.588
+SSP1;NEN;BEV;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.08;0.336;0.588;0.588
+SSP1;NEN;BEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.5074;1;1;1
+SSP1;NEN;BEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.2018;0.636;1;1
+SSP1;NEN;BEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.2018;0.636;1;1
+SSP1;NEN;BEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.2018;0.636;1;1
+SSP1;NEN;BEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.5074;1;1;1
 SSP1;NEN;Electric;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;1;1;1;1;1
 SSP1;NEN;Electric;HSR_tmp_vehicletype;HSR_tmp_subsectorL3;HSR_tmp_subsectorL2;HSR;trn_pass;FV;1;1;1;1;1
 SSP1;NEN;Electric;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;1;1;1;1;1
 SSP1;NEN;FCEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.002924;0.02127;0.02812;0.02812
-SSP1;NEN;FCEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.007914;0.4268;0.1675;0.1675
-SSP1;NEN;FCEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.002924;0.1914;0.1181;0.1181
-SSP1;NEN;FCEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.002924;0.1914;0.1181;0.1181
-SSP1;NEN;FCEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.002924;0.1914;0.1181;0.1181
-SSP1;NEN;FCEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.007914;0.4268;0.1675;0.1675
+SSP1;NEN;FCEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02374;0.4268;0.1675;0.1675
+SSP1;NEN;FCEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.008772;0.1914;0.1181;0.1181
+SSP1;NEN;FCEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.008772;0.1914;0.1181;0.1181
+SSP1;NEN;FCEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.008772;0.1914;0.1181;0.1181
+SSP1;NEN;FCEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02374;0.4268;0.1675;0.1675
 SSP1;NEN;Gases;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0.02362;0.03778;0.09872;0.06397;0.06397
 SSP1;NEN;Gases;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.006427;0.03257;0.07178;0.08156;0.08156
 SSP1;NEN;Gases;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02632;0.07895;0.08178;0.08178
@@ -6667,65 +6667,65 @@ SSP1;NEN;Hydrogen;Domestic Aviation_tmp_vehicletype;Domestic Aviation_tmp_subsec
 SSP1;NEN;Liquids;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;1;1;1;0.5073;0.5073
 SSP1;NEN;Liquids;Domestic Aviation_tmp_vehicletype;Domestic Aviation_tmp_subsectorL3;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;trn_pass;FV;1;1;1;1;1
 SSP1;NEN;Liquids;Domestic Ship_tmp_vehicletype;Domestic Ship_tmp_subsectorL3;Domestic Ship_tmp_subsectorL2;Domestic Ship;trn_freight;FV;1;1;1;1;1
-SSP1;NEN;Liquids;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;0.1317;0.1317;0.06585;0.06585;0.06585
+SSP1;NEN;Liquids;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;0.1317;0.06585;0.06585;0.06585;0.06585
 SSP1;NEN;Liquids;International Aviation_tmp_vehicletype;International Aviation_tmp_subsectorL3;International Aviation_tmp_subsectorL2;International Aviation;trn_aviation_intl;FV;1;1;1;1;1
 SSP1;NEN;Liquids;International Ship_tmp_vehicletype;International Ship_tmp_subsectorL3;International Ship_tmp_subsectorL2;International Ship;trn_shipping_intl;FV;1;1;1;1;1
 SSP1;NEN;Liquids;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;1;1;1
 SSP1;NEN;Liquids;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;1;1;1
 SSP1;NEN;Liquids;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;1;1;1
-SSP1;NEN;Liquids;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;0.0154;0.0154;0.0077;0.005133;0.005133
+SSP1;NEN;Liquids;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;0.0154;0.01027;0.0077;0.005133;0.005133
 SSP1;NEN;Liquids;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;0.8457;0.5598;0.5598
 SSP1;NEN;Liquids;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;0.5771;0.5771
 SSP1;NEN;Liquids;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;0.5771;0.5771
 SSP1;NEN;Liquids;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;0.5771;0.5771
 SSP1;NEN;Liquids;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;0.8457;0.5598;0.5598
 SSP1;NES;;;;;Cycle;trn_pass;S1S;0.008738;0.007802;0.009929;0.01365;0.01365
-SSP1;NES;;;;;Domestic Aviation;trn_pass;S1S;0.004721;0.003372;0.0003577;9.84E-05;9.84E-05
+SSP1;NES;;;;;Domestic Aviation;trn_pass;S1S;0.004721;0.0004215;0.0003577;9.84E-05;9.84E-05
 SSP1;NES;;;;;Domestic Ship;trn_freight;S1S;0.01468;0.01468;0.01468;0.01322;0.01322
-SSP1;NES;;;;;Freight Rail;trn_freight;S1S;0.01697;0.01697;0.02545;0.02545;0.02545
+SSP1;NES;;;;;Freight Rail;trn_freight;S1S;0.01697;0.02545;0.02545;0.02545;0.02545
 SSP1;NES;;;;;HSR;trn_pass;S1S;0.0005085;0.0003632;0.0002311;0.0001271;0.0001271
 SSP1;NES;;;;;International Aviation;trn_aviation_intl;S1S;1;1;1;1;1
 SSP1;NES;;;;;International Ship;trn_shipping_intl;S1S;1;1;1;1;1
-SSP1;NES;;;;;Passenger Rail;trn_pass;S1S;0.001607;0.001148;0.001461;0.0008034;0.0008034
-SSP1;NES;;;;;Walk;trn_pass;S1S;1;1;1;1;1
+SSP1;NES;;;;;Passenger Rail;trn_pass;S1S;0.001607;0.002296;0.001461;0.0008034;0.0008034
+SSP1;NES;;;;;Walk;trn_pass;S1S;1;0.8;1;1;1
 SSP1;NES;;;;;trn_freight_road;trn_freight;S1S;1;1;1;1;1
-SSP1;NES;;;;;trn_pass_road;trn_pass;S1S;0.2727;0.2818;0.1121;0.06165;0.06165
-SSP1;NES;;;;Bus;trn_pass_road;trn_pass;S2S1;0.08401;0.03734;0.0336;0.0336;0.0336
+SSP1;NES;;;;;trn_pass_road;trn_pass;S1S;0.2727;0.1409;0.1121;0.06165;0.06165
+SSP1;NES;;;;Bus;trn_pass_road;trn_pass;S2S1;0.08401;0.05601;0.0336;0.0336;0.0336
 SSP1;NES;;;;trn_pass_road_LDV;trn_pass_road;trn_pass;S2S1;1;1;1;1;1
 SSP1;NES;;;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;0.02;0.02;0.02;0.02;0.02
 SSP1;NES;;;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;1;1;1;1;1
-SSP1;NES;;Compact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.576;0.576;1;1;1
+SSP1;NES;;Compact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.576;0.864;1;1;1
 SSP1;NES;;Large Car and SUV;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;1;1;0.8138;0.5425;0.5425
 SSP1;NES;;Midsize Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.2352;0.2352;0.1914;0.1276;0.1276
-SSP1;NES;;Mini Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.001886;0.001886;0.003275;0.003275;0.003275
+SSP1;NES;;Mini Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.001886;0.002829;0.003275;0.003275;0.003275
 SSP1;NES;;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.01148;0.01148;0.01148;0.01148;0.01148
 SSP1;NES;;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.1337;0.1337;0.1337;0.1337;0.1337
 SSP1;NES;;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;1;1;1;1;1
-SSP1;NES;;Subcompact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.09325;0.09325;0.1619;0.1619;0.1619
+SSP1;NES;;Subcompact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.09325;0.1399;0.1619;0.1619;0.1619
 SSP1;NES;;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;1;1;1;1;1
 SSP1;NES;;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.06299;0.06299;0.06299;0.06299;0.06299
 SSP1;NES;;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.3651;0.3651;0.3651;0.3651;0.3651
 SSP1;NES;;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.5704;0.5704;0.5704;0.5704;0.5704
 SSP1;NES;;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.4799;0.4799;0.4799;0.4799;0.4799
 SSP1;NES;;Van;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.00288;0.00288;0.002344;0.001563;0.001563
-SSP1;NES;BEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.05175;0.3478;0.693;0.693
-SSP1;NES;BEV;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.04;0.336;0.672;0.672
-SSP1;NES;BEV;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.04;0.336;0.672;0.672
-SSP1;NES;BEV;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.04;0.336;0.672;0.672
-SSP1;NES;BEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1138;0.4364;0.643;0.643
-SSP1;NES;BEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.04528;0.2348;0.6236;0.6236
-SSP1;NES;BEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.04528;0.2348;0.6236;0.6236
-SSP1;NES;BEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.04528;0.2348;0.6236;0.6236
-SSP1;NES;BEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1138;0.4364;0.643;0.643
-SSP1;NES;Electric;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;0.2081;0.3071;1;1;1
+SSP1;NES;BEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.1035;0.3478;0.693;0.693
+SSP1;NES;BEV;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.08;0.336;0.672;0.672
+SSP1;NES;BEV;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.08;0.336;0.672;0.672
+SSP1;NES;BEV;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.08;0.336;0.672;0.672
+SSP1;NES;BEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.2276;0.4364;0.643;0.643
+SSP1;NES;BEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.09056;0.2348;0.6236;0.6236
+SSP1;NES;BEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.09056;0.2348;0.6236;0.6236
+SSP1;NES;BEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.09056;0.2348;0.6236;0.6236
+SSP1;NES;BEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.2276;0.4364;0.643;0.643
+SSP1;NES;Electric;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;0.2081;0.6142;1;1;1
 SSP1;NES;Electric;HSR_tmp_vehicletype;HSR_tmp_subsectorL3;HSR_tmp_subsectorL2;HSR;trn_pass;FV;1;1;1;1;1
 SSP1;NES;Electric;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;1;1;1;1;1
 SSP1;NES;FCEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.002698;0.01454;0.03637;0.03637
-SSP1;NES;FCEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.009129;0.115;0.2513;0.2513
-SSP1;NES;FCEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.003373;0.04362;0.1719;0.1719
-SSP1;NES;FCEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.003373;0.04362;0.1719;0.1719
-SSP1;NES;FCEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.003373;0.04362;0.1719;0.1719
-SSP1;NES;FCEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.009129;0.115;0.2513;0.2513
+SSP1;NES;FCEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02739;0.115;0.2513;0.2513
+SSP1;NES;FCEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.01012;0.04362;0.1719;0.1719
+SSP1;NES;FCEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.01012;0.04362;0.1719;0.1719
+SSP1;NES;FCEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.01012;0.04362;0.1719;0.1719
+SSP1;NES;FCEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02739;0.115;0.2513;0.2513
 SSP1;NES;Gases;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0.003476;0.0297;0.06085;0.07482;0.07482
 SSP1;NES;Gases;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.03289;0.08772;0.1289;0.1289
 SSP1;NES;Gases;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.03289;0.08772;0.1289;0.1289
@@ -6742,60 +6742,60 @@ SSP1;NES;Liquids;International Ship_tmp_vehicletype;International Ship_tmp_subse
 SSP1;NES;Liquids;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;1;1;1
 SSP1;NES;Liquids;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;1;1;1
 SSP1;NES;Liquids;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;1;1;1
-SSP1;NES;Liquids;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;0.4782;0.4782;0.2391;0.1594;0.1594
+SSP1;NES;Liquids;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;0.4782;0.3188;0.2391;0.1594;0.1594
 SSP1;NES;Liquids;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
 SSP1;NES;Liquids;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
 SSP1;NES;Liquids;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
 SSP1;NES;Liquids;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
 SSP1;NES;Liquids;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
 SSP1;OAS;;;;;Cycle;trn_pass;S1S;0.01256;0.03616;0.04821;0.1205;0.1205
-SSP1;OAS;;;;;Domestic Aviation;trn_pass;S1S;0.02456;0.03684;0.0129;0.03315;0.03315
+SSP1;OAS;;;;;Domestic Aviation;trn_pass;S1S;0.02456;0.00921;0.0129;0.03315;0.03315
 SSP1;OAS;;;;;Domestic Ship;trn_freight;S1S;0.03712;0.03375;0.02856;0.027;0.027
-SSP1;OAS;;;;;Freight Rail;trn_freight;S1S;0.04736;0.04305;0.05464;0.05166;0.05166
+SSP1;OAS;;;;;Freight Rail;trn_freight;S1S;0.04736;0.06457;0.05464;0.05166;0.05166
 SSP1;OAS;;;;;HSR;trn_pass;S1S;0.000966;0.004347;0.004347;0.005796;0.005796
 SSP1;OAS;;;;;International Aviation;trn_aviation_intl;S1S;1;1;1;1;1
 SSP1;OAS;;;;;International Ship;trn_shipping_intl;S1S;1;1;1;1;1
-SSP1;OAS;;;;;Passenger Rail;trn_pass;S1S;0.0007701;0.001155;0.003466;0.00462;0.00462
-SSP1;OAS;;;;;Walk;trn_pass;S1S;1;1;1;1;1
+SSP1;OAS;;;;;Passenger Rail;trn_pass;S1S;0.0007701;0.00231;0.003466;0.00462;0.00462
+SSP1;OAS;;;;;Walk;trn_pass;S1S;1;0.8;1;1;1
 SSP1;OAS;;;;;trn_freight_road;trn_freight;S1S;1;1;1;1;1
-SSP1;OAS;;;;;trn_pass_road;trn_pass;S1S;0.4452;0.5697;0.2848;0.356;0.356
-SSP1;OAS;;;;Bus;trn_pass_road;trn_pass;S2S1;0.4352;0.2571;0.1683;0.1443;0.1443
-SSP1;OAS;;;;trn_pass_road_LDV;trn_pass_road;trn_pass;S2S1;1.2;1;1;1;1
+SSP1;OAS;;;;;trn_pass_road;trn_pass;S1S;0.4452;0.2848;0.2848;0.356;0.356
+SSP1;OAS;;;;Bus;trn_pass_road;trn_pass;S2S1;0.4352;0.3856;0.1683;0.1443;0.1443
+SSP1;OAS;;;;trn_pass_road_LDV;trn_pass_road;trn_pass;S2S1;1;1;1;1;1
 SSP1;OAS;;;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;0.8;0.5;0.3;0.2;0.2
 SSP1;OAS;;;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;1;1;1;1;1
-SSP1;OAS;;Compact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.002698;0.002811;0.008432;0.01686;0.01686
+SSP1;OAS;;Compact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.002698;0.004216;0.008432;0.01686;0.01686
 SSP1;OAS;;Large Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.3018;0.3018;0.3018;0.3018;0.3018
 SSP1;OAS;;Large Car and SUV;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.0006459;0.0006459;0.0006459;0.0006459;0.0006459
 SSP1;OAS;;Midsize Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.00025;0.00025;0.00025;0.00025;0.00025
-SSP1;OAS;;Mini Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;2.78E-05;2.89E-05;8.67E-05;0.0001735;0.0001735
+SSP1;OAS;;Mini Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;2.78E-05;4.34E-05;8.67E-05;0.0001735;0.0001735
 SSP1;OAS;;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.007762;0.007762;0.007762;0.007762;0.007762
 SSP1;OAS;;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;1;1;1;1;1
 SSP1;OAS;;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.006391;0.006391;0.006391;0.006391;0.006391
-SSP1;OAS;;Subcompact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.003403;0.003545;0.01064;0.02127;0.02127
+SSP1;OAS;;Subcompact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.003403;0.005318;0.01064;0.02127;0.02127
 SSP1;OAS;;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.3765;0.3765;0.3765;0.3765;0.3765
 SSP1;OAS;;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.4784;0.4784;0.4784;0.4784;0.4784
 SSP1;OAS;;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.001365;0.001365;0.001365;0.001365;0.001365
 SSP1;OAS;;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.0007361;0.0007361;0.0007361;0.0007361;0.0007361
 SSP1;OAS;;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;1;1;1;1;1
 SSP1;OAS;;Van;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;1.03E-05;1.03E-05;1.03E-05;1.03E-05;1.03E-05
-SSP1;OAS;BEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.1411;1;1;1
-SSP1;OAS;BEV;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.044;0.336;0.588;0.588
-SSP1;OAS;BEV;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.044;0.336;0.588;0.588
-SSP1;OAS;BEV;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.044;0.336;0.588;0.588
-SSP1;OAS;BEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.03469;0.1091;0.1429;0.1429
-SSP1;OAS;BEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.0138;0.0587;0.1386;0.1386
-SSP1;OAS;BEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.0138;0.0587;0.1386;0.1386
-SSP1;OAS;BEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.0138;0.0587;0.1386;0.1386
-SSP1;OAS;BEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.03469;0.1091;0.1429;0.1429
-SSP1;OAS;Electric;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;0.1733;0.2767;0.9666;1;1
+SSP1;OAS;BEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.2822;1;1;1
+SSP1;OAS;BEV;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.088;0.336;0.588;0.588
+SSP1;OAS;BEV;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.088;0.336;0.588;0.588
+SSP1;OAS;BEV;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.088;0.336;0.588;0.588
+SSP1;OAS;BEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.06938;0.1091;0.1429;0.1429
+SSP1;OAS;BEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.0276;0.0587;0.1386;0.1386
+SSP1;OAS;BEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.0276;0.0587;0.1386;0.1386
+SSP1;OAS;BEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.0276;0.0587;0.1386;0.1386
+SSP1;OAS;BEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.06938;0.1091;0.1429;0.1429
+SSP1;OAS;Electric;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;0.1733;0.5534;0.9666;1;1
 SSP1;OAS;Electric;HSR_tmp_vehicletype;HSR_tmp_subsectorL3;HSR_tmp_subsectorL2;HSR;trn_pass;FV;1;1;1;1;1
-SSP1;OAS;Electric;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;0.353;0.4338;1;1;1
+SSP1;OAS;Electric;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;0.353;0.6507;1;1;1
 SSP1;OAS;FCEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.002453;0.01337;0.03645;0.03645
-SSP1;OAS;FCEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.01217;0.03882;0.06381;0.06381
-SSP1;OAS;FCEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.004497;0.01472;0.04365;0.04365
-SSP1;OAS;FCEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.004497;0.01472;0.04365;0.04365
-SSP1;OAS;FCEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.004497;0.01472;0.04365;0.04365
-SSP1;OAS;FCEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.01217;0.03882;0.06381;0.06381
+SSP1;OAS;FCEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.03651;0.03882;0.06381;0.06381
+SSP1;OAS;FCEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.01349;0.01472;0.04365;0.04365
+SSP1;OAS;FCEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.01349;0.01472;0.04365;0.04365
+SSP1;OAS;FCEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.01349;0.01472;0.04365;0.04365
+SSP1;OAS;FCEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.03651;0.03882;0.06381;0.06381
 SSP1;OAS;Gases;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0.1967;0.198;0.1773;0.1152;0.1152
 SSP1;OAS;Gases;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.0004535;0.008919;0.03968;0.06153;0.06153
 SSP1;OAS;Gases;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.008772;0.03947;0.0614;0.0614
@@ -6818,52 +6818,52 @@ SSP1;OAS;Liquids;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_t
 SSP1;OAS;Liquids;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
 SSP1;OAS;Liquids;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
 SSP1;OAS;Liquids;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
-SSP1;REF;;;;;Cycle;trn_pass;S1S;0.01379;0.01206;0.0745;0.07824;0.07824
-SSP1;REF;;;;;Domestic Aviation;trn_pass;S1S;0.03574;0.02995;0.01156;0.003468;0.003468
+SSP1;REF;;;;;Cycle;trn_pass;S1S;0.01379;0.0149;0.0745;0.07824;0.07824
+SSP1;REF;;;;;Domestic Aviation;trn_pass;S1S;0.03574;0.01163;0.01156;0.003468;0.003468
 SSP1;REF;;;;;Domestic Ship;trn_freight;S1S;0.007227;0.007227;0.007227;0.007227;0.007227
-SSP1;REF;;;;;Freight Rail;trn_freight;S1S;0.1296;0.1296;0.1944;0.1944;0.1944
-SSP1;REF;;;;;HSR;trn_pass;S1S;0;0.002037;0.002516;0.000755;0.000755
+SSP1;REF;;;;;Freight Rail;trn_freight;S1S;0.1296;0.1944;0.1944;0.1944;0.1944
+SSP1;REF;;;;;HSR;trn_pass;S1S;0;0.002516;0.002516;0.000755;0.000755
 SSP1;REF;;;;;International Aviation;trn_aviation_intl;S1S;1;1;1;1;1
 SSP1;REF;;;;;International Ship;trn_shipping_intl;S1S;1;1;1;1;1
-SSP1;REF;;;;;Passenger Rail;trn_pass;S1S;0.006884;0.01205;0.03721;0.02232;0.02232
-SSP1;REF;;;;;Walk;trn_pass;S1S;0.9251;0.8095;1;1;1
+SSP1;REF;;;;;Passenger Rail;trn_pass;S1S;0.006884;0.02977;0.03721;0.02232;0.02232
+SSP1;REF;;;;;Walk;trn_pass;S1S;0.9251;0.8;1;1;1
 SSP1;REF;;;;;trn_freight_road;trn_freight;S1S;1;1;1;1;1
-SSP1;REF;;;;;trn_pass_road;trn_pass;S1S;1;1;0.6177;0.2316;0.2316
-SSP1;REF;;;;Bus;trn_pass_road;trn_pass;S2S1;0.2684;0.1864;0.2329;0.1863;0.1863
+SSP1;REF;;;;;trn_pass_road;trn_pass;S1S;1;0.6177;0.6177;0.2316;0.2316
+SSP1;REF;;;;Bus;trn_pass_road;trn_pass;S2S1;0.2684;0.2796;0.2329;0.1863;0.1863
 SSP1;REF;;;;trn_pass_road_LDV;trn_pass_road;trn_pass;S2S1;1;1;1;1;1
 SSP1;REF;;;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;0.8;0.7;0.5;0.5;0.5
 SSP1;REF;;;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;1;1;1;1;1
-SSP1;REF;;Compact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.4455;0.4176;0.8352;1;1
+SSP1;REF;;Compact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.4455;0.6264;0.8352;1;1
 SSP1;REF;;Large Car and SUV;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;1;1;1;0.8731;0.8731
 SSP1;REF;;Midsize Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.1842;0.1842;0.1842;0.1608;0.1608
-SSP1;REF;;Mini Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.0001425;0.0001336;0.0002672;0.0003201;0.0003201
+SSP1;REF;;Mini Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.0001425;0.0002004;0.0002672;0.0003201;0.0003201
 SSP1;REF;;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.003376;0.003376;0.003376;0.003376;0.003376
 SSP1;REF;;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;1;1;1;1;1
 SSP1;REF;;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.4141;0.4141;0.4141;0.4141;0.4141
-SSP1;REF;;Subcompact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.02508;0.02351;0.04702;0.05631;0.05631
+SSP1;REF;;Subcompact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.02508;0.03526;0.04702;0.05631;0.05631
 SSP1;REF;;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;1;1;1;1;1
 SSP1;REF;;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.005081;0.005081;0.005081;0.005081;0.005081
 SSP1;REF;;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.5837;0.5837;0.5837;0.5837;0.5837
 SSP1;REF;;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.1888;0.1888;0.1888;0.1888;0.1888
 SSP1;REF;;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.01676;0.01676;0.01676;0.01676;0.01676
-SSP1;REF;BEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.07245;0.6404;1;1
-SSP1;REF;BEV;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.04;0.336;0.672;0.672
-SSP1;REF;BEV;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.04;0.336;0.672;0.672
-SSP1;REF;BEV;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.04;0.336;0.672;0.672
-SSP1;REF;BEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1183;0.5356;0.7914;0.7914
-SSP1;REF;BEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.04705;0.2882;0.7676;0.7676
-SSP1;REF;BEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.04705;0.2882;0.7676;0.7676
-SSP1;REF;BEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.04705;0.2882;0.7676;0.7676
-SSP1;REF;BEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1183;0.5356;0.7914;0.7914
+SSP1;REF;BEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.1449;0.6404;1;1
+SSP1;REF;BEV;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.08;0.336;0.672;0.672
+SSP1;REF;BEV;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.08;0.336;0.672;0.672
+SSP1;REF;BEV;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.08;0.336;0.672;0.672
+SSP1;REF;BEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.2366;0.5356;0.7914;0.7914
+SSP1;REF;BEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.0941;0.2882;0.7676;0.7676
+SSP1;REF;BEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.0941;0.2882;0.7676;0.7676
+SSP1;REF;BEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.0941;0.2882;0.7676;0.7676
+SSP1;REF;BEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.2366;0.5356;0.7914;0.7914
 SSP1;REF;Electric;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;1;1;1;1;1
 SSP1;REF;Electric;HSR_tmp_vehicletype;HSR_tmp_subsectorL3;HSR_tmp_subsectorL2;HSR;trn_pass;FV;1;1;1;1;1
 SSP1;REF;Electric;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;1;1;1;1;1
 SSP1;REF;FCEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.002698;0.03569;0.04199;0.04199
-SSP1;REF;FCEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.05975;0.1411;0.1657;0.1657
-SSP1;REF;FCEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02208;0.05352;0.1133;0.1133
-SSP1;REF;FCEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02208;0.05352;0.1133;0.1133
-SSP1;REF;FCEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02208;0.05352;0.1133;0.1133
-SSP1;REF;FCEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.05975;0.1411;0.1657;0.1657
+SSP1;REF;FCEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1792;0.1411;0.1657;0.1657
+SSP1;REF;FCEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.06624;0.05352;0.1133;0.1133
+SSP1;REF;FCEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.06624;0.05352;0.1133;0.1133
+SSP1;REF;FCEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.06624;0.05352;0.1133;0.1133
+SSP1;REF;FCEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1792;0.1411;0.1657;0.1657
 SSP1;REF;Gases;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0.014;0.03195;0.06011;0.05269;0.05269
 SSP1;REF;Gases;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.03465;0.06073;0.09593;0.1342;0.1342
 SSP1;REF;Gases;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02392;0.06459;0.1134;0.1134
@@ -6874,35 +6874,35 @@ SSP1;REF;Hydrogen;Domestic Aviation_tmp_vehicletype;Domestic Aviation_tmp_subsec
 SSP1;REF;Liquids;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;1;1;1;0.6734;0.6734
 SSP1;REF;Liquids;Domestic Aviation_tmp_vehicletype;Domestic Aviation_tmp_subsectorL3;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;trn_pass;FV;1;1;1;1;1
 SSP1;REF;Liquids;Domestic Ship_tmp_vehicletype;Domestic Ship_tmp_subsectorL3;Domestic Ship_tmp_subsectorL2;Domestic Ship;trn_freight;FV;1;1;1;1;1
-SSP1;REF;Liquids;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;0.4599;0.4599;0.2299;0.2299;0.2299
+SSP1;REF;Liquids;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;0.4599;0.2299;0.2299;0.2299;0.2299
 SSP1;REF;Liquids;International Aviation_tmp_vehicletype;International Aviation_tmp_subsectorL3;International Aviation_tmp_subsectorL2;International Aviation;trn_aviation_intl;FV;1;1;1;1;1
 SSP1;REF;Liquids;International Ship_tmp_vehicletype;International Ship_tmp_subsectorL3;International Ship_tmp_subsectorL2;International Ship;trn_shipping_intl;FV;1;1;1;1;1
 SSP1;REF;Liquids;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;1;1;1
 SSP1;REF;Liquids;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;1;1;1
 SSP1;REF;Liquids;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;1;1;1
-SSP1;REF;Liquids;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;0.2359;0.2359;0.1179;0.07863;0.07863
+SSP1;REF;Liquids;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;0.2359;0.1573;0.1179;0.07863;0.07863
 SSP1;REF;Liquids;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
 SSP1;REF;Liquids;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
 SSP1;REF;Liquids;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
 SSP1;REF;Liquids;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
 SSP1;REF;Liquids;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
 SSP1;SSA;;;;;Cycle;trn_pass;S1S;0.01388;0.01987;0.02915;0.03279;0.03279
-SSP1;SSA;;;;;Domestic Aviation;trn_pass;S1S;0.033;0.05387;0.009878;0.001481;0.001481
+SSP1;SSA;;;;;Domestic Aviation;trn_pass;S1S;0.008602;0.01347;0.009878;0.001481;0.001481
 SSP1;SSA;;;;;Domestic Ship;trn_freight;S1S;0.001495;0.001495;0.001495;0.001495;0.001495
-SSP1;SSA;;;;;Freight Rail;trn_freight;S1S;0.01665;0.01665;0.02498;0.02247;0.02247
+SSP1;SSA;;;;;Freight Rail;trn_freight;S1S;0.01665;0.02498;0.02498;0.02247;0.02247
 SSP1;SSA;;;;;HSR;trn_pass;S1S;1.48E-05;2.22E-05;0.06504;0.009756;0.009756
 SSP1;SSA;;;;;International Aviation;trn_aviation_intl;S1S;1;1;1;1;1
 SSP1;SSA;;;;;International Ship;trn_shipping_intl;S1S;1;1;1;1;1
-SSP1;SSA;;;;;Passenger Rail;trn_pass;S1S;0.0006024;0.001725;0.00506;0.001139;0.001139
+SSP1;SSA;;;;;Passenger Rail;trn_pass;S1S;0.0006024;0.00345;0.00506;0.001139;0.001139
 SSP1;SSA;;;;;Walk;trn_pass;S1S;1;1;1;1;1
 SSP1;SSA;;;;;trn_freight_road;trn_freight;S1S;1;1;1;1;1
-SSP1;SSA;;;;;trn_pass_road;trn_pass;S1S;0.2622;0.326;0.1434;0.0239;0.0239
-SSP1;SSA;;;;Bus;trn_pass_road;trn_pass;S2S1;0.7568;0.3234;0.224;0.1455;0.1455
+SSP1;SSA;;;;;trn_pass_road;trn_pass;S1S;0.2622;0.163;0.1434;0.0239;0.0239
+SSP1;SSA;;;;Bus;trn_pass_road;trn_pass;S2S1;0.7568;0.4851;0.224;0.1455;0.1455
 SSP1;SSA;;;;trn_pass_road_LDV;trn_pass_road;trn_pass;S2S1;1;1;1;1;1
 SSP1;SSA;;;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;0.02619;0.02619;0.02619;0.03928;0.03928
 SSP1;SSA;;;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;1;1;1;1;1
 SSP1;SSA;;Compact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;1;1;1;1;1
-SSP1;SSA;;Large Car and SUV;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.003022;0.003022;0.001511;0.001007;0.001007
+SSP1;SSA;;Large Car and SUV;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.003022;0.002015;0.001511;0.001007;0.001007
 SSP1;SSA;;Mini Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.02706;0.02706;0.02706;0.02706;0.02706
 SSP1;SSA;;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.3828;0.3828;0.3828;0.3828;0.3828
 SSP1;SSA;;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;1;1;1;1;1
@@ -6913,25 +6913,25 @@ SSP1;SSA;;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subs
 SSP1;SSA;;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;5.61E-06;5.61E-06;5.61E-06;5.61E-06;5.61E-06
 SSP1;SSA;;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;4.21E-06;4.21E-06;4.21E-06;4.21E-06;4.21E-06
 SSP1;SSA;;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;1;1;1;1;1
-SSP1;SSA;;Van;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;7.57E-05;7.57E-05;3.79E-05;2.52E-05;2.52E-05
-SSP1;SSA;BEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.0621;0.7924;1;1
-SSP1;SSA;BEV;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.1;0.432;0.672;0.672
-SSP1;SSA;BEV;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.1;0.432;0.672;0.672
-SSP1;SSA;BEV;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.1;0.432;0.672;0.672
-SSP1;SSA;BEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02602;0.2014;0.3022;0.3022
-SSP1;SSA;BEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.01035;0.1084;0.2932;0.2932
-SSP1;SSA;BEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.01035;0.1084;0.2932;0.2932
-SSP1;SSA;BEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.01035;0.1084;0.2932;0.2932
-SSP1;SSA;BEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02602;0.2014;0.3022;0.3022
+SSP1;SSA;;Van;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;7.57E-05;5.05E-05;3.79E-05;2.52E-05;2.52E-05
+SSP1;SSA;BEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.1242;0.7924;1;1
+SSP1;SSA;BEV;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.2;0.432;0.672;0.672
+SSP1;SSA;BEV;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.2;0.432;0.672;0.672
+SSP1;SSA;BEV;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.2;0.432;0.672;0.672
+SSP1;SSA;BEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.05204;0.2014;0.3022;0.3022
+SSP1;SSA;BEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.0207;0.1084;0.2932;0.2932
+SSP1;SSA;BEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.0207;0.1084;0.2932;0.2932
+SSP1;SSA;BEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.0207;0.1084;0.2932;0.2932
+SSP1;SSA;BEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.05204;0.2014;0.3022;0.3022
 SSP1;SSA;Electric;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;1;1;1;1;1
 SSP1;SSA;Electric;HSR_tmp_vehicletype;HSR_tmp_subsectorL3;HSR_tmp_subsectorL2;HSR;trn_pass;FV;1;1;1;1;1
 SSP1;SSA;Electric;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;1;1;1;1;1
 SSP1;SSA;FCEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.002698;0.01963;0.02863;0.02863
-SSP1;SSA;FCEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.007303;0.03582;0.06135;0.06135
-SSP1;SSA;FCEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.002698;0.01359;0.04197;0.04197
-SSP1;SSA;FCEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.002698;0.01359;0.04197;0.04197
-SSP1;SSA;FCEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.002698;0.01359;0.04197;0.04197
-SSP1;SSA;FCEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.007303;0.03582;0.06135;0.06135
+SSP1;SSA;FCEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02191;0.03582;0.06135;0.06135
+SSP1;SSA;FCEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.008094;0.01359;0.04197;0.04197
+SSP1;SSA;FCEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.008094;0.01359;0.04197;0.04197
+SSP1;SSA;FCEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.008094;0.01359;0.04197;0.04197
+SSP1;SSA;FCEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02191;0.03582;0.06135;0.06135
 SSP1;SSA;Gases;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0.0003981;0.0267;0.04997;0.04035;0.04035
 SSP1;SSA;Gases;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02632;0.04251;0.05904;0.05904
 SSP1;SSA;Gases;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02632;0.04251;0.05904;0.05904
@@ -6942,65 +6942,65 @@ SSP1;SSA;Hydrogen;Domestic Aviation_tmp_vehicletype;Domestic Aviation_tmp_subsec
 SSP1;SSA;Liquids;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;1;1;1;0.5903;0.5903
 SSP1;SSA;Liquids;Domestic Aviation_tmp_vehicletype;Domestic Aviation_tmp_subsectorL3;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;trn_pass;FV;1;1;1;1;1
 SSP1;SSA;Liquids;Domestic Ship_tmp_vehicletype;Domestic Ship_tmp_subsectorL3;Domestic Ship_tmp_subsectorL2;Domestic Ship;trn_freight;FV;1;1;1;1;1
-SSP1;SSA;Liquids;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;0.6248;0.6248;0.3124;0.3124;0.3124
+SSP1;SSA;Liquids;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;0.6248;0.3124;0.3124;0.3124;0.3124
 SSP1;SSA;Liquids;International Aviation_tmp_vehicletype;International Aviation_tmp_subsectorL3;International Aviation_tmp_subsectorL2;International Aviation;trn_aviation_intl;FV;1;1;1;1;1
 SSP1;SSA;Liquids;International Ship_tmp_vehicletype;International Ship_tmp_subsectorL3;International Ship_tmp_subsectorL2;International Ship;trn_shipping_intl;FV;1;1;1;1;1
 SSP1;SSA;Liquids;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;1;1;1
 SSP1;SSA;Liquids;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;1;1;1
 SSP1;SSA;Liquids;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;1;1;1
-SSP1;SSA;Liquids;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;0.07561;0.07561;0.0378;0.0252;0.0252
+SSP1;SSA;Liquids;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;0.07561;0.05041;0.0378;0.0252;0.0252
 SSP1;SSA;Liquids;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
 SSP1;SSA;Liquids;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
 SSP1;SSA;Liquids;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
 SSP1;SSA;Liquids;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
 SSP1;SSA;Liquids;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
 SSP1;UKI;;;;;Cycle;trn_pass;S1S;0.025;0.01092;0.03277;0.06553;0.06553
-SSP1;UKI;;;;;Domestic Aviation;trn_pass;S1S;5.97E-05;8.94E-06;2.23E-06;2.23E-06;2.23E-06
+SSP1;UKI;;;;;Domestic Aviation;trn_pass;S1S;5.97E-05;2.23E-06;2.23E-06;2.23E-06;2.23E-06
 SSP1;UKI;;;;;Domestic Ship;trn_freight;S1S;0.00867;0.00867;0.00867;0.00867;0.00867
-SSP1;UKI;;;;;Freight Rail;trn_freight;S1S;0.00618;0.00618;0.00927;0.00927;0.00927
+SSP1;UKI;;;;;Freight Rail;trn_freight;S1S;0.00618;0.00927;0.00927;0.00927;0.00927
 SSP1;UKI;;;;;HSR;trn_pass;S1S;0.000125;0.0001334;0.0001779;0.0002224;0.0002224
 SSP1;UKI;;;;;International Aviation;trn_aviation_intl;S1S;1;1;1;1;1
 SSP1;UKI;;;;;International Ship;trn_shipping_intl;S1S;1;1;1;1;1
-SSP1;UKI;;;;;Passenger Rail;trn_pass;S1S;0.003125;0.002502;0.003752;0.003752;0.003752
-SSP1;UKI;;;;;Walk;trn_pass;S1S;1;1;1;1;1
+SSP1;UKI;;;;;Passenger Rail;trn_pass;S1S;0.003125;0.005004;0.003752;0.003752;0.003752
+SSP1;UKI;;;;;Walk;trn_pass;S1S;1;0.8;1;1;1
 SSP1;UKI;;;;;trn_freight_road;trn_freight;S1S;1;1;1;1;1
-SSP1;UKI;;;;;trn_pass_road;trn_pass;S1S;0.07363;0.05228;0.01673;0.01673;0.01673
-SSP1;UKI;;;;Bus;trn_pass_road;trn_pass;S2S1;0.2546;0.2048;0.2816;0.2559;0.2559
+SSP1;UKI;;;;;trn_pass_road;trn_pass;S1S;0.07363;0.02614;0.01673;0.01673;0.01673
+SSP1;UKI;;;;Bus;trn_pass_road;trn_pass;S2S1;0.2546;0.3072;0.2816;0.2559;0.2559
 SSP1;UKI;;;;trn_pass_road_LDV;trn_pass_road;trn_pass;S2S1;1;1;1;1;1
 SSP1;UKI;;;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;0.1;0.1;0.1;0.1;0.1
 SSP1;UKI;;;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;1;1;1;1;1
-SSP1;UKI;;Compact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.5404;0.5404;0.9502;0.9502;0.9502
+SSP1;UKI;;Compact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.5404;0.8106;0.9502;0.9502;0.9502
 SSP1;UKI;;Large Car and SUV;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;1;1;0.9768;0.6512;0.6512
 SSP1;UKI;;Midsize Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.2616;0.2616;0.2555;0.1703;0.1703
-SSP1;UKI;;Mini Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;5.28E-07;5.28E-07;9.28E-07;9.28E-07;9.28E-07
+SSP1;UKI;;Mini Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;5.28E-07;7.92E-07;9.28E-07;9.28E-07;9.28E-07
 SSP1;UKI;;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.02088;0.02088;0.02088;0.02088;0.02088
 SSP1;UKI;;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.003798;0.003798;0.003798;0.003798;0.003798
 SSP1;UKI;;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;1;1;1;1;1
-SSP1;UKI;;Subcompact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.5688;0.5688;1;1;1
+SSP1;UKI;;Subcompact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.5688;0.8532;1;1;1
 SSP1;UKI;;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;1;1;1;1;1
 SSP1;UKI;;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.04528;0.04528;0.04528;0.04528;0.04528
 SSP1;UKI;;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.09437;0.09437;0.09437;0.09437;0.09437
 SSP1;UKI;;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.5696;0.5696;0.5696;0.5696;0.5696
 SSP1;UKI;;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.7765;0.7765;0.7765;0.7765;0.7765
 SSP1;UKI;;Van;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.002681;0.002681;0.002619;0.001746;0.001746
-SSP1;UKI;BEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0.025;0.1168;0.6868;1;1
-SSP1;UKI;BEV;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.05;0.4;0.74;0.74
-SSP1;UKI;BEV;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.05;0.4;0.74;0.74
-SSP1;UKI;BEV;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.05;0.4;0.74;0.74
-SSP1;UKI;BEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.2819;1;1;1
-SSP1;UKI;BEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1122;0.6296;1;1
-SSP1;UKI;BEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1122;0.6296;1;1
-SSP1;UKI;BEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1122;0.6296;1;1
-SSP1;UKI;BEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.2819;1;1;1
-SSP1;UKI;Electric;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;0.826;0.8478;1;1;1
+SSP1;UKI;BEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0.025;0.2336;0.6868;1;1
+SSP1;UKI;BEV;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.1;0.4;0.74;0.74
+SSP1;UKI;BEV;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.1;0.4;0.74;0.74
+SSP1;UKI;BEV;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.1;0.4;0.74;0.74
+SSP1;UKI;BEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.5638;1;1;1
+SSP1;UKI;BEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.2244;0.6296;1;1
+SSP1;UKI;BEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.2244;0.6296;1;1
+SSP1;UKI;BEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.2244;0.6296;1;1
+SSP1;UKI;BEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.5638;1;1;1
+SSP1;UKI;Electric;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;0.826;1;1;1;1
 SSP1;UKI;Electric;HSR_tmp_vehicletype;HSR_tmp_subsectorL3;HSR_tmp_subsectorL2;HSR;trn_pass;FV;1;1;1;1;1
 SSP1;UKI;Electric;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;1;1;1;1;1
 SSP1;UKI;FCEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;2.5E-05;0.01218;0.02127;0.05302;0.05302
-SSP1;UKI;FCEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.07914;0.5748;0.3102;0.3102
-SSP1;UKI;FCEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02924;0.2552;0.2186;0.2186
-SSP1;UKI;FCEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02924;0.2552;0.2186;0.2186
-SSP1;UKI;FCEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02924;0.2552;0.2186;0.2186
-SSP1;UKI;FCEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.07914;0.5748;0.3102;0.3102
+SSP1;UKI;FCEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.2374;0.5748;0.3102;0.3102
+SSP1;UKI;FCEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.08772;0.2552;0.2186;0.2186
+SSP1;UKI;FCEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.08772;0.2552;0.2186;0.2186
+SSP1;UKI;FCEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.08772;0.2552;0.2186;0.2186
+SSP1;UKI;FCEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.2374;0.5748;0.3102;0.3102
 SSP1;UKI;Gases;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0.000904;0.02222;0.07928;0.08273;0.08273
 SSP1;UKI;Gases;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02632;0.06744;0.1102;0.1102
 SSP1;UKI;Gases;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02632;0.07895;0.1136;0.1136
@@ -7011,34 +7011,34 @@ SSP1;UKI;Hydrogen;Domestic Aviation_tmp_vehicletype;Domestic Aviation_tmp_subsec
 SSP1;UKI;Liquids;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;1;1;1;0.6726;0.6726
 SSP1;UKI;Liquids;Domestic Aviation_tmp_vehicletype;Domestic Aviation_tmp_subsectorL3;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;trn_pass;FV;1;1;1;1;1
 SSP1;UKI;Liquids;Domestic Ship_tmp_vehicletype;Domestic Ship_tmp_subsectorL3;Domestic Ship_tmp_subsectorL2;Domestic Ship;trn_freight;FV;1;1;1;1;1
-SSP1;UKI;Liquids;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;1;1;0.561;0.5111;0.5111
+SSP1;UKI;Liquids;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;1;0.5898;0.561;0.5111;0.5111
 SSP1;UKI;Liquids;International Aviation_tmp_vehicletype;International Aviation_tmp_subsectorL3;International Aviation_tmp_subsectorL2;International Aviation;trn_aviation_intl;FV;1;1;1;1;1
 SSP1;UKI;Liquids;International Ship_tmp_vehicletype;International Ship_tmp_subsectorL3;International Ship_tmp_subsectorL2;International Ship;trn_shipping_intl;FV;1;1;1;1;1
 SSP1;UKI;Liquids;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;1;1;1
 SSP1;UKI;Liquids;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;1;1;1
 SSP1;UKI;Liquids;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;1;1;1
-SSP1;UKI;Liquids;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;0.5355;0.5355;0.2677;0.1785;0.1785
+SSP1;UKI;Liquids;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;0.5355;0.357;0.2677;0.1785;0.1785
 SSP1;UKI;Liquids;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;0.8543;0.5981;0.5981
 SSP1;UKI;Liquids;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;0.6165;0.6165
 SSP1;UKI;Liquids;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;0.6165;0.6165
 SSP1;UKI;Liquids;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;0.6165;0.6165
 SSP1;UKI;Liquids;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;0.8543;0.5981;0.5981
 SSP1;USA;;;;;Cycle;trn_pass;S1S;0.008197;0.008197;0.008197;0.04098;0.04098
-SSP1;USA;;;;;Domestic Aviation;trn_pass;S1S;0.001009;0.001527;0.0004295;0.0002625;0.0002625
+SSP1;USA;;;;;Domestic Aviation;trn_pass;S1S;0.001009;0.0003817;0.0004295;0.0002625;0.0002625
 SSP1;USA;;;;;Domestic Ship;trn_freight;S1S;0.003267;0.003267;0.003267;0.003267;0.003267
-SSP1;USA;;;;;Freight Rail;trn_freight;S1S;0.03427;0.03427;0.0514;0.0514;0.0514
+SSP1;USA;;;;;Freight Rail;trn_freight;S1S;0.03427;0.0514;0.0514;0.0514;0.0514
 SSP1;USA;;;;;HSR;trn_pass;S1S;4.53E-06;4.53E-06;4.53E-06;0.0002265;0.0002265
 SSP1;USA;;;;;International Aviation;trn_aviation_intl;S1S;1;1;1;1;1
 SSP1;USA;;;;;International Ship;trn_shipping_intl;S1S;1;1;1;1;1
-SSP1;USA;;;;;Passenger Rail;trn_pass;S1S;0.001933;0.001933;0.003866;0.001933;0.001933
-SSP1;USA;;;;;Walk;trn_pass;S1S;1;1;1;1;1
+SSP1;USA;;;;;Passenger Rail;trn_pass;S1S;0.001933;0.003866;0.003866;0.001933;0.001933
+SSP1;USA;;;;;Walk;trn_pass;S1S;1;0.8;1;1;1
 SSP1;USA;;;;;trn_freight_road;trn_freight;S1S;1;1;1;1;1
-SSP1;USA;;;;;trn_pass_road;trn_pass;S1S;0.1305;0.1436;0.06265;0.03263;0.03263
-SSP1;USA;;;;Bus;trn_pass_road;trn_pass;S2S1;0.0872;0.109;0.1635;0.1852;0.1852
+SSP1;USA;;;;;trn_pass_road;trn_pass;S1S;0.1305;0.06525;0.06265;0.03263;0.03263
+SSP1;USA;;;;Bus;trn_pass_road;trn_pass;S2S1;0.0872;0.1635;0.1635;0.1852;0.1852
 SSP1;USA;;;;trn_pass_road_LDV;trn_pass_road;trn_pass;S2S1;1;1;1;1;1
 SSP1;USA;;;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;0.06;0.06;0.06;0.05;0.05
 SSP1;USA;;;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;1;1;1;1;1
-SSP1;USA;;Compact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.3784;0.3784;0.7568;1;1
+SSP1;USA;;Compact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.3784;0.5676;0.7568;1;1
 SSP1;USA;;Large Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.2661;0.2661;0.2661;0.2344;0.2344
 SSP1;USA;;Large Car and SUV;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;1;1;1;0.8809;0.8809
 SSP1;USA;;Midsize Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.3745;0.3745;0.3745;0.3299;0.3299
@@ -7048,22 +7048,22 @@ SSP1;USA;;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subs
 SSP1;USA;;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.9;1;1;1;1
 SSP1;USA;;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.9;1;1;1;1
 SSP1;USA;;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.6263;0.6263;0.6263;0.6263;0.6263
-SSP1;USA;BEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.1122;1;1;1
-SSP1;USA;BEV;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.044;0.432;0.756;0.756
-SSP1;USA;BEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.01626;0.4646;1;1
-SSP1;USA;BEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.00647;0.2498;1;1
-SSP1;USA;BEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.03547;0.1364;0.929;1;1
-SSP1;USA;BEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.03547;0.1364;0.929;1;1
-SSP1;USA;BEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.01626;0.4646;1;1
-SSP1;USA;Electric;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;0;0.125;0.75;1;1
+SSP1;USA;BEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.2244;1;1;1
+SSP1;USA;BEV;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.088;0.432;0.756;0.756
+SSP1;USA;BEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.03252;0.4646;1;1
+SSP1;USA;BEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.01294;0.2498;1;1
+SSP1;USA;BEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.03547;0.2728;0.929;1;1
+SSP1;USA;BEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.03547;0.2728;0.929;1;1
+SSP1;USA;BEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.03252;0.4646;1;1
+SSP1;USA;Electric;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;0;0.25;0.75;1;1
 SSP1;USA;Electric;HSR_tmp_vehicletype;HSR_tmp_subsectorL3;HSR_tmp_subsectorL2;HSR;trn_pass;FV;1;1;1;1;1
 SSP1;USA;Electric;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;1;1;1;1;1
 SSP1;USA;FCEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.02436;0.0152;0.03888;0.03888
-SSP1;USA;FCEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.001218;0.03606;0.217;0.217
-SSP1;USA;FCEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.0004498;0.01367;0.1531;0.1531
-SSP1;USA;FCEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.05912;0.1819;0.7602;0.2915;0.2915
-SSP1;USA;FCEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.05912;0.1819;0.7602;0.2915;0.2915
-SSP1;USA;FCEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.001218;0.03606;0.217;0.217
+SSP1;USA;FCEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.003654;0.03606;0.217;0.217
+SSP1;USA;FCEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.001349;0.01367;0.1531;0.1531
+SSP1;USA;FCEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.05912;0.5457;0.7602;0.2915;0.2915
+SSP1;USA;FCEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.05912;0.5457;0.7602;0.2915;0.2915
+SSP1;USA;FCEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.003654;0.03606;0.217;0.217
 SSP1;USA;Gases;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0.08478;0.09072;0.1122;0.0833;0.0833
 SSP1;USA;Gases;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.004049;0.02256;0.04406;0.04406
 SSP1;USA;Gases;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.004049;0.02256;0.04543;0.04543
@@ -7078,7 +7078,7 @@ SSP1;USA;Liquids;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freig
 SSP1;USA;Liquids;International Aviation_tmp_vehicletype;International Aviation_tmp_subsectorL3;International Aviation_tmp_subsectorL2;International Aviation;trn_aviation_intl;FV;1;1;1;1;1
 SSP1;USA;Liquids;International Ship_tmp_vehicletype;International Ship_tmp_subsectorL3;International Ship_tmp_subsectorL2;International Ship;trn_shipping_intl;FV;1;1;1;1;1
 SSP1;USA;Liquids;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;1;1;1
-SSP1;USA;Liquids;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;0.4393;0.4393;0.2197;0.1464;0.1464
+SSP1;USA;Liquids;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;0.4393;0.2929;0.2197;0.1464;0.1464
 SSP1;USA;Liquids;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;0.7177;0.7177
 SSP1;USA;Liquids;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;0.7399;0.7399
 SSP1;USA;Liquids;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;0.7047;0.7047

--- a/inst/extdata/genParBaselinePrefTrends.csv
+++ b/inst/extdata/genParBaselinePrefTrends.csv
@@ -5668,53 +5668,53 @@ SDP_RC;USA;Liquids;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road
 SDP_RC;USA;Liquids;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;0.5382;0.3524;0.3524
 SDP_RC;USA;Liquids;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;0.3588;0.3588
 SSP1;CAZ;;;;;Cycle;trn_pass;S1S;0.01911;0.03822;0.03822;0.07645;0.07645
-SSP1;CAZ;;;;;Domestic Aviation;trn_pass;S1S;0.001432;0.001145;0.0004532;0.0004773;0.0004773
+SSP1;CAZ;;;;;Domestic Aviation;trn_pass;S1S;0.001432;0.001527;0.0004532;0.0004773;0.0004773
 SSP1;CAZ;;;;;Domestic Ship;trn_freight;S1S;0.01583;0.01583;0.01583;0.01583;0.01583
-SSP1;CAZ;;;;;Freight Rail;trn_freight;S1S;0.107;0.1605;0.1605;0.1445;0.1445
+SSP1;CAZ;;;;;Freight Rail;trn_freight;S1S;0.107;0.107;0.1605;0.1445;0.1445
 SSP1;CAZ;;;;;HSR;trn_pass;S1S;8.79E-08;8.79E-05;0.0002638;0.0002638;0.0002638
 SSP1;CAZ;;;;;International Aviation;trn_aviation_intl;S1S;1;1;1;1;1
 SSP1;CAZ;;;;;International Ship;trn_shipping_intl;S1S;1;1;1;1;1
-SSP1;CAZ;;;;;Passenger Rail;trn_pass;S1S;0.0008785;0.001757;0.001757;0.001757;0.001757
-SSP1;CAZ;;;;;Walk;trn_pass;S1S;1;0.8;1;1;1
+SSP1;CAZ;;;;;Passenger Rail;trn_pass;S1S;0.0008785;0.0008785;0.001757;0.001757;0.001757
+SSP1;CAZ;;;;;Walk;trn_pass;S1S;1;1;1;1;1
 SSP1;CAZ;;;;;trn_freight_road;trn_freight;S1S;1;1;1;1;1
-SSP1;CAZ;;;;;trn_pass_road;trn_pass;S1S;0.1509;0.1056;0.06036;0.07545;0.07545
-SSP1;CAZ;;;;Bus;trn_pass_road;trn_pass;S2S1;0.08852;0.1328;0.1661;0.2103;0.2103
-SSP1;CAZ;;;;trn_pass_road_LDV;trn_pass_road;trn_pass;S2S1;1;1.2;1;1;1
-SSP1;CAZ;;;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;0.04;0.034;0.03;0.02;0.02
+SSP1;CAZ;;;;;trn_pass_road;trn_pass;S1S;0.1509;0.1509;0.06036;0.07545;0.07545
+SSP1;CAZ;;;;Bus;trn_pass_road;trn_pass;S2S1;0.08852;0.08852;0.1661;0.2103;0.2103
+SSP1;CAZ;;;;trn_pass_road_LDV;trn_pass_road;trn_pass;S2S1;1;1;1;1;1
+SSP1;CAZ;;;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;0.999;0.034;0.03;0.02;0.02
 SSP1;CAZ;;;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;1;1;1;1;1
-SSP1;CAZ;;Compact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.1291;0.1936;0.2582;0.3873;0.3873
+SSP1;CAZ;;Compact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.1291;0.1291;0.2582;0.3873;0.3873
 SSP1;CAZ;;Large Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.3264;0.3264;0.3264;0.3264;0.3264
 SSP1;CAZ;;Large Car and SUV;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;6.97E-05;6.97E-05;6.97E-05;6.97E-05;6.97E-05
 SSP1;CAZ;;Midsize Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;1;1;1;1;1
-SSP1;CAZ;;Mini Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;9.88E-09;1.48E-08;1.98E-08;2.96E-08;2.96E-08
+SSP1;CAZ;;Mini Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;9.88E-09;9.88E-09;1.98E-08;2.96E-08;2.96E-08
 SSP1;CAZ;;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.0002867;0.0002867;0.0002867;0.0002867;0.0002867
 SSP1;CAZ;;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.0001994;0.0001994;0.0001994;0.0001994;0.0001994
 SSP1;CAZ;;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;1;1;1;1;1
-SSP1;CAZ;;Subcompact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;6.73E-05;0.0001009;0.0001346;0.0002018;0.0002018
+SSP1;CAZ;;Subcompact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;6.73E-05;6.73E-05;0.0001346;0.0002018;0.0002018
 SSP1;CAZ;;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;1;1;1;1;1
 SSP1;CAZ;;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.2333;0.2333;0.2333;0.2333;0.2333
 SSP1;CAZ;;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.8337;0.8337;0.8337;0.8337;0.8337
 SSP1;CAZ;;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;3.5E-05;3.5E-05;3.5E-05;3.5E-05;3.5E-05
 SSP1;CAZ;;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.6282;0.6282;0.6282;0.6282;0.6282
 SSP1;CAZ;;Van;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.2082;0.2082;0.2082;0.2082;0.2082
-SSP1;CAZ;BEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.2244;0.8846;1;1
-SSP1;CAZ;BEV;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.088;0.384;0.672;0.672
-SSP1;CAZ;BEV;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.088;0.384;0.672;0.672
-SSP1;CAZ;BEV;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.088;0.384;0.672;0.672
-SSP1;CAZ;BEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.2818;0.6622;0.8708;0.8708
-SSP1;CAZ;BEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1122;0.3562;0.8448;0.8448
-SSP1;CAZ;BEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1122;0.3562;0.8448;0.8448
-SSP1;CAZ;BEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1122;0.3562;0.8448;0.8448
-SSP1;CAZ;BEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.2818;0.6622;0.8708;0.8708
-SSP1;CAZ;Electric;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;0.09074;0.4088;0.8634;1;1
+SSP1;CAZ;BEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.1122;0.8846;1;1
+SSP1;CAZ;BEV;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.044;0.384;0.672;0.672
+SSP1;CAZ;BEV;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.044;0.384;0.672;0.672
+SSP1;CAZ;BEV;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.044;0.384;0.672;0.672
+SSP1;CAZ;BEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1409;0.6622;0.8708;0.8708
+SSP1;CAZ;BEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.05608;0.3562;0.8448;0.8448
+SSP1;CAZ;BEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.05608;0.3562;0.8448;0.8448
+SSP1;CAZ;BEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.05608;0.3562;0.8448;0.8448
+SSP1;CAZ;BEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1409;0.6622;0.8708;0.8708
+SSP1;CAZ;Electric;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;0.09074;0.2044;0.8634;1;1
 SSP1;CAZ;Electric;HSR_tmp_vehicletype;HSR_tmp_subsectorL3;HSR_tmp_subsectorL2;HSR;trn_pass;FV;1;1;1;1;1
 SSP1;CAZ;Electric;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;1;1;1;1;1
 SSP1;CAZ;FCEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.01462;0.01933;0.03904;0.03904
-SSP1;CAZ;FCEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1187;0.1682;0.3459;0.3459
-SSP1;CAZ;FCEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.04386;0.06381;0.2365;0.2365
-SSP1;CAZ;FCEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.04386;0.06381;0.2365;0.2365
-SSP1;CAZ;FCEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.04386;0.06381;0.2365;0.2365
-SSP1;CAZ;FCEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1187;0.1682;0.3459;0.3459
+SSP1;CAZ;FCEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.03957;0.1682;0.3459;0.3459
+SSP1;CAZ;FCEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.01462;0.06381;0.2365;0.2365
+SSP1;CAZ;FCEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.01462;0.06381;0.2365;0.2365
+SSP1;CAZ;FCEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.01462;0.06381;0.2365;0.2365
+SSP1;CAZ;FCEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.03957;0.1682;0.3459;0.3459
 SSP1;CAZ;Gases;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0.03104;0.05654;0.09776;0.07689;0.07689
 SSP1;CAZ;Gases;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02632;0.07895;0.1535;0.1535
 SSP1;CAZ;Gases;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02632;0.07895;0.1535;0.1535
@@ -5731,57 +5731,57 @@ SSP1;CAZ;Liquids;International Ship_tmp_vehicletype;International Ship_tmp_subse
 SSP1;CAZ;Liquids;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;1;1;1
 SSP1;CAZ;Liquids;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;1;1;1
 SSP1;CAZ;Liquids;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;1;1;1
-SSP1;CAZ;Liquids;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;0.2746;0.1831;0.1373;0.09153;0.09153
+SSP1;CAZ;Liquids;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;0.2746;0.2746;0.1373;0.09153;0.09153
 SSP1;CAZ;Liquids;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
 SSP1;CAZ;Liquids;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
 SSP1;CAZ;Liquids;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
 SSP1;CAZ;Liquids;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
 SSP1;CAZ;Liquids;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
 SSP1;CHA;;;;;Cycle;trn_pass;S1S;0.09454;0.04412;0.03782;0.04848;0.04848
-SSP1;CHA;;;;;Domestic Aviation;trn_pass;S1S;0.12;0.01;0.004363;0.0008393;0.0008393
+SSP1;CHA;;;;;Domestic Aviation;trn_pass;S1S;0.12;0.02712;0.004363;0.0008393;0.0008393
 SSP1;CHA;;;;;Domestic Ship;trn_freight;S1S;0.01847;0.01922;0.02232;0.02232;0.02232
-SSP1;CHA;;;;;Freight Rail;trn_freight;S1S;0.03204;0.05355;0.05693;0.05693;0.05693
+SSP1;CHA;;;;;Freight Rail;trn_freight;S1S;0.03204;0.0357;0.05693;0.05693;0.05693
 SSP1;CHA;;;;;HSR;trn_pass;S1S;0.2402;0.08143;0.01916;0.003695;0.003695
 SSP1;CHA;;;;;International Aviation;trn_aviation_intl;S1S;1;1;1;1;1
 SSP1;CHA;;;;;International Ship;trn_shipping_intl;S1S;1;1;1;1;1
-SSP1;CHA;;;;;Passenger Rail;trn_pass;S1S;0.006222;0.006222;0.003734;0.001914;0.001914
-SSP1;CHA;;;;;Walk;trn_pass;S1S;1;0.8;1;1;1
+SSP1;CHA;;;;;Passenger Rail;trn_pass;S1S;0.006222;0.003111;0.003734;0.001914;0.001914
+SSP1;CHA;;;;;Walk;trn_pass;S1S;1;1;1;1;1
 SSP1;CHA;;;;;trn_freight_road;trn_freight;S1S;1;1;1;1;1
-SSP1;CHA;;;;;trn_pass_road;trn_pass;S1S;0.6711;0.1342;0.0671;0.02007;0.02007
-SSP1;CHA;;;;Bus;trn_pass_road;trn_pass;S2S1;0.6609;0.439;0.4168;0.2895;0.2895
+SSP1;CHA;;;;;trn_pass_road;trn_pass;S1S;0.6711;0.2684;0.0671;0.02007;0.02007
+SSP1;CHA;;;;Bus;trn_pass_road;trn_pass;S2S1;0.6609;0.2927;0.4168;0.2895;0.2895
 SSP1;CHA;;;;trn_pass_road_LDV;trn_pass_road;trn_pass;S2S1;1;1;1;1;1
 SSP1;CHA;;;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;0.6;0.4;0.3;0.3;0.3
 SSP1;CHA;;;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;1;1;1;1;1
-SSP1;CHA;;Compact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.8035;1;1;1;1
-SSP1;CHA;;Large Car and SUV;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;1;0.9218;0.7606;0.5992;0.5992
-SSP1;CHA;;Mini Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.01783;0.02219;0.02219;0.02218;0.02218
+SSP1;CHA;;Compact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.8035;0.7232;1;1;1
+SSP1;CHA;;Large Car and SUV;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;1;1;0.7606;0.5992;0.5992
+SSP1;CHA;;Mini Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.01783;0.01605;0.02219;0.02218;0.02218
 SSP1;CHA;;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.04044;0.04044;0.04044;0.04044;0.04044
 SSP1;CHA;;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;1;1;1;1;1
 SSP1;CHA;;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;1;1;1;1;1
-SSP1;CHA;;Subcompact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.08662;0.1078;0.1078;0.1078;0.1078
+SSP1;CHA;;Subcompact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.08662;0.07795;0.1078;0.1078;0.1078
 SSP1;CHA;;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;1;1;1;1;1
 SSP1;CHA;;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.2234;0.2234;0.2234;0.2234;0.2234
 SSP1;CHA;;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.4022;0.3352;0.3016;0.3352;0.3352
 SSP1;CHA;;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.4022;0.3352;0.3016;0.3352;0.3352
 SSP1;CHA;;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.1657;0.1657;0.1657;0.1657;0.1657
-SSP1;CHA;BEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.6038;1;1;1
-SSP1;CHA;BEV;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;1;1;1;1
-SSP1;CHA;BEV;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0.06;1;1;1;1
-SSP1;CHA;BEV;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0;0;0;0
-SSP1;CHA;BEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.08004;0.745;1;1
-SSP1;CHA;BEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.03184;0.4008;1;1
-SSP1;CHA;BEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.0992;0.6716;1;1;1
-SSP1;CHA;BEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.0992;0.6716;1;1;1
-SSP1;CHA;BEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.08004;0.745;1;1
-SSP1;CHA;Electric;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;0.4553;1;1;1;1
+SSP1;CHA;BEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.3019;1;1;1
+SSP1;CHA;BEV;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.6;1;1;1
+SSP1;CHA;BEV;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0.06;0.6;1;1;1
+SSP1;CHA;BEV;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.6;0;0;0
+SSP1;CHA;BEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.04002;0.745;1;1
+SSP1;CHA;BEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.01592;0.4008;1;1
+SSP1;CHA;BEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.0992;0.3358;1;1;1
+SSP1;CHA;BEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.0992;0.3358;1;1;1
+SSP1;CHA;BEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.04002;0.745;1;1
+SSP1;CHA;Electric;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;0.4553;0.5234;1;1;1
 SSP1;CHA;Electric;HSR_tmp_vehicletype;HSR_tmp_subsectorL3;HSR_tmp_subsectorL2;HSR;trn_pass;FV;1;1;1;1;1
-SSP1;CHA;Electric;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;0.4158;0.7332;1;1;1
+SSP1;CHA;Electric;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;0.4158;0.4888;1;1;1
 SSP1;CHA;FCEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.02024;0.04777;0.03499;0.03499
-SSP1;CHA;FCEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.003372;0.05139;0.2481;0.2481
-SSP1;CHA;FCEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.001245;0.01949;0.175;0.175
-SSP1;CHA;FCEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.00992;0.5037;0.7272;0.3333;0.3333
-SSP1;CHA;FCEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.00992;0.5037;0.7272;0.3333;0.3333
-SSP1;CHA;FCEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.003372;0.05139;0.2481;0.2481
+SSP1;CHA;FCEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.001124;0.05139;0.2481;0.2481
+SSP1;CHA;FCEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.0004151;0.01949;0.175;0.175
+SSP1;CHA;FCEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.00992;0.1679;0.7272;0.3333;0.3333
+SSP1;CHA;FCEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.00992;0.1679;0.7272;0.3333;0.3333
+SSP1;CHA;FCEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.001124;0.05139;0.2481;0.2481
 SSP1;CHA;Gases;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0.1421;0.1329;0.05905;0.05275;0.05275
 SSP1;CHA;Gases;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1.71E-05;0.01014;0.03814;0.04776;0.04776
 SSP1;CHA;Gases;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.000714;0.0111;0.03928;0.04979;0.04979
@@ -5792,11 +5792,11 @@ SSP1;CHA;Hydrogen;Domestic Aviation_tmp_vehicletype;Domestic Aviation_tmp_subsec
 SSP1;CHA;Liquids;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;1;1;0.4868;0.1764;0.1764
 SSP1;CHA;Liquids;Domestic Aviation_tmp_vehicletype;Domestic Aviation_tmp_subsectorL3;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;trn_pass;FV;1;1;1;1;1
 SSP1;CHA;Liquids;Domestic Ship_tmp_vehicletype;Domestic Ship_tmp_subsectorL3;Domestic Ship_tmp_subsectorL2;Domestic Ship;trn_freight;FV;1;1;1;1;1
-SSP1;CHA;Liquids;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;1;0.9553;0.7582;0.5365;0.5365
+SSP1;CHA;Liquids;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;1;1;0.7582;0.5365;0.5365
 SSP1;CHA;Liquids;International Aviation_tmp_vehicletype;International Aviation_tmp_subsectorL3;International Aviation_tmp_subsectorL2;International Aviation;trn_aviation_intl;FV;1;1;1;1;1
 SSP1;CHA;Liquids;International Ship_tmp_vehicletype;International Ship_tmp_subsectorL3;International Ship_tmp_subsectorL2;International Ship;trn_shipping_intl;FV;1;1;1;1;1
-SSP1;CHA;Liquids;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;0.8333;0.4167;0.3402;0.3402
-SSP1;CHA;Liquids;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;0.8333;0.4167;0.3402;0.3402
+SSP1;CHA;Liquids;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;0.4167;0.3402;0.3402
+SSP1;CHA;Liquids;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;0.4167;0.3402;0.3402
 SSP1;CHA;Liquids;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;1;1;1
 SSP1;CHA;Liquids;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;1;1;0.7875;0.3596;0.3596
 SSP1;CHA;Liquids;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;0.5703;0.5703
@@ -5804,51 +5804,51 @@ SSP1;CHA;Liquids;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_t
 SSP1;CHA;Liquids;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;0.6711;0.56;0.56
 SSP1;CHA;Liquids;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;0.6711;0.56;0.56
 SSP1;CHA;Liquids;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;0.5703;0.5703
-SSP1;DEU;;;;;Cycle;trn_pass;S1S;0.042;0.025;0.025;0.1875;0.1875
-SSP1;DEU;;;;;Domestic Aviation;trn_pass;S1S;6.6E-05;2E-05;1.49E-05;1.49E-05;1.49E-05
-SSP1;DEU;;;;;Domestic Ship;trn_freight;S1S;0.004;0.002127;0.002127;0.002127;0.002127
-SSP1;DEU;;;;;Freight Rail;trn_freight;S1S;0.032;0.042;0.042;0.042;0.042
-SSP1;DEU;;;;;HSR;trn_pass;S1S;0.00018;0.00025;0.000625;0.000625;0.000625
+SSP1;DEU;;;;;Cycle;trn_pass;S1S;0.042;0.05;0.025;0.1875;0.1875
+SSP1;DEU;;;;;Domestic Aviation;trn_pass;S1S;6.6E-05;6.2E-05;1.49E-05;1.49E-05;1.49E-05
+SSP1;DEU;;;;;Domestic Ship;trn_freight;S1S;0.004;0.004;0.002127;0.002127;0.002127
+SSP1;DEU;;;;;Freight Rail;trn_freight;S1S;0.032;0.032;0.042;0.042;0.042
+SSP1;DEU;;;;;HSR;trn_pass;S1S;0.00018;0.0002;0.000625;0.000625;0.000625
 SSP1;DEU;;;;;International Aviation;trn_aviation_intl;S1S;1;1;1;1;1
 SSP1;DEU;;;;;International Ship;trn_shipping_intl;S1S;1;1;1;1;1
-SSP1;DEU;;;;;Passenger Rail;trn_pass;S1S;0.0032;0.0075;0.0075;0.0075;0.0075
-SSP1;DEU;;;;;Walk;trn_pass;S1S;1;0.8;1;1;1
-SSP1;DEU;;;;;trn_freight_road;trn_freight;S1S;0.94;1;1;1;1
-SSP1;DEU;;;;;trn_pass_road;trn_pass;S1S;0.0725;0.03682;0.03682;0.03682;0.03682
-SSP1;DEU;;;;Bus;trn_pass_road;trn_pass;S2S1;0.04;0.1222;0.1222;0.2292;0.2292
+SSP1;DEU;;;;;Passenger Rail;trn_pass;S1S;0.0032;0.004;0.0075;0.0075;0.0075
+SSP1;DEU;;;;;Walk;trn_pass;S1S;1;1;1;1;1
+SSP1;DEU;;;;;trn_freight_road;trn_freight;S1S;0.94;0.94;1;1;1
+SSP1;DEU;;;;;trn_pass_road;trn_pass;S1S;0.0725;0.0725;0.03682;0.03682;0.03682
+SSP1;DEU;;;;Bus;trn_pass_road;trn_pass;S2S1;0.04;0.06;0.1222;0.2292;0.2292
 SSP1;DEU;;;;trn_pass_road_LDV;trn_pass_road;trn_pass;S2S1;1;1;1;1;1
 SSP1;DEU;;;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;0.06;0.06;0.06;0.06;0.06
 SSP1;DEU;;;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;1;1;1;1;1
-SSP1;DEU;;Compact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.5249;0.7873;0.9448;0.9836;0.9836
+SSP1;DEU;;Compact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.5249;0.5249;0.9448;0.9836;0.9836
 SSP1;DEU;;Large Car and SUV;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;1;1;1;0.694;0.694
 SSP1;DEU;;Midsize Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.2716;0.2716;0.2716;0.1885;0.1885
 SSP1;DEU;;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.2183;0.2183;0.2183;0.2183;0.2183
 SSP1;DEU;;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.00663;0.00663;0.00663;0.00663;0.00663
 SSP1;DEU;;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;1;1;1;1;1
-SSP1;DEU;;Subcompact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.5337;0.8005;0.9606;1;1
+SSP1;DEU;;Subcompact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.5337;0.5337;0.9606;1;1
 SSP1;DEU;;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;1;1;1;1;1
 SSP1;DEU;;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.1873;0.1873;0.1873;0.1873;0.1873
 SSP1;DEU;;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.257;0.257;0.257;0.257;0.257
 SSP1;DEU;;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.8568;0.8568;0.8568;0.8568;0.8568
 SSP1;DEU;;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.4959;0.4959;0.4959;0.4959;0.4959
-SSP1;DEU;BEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.2588;0.7338;1;1
-SSP1;DEU;BEV;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.04;0.5;0.9;0.9
-SSP1;DEU;BEV;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.04;0.5;0.9;0.9
-SSP1;DEU;BEV;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.04;0.5;0.9;0.9
-SSP1;DEU;BEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.7048;1;1;1
-SSP1;DEU;BEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.2804;0.7298;1;1
-SSP1;DEU;BEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.2804;0.7298;1;1
-SSP1;DEU;BEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.2804;0.7298;1;1
-SSP1;DEU;BEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.7048;1;1;1
+SSP1;DEU;BEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.1294;0.7338;1;1
+SSP1;DEU;BEV;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.02;0.5;0.9;0.9
+SSP1;DEU;BEV;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.02;0.5;0.9;0.9
+SSP1;DEU;BEV;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.02;0.5;0.9;0.9
+SSP1;DEU;BEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.3524;1;1;1
+SSP1;DEU;BEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1402;0.7298;1;1
+SSP1;DEU;BEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1402;0.7298;1;1
+SSP1;DEU;BEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1402;0.7298;1;1
+SSP1;DEU;BEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.3524;1;1;1
 SSP1;DEU;Electric;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;1;1;1;1;1
 SSP1;DEU;Electric;HSR_tmp_vehicletype;HSR_tmp_subsectorL3;HSR_tmp_subsectorL2;HSR;trn_pass;FV;1;1;1;1;1
 SSP1;DEU;Electric;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;1;1;1;1;1
 SSP1;DEU;FCEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.002249;0.01636;0.02916;0.02916
-SSP1;DEU;FCEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.2849;0.8679;0.3164;0.3164
-SSP1;DEU;FCEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1052;0.4467;0.2232;0.2232
-SSP1;DEU;FCEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1052;0.4467;0.2232;0.2232
-SSP1;DEU;FCEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1052;0.4467;0.2232;0.2232
-SSP1;DEU;FCEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.2849;0.8679;0.3164;0.3164
+SSP1;DEU;FCEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.09497;0.8679;0.3164;0.3164
+SSP1;DEU;FCEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.03508;0.4467;0.2232;0.2232
+SSP1;DEU;FCEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.03508;0.4467;0.2232;0.2232
+SSP1;DEU;FCEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.03508;0.4467;0.2232;0.2232
+SSP1;DEU;FCEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.09497;0.8679;0.3164;0.3164
 SSP1;DEU;Gases;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0.03948;0.04981;0.0887;0.08541;0.08541
 SSP1;DEU;Gases;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.02615;0.04142;0.07591;0.09835;0.09835
 SSP1;DEU;Gases;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02105;0.07895;0.09085;0.09085
@@ -5859,63 +5859,63 @@ SSP1;DEU;Hydrogen;Domestic Aviation_tmp_vehicletype;Domestic Aviation_tmp_subsec
 SSP1;DEU;Liquids;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;1;1;1;0.6412;0.6412
 SSP1;DEU;Liquids;Domestic Aviation_tmp_vehicletype;Domestic Aviation_tmp_subsectorL3;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;trn_pass;FV;1;1;1;1;1
 SSP1;DEU;Liquids;Domestic Ship_tmp_vehicletype;Domestic Ship_tmp_subsectorL3;Domestic Ship_tmp_subsectorL2;Domestic Ship;trn_freight;FV;1;1;1;1;1
-SSP1;DEU;Liquids;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;0.2523;0.1262;0.1262;0.1262;0.1262
+SSP1;DEU;Liquids;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;0.2523;0.2523;0.1262;0.1262;0.1262
 SSP1;DEU;Liquids;International Aviation_tmp_vehicletype;International Aviation_tmp_subsectorL3;International Aviation_tmp_subsectorL2;International Aviation;trn_aviation_intl;FV;1;1;1;1;1
 SSP1;DEU;Liquids;International Ship_tmp_vehicletype;International Ship_tmp_subsectorL3;International Ship_tmp_subsectorL2;International Ship;trn_shipping_intl;FV;1;1;1;1;1
 SSP1;DEU;Liquids;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;1;1;1
 SSP1;DEU;Liquids;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;1;1;1
 SSP1;DEU;Liquids;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;1;1;1
-SSP1;DEU;Liquids;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;0.05386;0.03591;0.02693;0.01795;0.01795
+SSP1;DEU;Liquids;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;0.05386;0.05386;0.02693;0.01795;0.01795
 SSP1;DEU;Liquids;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;0.737;0.5741;0.5741
 SSP1;DEU;Liquids;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;0.5919;0.5919
 SSP1;DEU;Liquids;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;0.5919;0.5919
 SSP1;DEU;Liquids;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;0.5919;0.5919
 SSP1;DEU;Liquids;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;0.737;0.5741;0.5741
 SSP1;ECE;;;;;Cycle;trn_pass;S1S;0.01942;0.01942;0.09709;0.1092;0.1092
-SSP1;ECE;;;;;Domestic Aviation;trn_pass;S1S;6.98E-05;1.75E-05;1.75E-05;4.91E-06;4.91E-06
+SSP1;ECE;;;;;Domestic Aviation;trn_pass;S1S;6.98E-05;6.98E-05;1.75E-05;4.91E-06;4.91E-06
 SSP1;ECE;;;;;Domestic Ship;trn_freight;S1S;0.0003966;0.0003966;0.0003966;0.0003966;0.0003966
-SSP1;ECE;;;;;Freight Rail;trn_freight;S1S;0.06019;0.09029;0.08125;0.08125;0.08125
+SSP1;ECE;;;;;Freight Rail;trn_freight;S1S;0.06019;0.06019;0.08125;0.08125;0.08125
 SSP1;ECE;;;;;HSR;trn_pass;S1S;0.0001139;0.0001708;0.0004555;0.0003202;0.0003202
 SSP1;ECE;;;;;International Aviation;trn_aviation_intl;S1S;1;1;1;1;1
 SSP1;ECE;;;;;International Ship;trn_shipping_intl;S1S;1;1;1;1;1
-SSP1;ECE;;;;;Passenger Rail;trn_pass;S1S;0.006799;0.0136;0.01813;0.007648;0.007648
-SSP1;ECE;;;;;Walk;trn_pass;S1S;1;0.8;1;1;1
+SSP1;ECE;;;;;Passenger Rail;trn_pass;S1S;0.006799;0.006799;0.01813;0.007648;0.007648
+SSP1;ECE;;;;;Walk;trn_pass;S1S;1;1;1;1;1
 SSP1;ECE;;;;;trn_freight_road;trn_freight;S1S;1;1;1;1;1
-SSP1;ECE;;;;;trn_pass_road;trn_pass;S1S;0.6166;0.3083;0.2467;0.0634;0.0634
-SSP1;ECE;;;;Bus;trn_pass_road;trn_pass;S2S1;0.2712;0.3815;0.2203;0.1695;0.1695
+SSP1;ECE;;;;;trn_pass_road;trn_pass;S1S;0.6166;0.6166;0.2467;0.0634;0.0634
+SSP1;ECE;;;;Bus;trn_pass_road;trn_pass;S2S1;0.2712;0.2543;0.2203;0.1695;0.1695
 SSP1;ECE;;;;trn_pass_road_LDV;trn_pass_road;trn_pass;S2S1;1;1;1;1;1
 SSP1;ECE;;;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;0.02;0.02;0.02;0.02;0.02
 SSP1;ECE;;;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;1;1;1;1;1
-SSP1;ECE;;Compact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.4706;0.7059;0.7369;0.7369;0.7369
+SSP1;ECE;;Compact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.4706;0.4706;0.7369;0.7369;0.7369
 SSP1;ECE;;Large Car and SUV;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.7825;0.7825;0.6266;0.4456;0.4456
 SSP1;ECE;;Midsize Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;1;1;0.8008;0.5694;0.5694
 SSP1;ECE;;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.05321;0.05321;0.05321;0.05321;0.05321
 SSP1;ECE;;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.0004728;0.0004728;0.0004728;0.0004728;0.0004728
 SSP1;ECE;;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;1;1;1;1;1
-SSP1;ECE;;Subcompact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.6386;0.9579;1;1;1
+SSP1;ECE;;Subcompact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.6386;0.6386;1;1;1
 SSP1;ECE;;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.6161;0.6161;0.6161;0.6161;0.6161
 SSP1;ECE;;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.1384;0.1384;0.1384;0.1384;0.1384
 SSP1;ECE;;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.137;0.137;0.137;0.137;0.137
 SSP1;ECE;;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.1691;0.1691;0.1691;0.1691;0.1691
 SSP1;ECE;;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;1;1;1;1;1
-SSP1;ECE;BEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.3106;1;1;1
-SSP1;ECE;BEV;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.08;0.38;0.86;0.86
-SSP1;ECE;BEV;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.08;0.38;0.86;0.86
-SSP1;ECE;BEV;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.08;0.38;0.86;0.86
-SSP1;ECE;BEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1301;0.291;0.5572;0.5572
-SSP1;ECE;BEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.05176;0.1565;0.5406;0.5406
-SSP1;ECE;BEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.05176;0.1565;0.5406;0.5406
-SSP1;ECE;BEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.05176;0.1565;0.5406;0.5406
-SSP1;ECE;BEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1301;0.291;0.5572;0.5572
+SSP1;ECE;BEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.1553;1;1;1
+SSP1;ECE;BEV;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.04;0.38;0.86;0.86
+SSP1;ECE;BEV;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.04;0.38;0.86;0.86
+SSP1;ECE;BEV;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.04;0.38;0.86;0.86
+SSP1;ECE;BEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.06504;0.291;0.5572;0.5572
+SSP1;ECE;BEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02588;0.1565;0.5406;0.5406
+SSP1;ECE;BEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02588;0.1565;0.5406;0.5406
+SSP1;ECE;BEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02588;0.1565;0.5406;0.5406
+SSP1;ECE;BEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.06504;0.291;0.5572;0.5572
 SSP1;ECE;Electric;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;1;1;1;1;1
 SSP1;ECE;Electric;HSR_tmp_vehicletype;HSR_tmp_subsectorL3;HSR_tmp_subsectorL2;HSR;trn_pass;FV;1;1;1;1;1
 SSP1;ECE;Electric;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;1;1;1;1;1
 SSP1;ECE;FCEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.01349;0.01858;0.04374;0.04374
-SSP1;ECE;FCEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.04383;0.1725;0.1915;0.1915
-SSP1;ECE;FCEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.01619;0.06543;0.131;0.131
-SSP1;ECE;FCEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.01619;0.06543;0.131;0.131
-SSP1;ECE;FCEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.01619;0.06543;0.131;0.131
-SSP1;ECE;FCEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.04383;0.1725;0.1915;0.1915
+SSP1;ECE;FCEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.01461;0.1725;0.1915;0.1915
+SSP1;ECE;FCEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.005396;0.06543;0.131;0.131
+SSP1;ECE;FCEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.005396;0.06543;0.131;0.131
+SSP1;ECE;FCEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.005396;0.06543;0.131;0.131
+SSP1;ECE;FCEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.01461;0.1725;0.1915;0.1915
 SSP1;ECE;Gases;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0.01;0.02;0.06625;0.045;0.045
 SSP1;ECE;Gases;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.05;0.1111;0.1867;0.1867
 SSP1;ECE;Gases;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.05;0.1111;0.1867;0.1867
@@ -5926,63 +5926,63 @@ SSP1;ECE;Hydrogen;Domestic Aviation_tmp_vehicletype;Domestic Aviation_tmp_subsec
 SSP1;ECE;Liquids;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;1;1;0.9464;0.4008;0.4008
 SSP1;ECE;Liquids;Domestic Aviation_tmp_vehicletype;Domestic Aviation_tmp_subsectorL3;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;trn_pass;FV;1;1;1;1;1
 SSP1;ECE;Liquids;Domestic Ship_tmp_vehicletype;Domestic Ship_tmp_subsectorL3;Domestic Ship_tmp_subsectorL2;Domestic Ship;trn_freight;FV;1;1;1;1;1
-SSP1;ECE;Liquids;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;0.587;0.2935;0.2935;0.2935;0.2935
+SSP1;ECE;Liquids;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;0.587;0.587;0.2935;0.2935;0.2935
 SSP1;ECE;Liquids;International Aviation_tmp_vehicletype;International Aviation_tmp_subsectorL3;International Aviation_tmp_subsectorL2;International Aviation;trn_aviation_intl;FV;1;1;1;1;1
 SSP1;ECE;Liquids;International Ship_tmp_vehicletype;International Ship_tmp_subsectorL3;International Ship_tmp_subsectorL2;International Ship;trn_shipping_intl;FV;1;1;1;1;1
 SSP1;ECE;Liquids;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;1;1;1
 SSP1;ECE;Liquids;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;1;1;1
 SSP1;ECE;Liquids;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;1;1;1
-SSP1;ECE;Liquids;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;0.1453;0.09687;0.07265;0.04843;0.04843
+SSP1;ECE;Liquids;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;0.1453;0.1453;0.07265;0.04843;0.04843
 SSP1;ECE;Liquids;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
 SSP1;ECE;Liquids;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
 SSP1;ECE;Liquids;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
 SSP1;ECE;Liquids;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
 SSP1;ECE;Liquids;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
 SSP1;ECS;;;;;Cycle;trn_pass;S1S;0.01092;0.03277;0.1311;0.08738;0.08738
-SSP1;ECS;;;;;Domestic Aviation;trn_pass;S1S;0.003717;0.0009292;0.0009292;9.29E-05;9.29E-05
+SSP1;ECS;;;;;Domestic Aviation;trn_pass;S1S;0.003717;0.003717;0.0009292;9.29E-05;9.29E-05
 SSP1;ECS;;;;;Domestic Ship;trn_freight;S1S;0.00395;0.00395;0.003591;0.00395;0.00395
-SSP1;ECS;;;;;Freight Rail;trn_freight;S1S;0.05976;0.08964;0.08149;0.08069;0.08069
+SSP1;ECS;;;;;Freight Rail;trn_freight;S1S;0.05976;0.05976;0.08149;0.08069;0.08069
 SSP1;ECS;;;;;HSR;trn_pass;S1S;0.0002969;0.0002969;0.0007917;0.0004;0.0004
 SSP1;ECS;;;;;International Aviation;trn_aviation_intl;S1S;1;1;1;1;1
 SSP1;ECS;;;;;International Ship;trn_shipping_intl;S1S;1;1;1;1;1
-SSP1;ECS;;;;;Passenger Rail;trn_pass;S1S;0.007915;0.0211;0.02638;0.005276;0.005276
-SSP1;ECS;;;;;Walk;trn_pass;S1S;1;0.8;1;1;1
+SSP1;ECS;;;;;Passenger Rail;trn_pass;S1S;0.007915;0.01055;0.02638;0.005276;0.005276
+SSP1;ECS;;;;;Walk;trn_pass;S1S;1;1;1;1;1
 SSP1;ECS;;;;;trn_freight_road;trn_freight;S1S;1;1;1;1;1
-SSP1;ECS;;;;;trn_pass_road;trn_pass;S1S;0.7451;0.3725;0.3725;0.04471;0.04471
-SSP1;ECS;;;;Bus;trn_pass_road;trn_pass;S2S1;0.209;0.2613;0.1829;0.1568;0.1568
+SSP1;ECS;;;;;trn_pass_road;trn_pass;S1S;0.7451;0.7451;0.3725;0.04471;0.04471
+SSP1;ECS;;;;Bus;trn_pass_road;trn_pass;S2S1;0.209;0.1742;0.1829;0.1568;0.1568
 SSP1;ECS;;;;trn_pass_road_LDV;trn_pass_road;trn_pass;S2S1;1;1;1;1;1
 SSP1;ECS;;;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;0.01;0.01;0.01;0.01;0.01
 SSP1;ECS;;;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;1;1;1;1;1
-SSP1;ECS;;Compact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.5004;0.5117;0.5117;0.5116;0.5116
-SSP1;ECS;;Large Car and SUV;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;1;0.6817;0.5112;0.3749;0.3749
-SSP1;ECS;;Midsize Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.9609;0.655;0.4913;0.3603;0.3603
+SSP1;ECS;;Compact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.5004;0.5004;0.5117;0.5116;0.5116
+SSP1;ECS;;Large Car and SUV;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;1;1;0.5112;0.3749;0.3749
+SSP1;ECS;;Midsize Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.9609;0.9609;0.4913;0.3603;0.3603
 SSP1;ECS;;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.1125;0.1125;0.1125;0.1125;0.1125
 SSP1;ECS;;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.03579;0.03579;0.03579;0.03579;0.03579
 SSP1;ECS;;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;1;1;1;1;1
-SSP1;ECS;;Subcompact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.978;1;1;1;1
+SSP1;ECS;;Subcompact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.978;0.978;1;1;1
 SSP1;ECS;;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;1;1;1;1;1
 SSP1;ECS;;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.2555;0.2555;0.2555;0.2555;0.2555
 SSP1;ECS;;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.3104;0.3104;0.3104;0.3104;0.3104
 SSP1;ECS;;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.1282;0.1282;0.1282;0.1282;0.1282
 SSP1;ECS;;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.4409;0.4409;0.4409;0.4409;0.4409
-SSP1;ECS;BEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.1863;0.763;1;1
-SSP1;ECS;BEV;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.064;0.384;0.84;0.84
-SSP1;ECS;BEV;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.064;0.384;0.84;0.84
-SSP1;ECS;BEV;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.064;0.384;0.84;0.84
-SSP1;ECS;BEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.2082;0.4364;0.5786;0.5786
-SSP1;ECS;BEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.0828;0.2348;0.5614;0.5614
-SSP1;ECS;BEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.0828;0.2348;0.5614;0.5614
-SSP1;ECS;BEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.0828;0.2348;0.5614;0.5614
-SSP1;ECS;BEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.2082;0.4364;0.5786;0.5786
+SSP1;ECS;BEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.09315;0.763;1;1
+SSP1;ECS;BEV;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.032;0.384;0.84;0.84
+SSP1;ECS;BEV;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.032;0.384;0.84;0.84
+SSP1;ECS;BEV;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.032;0.384;0.84;0.84
+SSP1;ECS;BEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1041;0.4364;0.5786;0.5786
+SSP1;ECS;BEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.0414;0.2348;0.5614;0.5614
+SSP1;ECS;BEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.0414;0.2348;0.5614;0.5614
+SSP1;ECS;BEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.0414;0.2348;0.5614;0.5614
+SSP1;ECS;BEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1041;0.4364;0.5786;0.5786
 SSP1;ECS;Electric;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;1;1;1;1;1
 SSP1;ECS;Electric;HSR_tmp_vehicletype;HSR_tmp_subsectorL3;HSR_tmp_subsectorL2;HSR;trn_pass;FV;1;1;1;1;1
 SSP1;ECS;Electric;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;1;1;1;1;1
 SSP1;ECS;FCEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.002698;0.0736;0.06479;0.06479
-SSP1;ECS;FCEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.04383;0.207;0.2393;0.2393
-SSP1;ECS;FCEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.01619;0.07851;0.1637;0.1637
-SSP1;ECS;FCEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.01619;0.07851;0.1637;0.1637
-SSP1;ECS;FCEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.01619;0.07851;0.1637;0.1637
-SSP1;ECS;FCEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.04383;0.207;0.2393;0.2393
+SSP1;ECS;FCEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.01461;0.207;0.2393;0.2393
+SSP1;ECS;FCEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.005396;0.07851;0.1637;0.1637
+SSP1;ECS;FCEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.005396;0.07851;0.1637;0.1637
+SSP1;ECS;FCEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.005396;0.07851;0.1637;0.1637
+SSP1;ECS;FCEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.01461;0.207;0.2393;0.2393
 SSP1;ECS;Gases;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0.01;0.02;0.0625;0.05938;0.05938
 SSP1;ECS;Gases;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1E-05;0.013;0.06667;0.14;0.14
 SSP1;ECS;Gases;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1E-05;0.013;0.06667;0.14;0.14
@@ -5993,65 +5993,65 @@ SSP1;ECS;Hydrogen;Domestic Aviation_tmp_vehicletype;Domestic Aviation_tmp_subsec
 SSP1;ECS;Liquids;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;1;1;1;0.5938;0.5938
 SSP1;ECS;Liquids;Domestic Aviation_tmp_vehicletype;Domestic Aviation_tmp_subsectorL3;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;trn_pass;FV;1;1;1;1;1
 SSP1;ECS;Liquids;Domestic Ship_tmp_vehicletype;Domestic Ship_tmp_subsectorL3;Domestic Ship_tmp_subsectorL2;Domestic Ship;trn_freight;FV;1;1;1;1;1
-SSP1;ECS;Liquids;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;0.6302;0.3151;0.3151;0.3151;0.3151
+SSP1;ECS;Liquids;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;0.6302;0.6302;0.3151;0.3151;0.3151
 SSP1;ECS;Liquids;International Aviation_tmp_vehicletype;International Aviation_tmp_subsectorL3;International Aviation_tmp_subsectorL2;International Aviation;trn_aviation_intl;FV;1;1;1;1;1
 SSP1;ECS;Liquids;International Ship_tmp_vehicletype;International Ship_tmp_subsectorL3;International Ship_tmp_subsectorL2;International Ship;trn_shipping_intl;FV;1;1;1;1;1
 SSP1;ECS;Liquids;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;1;1;1
 SSP1;ECS;Liquids;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;1;1;1
 SSP1;ECS;Liquids;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;1;1;1
-SSP1;ECS;Liquids;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;0.2298;0.1532;0.1149;0.0766;0.0766
+SSP1;ECS;Liquids;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;0.2298;0.2298;0.1149;0.0766;0.0766
 SSP1;ECS;Liquids;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
 SSP1;ECS;Liquids;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
 SSP1;ECS;Liquids;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
 SSP1;ECS;Liquids;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
 SSP1;ECS;Liquids;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
 SSP1;ENC;;;;;Cycle;trn_pass;S1S;0.025;0.025;0.05556;0.1;0.1
-SSP1;ENC;;;;;Domestic Aviation;trn_pass;S1S;5.97E-05;2E-05;1.33E-05;5.97E-06;5.97E-06
+SSP1;ENC;;;;;Domestic Aviation;trn_pass;S1S;5.97E-05;5.97E-05;1.33E-05;5.97E-06;5.97E-06
 SSP1;ENC;;;;;Domestic Ship;trn_freight;S1S;0.01246;0.01246;0.01246;0.01246;0.01246
-SSP1;ENC;;;;;Freight Rail;trn_freight;S1S;0.02928;0.04392;0.04392;0.04392;0.04392
+SSP1;ENC;;;;;Freight Rail;trn_freight;S1S;0.02928;0.02928;0.04392;0.04392;0.04392
 SSP1;ENC;;;;;HSR;trn_pass;S1S;0.000125;0.00025;0.0002222;0.0002;0.0002
 SSP1;ENC;;;;;International Aviation;trn_aviation_intl;S1S;1;1;1;1;1
 SSP1;ENC;;;;;International Ship;trn_shipping_intl;S1S;1;1;1;1;1
-SSP1;ENC;;;;;Passenger Rail;trn_pass;S1S;0.003125;0.00625;0.006666;0.004;0.004
-SSP1;ENC;;;;;Walk;trn_pass;S1S;1;0.8;1;1;1
+SSP1;ENC;;;;;Passenger Rail;trn_pass;S1S;0.003125;0.003125;0.006666;0.004;0.004
+SSP1;ENC;;;;;Walk;trn_pass;S1S;1;1;1;1;1
 SSP1;ENC;;;;;trn_freight_road;trn_freight;S1S;1;1;1;1;1
-SSP1;ENC;;;;;trn_pass_road;trn_pass;S1S;0.07363;0.03682;0.03272;0.01473;0.01473
-SSP1;ENC;;;;Bus;trn_pass_road;trn_pass;S2S1;0.2037;0.2292;0.2292;0.2292;0.2292
+SSP1;ENC;;;;;trn_pass_road;trn_pass;S1S;0.07363;0.07363;0.03272;0.01473;0.01473
+SSP1;ENC;;;;Bus;trn_pass_road;trn_pass;S2S1;0.2037;0.1528;0.2292;0.2292;0.2292
 SSP1;ENC;;;;trn_pass_road_LDV;trn_pass_road;trn_pass;S2S1;1;1;1;1;1
 SSP1;ENC;;;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;0.06;0.06;0.06;0.06;0.06
 SSP1;ENC;;;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;1;1;1;1;1
-SSP1;ENC;;Compact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.3955;0.5933;0.791;1;1
+SSP1;ENC;;Compact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.3955;0.3955;0.791;1;1
 SSP1;ENC;;Large Car and SUV;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;1;1;1;0.9366;0.9366
 SSP1;ENC;;Midsize Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.196;0.196;0.196;0.1836;0.1836
-SSP1;ENC;;Mini Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;2.62E-07;3.93E-07;5.24E-07;6.62E-07;6.62E-07
+SSP1;ENC;;Mini Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;2.62E-07;2.62E-07;5.24E-07;6.62E-07;6.62E-07
 SSP1;ENC;;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.1576;0.1576;0.1576;0.1576;0.1576
 SSP1;ENC;;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.03751;0.03751;0.03751;0.03751;0.03751
 SSP1;ENC;;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;1;1;1;1;1
-SSP1;ENC;;Subcompact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.2181;0.3271;0.4362;0.5516;0.5516
+SSP1;ENC;;Subcompact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.2181;0.2181;0.4362;0.5516;0.5516
 SSP1;ENC;;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;1;1;1;1;1
 SSP1;ENC;;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.1002;0.1002;0.1002;0.1002;0.1002
 SSP1;ENC;;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.3593;0.3593;0.3593;0.3593;0.3593
 SSP1;ENC;;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.4374;0.4374;0.4374;0.4374;0.4374
 SSP1;ENC;;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.4946;0.4946;0.4946;0.4946;0.4946
 SSP1;ENC;;Van;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.001049;0.001049;0.001049;0.0009825;0.0009825
-SSP1;ENC;BEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.4314;1;1;1
-SSP1;ENC;BEV;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.1;0.46;1;1
-SSP1;ENC;BEV;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.1;0.46;1;1
-SSP1;ENC;BEV;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.1;0.46;1;1
-SSP1;ENC;BEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.6202;1;1;1
-SSP1;ENC;BEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.2468;0.6868;1;1
-SSP1;ENC;BEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.2468;0.6868;1;1
-SSP1;ENC;BEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.2468;0.6868;1;1
-SSP1;ENC;BEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.6202;1;1;1
+SSP1;ENC;BEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.2157;1;1;1
+SSP1;ENC;BEV;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.05;0.46;1;1
+SSP1;ENC;BEV;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.05;0.46;1;1
+SSP1;ENC;BEV;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.05;0.46;1;1
+SSP1;ENC;BEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.3101;1;1;1
+SSP1;ENC;BEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1234;0.6868;1;1
+SSP1;ENC;BEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1234;0.6868;1;1
+SSP1;ENC;BEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1234;0.6868;1;1
+SSP1;ENC;BEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.3101;1;1;1
 SSP1;ENC;Electric;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;1;1;1;1;1
 SSP1;ENC;Electric;HSR_tmp_vehicletype;HSR_tmp_subsectorL3;HSR_tmp_subsectorL2;HSR;trn_pass;FV;1;1;1;1;1
 SSP1;ENC;Electric;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;1;1;1;1;1
 SSP1;ENC;FCEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.01124;0.04013;0.05105;0.05105
-SSP1;ENC;FCEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.2374;0.6586;0.2792;0.2792
-SSP1;ENC;FCEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.08772;0.3189;0.1969;0.1969
-SSP1;ENC;FCEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.08772;0.3189;0.1969;0.1969
-SSP1;ENC;FCEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.08772;0.3189;0.1969;0.1969
-SSP1;ENC;FCEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.2374;0.6586;0.2792;0.2792
+SSP1;ENC;FCEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.07914;0.6586;0.2792;0.2792
+SSP1;ENC;FCEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02924;0.3189;0.1969;0.1969
+SSP1;ENC;FCEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02924;0.3189;0.1969;0.1969
+SSP1;ENC;FCEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02924;0.3189;0.1969;0.1969
+SSP1;ENC;FCEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.07914;0.6586;0.2792;0.2792
 SSP1;ENC;Gases;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0.02533;0.03921;0.06433;0.05055;0.05055
 SSP1;ENC;Gases;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02632;0.06181;0.09915;0.09915
 SSP1;ENC;Gases;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02632;0.07895;0.1022;0.1022
@@ -6062,36 +6062,36 @@ SSP1;ENC;Hydrogen;Domestic Aviation_tmp_vehicletype;Domestic Aviation_tmp_subsec
 SSP1;ENC;Liquids;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;1;1;0.6919;0.2713;0.2713
 SSP1;ENC;Liquids;Domestic Aviation_tmp_vehicletype;Domestic Aviation_tmp_subsectorL3;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;trn_pass;FV;1;1;1;1;1
 SSP1;ENC;Liquids;Domestic Ship_tmp_vehicletype;Domestic Ship_tmp_subsectorL3;Domestic Ship_tmp_subsectorL2;Domestic Ship;trn_freight;FV;1;1;1;1;1
-SSP1;ENC;Liquids;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;0.1341;0.06705;0.06705;0.06705;0.06705
+SSP1;ENC;Liquids;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;0.1341;0.1341;0.06705;0.06705;0.06705
 SSP1;ENC;Liquids;International Aviation_tmp_vehicletype;International Aviation_tmp_subsectorL3;International Aviation_tmp_subsectorL2;International Aviation;trn_aviation_intl;FV;1;1;1;1;1
 SSP1;ENC;Liquids;International Ship_tmp_vehicletype;International Ship_tmp_subsectorL3;International Ship_tmp_subsectorL2;International Ship;trn_shipping_intl;FV;1;1;1;1;1
 SSP1;ENC;Liquids;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;1;1;1
 SSP1;ENC;Liquids;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;1;1;1
 SSP1;ENC;Liquids;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;1;1;1
-SSP1;ENC;Liquids;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;0.1258;0.08387;0.0629;0.04193;0.04193
+SSP1;ENC;Liquids;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;0.1258;0.1258;0.0629;0.04193;0.04193
 SSP1;ENC;Liquids;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;0.783;0.5383;0.5383
 SSP1;ENC;Liquids;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;0.5549;0.5549
 SSP1;ENC;Liquids;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;0.5549;0.5549
 SSP1;ENC;Liquids;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;0.5549;0.5549
 SSP1;ENC;Liquids;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;0.783;0.5383;0.5383
 SSP1;ESC;;;;;Cycle;trn_pass;S1S;0.01942;0.02184;0.04369;0.1638;0.1638
-SSP1;ESC;;;;;Domestic Aviation;trn_pass;S1S;0.0001286;7.04E-06;9.04E-06;1.81E-05;1.81E-05
+SSP1;ESC;;;;;Domestic Aviation;trn_pass;S1S;0.0001286;3.62E-05;9.04E-06;1.81E-05;1.81E-05
 SSP1;ESC;;;;;Domestic Ship;trn_freight;S1S;0.01209;0.01209;0.01209;0.01209;0.01209
-SSP1;ESC;;;;;Freight Rail;trn_freight;S1S;0.004094;0.006141;0.006141;0.006141;0.006141
+SSP1;ESC;;;;;Freight Rail;trn_freight;S1S;0.004094;0.004094;0.006141;0.006141;0.006141
 SSP1;ESC;;;;;HSR;trn_pass;S1S;0.0006613;0.000186;0.00062;0.00062;0.00062
 SSP1;ESC;;;;;International Aviation;trn_aviation_intl;S1S;1;1;1;1;1
 SSP1;ESC;;;;;International Ship;trn_shipping_intl;S1S;1;1;1;1;1
-SSP1;ESC;;;;;Passenger Rail;trn_pass;S1S;0.003195;0.005392;0.005392;0.008088;0.008088
-SSP1;ESC;;;;;Walk;trn_pass;S1S;1;0.8;1;1;1
+SSP1;ESC;;;;;Passenger Rail;trn_pass;S1S;0.003195;0.002696;0.005392;0.008088;0.008088
+SSP1;ESC;;;;;Walk;trn_pass;S1S;1;1;1;1;1
 SSP1;ESC;;;;;trn_freight_road;trn_freight;S1S;1;1;1;1;1
-SSP1;ESC;;;;;trn_pass_road;trn_pass;S1S;0.1798;0.05055;0.04046;0.03236;0.03236
-SSP1;ESC;;;;Bus;trn_pass_road;trn_pass;S2S1;0.06714;0.1007;0.1007;0.151;0.151
+SSP1;ESC;;;;;trn_pass_road;trn_pass;S1S;0.1798;0.1011;0.04046;0.03236;0.03236
+SSP1;ESC;;;;Bus;trn_pass_road;trn_pass;S2S1;0.06714;0.06714;0.1007;0.151;0.151
 SSP1;ESC;;;;trn_pass_road_LDV;trn_pass_road;trn_pass;S2S1;1;1;1;1;1
 SSP1;ESC;;;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;0.4;0.4;0.4;0.4;0.4
 SSP1;ESC;;;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;1;1;1;1;1
 SSP1;ESC;;Compact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.3942;0.3942;0.3942;0.3942;0.3942
-SSP1;ESC;;Large Car and SUV;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.8712;0.5227;0.4356;0.2904;0.2904
-SSP1;ESC;;Midsize Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.2323;0.1394;0.1162;0.07743;0.07743
+SSP1;ESC;;Large Car and SUV;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.8712;0.784;0.4356;0.2904;0.2904
+SSP1;ESC;;Midsize Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.2323;0.2091;0.1162;0.07743;0.07743
 SSP1;ESC;;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.1009;0.1009;0.1009;0.1009;0.1009
 SSP1;ESC;;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.06375;0.06375;0.06375;0.06375;0.06375
 SSP1;ESC;;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;1;1;1;1;1
@@ -6101,24 +6101,24 @@ SSP1;ESC;;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subs
 SSP1;ESC;;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.2234;0.2234;0.2234;0.2234;0.2234
 SSP1;ESC;;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.2172;0.2172;0.2172;0.2172;0.2172
 SSP1;ESC;;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;1;1;1;1;1
-SSP1;ESC;BEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.2718;0.7632;1;1
-SSP1;ESC;BEV;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.08;0.44;0.84;0.84
-SSP1;ESC;BEV;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.08;0.44;0.84;0.84
-SSP1;ESC;BEV;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.08;0.44;0.84;0.84
-SSP1;ESC;BEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.5638;1;1;1
-SSP1;ESC;BEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.2244;0.5724;1;1
-SSP1;ESC;BEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.2244;0.5724;1;1
-SSP1;ESC;BEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.2244;0.5724;1;1
-SSP1;ESC;BEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.5638;1;1;1
+SSP1;ESC;BEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.1359;0.7632;1;1
+SSP1;ESC;BEV;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.04;0.44;0.84;0.84
+SSP1;ESC;BEV;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.04;0.44;0.84;0.84
+SSP1;ESC;BEV;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.04;0.44;0.84;0.84
+SSP1;ESC;BEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.2819;1;1;1
+SSP1;ESC;BEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1122;0.5724;1;1
+SSP1;ESC;BEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1122;0.5724;1;1
+SSP1;ESC;BEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1122;0.5724;1;1
+SSP1;ESC;BEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.2819;1;1;1
 SSP1;ESC;Electric;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;1;1;1;1;1
 SSP1;ESC;Electric;HSR_tmp_vehicletype;HSR_tmp_subsectorL3;HSR_tmp_subsectorL2;HSR;trn_pass;FV;1;1;1;1;1
 SSP1;ESC;Electric;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;1;1;1;1;1
 SSP1;ESC;FCEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.01124;0.0638;0.04666;0.04666
-SSP1;ESC;FCEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.2374;0.1581;0.2792;0.2792
-SSP1;ESC;FCEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.08772;0.06381;0.1968;0.1968
-SSP1;ESC;FCEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.08772;0.06381;0.1968;0.1968
-SSP1;ESC;FCEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.08772;0.06381;0.1968;0.1968
-SSP1;ESC;FCEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.2374;0.1581;0.2792;0.2792
+SSP1;ESC;FCEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.07914;0.1581;0.2792;0.2792
+SSP1;ESC;FCEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02924;0.06381;0.1968;0.1968
+SSP1;ESC;FCEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02924;0.06381;0.1968;0.1968
+SSP1;ESC;FCEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02924;0.06381;0.1968;0.1968
+SSP1;ESC;FCEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.07914;0.1581;0.2792;0.2792
 SSP1;ESC;Gases;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0.02742;0.04078;0.1042;0.1019;0.1019
 SSP1;ESC;Gases;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02632;0.07419;0.09915;0.09915
 SSP1;ESC;Gases;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02632;0.07895;0.1022;0.1022
@@ -6129,63 +6129,63 @@ SSP1;ESC;Hydrogen;Domestic Aviation_tmp_vehicletype;Domestic Aviation_tmp_subsec
 SSP1;ESC;Liquids;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;1;1;1;0.5919;0.5919
 SSP1;ESC;Liquids;Domestic Aviation_tmp_vehicletype;Domestic Aviation_tmp_subsectorL3;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;trn_pass;FV;1;1;1;1;1
 SSP1;ESC;Liquids;Domestic Ship_tmp_vehicletype;Domestic Ship_tmp_subsectorL3;Domestic Ship_tmp_subsectorL2;Domestic Ship;trn_freight;FV;1;1;1;1;1
-SSP1;ESC;Liquids;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;0.1241;0.06205;0.06205;0.06205;0.06205
+SSP1;ESC;Liquids;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;0.1241;0.1241;0.06205;0.06205;0.06205
 SSP1;ESC;Liquids;International Aviation_tmp_vehicletype;International Aviation_tmp_subsectorL3;International Aviation_tmp_subsectorL2;International Aviation;trn_aviation_intl;FV;1;1;1;1;1
 SSP1;ESC;Liquids;International Ship_tmp_vehicletype;International Ship_tmp_subsectorL3;International Ship_tmp_subsectorL2;International Ship;trn_shipping_intl;FV;1;1;1;1;1
 SSP1;ESC;Liquids;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;1;1;1
 SSP1;ESC;Liquids;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;1;1;1
 SSP1;ESC;Liquids;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;1;1;1
-SSP1;ESC;Liquids;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;0.07003;0.04669;0.03501;0.02334;0.02334
+SSP1;ESC;Liquids;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;0.07003;0.07003;0.03501;0.02334;0.02334
 SSP1;ESC;Liquids;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;0.9397;0.6459;0.6459
 SSP1;ESC;Liquids;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;0.6659;0.6659
 SSP1;ESC;Liquids;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;0.6659;0.6659
 SSP1;ESC;Liquids;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;0.6659;0.6659
 SSP1;ESC;Liquids;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;0.9397;0.6459;0.6459
 SSP1;ESW;;;;;Cycle;trn_pass;S1S;0.01942;0.03884;0.05825;0.1019;0.1019
-SSP1;ESW;;;;;Domestic Aviation;trn_pass;S1S;0.0006852;0.0001713;0.000137;3.21E-05;3.21E-05
+SSP1;ESW;;;;;Domestic Aviation;trn_pass;S1S;0.0006852;0.0006852;0.000137;3.21E-05;3.21E-05
 SSP1;ESW;;;;;Domestic Ship;trn_freight;S1S;0.00613;0.00613;0.00613;0.00613;0.00613
-SSP1;ESW;;;;;Freight Rail;trn_freight;S1S;0.0142;0.0213;0.0213;0.0213;0.0213
+SSP1;ESW;;;;;Freight Rail;trn_freight;S1S;0.0142;0.0142;0.0213;0.0213;0.0213
 SSP1;ESW;;;;;HSR;trn_pass;S1S;0.0009579;0.0009579;0.0009579;0.0003592;0.0003592
 SSP1;ESW;;;;;International Aviation;trn_aviation_intl;S1S;1;1;1;1;1
 SSP1;ESW;;;;;International Ship;trn_shipping_intl;S1S;1;1;1;1;1
-SSP1;ESW;;;;;Passenger Rail;trn_pass;S1S;0.003621;0.007242;0.01086;0.004074;0.004074
-SSP1;ESW;;;;;Walk;trn_pass;S1S;1;0.8;1;1;1
+SSP1;ESW;;;;;Passenger Rail;trn_pass;S1S;0.003621;0.003621;0.01086;0.004074;0.004074
+SSP1;ESW;;;;;Walk;trn_pass;S1S;1;1;1;1;1
 SSP1;ESW;;;;;trn_freight_road;trn_freight;S1S;1;1;1;1;1
-SSP1;ESW;;;;;trn_pass_road;trn_pass;S1S;0.1385;0.0554;0.0554;0.01558;0.01558
-SSP1;ESW;;;;Bus;trn_pass_road;trn_pass;S2S1;0.05772;0.08658;0.1082;0.1623;0.1623
+SSP1;ESW;;;;;trn_pass_road;trn_pass;S1S;0.1385;0.1108;0.0554;0.01558;0.01558
+SSP1;ESW;;;;Bus;trn_pass_road;trn_pass;S2S1;0.05772;0.05772;0.1082;0.1623;0.1623
 SSP1;ESW;;;;trn_pass_road_LDV;trn_pass_road;trn_pass;S2S1;1;1;1;1;1
 SSP1;ESW;;;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;0.2;0.2;0.2;0.2;0.2
 SSP1;ESW;;;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;1;1;1;1;1
-SSP1;ESW;;Compact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.5725;0.8588;1;1;1
+SSP1;ESW;;Compact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.5725;0.5725;1;1;1
 SSP1;ESW;;Large Car and SUV;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;1;1;0.8734;0.5822;0.5822
 SSP1;ESW;;Midsize Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.2963;0.2963;0.2588;0.1725;0.1725
 SSP1;ESW;;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.09741;0.09741;0.09741;0.09741;0.09741
 SSP1;ESW;;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.1669;0.1669;0.1669;0.1669;0.1669
 SSP1;ESW;;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;1;1;1;1;1
-SSP1;ESW;;Subcompact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.4448;0.6672;0.7769;0.7769;0.7769
+SSP1;ESW;;Subcompact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.4448;0.4448;0.7769;0.7769;0.7769
 SSP1;ESW;;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.285;0.285;0.285;0.285;0.285
 SSP1;ESW;;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.06043;0.06043;0.06043;0.06043;0.06043
 SSP1;ESW;;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.08424;0.08424;0.08424;0.08424;0.08424
 SSP1;ESW;;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.4041;0.4041;0.4041;0.4041;0.4041
 SSP1;ESW;;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;1;1;1;1;1
-SSP1;ESW;BEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0.01078;0.2328;0.587;1;1
-SSP1;ESW;BEV;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.096;0.432;0.84;0.84
-SSP1;ESW;BEV;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.096;0.432;0.84;0.84
-SSP1;ESW;BEV;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.096;0.432;0.84;0.84
-SSP1;ESW;BEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.7804;1;1;1
-SSP1;ESW;BEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.3106;0.7396;1;1
-SSP1;ESW;BEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.3106;0.7396;1;1
-SSP1;ESW;BEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.3106;0.7396;1;1
-SSP1;ESW;BEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.7804;1;1;1
-SSP1;ESW;Electric;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;0.7295;1;1;1;1
+SSP1;ESW;BEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0.01078;0.1164;0.587;1;1
+SSP1;ESW;BEV;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.048;0.432;0.84;0.84
+SSP1;ESW;BEV;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.048;0.432;0.84;0.84
+SSP1;ESW;BEV;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.048;0.432;0.84;0.84
+SSP1;ESW;BEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.3902;1;1;1
+SSP1;ESW;BEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1553;0.7396;1;1
+SSP1;ESW;BEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1553;0.7396;1;1
+SSP1;ESW;BEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1553;0.7396;1;1
+SSP1;ESW;BEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.3902;1;1;1
+SSP1;ESW;Electric;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;0.7295;0.7633;1;1;1
 SSP1;ESW;Electric;HSR_tmp_vehicletype;HSR_tmp_subsectorL3;HSR_tmp_subsectorL2;HSR;trn_pass;FV;1;1;1;1;1
 SSP1;ESW;Electric;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;1;1;1;1;1
 SSP1;ESW;FCEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0.002248;0.002698;0.01963;0.04687;0.04687
-SSP1;ESW;FCEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.2191;0.5647;0.2233;0.2233
-SSP1;ESW;FCEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.08094;0.2944;0.1575;0.1575
-SSP1;ESW;FCEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.08094;0.2944;0.1575;0.1575
-SSP1;ESW;FCEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.08094;0.2944;0.1575;0.1575
-SSP1;ESW;FCEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.2191;0.5647;0.2233;0.2233
+SSP1;ESW;FCEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.07303;0.5647;0.2233;0.2233
+SSP1;ESW;FCEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02698;0.2944;0.1575;0.1575
+SSP1;ESW;FCEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02698;0.2944;0.1575;0.1575
+SSP1;ESW;FCEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02698;0.2944;0.1575;0.1575
+SSP1;ESW;FCEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.07303;0.5647;0.2233;0.2233
 SSP1;ESW;Gases;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0.01754;0.02632;0.07895;0.1055;0.1055
 SSP1;ESW;Gases;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02632;0.05742;0.08595;0.08595
 SSP1;ESW;Gases;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02632;0.07895;0.0886;0.0886
@@ -6196,63 +6196,63 @@ SSP1;ESW;Hydrogen;Domestic Aviation_tmp_vehicletype;Domestic Aviation_tmp_subsec
 SSP1;ESW;Liquids;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;1;1;1;0.8017;0.8017
 SSP1;ESW;Liquids;Domestic Aviation_tmp_vehicletype;Domestic Aviation_tmp_subsectorL3;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;trn_pass;FV;1;1;1;1;1
 SSP1;ESW;Liquids;Domestic Ship_tmp_vehicletype;Domestic Ship_tmp_subsectorL3;Domestic Ship_tmp_subsectorL2;Domestic Ship;trn_freight;FV;1;1;1;1;1
-SSP1;ESW;Liquids;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;1;0.6551;0.6018;0.5175;0.5175
+SSP1;ESW;Liquids;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;1;1;0.6018;0.5175;0.5175
 SSP1;ESW;Liquids;International Aviation_tmp_vehicletype;International Aviation_tmp_subsectorL3;International Aviation_tmp_subsectorL2;International Aviation;trn_aviation_intl;FV;1;1;1;1;1
 SSP1;ESW;Liquids;International Ship_tmp_vehicletype;International Ship_tmp_subsectorL3;International Ship_tmp_subsectorL2;International Ship;trn_shipping_intl;FV;1;1;1;1;1
 SSP1;ESW;Liquids;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;1;1;1
 SSP1;ESW;Liquids;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;1;1;1
 SSP1;ESW;Liquids;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;1;1;1
-SSP1;ESW;Liquids;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;0.5162;0.3441;0.2581;0.1721;0.1721
+SSP1;ESW;Liquids;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;0.5162;0.5162;0.2581;0.1721;0.1721
 SSP1;ESW;Liquids;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;0.7273;0.4666;0.4666
 SSP1;ESW;Liquids;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;0.481;0.481
 SSP1;ESW;Liquids;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;0.481;0.481
 SSP1;ESW;Liquids;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;0.481;0.481
 SSP1;ESW;Liquids;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;0.7273;0.4666;0.4666
 SSP1;EWN;;;;;Cycle;trn_pass;S1S;0.01;0.01;0.05;0.1;0.1
-SSP1;EWN;;;;;Domestic Aviation;trn_pass;S1S;4.77E-05;2.19E-05;1.19E-05;1.19E-06;1.19E-06
+SSP1;EWN;;;;;Domestic Aviation;trn_pass;S1S;4.77E-05;4.77E-05;1.19E-05;1.19E-06;1.19E-06
 SSP1;EWN;;;;;Domestic Ship;trn_freight;S1S;0.006261;0.006957;0.006261;0.006261;0.006261
-SSP1;EWN;;;;;Freight Rail;trn_freight;S1S;0.0127;0.02116;0.01905;0.01905;0.01905
+SSP1;EWN;;;;;Freight Rail;trn_freight;S1S;0.0127;0.01411;0.01905;0.01905;0.01905
 SSP1;EWN;;;;;HSR;trn_pass;S1S;0.0001;0.0001;0.0004;0.0002;0.0002
 SSP1;EWN;;;;;International Aviation;trn_aviation_intl;S1S;1;1;1;1;1
 SSP1;EWN;;;;;International Ship;trn_shipping_intl;S1S;1;1;1;1;1
-SSP1;EWN;;;;;Passenger Rail;trn_pass;S1S;0.002;0.006;0.006;0.004;0.004
-SSP1;EWN;;;;;Walk;trn_pass;S1S;1;0.8;1;1;1
+SSP1;EWN;;;;;Passenger Rail;trn_pass;S1S;0.002;0.003;0.006;0.004;0.004
+SSP1;EWN;;;;;Walk;trn_pass;S1S;1;1;1;1;1
 SSP1;EWN;;;;;trn_freight_road;trn_freight;S1S;1;1;1;1;1
-SSP1;EWN;;;;;trn_pass_road;trn_pass;S1S;0.05891;0.02945;0.02945;0.01473;0.01473
-SSP1;EWN;;;;Bus;trn_pass_road;trn_pass;S2S1;0.1019;0.1529;0.1529;0.2292;0.2292
+SSP1;EWN;;;;;trn_pass_road;trn_pass;S1S;0.05891;0.05891;0.02945;0.01473;0.01473
+SSP1;EWN;;;;Bus;trn_pass_road;trn_pass;S2S1;0.1019;0.1019;0.1529;0.2292;0.2292
 SSP1;EWN;;;;trn_pass_road_LDV;trn_pass_road;trn_pass;S2S1;1;1;1;1;1
 SSP1;EWN;;;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;0.1;0.1;0.1;0.1;0.1
 SSP1;EWN;;;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;1;1;1;1;1
-SSP1;EWN;;Compact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.4317;0.6475;0.7772;0.8878;0.8878
+SSP1;EWN;;Compact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.4317;0.4317;0.7772;0.8878;0.8878
 SSP1;EWN;;Large Car and SUV;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;1;1;1;0.7616;0.7616
 SSP1;EWN;;Midsize Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.2283;0.2283;0.2283;0.1739;0.1739
 SSP1;EWN;;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.1183;0.1183;0.1183;0.1183;0.1183
 SSP1;EWN;;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.04339;0.04339;0.04339;0.04339;0.04339
 SSP1;EWN;;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;1;1;1;1;1
-SSP1;EWN;;Subcompact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.4864;0.7296;0.8754;1;1
+SSP1;EWN;;Subcompact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.4864;0.4864;0.8754;1;1
 SSP1;EWN;;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;1;1;1;1;1
 SSP1;EWN;;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.1164;0.1164;0.1164;0.1164;0.1164
 SSP1;EWN;;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.5225;0.5225;0.5225;0.5225;0.5225
 SSP1;EWN;;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.4061;0.4061;0.4061;0.4061;0.4061
 SSP1;EWN;;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.5651;0.5651;0.5651;0.5651;0.5651
-SSP1;EWN;BEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.1759;0.4394;1;1
-SSP1;EWN;BEV;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0.001;0.12;0.49;0.9;0.9
-SSP1;EWN;BEV;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0.001;0.12;0.49;0.9;0.9
-SSP1;EWN;BEV;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0.001;0.12;0.49;0.9;0.9
-SSP1;EWN;BEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.6872;1;1;1
-SSP1;EWN;BEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.2734;0.689;1;1
-SSP1;EWN;BEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.2734;0.689;1;1
-SSP1;EWN;BEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.2734;0.689;1;1
-SSP1;EWN;BEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.6872;1;1;1
+SSP1;EWN;BEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.08794;0.4394;1;1
+SSP1;EWN;BEV;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0.001;0.06;0.49;0.9;0.9
+SSP1;EWN;BEV;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0.001;0.06;0.49;0.9;0.9
+SSP1;EWN;BEV;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0.001;0.06;0.49;0.9;0.9
+SSP1;EWN;BEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.3436;1;1;1
+SSP1;EWN;BEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1367;0.689;1;1
+SSP1;EWN;BEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1367;0.689;1;1
+SSP1;EWN;BEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1367;0.689;1;1
+SSP1;EWN;BEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.3436;1;1;1
 SSP1;EWN;Electric;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;1;1;1;1;1
 SSP1;EWN;Electric;HSR_tmp_vehicletype;HSR_tmp_subsectorL3;HSR_tmp_subsectorL2;HSR;trn_pass;FV;1;1;1;1;1
 SSP1;EWN;Electric;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;1;1;1;1;1
 SSP1;EWN;FCEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.001861;0.007734;0.02187;0.02187
-SSP1;EWN;FCEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.04155;0.248;0.09971;0.09971
-SSP1;EWN;FCEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.01535;0.1205;0.07031;0.07031
-SSP1;EWN;FCEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.01535;0.1205;0.07031;0.07031
-SSP1;EWN;FCEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.01535;0.1205;0.07031;0.07031
-SSP1;EWN;FCEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.04155;0.248;0.09971;0.09971
+SSP1;EWN;FCEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.01385;0.248;0.09971;0.09971
+SSP1;EWN;FCEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.005116;0.1205;0.07031;0.07031
+SSP1;EWN;FCEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.005116;0.1205;0.07031;0.07031
+SSP1;EWN;FCEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.005116;0.1205;0.07031;0.07031
+SSP1;EWN;FCEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.01385;0.248;0.09971;0.09971
 SSP1;EWN;Gases;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0.00807;0.03107;0.06282;0.09704;0.09704
 SSP1;EWN;Gases;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.0008171;0.03389;0.06913;0.07109;0.07109
 SSP1;EWN;Gases;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.03289;0.08772;0.073;0.073
@@ -6263,63 +6263,63 @@ SSP1;EWN;Hydrogen;Domestic Aviation_tmp_vehicletype;Domestic Aviation_tmp_subsec
 SSP1;EWN;Liquids;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;1;1;1;0.9988;0.9988
 SSP1;EWN;Liquids;Domestic Aviation_tmp_vehicletype;Domestic Aviation_tmp_subsectorL3;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;trn_pass;FV;1;1;1;1;1
 SSP1;EWN;Liquids;Domestic Ship_tmp_vehicletype;Domestic Ship_tmp_subsectorL3;Domestic Ship_tmp_subsectorL2;Domestic Ship;trn_freight;FV;1;1;1;1;1
-SSP1;EWN;Liquids;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;0.3943;0.1971;0.1971;0.1971;0.1971
+SSP1;EWN;Liquids;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;0.3943;0.3943;0.1971;0.1971;0.1971
 SSP1;EWN;Liquids;International Aviation_tmp_vehicletype;International Aviation_tmp_subsectorL3;International Aviation_tmp_subsectorL2;International Aviation;trn_aviation_intl;FV;1;1;1;1;1
 SSP1;EWN;Liquids;International Ship_tmp_vehicletype;International Ship_tmp_subsectorL3;International Ship_tmp_subsectorL2;International Ship;trn_shipping_intl;FV;1;1;1;1;1
 SSP1;EWN;Liquids;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;1;1;1
 SSP1;EWN;Liquids;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;1;1;1
 SSP1;EWN;Liquids;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;1;1;1
-SSP1;EWN;Liquids;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;0.03824;0.02549;0.01912;0.01275;0.01275
+SSP1;EWN;Liquids;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;0.03824;0.03824;0.01912;0.01275;0.01275
 SSP1;EWN;Liquids;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;0.7806;0.5536;0.5536
 SSP1;EWN;Liquids;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;0.5708;0.5708
 SSP1;EWN;Liquids;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;0.5708;0.5708
 SSP1;EWN;Liquids;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;0.5708;0.5708
 SSP1;EWN;Liquids;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;0.7806;0.5536;0.5536
 SSP1;FRA;;;;;Cycle;trn_pass;S1S;0.01942;0.02184;0.03641;0.1019;0.1019
-SSP1;FRA;;;;;Domestic Aviation;trn_pass;S1S;0.0001169;3E-05;1.1E-05;5.48E-06;5.48E-06
+SSP1;FRA;;;;;Domestic Aviation;trn_pass;S1S;0.0001169;6.58E-05;1.1E-05;5.48E-06;5.48E-06
 SSP1;FRA;;;;;Domestic Ship;trn_freight;S1S;0.003419;0.003419;0.003419;0.003419;0.003419
-SSP1;FRA;;;;;Freight Rail;trn_freight;S1S;0.01799;0.02698;0.02698;0.02698;0.02698
+SSP1;FRA;;;;;Freight Rail;trn_freight;S1S;0.01799;0.01799;0.02698;0.02698;0.02698
 SSP1;FRA;;;;;HSR;trn_pass;S1S;0.0003359;0.0002267;0.0002015;0.0002015;0.0002015
 SSP1;FRA;;;;;International Aviation;trn_aviation_intl;S1S;1;1;1;1;1
 SSP1;FRA;;;;;International Ship;trn_shipping_intl;S1S;1;1;1;1;1
-SSP1;FRA;;;;;Passenger Rail;trn_pass;S1S;0.003972;0.005958;0.003972;0.003972;0.003972
-SSP1;FRA;;;;;Walk;trn_pass;S1S;1;0.8;1;1;1
+SSP1;FRA;;;;;Passenger Rail;trn_pass;S1S;0.003972;0.002979;0.003972;0.003972;0.003972
+SSP1;FRA;;;;;Walk;trn_pass;S1S;1;1;1;1;1
 SSP1;FRA;;;;;trn_freight_road;trn_freight;S1S;1;1;1;1;1
-SSP1;FRA;;;;;trn_pass_road;trn_pass;S1S;0.09055;0.02547;0.01698;0.01358;0.01358
-SSP1;FRA;;;;Bus;trn_pass_road;trn_pass;S2S1;0.07932;0.1309;0.1428;0.2142;0.2142
+SSP1;FRA;;;;;trn_pass_road;trn_pass;S1S;0.09055;0.05094;0.01698;0.01358;0.01358
+SSP1;FRA;;;;Bus;trn_pass_road;trn_pass;S2S1;0.07932;0.08726;0.1428;0.2142;0.2142
 SSP1;FRA;;;;trn_pass_road_LDV;trn_pass_road;trn_pass;S2S1;1;1;1;1;1
 SSP1;FRA;;;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;0.2;0.2;0.2;0.2;0.2
 SSP1;FRA;;;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;1;1;1;1;1
-SSP1;FRA;;Compact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.6352;0.7912;0.7912;0.7912;0.7912
-SSP1;FRA;;Large Car and SUV;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;1;0.8304;0.6228;0.4152;0.4152
-SSP1;FRA;;Midsize Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.3632;0.3016;0.2262;0.1508;0.1508
+SSP1;FRA;;Compact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.6352;0.6352;0.7912;0.7912;0.7912
+SSP1;FRA;;Large Car and SUV;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;1;1;0.6228;0.4152;0.4152
+SSP1;FRA;;Midsize Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.3632;0.3632;0.2262;0.1508;0.1508
 SSP1;FRA;;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.092;0.092;0.092;0.092;0.092
 SSP1;FRA;;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.06774;0.06774;0.06774;0.06774;0.06774
 SSP1;FRA;;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;1;1;1;1;1
-SSP1;FRA;;Subcompact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.8028;1;1;1;1
+SSP1;FRA;;Subcompact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.8028;0.8028;1;1;1
 SSP1;FRA;;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;1;1;1;1;1
 SSP1;FRA;;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.1408;0.1408;0.1408;0.1408;0.1408
 SSP1;FRA;;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.1602;0.1602;0.1602;0.1602;0.1602
 SSP1;FRA;;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.4011;0.4011;0.4011;0.4011;0.4011
 SSP1;FRA;;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.3755;0.3755;0.3755;0.3755;0.3755
-SSP1;FRA;BEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0.01402;0.3364;0.9158;1;1
-SSP1;FRA;BEV;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.08;0.48;0.84;0.84
-SSP1;FRA;BEV;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.08;0.48;0.84;0.84
-SSP1;FRA;BEV;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.08;0.48;0.84;0.84
-SSP1;FRA;BEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.6342;1;1;1
-SSP1;FRA;BEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.2524;0.7156;1;1
-SSP1;FRA;BEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.2524;0.7156;1;1
-SSP1;FRA;BEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.2524;0.7156;1;1
-SSP1;FRA;BEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.6342;1;1;1
+SSP1;FRA;BEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0.01402;0.1682;0.9158;1;1
+SSP1;FRA;BEV;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.04;0.48;0.84;0.84
+SSP1;FRA;BEV;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.04;0.48;0.84;0.84
+SSP1;FRA;BEV;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.04;0.48;0.84;0.84
+SSP1;FRA;BEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.3171;1;1;1
+SSP1;FRA;BEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1262;0.7156;1;1
+SSP1;FRA;BEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1262;0.7156;1;1
+SSP1;FRA;BEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1262;0.7156;1;1
+SSP1;FRA;BEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.3171;1;1;1
 SSP1;FRA;Electric;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;1;1;1;1;1
 SSP1;FRA;Electric;HSR_tmp_vehicletype;HSR_tmp_subsectorL3;HSR_tmp_subsectorL2;HSR;trn_pass;FV;1;1;1;1;1
 SSP1;FRA;Electric;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;1;1;1;1;1
 SSP1;FRA;FCEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0.01218;0.01462;0.02127;0.04294;0.04294
-SSP1;FRA;FCEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.2374;0.5271;0.2481;0.2481
-SSP1;FRA;FCEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.08772;0.2658;0.1749;0.1749
-SSP1;FRA;FCEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.08772;0.2658;0.1749;0.1749
-SSP1;FRA;FCEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.08772;0.2658;0.1749;0.1749
-SSP1;FRA;FCEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.2374;0.5271;0.2481;0.2481
+SSP1;FRA;FCEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.07914;0.5271;0.2481;0.2481
+SSP1;FRA;FCEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02924;0.2658;0.1749;0.1749
+SSP1;FRA;FCEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02924;0.2658;0.1749;0.1749
+SSP1;FRA;FCEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02924;0.2658;0.1749;0.1749
+SSP1;FRA;FCEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.07914;0.5271;0.2481;0.2481
 SSP1;FRA;Gases;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0.01535;0.02632;0.07895;0.07434;0.07434
 SSP1;FRA;Gases;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02632;0.04946;0.08815;0.08815
 SSP1;FRA;Gases;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02632;0.06579;0.09087;0.09087
@@ -6330,32 +6330,32 @@ SSP1;FRA;Hydrogen;Domestic Aviation_tmp_vehicletype;Domestic Aviation_tmp_subsec
 SSP1;FRA;Liquids;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;1;1;1;0.5246;0.5246
 SSP1;FRA;Liquids;Domestic Aviation_tmp_vehicletype;Domestic Aviation_tmp_subsectorL3;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;trn_pass;FV;1;1;1;1;1
 SSP1;FRA;Liquids;Domestic Ship_tmp_vehicletype;Domestic Ship_tmp_subsectorL3;Domestic Ship_tmp_subsectorL2;Domestic Ship;trn_freight;FV;1;1;1;1;1
-SSP1;FRA;Liquids;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;0.1608;0.0804;0.0804;0.0804;0.0804
+SSP1;FRA;Liquids;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;0.1608;0.1608;0.0804;0.0804;0.0804
 SSP1;FRA;Liquids;International Aviation_tmp_vehicletype;International Aviation_tmp_subsectorL3;International Aviation_tmp_subsectorL2;International Aviation;trn_aviation_intl;FV;1;1;1;1;1
 SSP1;FRA;Liquids;International Ship_tmp_vehicletype;International Ship_tmp_subsectorL3;International Ship_tmp_subsectorL2;International Ship;trn_shipping_intl;FV;1;1;1;1;1
 SSP1;FRA;Liquids;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;1;1;1
 SSP1;FRA;Liquids;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;1;1;1
 SSP1;FRA;Liquids;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;1;1;1
-SSP1;FRA;Liquids;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;0.05395;0.03597;0.02697;0.01798;0.01798
+SSP1;FRA;Liquids;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;0.05395;0.05395;0.02697;0.01798;0.01798
 SSP1;FRA;Liquids;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;0.7518;0.5502;0.5502
 SSP1;FRA;Liquids;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;0.5672;0.5672
 SSP1;FRA;Liquids;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;0.5672;0.5672
 SSP1;FRA;Liquids;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;0.5672;0.5672
 SSP1;FRA;Liquids;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;0.7518;0.5502;0.5502
-SSP1;IND;;;;;Cycle;trn_pass;S1S;0.01915;0.04615;0.075;0.2;0.2
-SSP1;IND;;;;;Domestic Aviation;trn_pass;S1S;0.6659;0.2753;0.1312;0.04772;0.04772
+SSP1;IND;;;;;Cycle;trn_pass;S1S;0.01915;0.03175;0.075;0.2;0.2
+SSP1;IND;;;;;Domestic Aviation;trn_pass;S1S;1.4;0.7575;0.1312;0.04772;0.04772
 SSP1;IND;;;;;Domestic Ship;trn_freight;S1S;0.001202;0.001202;0.001092;0.0009244;0.0009244
-SSP1;IND;;;;;Freight Rail;trn_freight;S1S;0.1924;0.2886;0.2361;0.1998;0.1998
-SSP1;IND;;;;;HSR;trn_pass;S1S;0;0.0004615;0.00055;0.0003;0.0003
+SSP1;IND;;;;;Freight Rail;trn_freight;S1S;0.1924;0.1924;0.2361;0.1998;0.1998
+SSP1;IND;;;;;HSR;trn_pass;S1S;0;0.0003175;0.00055;0.0003;0.0003
 SSP1;IND;;;;;International Aviation;trn_aviation_intl;S1S;1;1;1;1;1
 SSP1;IND;;;;;International Ship;trn_shipping_intl;S1S;1;1;1;1;1
-SSP1;IND;;;;;Passenger Rail;trn_pass;S1S;0.004978;0.01354;0.012;0.008;0.008
-SSP1;IND;;;;;Walk;trn_pass;S1S;0.9573;0.8;1;1;1
+SSP1;IND;;;;;Passenger Rail;trn_pass;S1S;0.004978;0.00582;0.012;0.008;0.008
+SSP1;IND;;;;;Walk;trn_pass;S1S;1.053;0.6879;1;1;1
 SSP1;IND;;;;;trn_freight_road;trn_freight;S1S;1;1;1;1;1
-SSP1;IND;;;;;trn_pass_road;trn_pass;S1S;1;1.09;0.54;0.1472;0.1472
-SSP1;IND;;;;Bus;trn_pass_road;trn_pass;S2S1;1;0.5457;0.3948;0.3949;0.3949
-SSP1;IND;;;;trn_pass_road_LDV;trn_pass_road;trn_pass;S2S1;0.918;1;1;1;1
-SSP1;IND;;;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;0.09;0.06;0.05108;0.05108;0.05108
+SSP1;IND;;;;;trn_pass_road;trn_pass;S1S;1;1;0.54;0.1472;0.1472
+SSP1;IND;;;;Bus;trn_pass_road;trn_pass;S2S1;1;0.3638;0.3948;0.3949;0.3949
+SSP1;IND;;;;trn_pass_road_LDV;trn_pass_road;trn_pass;S2S1;0.7344;1;1;1;1
+SSP1;IND;;;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;0.072;0.06;0.05108;0.05108;0.05108
 SSP1;IND;;;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;1;1;1;1;1
 SSP1;IND;;Compact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;1;1;1;1;1
 SSP1;IND;;Large Car and SUV;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;1;1;1;1;1
@@ -6369,132 +6369,132 @@ SSP1;IND;;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subs
 SSP1;IND;;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0;0.05;0.1987;0.1987;0.1987
 SSP1;IND;;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0;0.05;0.1987;0.1987;0.1987
 SSP1;IND;;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;1;1;1;1;1
-SSP1;IND;BEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.1035;0.587;1;1
-SSP1;IND;BEV;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.4;0.72;0.756;0.756
-SSP1;IND;BEV;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.4;0.72;0.756;0.756
-SSP1;IND;BEV;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0;0;0;0
-SSP1;IND;BEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.05574;0.1273;0.1286;0.1286
-SSP1;IND;BEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02218;0.06848;0.1247;0.1247
-SSP1;IND;BEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;0.2;0.2546;0.1309;0.1309
-SSP1;IND;BEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;0.2;0.2546;0.1309;0.1309
-SSP1;IND;BEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.05574;0.1273;0.1286;0.1286
+SSP1;IND;BEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.05175;0.587;1;1
+SSP1;IND;BEV;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.2;0.72;0.756;0.756
+SSP1;IND;BEV;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.2;0.72;0.756;0.756
+SSP1;IND;BEV;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.2;0;0;0
+SSP1;IND;BEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02787;0.1273;0.1286;0.1286
+SSP1;IND;BEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.01109;0.06848;0.1247;0.1247
+SSP1;IND;BEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;0.2338;0.2546;0.1309;0.1309
+SSP1;IND;BEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;0.2338;0.2546;0.1309;0.1309
+SSP1;IND;BEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02787;0.1273;0.1286;0.1286
 SSP1;IND;Electric;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;1;1;1;1;1
 SSP1;IND;Electric;HSR_tmp_vehicletype;HSR_tmp_subsectorL3;HSR_tmp_subsectorL2;HSR;trn_pass;FV;1;1;1;1;1
-SSP1;IND;Electric;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;0.834;1;1;1;1
+SSP1;IND;Electric;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;0.834;0.8547;1;1;1
 SSP1;IND;FCEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.002698;0.01963;0.041;0.041
-SSP1;IND;FCEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.01565;0.02587;0.004785;0.004785
-SSP1;IND;FCEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.005781;0.009813;0.003273;0.003273
-SSP1;IND;FCEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;0.5457;0.006546;0.006546
-SSP1;IND;FCEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;0.5457;0.006546;0.006546
-SSP1;IND;FCEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.01565;0.02587;0.004785;0.004785
+SSP1;IND;FCEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.005217;0.02587;0.004785;0.004785
+SSP1;IND;FCEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.001927;0.009813;0.003273;0.003273
+SSP1;IND;FCEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;0.7794;0.5457;0.006546;0.006546
+SSP1;IND;FCEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;0.7794;0.5457;0.006546;0.006546
+SSP1;IND;FCEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.005217;0.02587;0.004785;0.004785
 SSP1;IND;Gases;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0.2408;0.2086;0.2105;0.143;0.143
 SSP1;IND;Gases;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.08768;0.07978;0.06655;0.02557;0.02557
 SSP1;IND;Gases;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.0188;0.03289;0.01842;0.01842
-SSP1;IND;Gases;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.9164;0.3055;0.4167;0.1;0.1
-SSP1;IND;Gases;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.9164;0.3055;0.4167;0.1;0.1
+SSP1;IND;Gases;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.9164;0.7143;0.4167;0.1;0.1
+SSP1;IND;Gases;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.9164;0.7143;0.4167;0.1;0.1
 SSP1;IND;Gases;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.0188;0.03289;0.01842;0.01842
 SSP1;IND;Hydrogen;Domestic Aviation_tmp_vehicletype;Domestic Aviation_tmp_subsectorL3;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;trn_pass;FV;0;8.32E-07;0.1362;0.3576;0.3576
 SSP1;IND;Liquids;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;1;1;1;0.7515;0.7515
 SSP1;IND;Liquids;Domestic Aviation_tmp_vehicletype;Domestic Aviation_tmp_subsectorL3;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;trn_pass;FV;1;1;1;1;1
 SSP1;IND;Liquids;Domestic Ship_tmp_vehicletype;Domestic Ship_tmp_subsectorL3;Domestic Ship_tmp_subsectorL2;Domestic Ship;trn_freight;FV;1;1;1;1;1
-SSP1;IND;Liquids;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;0.9342;0.4671;0.4671;0.4671;0.4671
+SSP1;IND;Liquids;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;0.9342;0.9342;0.4671;0.4671;0.4671
 SSP1;IND;Liquids;International Aviation_tmp_vehicletype;International Aviation_tmp_subsectorL3;International Aviation_tmp_subsectorL2;International Aviation;trn_aviation_intl;FV;1;1;1;1;1
 SSP1;IND;Liquids;International Ship_tmp_vehicletype;International Ship_tmp_subsectorL3;International Ship_tmp_subsectorL2;International Ship;trn_shipping_intl;FV;1;1;1;1;1
 SSP1;IND;Liquids;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;1;1;1
 SSP1;IND;Liquids;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;1;1;1
 SSP1;IND;Liquids;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;1;1;1
-SSP1;IND;Liquids;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;1;0.78;0.5579;0.3404;0.3404
+SSP1;IND;Liquids;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;1;1;0.5579;0.3404;0.3404
 SSP1;IND;Liquids;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
 SSP1;IND;Liquids;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
-SSP1;IND;Liquids;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.9164;0.4277;1;1;1
-SSP1;IND;Liquids;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.9164;0.4277;1;1;1
+SSP1;IND;Liquids;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.9164;1;1;1;1
+SSP1;IND;Liquids;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.9164;1;1;1;1
 SSP1;IND;Liquids;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
 SSP1;JPN;;;;;Cycle;trn_pass;S1S;0.01743;0.01743;0.03486;0.01961;0.01961
-SSP1;JPN;;;;;Domestic Aviation;trn_pass;S1S;0.0001729;0.0001623;0.0002334;6.57E-05;6.57E-05
+SSP1;JPN;;;;;Domestic Aviation;trn_pass;S1S;0.0001729;0.0002075;0.0002334;6.57E-05;6.57E-05
 SSP1;JPN;;;;;Domestic Ship;trn_freight;S1S;0.01167;0.01111;0.01167;0.01167;0.01167
-SSP1;JPN;;;;;Freight Rail;trn_freight;S1S;0.002833;0.004047;0.004249;0.004249;0.004249
-SSP1;JPN;;;;;HSR;trn_pass;S1S;0.0004081;0.0002857;0.0003673;0.0001033;0.0001033
+SSP1;JPN;;;;;Freight Rail;trn_freight;S1S;0.002833;0.002698;0.004249;0.004249;0.004249
+SSP1;JPN;;;;;HSR;trn_pass;S1S;0.0004081;0.0004081;0.0003673;0.0001033;0.0001033
 SSP1;JPN;;;;;International Aviation;trn_aviation_intl;S1S;1;1;1;1;1
 SSP1;JPN;;;;;International Ship;trn_shipping_intl;S1S;1;1;1;1;1
-SSP1;JPN;;;;;Passenger Rail;trn_pass;S1S;0.006084;0.006085;0.0084;0.00365;0.00365
-SSP1;JPN;;;;;Walk;trn_pass;S1S;1;0.5;1;1;1
+SSP1;JPN;;;;;Passenger Rail;trn_pass;S1S;0.006084;0.006084;0.0084;0.00365;0.00365
+SSP1;JPN;;;;;Walk;trn_pass;S1S;1;1;1;1;1
 SSP1;JPN;;;;;trn_freight_road;trn_freight;S1S;1;1;1;1;1
-SSP1;JPN;;;;;trn_pass_road;trn_pass;S1S;0.07113;0.04195;0.04195;0.0118;0.0118
-SSP1;JPN;;;;Bus;trn_pass_road;trn_pass;S2S1;0.06081;0.09122;0.09122;0.09122;0.09122
+SSP1;JPN;;;;;trn_pass_road;trn_pass;S1S;0.07113;0.07629;0.04195;0.0118;0.0118
+SSP1;JPN;;;;Bus;trn_pass_road;trn_pass;S2S1;0.06081;0.06081;0.09122;0.09122;0.09122
 SSP1;JPN;;;;trn_pass_road_LDV;trn_pass_road;trn_pass;S2S1;1;1;1;1;1
 SSP1;JPN;;;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;0.07;0.06;0.05491;0.05491;0.05491
 SSP1;JPN;;;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;1;1;1;1;1
-SSP1;JPN;;Compact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.1662;0.2493;0.3324;0.4986;0.4986
+SSP1;JPN;;Compact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.1662;0.1662;0.3324;0.4986;0.4986
 SSP1;JPN;;Large Car and SUV;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;1;1;1;1;1
-SSP1;JPN;;Mini Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.0484;0.0726;0.0968;0.1452;0.1452
+SSP1;JPN;;Mini Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.0484;0.0484;0.0968;0.1452;0.1452
 SSP1;JPN;;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;1;1;1;1;1
 SSP1;JPN;;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.6255;0.6255;0.6255;0.6255;0.6255
 SSP1;JPN;;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.5153;0.5153;0.5153;0.5153;0.5153
-SSP1;JPN;;Subcompact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.1286;0.1929;0.2572;0.3858;0.3858
+SSP1;JPN;;Subcompact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.1286;0.1286;0.2572;0.3858;0.3858
 SSP1;JPN;;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;1;1;1;1;1
 SSP1;JPN;;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0;0;0;0;0
 SSP1;JPN;;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0;0;0;0;0
 SSP1;JPN;;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0;0;0;0;0
 SSP1;JPN;;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.5896;0.5896;0.5896;0.5896;0.5896
-SSP1;JPN;BEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.1935;0.3588;0.7508;0.7508
-SSP1;JPN;BEV;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.32;1;1;1
-SSP1;JPN;BEV;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.32;1;1;1
-SSP1;JPN;BEV;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.32;1;1;1
-SSP1;JPN;BEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.2664;0.6828;1;1
-SSP1;JPN;BEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;0.03818;0.08;1;1
-SSP1;JPN;BEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;0.03818;0.08;1;1
-SSP1;JPN;BEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;0.03818;0.08;1;1
-SSP1;JPN;BEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.2664;0.6828;1;1
+SSP1;JPN;BEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.09673;0.3588;0.7508;0.7508
+SSP1;JPN;BEV;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.16;1;1;1
+SSP1;JPN;BEV;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.16;1;1;1
+SSP1;JPN;BEV;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.16;1;1;1
+SSP1;JPN;BEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1332;0.6828;1;1
+SSP1;JPN;BEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;0.05727;0.08;1;1
+SSP1;JPN;BEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;0.05727;0.08;1;1
+SSP1;JPN;BEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;0.05727;0.08;1;1
+SSP1;JPN;BEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1332;0.6828;1;1
 SSP1;JPN;Electric;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;1;1;1;1;1
 SSP1;JPN;Electric;HSR_tmp_vehicletype;HSR_tmp_subsectorL3;HSR_tmp_subsectorL2;HSR;trn_pass;FV;1;1;1;1;1
 SSP1;JPN;Electric;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;1;1;1;1;1
 SSP1;JPN;FCEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.06091;0.12;0.09854;0.09854
-SSP1;JPN;FCEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.3918;0.8097;0.4568;0.4568
+SSP1;JPN;FCEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1306;0.8097;0.4568;0.4568
 SSP1;JPN;FCEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;0.6137;0.6137
 SSP1;JPN;FCEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;0.6137;0.6137
 SSP1;JPN;FCEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;0.6137;0.6137
-SSP1;JPN;FCEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.3918;0.8097;0.4568;0.4568
+SSP1;JPN;FCEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1306;0.8097;0.4568;0.4568
 SSP1;JPN;Gases;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.006579;0.01215;0.01919;0.01919
 SSP1;JPN;Gases;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.01316;0.04222;0.02163;0.02163
-SSP1;JPN;Gases;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.8457;0.008543;0.03132;0.1153;0.1153
-SSP1;JPN;Gases;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.8457;0.008543;0.03132;0.1153;0.1153
-SSP1;JPN;Gases;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.8457;0.008543;0.03132;0.1153;0.1153
+SSP1;JPN;Gases;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.8457;0.02563;0.03132;0.1153;0.1153
+SSP1;JPN;Gases;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.8457;0.02563;0.03132;0.1153;0.1153
+SSP1;JPN;Gases;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.8457;0.02563;0.03132;0.1153;0.1153
 SSP1;JPN;Gases;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.01316;0.04222;0.02163;0.02163
 SSP1;JPN;Hydrogen;Domestic Aviation_tmp_vehicletype;Domestic Aviation_tmp_subsectorL3;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;trn_pass;FV;0;8.32E-07;0.1362;0.3576;0.3576
 SSP1;JPN;Liquids;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;1;1;1;1;1
 SSP1;JPN;Liquids;Domestic Aviation_tmp_vehicletype;Domestic Aviation_tmp_subsectorL3;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;trn_pass;FV;1;1;1;1;1
 SSP1;JPN;Liquids;Domestic Ship_tmp_vehicletype;Domestic Ship_tmp_subsectorL3;Domestic Ship_tmp_subsectorL2;Domestic Ship;trn_freight;FV;1;1;1;1;1
-SSP1;JPN;Liquids;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;0.8837;0.4419;0.4419;0.4419;0.4419
+SSP1;JPN;Liquids;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;0.8837;0.8837;0.4419;0.4419;0.4419
 SSP1;JPN;Liquids;International Aviation_tmp_vehicletype;International Aviation_tmp_subsectorL3;International Aviation_tmp_subsectorL2;International Aviation;trn_aviation_intl;FV;1;1;1;1;1
 SSP1;JPN;Liquids;International Ship_tmp_vehicletype;International Ship_tmp_subsectorL3;International Ship_tmp_subsectorL2;International Ship;trn_shipping_intl;FV;1;1;1;1;1
 SSP1;JPN;Liquids;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;0.947;0.496;0.496
 SSP1;JPN;Liquids;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;0.947;0.496;0.496
 SSP1;JPN;Liquids;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;0.947;0.496;0.496
-SSP1;JPN;Liquids;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;0.03433;0.02289;0.01716;0.01144;0.01144
+SSP1;JPN;Liquids;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;0.03433;0.03433;0.01716;0.01144;0.01144
 SSP1;JPN;Liquids;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;0.5637;0.5637
-SSP1;JPN;Liquids;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.8457;0.01709;0.05857;0.5536;0.5536
-SSP1;JPN;Liquids;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.8457;0.01709;0.05857;0.5536;0.5536
-SSP1;JPN;Liquids;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.8457;0.01709;0.05857;0.5536;0.5536
+SSP1;JPN;Liquids;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.8457;0.05126;0.05857;0.5536;0.5536
+SSP1;JPN;Liquids;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.8457;0.05126;0.05857;0.5536;0.5536
+SSP1;JPN;Liquids;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.8457;0.05126;0.05857;0.5536;0.5536
 SSP1;JPN;Liquids;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;0.5637;0.5637
 SSP1;LAM;;;;;Cycle;trn_pass;S1S;0.01091;0.02182;0.05455;0.2728;0.2728
-SSP1;LAM;;;;;Domestic Aviation;trn_pass;S1S;0.008921;0.002975;0.007435;0.005575;0.005575
+SSP1;LAM;;;;;Domestic Aviation;trn_pass;S1S;0.008921;0.0119;0.007435;0.005575;0.005575
 SSP1;LAM;;;;;Domestic Ship;trn_freight;S1S;0.0097;0.0097;0.008908;0.006736;0.006736
-SSP1;LAM;;;;;Freight Rail;trn_freight;S1S;0.04782;0.07173;0.06587;0.05978;0.05978
+SSP1;LAM;;;;;Freight Rail;trn_freight;S1S;0.04782;0.04782;0.06587;0.05978;0.05978
 SSP1;LAM;;;;;HSR;trn_pass;S1S;0.005236;0.2905;0.2905;0.2905;0.2905
 SSP1;LAM;;;;;International Aviation;trn_aviation_intl;S1S;1;1;1;1;1
 SSP1;LAM;;;;;International Ship;trn_shipping_intl;S1S;1;1;1;1;1
-SSP1;LAM;;;;;Passenger Rail;trn_pass;S1S;0.1499;0.2998;0.2998;0.1999;0.1999
-SSP1;LAM;;;;;Walk;trn_pass;S1S;1;0.8;1;1;1
+SSP1;LAM;;;;;Passenger Rail;trn_pass;S1S;0.1499;0.1499;0.2998;0.1999;0.1999
+SSP1;LAM;;;;;Walk;trn_pass;S1S;1;1;1;1;1
 SSP1;LAM;;;;;trn_freight_road;trn_freight;S1S;1;1;1;1;1
-SSP1;LAM;;;;;trn_pass_road;trn_pass;S1S;0.655;0.3471;0.3471;0.4049;0.4049
-SSP1;LAM;;;;Bus;trn_pass_road;trn_pass;S2S1;0.2647;0.2481;0.1984;0.1984;0.1984
-SSP1;LAM;;;;trn_pass_road_LDV;trn_pass_road;trn_pass;S2S1;1;1;1;1;1
+SSP1;LAM;;;;;trn_pass_road;trn_pass;S1S;0.655;0.6942;0.3471;0.4049;0.4049
+SSP1;LAM;;;;Bus;trn_pass_road;trn_pass;S2S1;0.2647;0.1654;0.1984;0.1984;0.1984
+SSP1;LAM;;;;trn_pass_road_LDV;trn_pass_road;trn_pass;S2S1;0.8;1;1;1;1
 SSP1;LAM;;;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;0.35;0.3;0.25;0.25;0.25
 SSP1;LAM;;;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;1;1;1;1;1
 SSP1;LAM;;Compact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;1;1;1;1;1
-SSP1;LAM;;Large Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.03279;0.02623;0.02049;0.01457;0.01457
-SSP1;LAM;;Large Car and SUV;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.3624;0.2899;0.2265;0.161;0.161
-SSP1;LAM;;Midsize Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.04788;0.0383;0.02992;0.02128;0.02128
+SSP1;LAM;;Large Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.03279;0.03935;0.02049;0.01457;0.01457
+SSP1;LAM;;Large Car and SUV;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.3624;0.4348;0.2265;0.161;0.161
+SSP1;LAM;;Midsize Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.04788;0.05745;0.02992;0.02128;0.02128
 SSP1;LAM;;Mini Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.01226;0.01226;0.01226;0.01226;0.01226
 SSP1;LAM;;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.000458;0.000458;0.000458;0.000458;0.000458
 SSP1;LAM;;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;1;1;1;1;1
@@ -6505,25 +6505,25 @@ SSP1;LAM;;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subs
 SSP1;LAM;;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;1;1;1;1;1
 SSP1;LAM;;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.0005079;0.0005079;0.0005079;0.0005079;0.0005079
 SSP1;LAM;;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.1892;0.1892;0.1892;0.1892;0.1892
-SSP1;LAM;;Van;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.001473;0.001179;0.000921;0.0006547;0.0006547
-SSP1;LAM;BEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.2588;1;1;1
-SSP1;LAM;BEV;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.112;0.432;1;1
-SSP1;LAM;BEV;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.112;0.432;1;1
-SSP1;LAM;BEV;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.112;0.432;1;1
-SSP1;LAM;BEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.2082;0.3928;0.4714;0.4714
-SSP1;LAM;BEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.0828;0.2114;0.4574;0.4574
-SSP1;LAM;BEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.0828;0.2114;0.4574;0.4574
-SSP1;LAM;BEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.0828;0.2114;0.4574;0.4574
-SSP1;LAM;BEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.2082;0.3928;0.4714;0.4714
-SSP1;LAM;Electric;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;0.0681;0.3692;0.8352;1;1
+SSP1;LAM;;Van;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.001473;0.001768;0.000921;0.0006547;0.0006547
+SSP1;LAM;BEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.1294;1;1;1
+SSP1;LAM;BEV;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.056;0.432;1;1
+SSP1;LAM;BEV;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.056;0.432;1;1
+SSP1;LAM;BEV;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.056;0.432;1;1
+SSP1;LAM;BEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1041;0.3928;0.4714;0.4714
+SSP1;LAM;BEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.0414;0.2114;0.4574;0.4574
+SSP1;LAM;BEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.0414;0.2114;0.4574;0.4574
+SSP1;LAM;BEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.0414;0.2114;0.4574;0.4574
+SSP1;LAM;BEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1041;0.3928;0.4714;0.4714
+SSP1;LAM;Electric;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;0.0681;0.1846;0.8352;1;1
 SSP1;LAM;Electric;HSR_tmp_vehicletype;HSR_tmp_subsectorL3;HSR_tmp_subsectorL2;HSR;trn_pass;FV;1;1;1;1;1
 SSP1;LAM;Electric;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;1;1;1;1;1
 SSP1;LAM;FCEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.002698;0.01672;0.03281;0.03281
-SSP1;LAM;FCEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02921;0.1863;0.2659;0.2659
-SSP1;LAM;FCEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.01079;0.07065;0.1819;0.1819
-SSP1;LAM;FCEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.01079;0.07065;0.1819;0.1819
-SSP1;LAM;FCEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.01079;0.07065;0.1819;0.1819
-SSP1;LAM;FCEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02921;0.1863;0.2659;0.2659
+SSP1;LAM;FCEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.009738;0.1863;0.2659;0.2659
+SSP1;LAM;FCEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.003598;0.07065;0.1819;0.1819
+SSP1;LAM;FCEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.003598;0.07065;0.1819;0.1819
+SSP1;LAM;FCEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.003598;0.07065;0.1819;0.1819
+SSP1;LAM;FCEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.009738;0.1863;0.2659;0.2659
 SSP1;LAM;Gases;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0.02689;0.04725;0.08835;0.062;0.062
 SSP1;LAM;Gases;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.01754;0.03158;0.0614;0.0614
 SSP1;LAM;Gases;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.01754;0.03158;0.0614;0.0614
@@ -6540,55 +6540,55 @@ SSP1;LAM;Liquids;International Ship_tmp_vehicletype;International Ship_tmp_subse
 SSP1;LAM;Liquids;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;1;0.9921;0.9921
 SSP1;LAM;Liquids;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;1;0.9921;0.9921
 SSP1;LAM;Liquids;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;1;0.9921;0.9921
-SSP1;LAM;Liquids;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;0.6477;0.4318;0.3239;0.2159;0.2159
+SSP1;LAM;Liquids;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;0.6477;0.6477;0.3239;0.2159;0.2159
 SSP1;LAM;Liquids;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
 SSP1;LAM;Liquids;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
 SSP1;LAM;Liquids;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
 SSP1;LAM;Liquids;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
 SSP1;LAM;Liquids;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
 SSP1;MEA;;;;;Cycle;trn_pass;S1S;0.0166;0.0166;0.0166;0.04149;0.04149
-SSP1;MEA;;;;;Domestic Aviation;trn_pass;S1S;0.008522;0.00282;0.00426;0.00625;0.00625
+SSP1;MEA;;;;;Domestic Aviation;trn_pass;S1S;0.008522;0.005681;0.00426;0.00625;0.00625
 SSP1;MEA;;;;;Domestic Ship;trn_freight;S1S;0.00206;0.00206;0.00206;0.00206;0.00206
-SSP1;MEA;;;;;Freight Rail;trn_freight;S1S;0.003202;0.004803;0.004803;0.004803;0.004803
+SSP1;MEA;;;;;Freight Rail;trn_freight;S1S;0.003202;0.003202;0.004803;0.004803;0.004803
 SSP1;MEA;;;;;HSR;trn_pass;S1S;0;0.01667;0.01667;0.01667;0.01667
 SSP1;MEA;;;;;International Aviation;trn_aviation_intl;S1S;1;1;1;1;1
 SSP1;MEA;;;;;International Ship;trn_shipping_intl;S1S;1;1;1;1;1
-SSP1;MEA;;;;;Passenger Rail;trn_pass;S1S;0.0005567;0.002226;0.002226;0.003712;0.003712
-SSP1;MEA;;;;;Walk;trn_pass;S1S;1;0.8;1;1;1
+SSP1;MEA;;;;;Passenger Rail;trn_pass;S1S;0.0005567;0.001113;0.002226;0.003712;0.003712
+SSP1;MEA;;;;;Walk;trn_pass;S1S;1;1;1;1;1
 SSP1;MEA;;;;;trn_freight_road;trn_freight;S1S;1;1;1;1;1
-SSP1;MEA;;;;;trn_pass_road;trn_pass;S1S;0.3767;0.2119;0.1908;0.1908;0.1908
-SSP1;MEA;;;;Bus;trn_pass_road;trn_pass;S2S1;0.2676;0.2809;0.1405;0.1124;0.1124
+SSP1;MEA;;;;;trn_pass_road;trn_pass;S1S;0.3767;0.4239;0.1908;0.1908;0.1908
+SSP1;MEA;;;;Bus;trn_pass_road;trn_pass;S2S1;0.2676;0.1873;0.1405;0.1124;0.1124
 SSP1;MEA;;;;trn_pass_road_LDV;trn_pass_road;trn_pass;S2S1;1;1;1;1;1
 SSP1;MEA;;;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;0.01502;0.01502;0.01502;0.01502;0.01502
 SSP1;MEA;;;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;1;1;1;1;1
-SSP1;MEA;;Compact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.5257;0.7098;0.8674;1;1
+SSP1;MEA;;Compact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.5257;0.4732;0.8674;1;1
 SSP1;MEA;;Large Car and SUV;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;1;1;1;0.8454;0.8454
-SSP1;MEA;;Mini Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.04395;0.05933;0.07252;0.08359;0.08359
+SSP1;MEA;;Mini Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.04395;0.03955;0.07252;0.08359;0.08359
 SSP1;MEA;;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;1;1;1;1;1
 SSP1;MEA;;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.001;0.001;0.001;0.001;0.001
-SSP1;MEA;;Subcompact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.2071;0.2796;0.3418;0.3939;0.3939
+SSP1;MEA;;Subcompact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.2071;0.1864;0.3418;0.3939;0.3939
 SSP1;MEA;;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.1304;0.1304;0.1304;0.1304;0.1304
 SSP1;MEA;;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.2013;0.2013;0.2013;0.2013;0.2013
 SSP1;MEA;;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0;0;0;0;0
 SSP1;MEA;;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0;0;0;0;0
 SSP1;MEA;;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;1;1;1;1;1
-SSP1;MEA;BEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.1035;0.587;1;1
-SSP1;MEA;BEV;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.24;0.432;0.42;0.42
-SSP1;MEA;BEV;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0;0;0;0
-SSP1;MEA;BEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1301;0.2182;0.2784;0.2784
-SSP1;MEA;BEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.05176;0.1174;0.27;0.27
-SSP1;MEA;BEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;0.3118;0.4364;0.2834;0.2834
-SSP1;MEA;BEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;0.3118;0.4364;0.2834;0.2834
-SSP1;MEA;BEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1301;0.2182;0.2784;0.2784
-SSP1;MEA;Electric;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;0.4021;0.9536;1;1;1
+SSP1;MEA;BEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.05175;0.587;1;1
+SSP1;MEA;BEV;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.12;0.432;0.42;0.42
+SSP1;MEA;BEV;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.12;0;0;0
+SSP1;MEA;BEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.06504;0.2182;0.2784;0.2784
+SSP1;MEA;BEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02588;0.1174;0.27;0.27
+SSP1;MEA;BEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;0.1559;0.4364;0.2834;0.2834
+SSP1;MEA;BEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;0.1559;0.4364;0.2834;0.2834
+SSP1;MEA;BEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.06504;0.2182;0.2784;0.2784
+SSP1;MEA;Electric;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;0.4021;0.4768;1;1;1
 SSP1;MEA;Electric;HSR_tmp_vehicletype;HSR_tmp_subsectorL3;HSR_tmp_subsectorL2;HSR;trn_pass;FV;1;1;1;1;1
 SSP1;MEA;Electric;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;1;1;1;1;1
 SSP1;MEA;FCEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.002698;0.01784;0.04294;0.04294
-SSP1;MEA;FCEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.01096;0.03105;0.001243;0.001243
-SSP1;MEA;FCEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.004047;0.01178;0.0008502;0.0008502
-SSP1;MEA;FCEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;0.4677;0.6546;0.001701;0.001701
-SSP1;MEA;FCEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;0.4677;0.6546;0.001701;0.001701
-SSP1;MEA;FCEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.01096;0.03105;0.001243;0.001243
+SSP1;MEA;FCEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.003652;0.03105;0.001243;0.001243
+SSP1;MEA;FCEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.001349;0.01178;0.0008502;0.0008502
+SSP1;MEA;FCEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;0.1559;0.6546;0.001701;0.001701
+SSP1;MEA;FCEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;0.1559;0.6546;0.001701;0.001701
+SSP1;MEA;FCEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.003652;0.03105;0.001243;0.001243
 SSP1;MEA;Gases;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0.01342;0.03938;0.083;0.08535;0.08535
 SSP1;MEA;Gases;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.0009283;0.09527;0.04788;0.04804;0.04804
 SSP1;MEA;Gases;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.09211;0.04737;0.04785;0.04785
@@ -6604,59 +6604,59 @@ SSP1;MEA;Liquids;International Aviation_tmp_vehicletype;International Aviation_t
 SSP1;MEA;Liquids;International Ship_tmp_vehicletype;International Ship_tmp_subsectorL3;International Ship_tmp_subsectorL2;International Ship;trn_shipping_intl;FV;1;1;1;1;1
 SSP1;MEA;Liquids;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;1;1;1
 SSP1;MEA;Liquids;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;1;1;1
-SSP1;MEA;Liquids;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;0.07852;0.05235;0.03926;0.02617;0.02617
+SSP1;MEA;Liquids;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;0.07852;0.07852;0.03926;0.02617;0.02617
 SSP1;MEA;Liquids;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
 SSP1;MEA;Liquids;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
 SSP1;MEA;Liquids;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.9164;0.2857;1;1;1
 SSP1;MEA;Liquids;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.9164;0.2857;1;1;1
 SSP1;MEA;Liquids;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
 SSP1;NEN;;;;;Cycle;trn_pass;S1S;0.003033;0.003024;0.002621;0.0182;0.0182
-SSP1;NEN;;;;;Domestic Aviation;trn_pass;S1S;7.21E-06;1.4E-06;6.12E-07;3.57E-07;3.57E-07
+SSP1;NEN;;;;;Domestic Aviation;trn_pass;S1S;7.5E-06;7.54E-06;6.12E-07;3.57E-07;3.57E-07
 SSP1;NEN;;;;;Domestic Ship;trn_freight;S1S;0.03175;0.03175;0.03175;0.03175;0.03175
-SSP1;NEN;;;;;Freight Rail;trn_freight;S1S;0.01925;0.02888;0.02888;0.02888;0.02888
+SSP1;NEN;;;;;Freight Rail;trn_freight;S1S;0.01925;0.01925;0.02888;0.02888;0.02888
 SSP1;NEN;;;;;HSR;trn_pass;S1S;2E-05;4.53E-05;7.36E-06;5.52E-06;5.52E-06
 SSP1;NEN;;;;;International Aviation;trn_aviation_intl;S1S;1;1;1;1;1
 SSP1;NEN;;;;;International Ship;trn_shipping_intl;S1S;1;1;1;1;1
-SSP1;NEN;;;;;Passenger Rail;trn_pass;S1S;3E-06;5.93E-06;1.35E-06;6.43E-07;6.43E-07
-SSP1;NEN;;;;;Walk;trn_pass;S1S;1;0.8;1;1;1
+SSP1;NEN;;;;;Passenger Rail;trn_pass;S1S;3E-06;2.97E-06;1.35E-06;6.43E-07;6.43E-07
+SSP1;NEN;;;;;Walk;trn_pass;S1S;1;1;1;1;1
 SSP1;NEN;;;;;trn_freight_road;trn_freight;S1S;1;1;1;1;1
-SSP1;NEN;;;;;trn_pass_road;trn_pass;S1S;0.0496;0.03434;0.01395;0.01162;0.01162
-SSP1;NEN;;;;Bus;trn_pass_road;trn_pass;S2S1;0.01287;0.01207;0.006033;0.003017;0.003017
+SSP1;NEN;;;;;trn_pass_road;trn_pass;S1S;0.0496;0.06868;0.01395;0.01162;0.01162
+SSP1;NEN;;;;Bus;trn_pass_road;trn_pass;S2S1;0.01287;0.008044;0.006033;0.003017;0.003017
 SSP1;NEN;;;;trn_pass_road_LDV;trn_pass_road;trn_pass;S2S1;1;1;1;1;1
 SSP1;NEN;;;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;0.09;0.09;0.09;0.09;0.09
 SSP1;NEN;;;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;1;1;1;1;1
-SSP1;NEN;;Compact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.4624;0.6936;0.9248;1;1
+SSP1;NEN;;Compact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.4624;0.4624;0.9248;1;1
 SSP1;NEN;;Large Car and SUV;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;1;1;1;0.7209;0.7209
 SSP1;NEN;;Midsize Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.3307;0.3307;0.3307;0.2384;0.2384
-SSP1;NEN;;Mini Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;6.43E-08;9.65E-08;1.29E-07;1.39E-07;1.39E-07
+SSP1;NEN;;Mini Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;6.43E-08;6.43E-08;1.29E-07;1.39E-07;1.39E-07
 SSP1;NEN;;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.3331;0.3331;0.3331;0.3331;0.3331
 SSP1;NEN;;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.1369;0.1369;0.1369;0.1369;0.1369
 SSP1;NEN;;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;1;1;1;1;1
-SSP1;NEN;;Subcompact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.3388;0.5082;0.6776;0.7327;0.7327
+SSP1;NEN;;Subcompact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.3388;0.3388;0.6776;0.7327;0.7327
 SSP1;NEN;;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;1;1;1;1;1
 SSP1;NEN;;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.143;0.143;0.143;0.143;0.143
 SSP1;NEN;;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.2745;0.2745;0.2745;0.2745;0.2745
 SSP1;NEN;;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.06397;0.06397;0.06397;0.06397;0.06397
 SSP1;NEN;;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.3433;0.3433;0.3433;0.3433;0.3433
 SSP1;NEN;;Van;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.00735;0.00735;0.00735;0.005298;0.005298
-SSP1;NEN;BEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0.05608;0.2804;0.8268;1;1
-SSP1;NEN;BEV;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.08;0.336;0.588;0.588
-SSP1;NEN;BEV;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.08;0.336;0.588;0.588
-SSP1;NEN;BEV;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.08;0.336;0.588;0.588
-SSP1;NEN;BEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.5074;1;1;1
-SSP1;NEN;BEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.2018;0.636;1;1
-SSP1;NEN;BEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.2018;0.636;1;1
-SSP1;NEN;BEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.2018;0.636;1;1
-SSP1;NEN;BEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.5074;1;1;1
+SSP1;NEN;BEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0.05608;0.1402;0.8268;1;1
+SSP1;NEN;BEV;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.04;0.336;0.588;0.588
+SSP1;NEN;BEV;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.04;0.336;0.588;0.588
+SSP1;NEN;BEV;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.04;0.336;0.588;0.588
+SSP1;NEN;BEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.2537;1;1;1
+SSP1;NEN;BEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1009;0.636;1;1
+SSP1;NEN;BEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1009;0.636;1;1
+SSP1;NEN;BEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1009;0.636;1;1
+SSP1;NEN;BEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.2537;1;1;1
 SSP1;NEN;Electric;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;1;1;1;1;1
 SSP1;NEN;Electric;HSR_tmp_vehicletype;HSR_tmp_subsectorL3;HSR_tmp_subsectorL2;HSR;trn_pass;FV;1;1;1;1;1
 SSP1;NEN;Electric;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;1;1;1;1;1
 SSP1;NEN;FCEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.002924;0.02127;0.02812;0.02812
-SSP1;NEN;FCEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02374;0.4268;0.1675;0.1675
-SSP1;NEN;FCEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.008772;0.1914;0.1181;0.1181
-SSP1;NEN;FCEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.008772;0.1914;0.1181;0.1181
-SSP1;NEN;FCEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.008772;0.1914;0.1181;0.1181
-SSP1;NEN;FCEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02374;0.4268;0.1675;0.1675
+SSP1;NEN;FCEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.007914;0.4268;0.1675;0.1675
+SSP1;NEN;FCEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.002924;0.1914;0.1181;0.1181
+SSP1;NEN;FCEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.002924;0.1914;0.1181;0.1181
+SSP1;NEN;FCEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.002924;0.1914;0.1181;0.1181
+SSP1;NEN;FCEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.007914;0.4268;0.1675;0.1675
 SSP1;NEN;Gases;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0.02362;0.03778;0.09872;0.06397;0.06397
 SSP1;NEN;Gases;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.006427;0.03257;0.07178;0.08156;0.08156
 SSP1;NEN;Gases;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02632;0.07895;0.08178;0.08178
@@ -6667,65 +6667,65 @@ SSP1;NEN;Hydrogen;Domestic Aviation_tmp_vehicletype;Domestic Aviation_tmp_subsec
 SSP1;NEN;Liquids;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;1;1;1;0.5073;0.5073
 SSP1;NEN;Liquids;Domestic Aviation_tmp_vehicletype;Domestic Aviation_tmp_subsectorL3;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;trn_pass;FV;1;1;1;1;1
 SSP1;NEN;Liquids;Domestic Ship_tmp_vehicletype;Domestic Ship_tmp_subsectorL3;Domestic Ship_tmp_subsectorL2;Domestic Ship;trn_freight;FV;1;1;1;1;1
-SSP1;NEN;Liquids;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;0.1317;0.06585;0.06585;0.06585;0.06585
+SSP1;NEN;Liquids;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;0.1317;0.1317;0.06585;0.06585;0.06585
 SSP1;NEN;Liquids;International Aviation_tmp_vehicletype;International Aviation_tmp_subsectorL3;International Aviation_tmp_subsectorL2;International Aviation;trn_aviation_intl;FV;1;1;1;1;1
 SSP1;NEN;Liquids;International Ship_tmp_vehicletype;International Ship_tmp_subsectorL3;International Ship_tmp_subsectorL2;International Ship;trn_shipping_intl;FV;1;1;1;1;1
 SSP1;NEN;Liquids;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;1;1;1
 SSP1;NEN;Liquids;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;1;1;1
 SSP1;NEN;Liquids;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;1;1;1
-SSP1;NEN;Liquids;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;0.0154;0.01027;0.0077;0.005133;0.005133
+SSP1;NEN;Liquids;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;0.0154;0.0154;0.0077;0.005133;0.005133
 SSP1;NEN;Liquids;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;0.8457;0.5598;0.5598
 SSP1;NEN;Liquids;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;0.5771;0.5771
 SSP1;NEN;Liquids;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;0.5771;0.5771
 SSP1;NEN;Liquids;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;0.5771;0.5771
 SSP1;NEN;Liquids;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;0.8457;0.5598;0.5598
 SSP1;NES;;;;;Cycle;trn_pass;S1S;0.008738;0.007802;0.009929;0.01365;0.01365
-SSP1;NES;;;;;Domestic Aviation;trn_pass;S1S;0.004721;0.0004215;0.0003577;9.84E-05;9.84E-05
+SSP1;NES;;;;;Domestic Aviation;trn_pass;S1S;0.004721;0.003372;0.0003577;9.84E-05;9.84E-05
 SSP1;NES;;;;;Domestic Ship;trn_freight;S1S;0.01468;0.01468;0.01468;0.01322;0.01322
-SSP1;NES;;;;;Freight Rail;trn_freight;S1S;0.01697;0.02545;0.02545;0.02545;0.02545
+SSP1;NES;;;;;Freight Rail;trn_freight;S1S;0.01697;0.01697;0.02545;0.02545;0.02545
 SSP1;NES;;;;;HSR;trn_pass;S1S;0.0005085;0.0003632;0.0002311;0.0001271;0.0001271
 SSP1;NES;;;;;International Aviation;trn_aviation_intl;S1S;1;1;1;1;1
 SSP1;NES;;;;;International Ship;trn_shipping_intl;S1S;1;1;1;1;1
-SSP1;NES;;;;;Passenger Rail;trn_pass;S1S;0.001607;0.002296;0.001461;0.0008034;0.0008034
-SSP1;NES;;;;;Walk;trn_pass;S1S;1;0.8;1;1;1
+SSP1;NES;;;;;Passenger Rail;trn_pass;S1S;0.001607;0.001148;0.001461;0.0008034;0.0008034
+SSP1;NES;;;;;Walk;trn_pass;S1S;1;1;1;1;1
 SSP1;NES;;;;;trn_freight_road;trn_freight;S1S;1;1;1;1;1
-SSP1;NES;;;;;trn_pass_road;trn_pass;S1S;0.2727;0.1409;0.1121;0.06165;0.06165
-SSP1;NES;;;;Bus;trn_pass_road;trn_pass;S2S1;0.08401;0.05601;0.0336;0.0336;0.0336
+SSP1;NES;;;;;trn_pass_road;trn_pass;S1S;0.2727;0.2818;0.1121;0.06165;0.06165
+SSP1;NES;;;;Bus;trn_pass_road;trn_pass;S2S1;0.08401;0.03734;0.0336;0.0336;0.0336
 SSP1;NES;;;;trn_pass_road_LDV;trn_pass_road;trn_pass;S2S1;1;1;1;1;1
 SSP1;NES;;;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;0.02;0.02;0.02;0.02;0.02
 SSP1;NES;;;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;1;1;1;1;1
-SSP1;NES;;Compact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.576;0.864;1;1;1
+SSP1;NES;;Compact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.576;0.576;1;1;1
 SSP1;NES;;Large Car and SUV;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;1;1;0.8138;0.5425;0.5425
 SSP1;NES;;Midsize Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.2352;0.2352;0.1914;0.1276;0.1276
-SSP1;NES;;Mini Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.001886;0.002829;0.003275;0.003275;0.003275
+SSP1;NES;;Mini Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.001886;0.001886;0.003275;0.003275;0.003275
 SSP1;NES;;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.01148;0.01148;0.01148;0.01148;0.01148
 SSP1;NES;;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.1337;0.1337;0.1337;0.1337;0.1337
 SSP1;NES;;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;1;1;1;1;1
-SSP1;NES;;Subcompact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.09325;0.1399;0.1619;0.1619;0.1619
+SSP1;NES;;Subcompact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.09325;0.09325;0.1619;0.1619;0.1619
 SSP1;NES;;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;1;1;1;1;1
 SSP1;NES;;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.06299;0.06299;0.06299;0.06299;0.06299
 SSP1;NES;;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.3651;0.3651;0.3651;0.3651;0.3651
 SSP1;NES;;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.5704;0.5704;0.5704;0.5704;0.5704
 SSP1;NES;;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.4799;0.4799;0.4799;0.4799;0.4799
 SSP1;NES;;Van;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.00288;0.00288;0.002344;0.001563;0.001563
-SSP1;NES;BEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.1035;0.3478;0.693;0.693
-SSP1;NES;BEV;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.08;0.336;0.672;0.672
-SSP1;NES;BEV;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.08;0.336;0.672;0.672
-SSP1;NES;BEV;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.08;0.336;0.672;0.672
-SSP1;NES;BEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.2276;0.4364;0.643;0.643
-SSP1;NES;BEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.09056;0.2348;0.6236;0.6236
-SSP1;NES;BEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.09056;0.2348;0.6236;0.6236
-SSP1;NES;BEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.09056;0.2348;0.6236;0.6236
-SSP1;NES;BEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.2276;0.4364;0.643;0.643
-SSP1;NES;Electric;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;0.2081;0.6142;1;1;1
+SSP1;NES;BEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.05175;0.3478;0.693;0.693
+SSP1;NES;BEV;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.04;0.336;0.672;0.672
+SSP1;NES;BEV;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.04;0.336;0.672;0.672
+SSP1;NES;BEV;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.04;0.336;0.672;0.672
+SSP1;NES;BEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1138;0.4364;0.643;0.643
+SSP1;NES;BEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.04528;0.2348;0.6236;0.6236
+SSP1;NES;BEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.04528;0.2348;0.6236;0.6236
+SSP1;NES;BEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.04528;0.2348;0.6236;0.6236
+SSP1;NES;BEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1138;0.4364;0.643;0.643
+SSP1;NES;Electric;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;0.2081;0.3071;1;1;1
 SSP1;NES;Electric;HSR_tmp_vehicletype;HSR_tmp_subsectorL3;HSR_tmp_subsectorL2;HSR;trn_pass;FV;1;1;1;1;1
 SSP1;NES;Electric;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;1;1;1;1;1
 SSP1;NES;FCEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.002698;0.01454;0.03637;0.03637
-SSP1;NES;FCEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02739;0.115;0.2513;0.2513
-SSP1;NES;FCEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.01012;0.04362;0.1719;0.1719
-SSP1;NES;FCEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.01012;0.04362;0.1719;0.1719
-SSP1;NES;FCEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.01012;0.04362;0.1719;0.1719
-SSP1;NES;FCEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02739;0.115;0.2513;0.2513
+SSP1;NES;FCEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.009129;0.115;0.2513;0.2513
+SSP1;NES;FCEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.003373;0.04362;0.1719;0.1719
+SSP1;NES;FCEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.003373;0.04362;0.1719;0.1719
+SSP1;NES;FCEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.003373;0.04362;0.1719;0.1719
+SSP1;NES;FCEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.009129;0.115;0.2513;0.2513
 SSP1;NES;Gases;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0.003476;0.0297;0.06085;0.07482;0.07482
 SSP1;NES;Gases;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.03289;0.08772;0.1289;0.1289
 SSP1;NES;Gases;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.03289;0.08772;0.1289;0.1289
@@ -6742,60 +6742,60 @@ SSP1;NES;Liquids;International Ship_tmp_vehicletype;International Ship_tmp_subse
 SSP1;NES;Liquids;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;1;1;1
 SSP1;NES;Liquids;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;1;1;1
 SSP1;NES;Liquids;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;1;1;1
-SSP1;NES;Liquids;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;0.4782;0.3188;0.2391;0.1594;0.1594
+SSP1;NES;Liquids;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;0.4782;0.4782;0.2391;0.1594;0.1594
 SSP1;NES;Liquids;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
 SSP1;NES;Liquids;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
 SSP1;NES;Liquids;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
 SSP1;NES;Liquids;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
 SSP1;NES;Liquids;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
 SSP1;OAS;;;;;Cycle;trn_pass;S1S;0.01256;0.03616;0.04821;0.1205;0.1205
-SSP1;OAS;;;;;Domestic Aviation;trn_pass;S1S;0.02456;0.00921;0.0129;0.03315;0.03315
+SSP1;OAS;;;;;Domestic Aviation;trn_pass;S1S;0.02456;0.03684;0.0129;0.03315;0.03315
 SSP1;OAS;;;;;Domestic Ship;trn_freight;S1S;0.03712;0.03375;0.02856;0.027;0.027
-SSP1;OAS;;;;;Freight Rail;trn_freight;S1S;0.04736;0.06457;0.05464;0.05166;0.05166
+SSP1;OAS;;;;;Freight Rail;trn_freight;S1S;0.04736;0.04305;0.05464;0.05166;0.05166
 SSP1;OAS;;;;;HSR;trn_pass;S1S;0.000966;0.004347;0.004347;0.005796;0.005796
 SSP1;OAS;;;;;International Aviation;trn_aviation_intl;S1S;1;1;1;1;1
 SSP1;OAS;;;;;International Ship;trn_shipping_intl;S1S;1;1;1;1;1
-SSP1;OAS;;;;;Passenger Rail;trn_pass;S1S;0.0007701;0.00231;0.003466;0.00462;0.00462
-SSP1;OAS;;;;;Walk;trn_pass;S1S;1;0.8;1;1;1
+SSP1;OAS;;;;;Passenger Rail;trn_pass;S1S;0.0007701;0.001155;0.003466;0.00462;0.00462
+SSP1;OAS;;;;;Walk;trn_pass;S1S;1;1;1;1;1
 SSP1;OAS;;;;;trn_freight_road;trn_freight;S1S;1;1;1;1;1
-SSP1;OAS;;;;;trn_pass_road;trn_pass;S1S;0.4452;0.2848;0.2848;0.356;0.356
-SSP1;OAS;;;;Bus;trn_pass_road;trn_pass;S2S1;0.4352;0.3856;0.1683;0.1443;0.1443
-SSP1;OAS;;;;trn_pass_road_LDV;trn_pass_road;trn_pass;S2S1;1;1;1;1;1
+SSP1;OAS;;;;;trn_pass_road;trn_pass;S1S;0.4452;0.5697;0.2848;0.356;0.356
+SSP1;OAS;;;;Bus;trn_pass_road;trn_pass;S2S1;0.4352;0.2571;0.1683;0.1443;0.1443
+SSP1;OAS;;;;trn_pass_road_LDV;trn_pass_road;trn_pass;S2S1;1.2;1;1;1;1
 SSP1;OAS;;;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;0.8;0.5;0.3;0.2;0.2
 SSP1;OAS;;;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;1;1;1;1;1
-SSP1;OAS;;Compact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.002698;0.004216;0.008432;0.01686;0.01686
+SSP1;OAS;;Compact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.002698;0.002811;0.008432;0.01686;0.01686
 SSP1;OAS;;Large Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.3018;0.3018;0.3018;0.3018;0.3018
 SSP1;OAS;;Large Car and SUV;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.0006459;0.0006459;0.0006459;0.0006459;0.0006459
 SSP1;OAS;;Midsize Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.00025;0.00025;0.00025;0.00025;0.00025
-SSP1;OAS;;Mini Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;2.78E-05;4.34E-05;8.67E-05;0.0001735;0.0001735
+SSP1;OAS;;Mini Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;2.78E-05;2.89E-05;8.67E-05;0.0001735;0.0001735
 SSP1;OAS;;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.007762;0.007762;0.007762;0.007762;0.007762
 SSP1;OAS;;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;1;1;1;1;1
 SSP1;OAS;;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.006391;0.006391;0.006391;0.006391;0.006391
-SSP1;OAS;;Subcompact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.003403;0.005318;0.01064;0.02127;0.02127
+SSP1;OAS;;Subcompact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.003403;0.003545;0.01064;0.02127;0.02127
 SSP1;OAS;;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.3765;0.3765;0.3765;0.3765;0.3765
 SSP1;OAS;;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.4784;0.4784;0.4784;0.4784;0.4784
 SSP1;OAS;;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.001365;0.001365;0.001365;0.001365;0.001365
 SSP1;OAS;;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.0007361;0.0007361;0.0007361;0.0007361;0.0007361
 SSP1;OAS;;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;1;1;1;1;1
 SSP1;OAS;;Van;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;1.03E-05;1.03E-05;1.03E-05;1.03E-05;1.03E-05
-SSP1;OAS;BEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.2822;1;1;1
-SSP1;OAS;BEV;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.088;0.336;0.588;0.588
-SSP1;OAS;BEV;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.088;0.336;0.588;0.588
-SSP1;OAS;BEV;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.088;0.336;0.588;0.588
-SSP1;OAS;BEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.06938;0.1091;0.1429;0.1429
-SSP1;OAS;BEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.0276;0.0587;0.1386;0.1386
-SSP1;OAS;BEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.0276;0.0587;0.1386;0.1386
-SSP1;OAS;BEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.0276;0.0587;0.1386;0.1386
-SSP1;OAS;BEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.06938;0.1091;0.1429;0.1429
-SSP1;OAS;Electric;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;0.1733;0.5534;0.9666;1;1
+SSP1;OAS;BEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.1411;1;1;1
+SSP1;OAS;BEV;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.044;0.336;0.588;0.588
+SSP1;OAS;BEV;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.044;0.336;0.588;0.588
+SSP1;OAS;BEV;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.044;0.336;0.588;0.588
+SSP1;OAS;BEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.03469;0.1091;0.1429;0.1429
+SSP1;OAS;BEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.0138;0.0587;0.1386;0.1386
+SSP1;OAS;BEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.0138;0.0587;0.1386;0.1386
+SSP1;OAS;BEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.0138;0.0587;0.1386;0.1386
+SSP1;OAS;BEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.03469;0.1091;0.1429;0.1429
+SSP1;OAS;Electric;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;0.1733;0.2767;0.9666;1;1
 SSP1;OAS;Electric;HSR_tmp_vehicletype;HSR_tmp_subsectorL3;HSR_tmp_subsectorL2;HSR;trn_pass;FV;1;1;1;1;1
-SSP1;OAS;Electric;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;0.353;0.6507;1;1;1
+SSP1;OAS;Electric;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;0.353;0.4338;1;1;1
 SSP1;OAS;FCEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.002453;0.01337;0.03645;0.03645
-SSP1;OAS;FCEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.03651;0.03882;0.06381;0.06381
-SSP1;OAS;FCEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.01349;0.01472;0.04365;0.04365
-SSP1;OAS;FCEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.01349;0.01472;0.04365;0.04365
-SSP1;OAS;FCEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.01349;0.01472;0.04365;0.04365
-SSP1;OAS;FCEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.03651;0.03882;0.06381;0.06381
+SSP1;OAS;FCEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.01217;0.03882;0.06381;0.06381
+SSP1;OAS;FCEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.004497;0.01472;0.04365;0.04365
+SSP1;OAS;FCEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.004497;0.01472;0.04365;0.04365
+SSP1;OAS;FCEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.004497;0.01472;0.04365;0.04365
+SSP1;OAS;FCEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.01217;0.03882;0.06381;0.06381
 SSP1;OAS;Gases;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0.1967;0.198;0.1773;0.1152;0.1152
 SSP1;OAS;Gases;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.0004535;0.008919;0.03968;0.06153;0.06153
 SSP1;OAS;Gases;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.008772;0.03947;0.0614;0.0614
@@ -6818,52 +6818,52 @@ SSP1;OAS;Liquids;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_t
 SSP1;OAS;Liquids;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
 SSP1;OAS;Liquids;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
 SSP1;OAS;Liquids;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
-SSP1;REF;;;;;Cycle;trn_pass;S1S;0.01379;0.0149;0.0745;0.07824;0.07824
-SSP1;REF;;;;;Domestic Aviation;trn_pass;S1S;0.03574;0.01163;0.01156;0.003468;0.003468
+SSP1;REF;;;;;Cycle;trn_pass;S1S;0.01379;0.01206;0.0745;0.07824;0.07824
+SSP1;REF;;;;;Domestic Aviation;trn_pass;S1S;0.03574;0.02995;0.01156;0.003468;0.003468
 SSP1;REF;;;;;Domestic Ship;trn_freight;S1S;0.007227;0.007227;0.007227;0.007227;0.007227
-SSP1;REF;;;;;Freight Rail;trn_freight;S1S;0.1296;0.1944;0.1944;0.1944;0.1944
-SSP1;REF;;;;;HSR;trn_pass;S1S;0;0.002516;0.002516;0.000755;0.000755
+SSP1;REF;;;;;Freight Rail;trn_freight;S1S;0.1296;0.1296;0.1944;0.1944;0.1944
+SSP1;REF;;;;;HSR;trn_pass;S1S;0;0.002037;0.002516;0.000755;0.000755
 SSP1;REF;;;;;International Aviation;trn_aviation_intl;S1S;1;1;1;1;1
 SSP1;REF;;;;;International Ship;trn_shipping_intl;S1S;1;1;1;1;1
-SSP1;REF;;;;;Passenger Rail;trn_pass;S1S;0.006884;0.02977;0.03721;0.02232;0.02232
-SSP1;REF;;;;;Walk;trn_pass;S1S;0.9251;0.8;1;1;1
+SSP1;REF;;;;;Passenger Rail;trn_pass;S1S;0.006884;0.01205;0.03721;0.02232;0.02232
+SSP1;REF;;;;;Walk;trn_pass;S1S;0.9251;0.8095;1;1;1
 SSP1;REF;;;;;trn_freight_road;trn_freight;S1S;1;1;1;1;1
-SSP1;REF;;;;;trn_pass_road;trn_pass;S1S;1;0.6177;0.6177;0.2316;0.2316
-SSP1;REF;;;;Bus;trn_pass_road;trn_pass;S2S1;0.2684;0.2796;0.2329;0.1863;0.1863
+SSP1;REF;;;;;trn_pass_road;trn_pass;S1S;1;1;0.6177;0.2316;0.2316
+SSP1;REF;;;;Bus;trn_pass_road;trn_pass;S2S1;0.2684;0.1864;0.2329;0.1863;0.1863
 SSP1;REF;;;;trn_pass_road_LDV;trn_pass_road;trn_pass;S2S1;1;1;1;1;1
 SSP1;REF;;;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;0.8;0.7;0.5;0.5;0.5
 SSP1;REF;;;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;1;1;1;1;1
-SSP1;REF;;Compact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.4455;0.6264;0.8352;1;1
+SSP1;REF;;Compact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.4455;0.4176;0.8352;1;1
 SSP1;REF;;Large Car and SUV;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;1;1;1;0.8731;0.8731
 SSP1;REF;;Midsize Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.1842;0.1842;0.1842;0.1608;0.1608
-SSP1;REF;;Mini Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.0001425;0.0002004;0.0002672;0.0003201;0.0003201
+SSP1;REF;;Mini Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.0001425;0.0001336;0.0002672;0.0003201;0.0003201
 SSP1;REF;;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.003376;0.003376;0.003376;0.003376;0.003376
 SSP1;REF;;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;1;1;1;1;1
 SSP1;REF;;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.4141;0.4141;0.4141;0.4141;0.4141
-SSP1;REF;;Subcompact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.02508;0.03526;0.04702;0.05631;0.05631
+SSP1;REF;;Subcompact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.02508;0.02351;0.04702;0.05631;0.05631
 SSP1;REF;;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;1;1;1;1;1
 SSP1;REF;;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.005081;0.005081;0.005081;0.005081;0.005081
 SSP1;REF;;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.5837;0.5837;0.5837;0.5837;0.5837
 SSP1;REF;;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.1888;0.1888;0.1888;0.1888;0.1888
 SSP1;REF;;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.01676;0.01676;0.01676;0.01676;0.01676
-SSP1;REF;BEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.1449;0.6404;1;1
-SSP1;REF;BEV;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.08;0.336;0.672;0.672
-SSP1;REF;BEV;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.08;0.336;0.672;0.672
-SSP1;REF;BEV;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.08;0.336;0.672;0.672
-SSP1;REF;BEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.2366;0.5356;0.7914;0.7914
-SSP1;REF;BEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.0941;0.2882;0.7676;0.7676
-SSP1;REF;BEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.0941;0.2882;0.7676;0.7676
-SSP1;REF;BEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.0941;0.2882;0.7676;0.7676
-SSP1;REF;BEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.2366;0.5356;0.7914;0.7914
+SSP1;REF;BEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.07245;0.6404;1;1
+SSP1;REF;BEV;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.04;0.336;0.672;0.672
+SSP1;REF;BEV;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.04;0.336;0.672;0.672
+SSP1;REF;BEV;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.04;0.336;0.672;0.672
+SSP1;REF;BEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1183;0.5356;0.7914;0.7914
+SSP1;REF;BEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.04705;0.2882;0.7676;0.7676
+SSP1;REF;BEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.04705;0.2882;0.7676;0.7676
+SSP1;REF;BEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.04705;0.2882;0.7676;0.7676
+SSP1;REF;BEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1183;0.5356;0.7914;0.7914
 SSP1;REF;Electric;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;1;1;1;1;1
 SSP1;REF;Electric;HSR_tmp_vehicletype;HSR_tmp_subsectorL3;HSR_tmp_subsectorL2;HSR;trn_pass;FV;1;1;1;1;1
 SSP1;REF;Electric;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;1;1;1;1;1
 SSP1;REF;FCEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.002698;0.03569;0.04199;0.04199
-SSP1;REF;FCEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1792;0.1411;0.1657;0.1657
-SSP1;REF;FCEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.06624;0.05352;0.1133;0.1133
-SSP1;REF;FCEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.06624;0.05352;0.1133;0.1133
-SSP1;REF;FCEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.06624;0.05352;0.1133;0.1133
-SSP1;REF;FCEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1792;0.1411;0.1657;0.1657
+SSP1;REF;FCEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.05975;0.1411;0.1657;0.1657
+SSP1;REF;FCEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02208;0.05352;0.1133;0.1133
+SSP1;REF;FCEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02208;0.05352;0.1133;0.1133
+SSP1;REF;FCEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02208;0.05352;0.1133;0.1133
+SSP1;REF;FCEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.05975;0.1411;0.1657;0.1657
 SSP1;REF;Gases;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0.014;0.03195;0.06011;0.05269;0.05269
 SSP1;REF;Gases;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.03465;0.06073;0.09593;0.1342;0.1342
 SSP1;REF;Gases;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02392;0.06459;0.1134;0.1134
@@ -6874,35 +6874,35 @@ SSP1;REF;Hydrogen;Domestic Aviation_tmp_vehicletype;Domestic Aviation_tmp_subsec
 SSP1;REF;Liquids;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;1;1;1;0.6734;0.6734
 SSP1;REF;Liquids;Domestic Aviation_tmp_vehicletype;Domestic Aviation_tmp_subsectorL3;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;trn_pass;FV;1;1;1;1;1
 SSP1;REF;Liquids;Domestic Ship_tmp_vehicletype;Domestic Ship_tmp_subsectorL3;Domestic Ship_tmp_subsectorL2;Domestic Ship;trn_freight;FV;1;1;1;1;1
-SSP1;REF;Liquids;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;0.4599;0.2299;0.2299;0.2299;0.2299
+SSP1;REF;Liquids;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;0.4599;0.4599;0.2299;0.2299;0.2299
 SSP1;REF;Liquids;International Aviation_tmp_vehicletype;International Aviation_tmp_subsectorL3;International Aviation_tmp_subsectorL2;International Aviation;trn_aviation_intl;FV;1;1;1;1;1
 SSP1;REF;Liquids;International Ship_tmp_vehicletype;International Ship_tmp_subsectorL3;International Ship_tmp_subsectorL2;International Ship;trn_shipping_intl;FV;1;1;1;1;1
 SSP1;REF;Liquids;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;1;1;1
 SSP1;REF;Liquids;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;1;1;1
 SSP1;REF;Liquids;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;1;1;1
-SSP1;REF;Liquids;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;0.2359;0.1573;0.1179;0.07863;0.07863
+SSP1;REF;Liquids;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;0.2359;0.2359;0.1179;0.07863;0.07863
 SSP1;REF;Liquids;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
 SSP1;REF;Liquids;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
 SSP1;REF;Liquids;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
 SSP1;REF;Liquids;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
 SSP1;REF;Liquids;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
 SSP1;SSA;;;;;Cycle;trn_pass;S1S;0.01388;0.01987;0.02915;0.03279;0.03279
-SSP1;SSA;;;;;Domestic Aviation;trn_pass;S1S;0.008602;0.01347;0.009878;0.001481;0.001481
+SSP1;SSA;;;;;Domestic Aviation;trn_pass;S1S;0.033;0.05387;0.009878;0.001481;0.001481
 SSP1;SSA;;;;;Domestic Ship;trn_freight;S1S;0.001495;0.001495;0.001495;0.001495;0.001495
-SSP1;SSA;;;;;Freight Rail;trn_freight;S1S;0.01665;0.02498;0.02498;0.02247;0.02247
+SSP1;SSA;;;;;Freight Rail;trn_freight;S1S;0.01665;0.01665;0.02498;0.02247;0.02247
 SSP1;SSA;;;;;HSR;trn_pass;S1S;1.48E-05;2.22E-05;0.06504;0.009756;0.009756
 SSP1;SSA;;;;;International Aviation;trn_aviation_intl;S1S;1;1;1;1;1
 SSP1;SSA;;;;;International Ship;trn_shipping_intl;S1S;1;1;1;1;1
-SSP1;SSA;;;;;Passenger Rail;trn_pass;S1S;0.0006024;0.00345;0.00506;0.001139;0.001139
+SSP1;SSA;;;;;Passenger Rail;trn_pass;S1S;0.0006024;0.001725;0.00506;0.001139;0.001139
 SSP1;SSA;;;;;Walk;trn_pass;S1S;1;1;1;1;1
 SSP1;SSA;;;;;trn_freight_road;trn_freight;S1S;1;1;1;1;1
-SSP1;SSA;;;;;trn_pass_road;trn_pass;S1S;0.2622;0.163;0.1434;0.0239;0.0239
-SSP1;SSA;;;;Bus;trn_pass_road;trn_pass;S2S1;0.7568;0.4851;0.224;0.1455;0.1455
+SSP1;SSA;;;;;trn_pass_road;trn_pass;S1S;0.2622;0.326;0.1434;0.0239;0.0239
+SSP1;SSA;;;;Bus;trn_pass_road;trn_pass;S2S1;0.7568;0.3234;0.224;0.1455;0.1455
 SSP1;SSA;;;;trn_pass_road_LDV;trn_pass_road;trn_pass;S2S1;1;1;1;1;1
 SSP1;SSA;;;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;0.02619;0.02619;0.02619;0.03928;0.03928
 SSP1;SSA;;;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;1;1;1;1;1
 SSP1;SSA;;Compact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;1;1;1;1;1
-SSP1;SSA;;Large Car and SUV;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.003022;0.002015;0.001511;0.001007;0.001007
+SSP1;SSA;;Large Car and SUV;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.003022;0.003022;0.001511;0.001007;0.001007
 SSP1;SSA;;Mini Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.02706;0.02706;0.02706;0.02706;0.02706
 SSP1;SSA;;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.3828;0.3828;0.3828;0.3828;0.3828
 SSP1;SSA;;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;1;1;1;1;1
@@ -6913,25 +6913,25 @@ SSP1;SSA;;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subs
 SSP1;SSA;;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;5.61E-06;5.61E-06;5.61E-06;5.61E-06;5.61E-06
 SSP1;SSA;;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;4.21E-06;4.21E-06;4.21E-06;4.21E-06;4.21E-06
 SSP1;SSA;;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;1;1;1;1;1
-SSP1;SSA;;Van;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;7.57E-05;5.05E-05;3.79E-05;2.52E-05;2.52E-05
-SSP1;SSA;BEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.1242;0.7924;1;1
-SSP1;SSA;BEV;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.2;0.432;0.672;0.672
-SSP1;SSA;BEV;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.2;0.432;0.672;0.672
-SSP1;SSA;BEV;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.2;0.432;0.672;0.672
-SSP1;SSA;BEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.05204;0.2014;0.3022;0.3022
-SSP1;SSA;BEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.0207;0.1084;0.2932;0.2932
-SSP1;SSA;BEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.0207;0.1084;0.2932;0.2932
-SSP1;SSA;BEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.0207;0.1084;0.2932;0.2932
-SSP1;SSA;BEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.05204;0.2014;0.3022;0.3022
+SSP1;SSA;;Van;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;7.57E-05;7.57E-05;3.79E-05;2.52E-05;2.52E-05
+SSP1;SSA;BEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.0621;0.7924;1;1
+SSP1;SSA;BEV;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.1;0.432;0.672;0.672
+SSP1;SSA;BEV;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.1;0.432;0.672;0.672
+SSP1;SSA;BEV;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.1;0.432;0.672;0.672
+SSP1;SSA;BEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02602;0.2014;0.3022;0.3022
+SSP1;SSA;BEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.01035;0.1084;0.2932;0.2932
+SSP1;SSA;BEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.01035;0.1084;0.2932;0.2932
+SSP1;SSA;BEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.01035;0.1084;0.2932;0.2932
+SSP1;SSA;BEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02602;0.2014;0.3022;0.3022
 SSP1;SSA;Electric;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;1;1;1;1;1
 SSP1;SSA;Electric;HSR_tmp_vehicletype;HSR_tmp_subsectorL3;HSR_tmp_subsectorL2;HSR;trn_pass;FV;1;1;1;1;1
 SSP1;SSA;Electric;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;1;1;1;1;1
 SSP1;SSA;FCEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.002698;0.01963;0.02863;0.02863
-SSP1;SSA;FCEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02191;0.03582;0.06135;0.06135
-SSP1;SSA;FCEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.008094;0.01359;0.04197;0.04197
-SSP1;SSA;FCEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.008094;0.01359;0.04197;0.04197
-SSP1;SSA;FCEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.008094;0.01359;0.04197;0.04197
-SSP1;SSA;FCEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02191;0.03582;0.06135;0.06135
+SSP1;SSA;FCEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.007303;0.03582;0.06135;0.06135
+SSP1;SSA;FCEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.002698;0.01359;0.04197;0.04197
+SSP1;SSA;FCEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.002698;0.01359;0.04197;0.04197
+SSP1;SSA;FCEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.002698;0.01359;0.04197;0.04197
+SSP1;SSA;FCEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.007303;0.03582;0.06135;0.06135
 SSP1;SSA;Gases;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0.0003981;0.0267;0.04997;0.04035;0.04035
 SSP1;SSA;Gases;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02632;0.04251;0.05904;0.05904
 SSP1;SSA;Gases;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02632;0.04251;0.05904;0.05904
@@ -6942,65 +6942,65 @@ SSP1;SSA;Hydrogen;Domestic Aviation_tmp_vehicletype;Domestic Aviation_tmp_subsec
 SSP1;SSA;Liquids;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;1;1;1;0.5903;0.5903
 SSP1;SSA;Liquids;Domestic Aviation_tmp_vehicletype;Domestic Aviation_tmp_subsectorL3;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;trn_pass;FV;1;1;1;1;1
 SSP1;SSA;Liquids;Domestic Ship_tmp_vehicletype;Domestic Ship_tmp_subsectorL3;Domestic Ship_tmp_subsectorL2;Domestic Ship;trn_freight;FV;1;1;1;1;1
-SSP1;SSA;Liquids;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;0.6248;0.3124;0.3124;0.3124;0.3124
+SSP1;SSA;Liquids;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;0.6248;0.6248;0.3124;0.3124;0.3124
 SSP1;SSA;Liquids;International Aviation_tmp_vehicletype;International Aviation_tmp_subsectorL3;International Aviation_tmp_subsectorL2;International Aviation;trn_aviation_intl;FV;1;1;1;1;1
 SSP1;SSA;Liquids;International Ship_tmp_vehicletype;International Ship_tmp_subsectorL3;International Ship_tmp_subsectorL2;International Ship;trn_shipping_intl;FV;1;1;1;1;1
 SSP1;SSA;Liquids;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;1;1;1
 SSP1;SSA;Liquids;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;1;1;1
 SSP1;SSA;Liquids;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;1;1;1
-SSP1;SSA;Liquids;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;0.07561;0.05041;0.0378;0.0252;0.0252
+SSP1;SSA;Liquids;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;0.07561;0.07561;0.0378;0.0252;0.0252
 SSP1;SSA;Liquids;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
 SSP1;SSA;Liquids;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
 SSP1;SSA;Liquids;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
 SSP1;SSA;Liquids;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
 SSP1;SSA;Liquids;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
 SSP1;UKI;;;;;Cycle;trn_pass;S1S;0.025;0.01092;0.03277;0.06553;0.06553
-SSP1;UKI;;;;;Domestic Aviation;trn_pass;S1S;5.97E-05;2.23E-06;2.23E-06;2.23E-06;2.23E-06
+SSP1;UKI;;;;;Domestic Aviation;trn_pass;S1S;5.97E-05;8.94E-06;2.23E-06;2.23E-06;2.23E-06
 SSP1;UKI;;;;;Domestic Ship;trn_freight;S1S;0.00867;0.00867;0.00867;0.00867;0.00867
-SSP1;UKI;;;;;Freight Rail;trn_freight;S1S;0.00618;0.00927;0.00927;0.00927;0.00927
+SSP1;UKI;;;;;Freight Rail;trn_freight;S1S;0.00618;0.00618;0.00927;0.00927;0.00927
 SSP1;UKI;;;;;HSR;trn_pass;S1S;0.000125;0.0001334;0.0001779;0.0002224;0.0002224
 SSP1;UKI;;;;;International Aviation;trn_aviation_intl;S1S;1;1;1;1;1
 SSP1;UKI;;;;;International Ship;trn_shipping_intl;S1S;1;1;1;1;1
-SSP1;UKI;;;;;Passenger Rail;trn_pass;S1S;0.003125;0.005004;0.003752;0.003752;0.003752
-SSP1;UKI;;;;;Walk;trn_pass;S1S;1;0.8;1;1;1
+SSP1;UKI;;;;;Passenger Rail;trn_pass;S1S;0.003125;0.002502;0.003752;0.003752;0.003752
+SSP1;UKI;;;;;Walk;trn_pass;S1S;1;1;1;1;1
 SSP1;UKI;;;;;trn_freight_road;trn_freight;S1S;1;1;1;1;1
-SSP1;UKI;;;;;trn_pass_road;trn_pass;S1S;0.07363;0.02614;0.01673;0.01673;0.01673
-SSP1;UKI;;;;Bus;trn_pass_road;trn_pass;S2S1;0.2546;0.3072;0.2816;0.2559;0.2559
+SSP1;UKI;;;;;trn_pass_road;trn_pass;S1S;0.07363;0.05228;0.01673;0.01673;0.01673
+SSP1;UKI;;;;Bus;trn_pass_road;trn_pass;S2S1;0.2546;0.2048;0.2816;0.2559;0.2559
 SSP1;UKI;;;;trn_pass_road_LDV;trn_pass_road;trn_pass;S2S1;1;1;1;1;1
 SSP1;UKI;;;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;0.1;0.1;0.1;0.1;0.1
 SSP1;UKI;;;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;1;1;1;1;1
-SSP1;UKI;;Compact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.5404;0.8106;0.9502;0.9502;0.9502
+SSP1;UKI;;Compact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.5404;0.5404;0.9502;0.9502;0.9502
 SSP1;UKI;;Large Car and SUV;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;1;1;0.9768;0.6512;0.6512
 SSP1;UKI;;Midsize Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.2616;0.2616;0.2555;0.1703;0.1703
-SSP1;UKI;;Mini Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;5.28E-07;7.92E-07;9.28E-07;9.28E-07;9.28E-07
+SSP1;UKI;;Mini Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;5.28E-07;5.28E-07;9.28E-07;9.28E-07;9.28E-07
 SSP1;UKI;;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.02088;0.02088;0.02088;0.02088;0.02088
 SSP1;UKI;;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.003798;0.003798;0.003798;0.003798;0.003798
 SSP1;UKI;;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;1;1;1;1;1
-SSP1;UKI;;Subcompact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.5688;0.8532;1;1;1
+SSP1;UKI;;Subcompact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.5688;0.5688;1;1;1
 SSP1;UKI;;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;1;1;1;1;1
 SSP1;UKI;;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.04528;0.04528;0.04528;0.04528;0.04528
 SSP1;UKI;;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.09437;0.09437;0.09437;0.09437;0.09437
 SSP1;UKI;;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.5696;0.5696;0.5696;0.5696;0.5696
 SSP1;UKI;;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.7765;0.7765;0.7765;0.7765;0.7765
 SSP1;UKI;;Van;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.002681;0.002681;0.002619;0.001746;0.001746
-SSP1;UKI;BEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0.025;0.2336;0.6868;1;1
-SSP1;UKI;BEV;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.1;0.4;0.74;0.74
-SSP1;UKI;BEV;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.1;0.4;0.74;0.74
-SSP1;UKI;BEV;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.1;0.4;0.74;0.74
-SSP1;UKI;BEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.5638;1;1;1
-SSP1;UKI;BEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.2244;0.6296;1;1
-SSP1;UKI;BEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.2244;0.6296;1;1
-SSP1;UKI;BEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.2244;0.6296;1;1
-SSP1;UKI;BEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.5638;1;1;1
-SSP1;UKI;Electric;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;0.826;1;1;1;1
+SSP1;UKI;BEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0.025;0.1168;0.6868;1;1
+SSP1;UKI;BEV;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.05;0.4;0.74;0.74
+SSP1;UKI;BEV;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.05;0.4;0.74;0.74
+SSP1;UKI;BEV;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.05;0.4;0.74;0.74
+SSP1;UKI;BEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.2819;1;1;1
+SSP1;UKI;BEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1122;0.6296;1;1
+SSP1;UKI;BEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1122;0.6296;1;1
+SSP1;UKI;BEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.1122;0.6296;1;1
+SSP1;UKI;BEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.2819;1;1;1
+SSP1;UKI;Electric;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;0.826;0.8478;1;1;1
 SSP1;UKI;Electric;HSR_tmp_vehicletype;HSR_tmp_subsectorL3;HSR_tmp_subsectorL2;HSR;trn_pass;FV;1;1;1;1;1
 SSP1;UKI;Electric;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;1;1;1;1;1
 SSP1;UKI;FCEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;2.5E-05;0.01218;0.02127;0.05302;0.05302
-SSP1;UKI;FCEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.2374;0.5748;0.3102;0.3102
-SSP1;UKI;FCEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.08772;0.2552;0.2186;0.2186
-SSP1;UKI;FCEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.08772;0.2552;0.2186;0.2186
-SSP1;UKI;FCEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.08772;0.2552;0.2186;0.2186
-SSP1;UKI;FCEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.2374;0.5748;0.3102;0.3102
+SSP1;UKI;FCEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.07914;0.5748;0.3102;0.3102
+SSP1;UKI;FCEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02924;0.2552;0.2186;0.2186
+SSP1;UKI;FCEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02924;0.2552;0.2186;0.2186
+SSP1;UKI;FCEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02924;0.2552;0.2186;0.2186
+SSP1;UKI;FCEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.07914;0.5748;0.3102;0.3102
 SSP1;UKI;Gases;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0.000904;0.02222;0.07928;0.08273;0.08273
 SSP1;UKI;Gases;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02632;0.06744;0.1102;0.1102
 SSP1;UKI;Gases;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.02632;0.07895;0.1136;0.1136
@@ -7011,34 +7011,34 @@ SSP1;UKI;Hydrogen;Domestic Aviation_tmp_vehicletype;Domestic Aviation_tmp_subsec
 SSP1;UKI;Liquids;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;1;1;1;0.6726;0.6726
 SSP1;UKI;Liquids;Domestic Aviation_tmp_vehicletype;Domestic Aviation_tmp_subsectorL3;Domestic Aviation_tmp_subsectorL2;Domestic Aviation;trn_pass;FV;1;1;1;1;1
 SSP1;UKI;Liquids;Domestic Ship_tmp_vehicletype;Domestic Ship_tmp_subsectorL3;Domestic Ship_tmp_subsectorL2;Domestic Ship;trn_freight;FV;1;1;1;1;1
-SSP1;UKI;Liquids;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;1;0.5898;0.561;0.5111;0.5111
+SSP1;UKI;Liquids;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;1;1;0.561;0.5111;0.5111
 SSP1;UKI;Liquids;International Aviation_tmp_vehicletype;International Aviation_tmp_subsectorL3;International Aviation_tmp_subsectorL2;International Aviation;trn_aviation_intl;FV;1;1;1;1;1
 SSP1;UKI;Liquids;International Ship_tmp_vehicletype;International Ship_tmp_subsectorL3;International Ship_tmp_subsectorL2;International Ship;trn_shipping_intl;FV;1;1;1;1;1
 SSP1;UKI;Liquids;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;1;1;1
 SSP1;UKI;Liquids;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;1;1;1
 SSP1;UKI;Liquids;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;1;1;1
-SSP1;UKI;Liquids;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;0.5355;0.357;0.2677;0.1785;0.1785
+SSP1;UKI;Liquids;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;0.5355;0.5355;0.2677;0.1785;0.1785
 SSP1;UKI;Liquids;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;0.8543;0.5981;0.5981
 SSP1;UKI;Liquids;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;0.6165;0.6165
 SSP1;UKI;Liquids;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;0.6165;0.6165
 SSP1;UKI;Liquids;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;0.6165;0.6165
 SSP1;UKI;Liquids;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;0.8543;0.5981;0.5981
 SSP1;USA;;;;;Cycle;trn_pass;S1S;0.008197;0.008197;0.008197;0.04098;0.04098
-SSP1;USA;;;;;Domestic Aviation;trn_pass;S1S;0.001009;0.0003817;0.0004295;0.0002625;0.0002625
+SSP1;USA;;;;;Domestic Aviation;trn_pass;S1S;0.001009;0.001527;0.0004295;0.0002625;0.0002625
 SSP1;USA;;;;;Domestic Ship;trn_freight;S1S;0.003267;0.003267;0.003267;0.003267;0.003267
-SSP1;USA;;;;;Freight Rail;trn_freight;S1S;0.03427;0.0514;0.0514;0.0514;0.0514
+SSP1;USA;;;;;Freight Rail;trn_freight;S1S;0.03427;0.03427;0.0514;0.0514;0.0514
 SSP1;USA;;;;;HSR;trn_pass;S1S;4.53E-06;4.53E-06;4.53E-06;0.0002265;0.0002265
 SSP1;USA;;;;;International Aviation;trn_aviation_intl;S1S;1;1;1;1;1
 SSP1;USA;;;;;International Ship;trn_shipping_intl;S1S;1;1;1;1;1
-SSP1;USA;;;;;Passenger Rail;trn_pass;S1S;0.001933;0.003866;0.003866;0.001933;0.001933
-SSP1;USA;;;;;Walk;trn_pass;S1S;1;0.8;1;1;1
+SSP1;USA;;;;;Passenger Rail;trn_pass;S1S;0.001933;0.001933;0.003866;0.001933;0.001933
+SSP1;USA;;;;;Walk;trn_pass;S1S;1;1;1;1;1
 SSP1;USA;;;;;trn_freight_road;trn_freight;S1S;1;1;1;1;1
-SSP1;USA;;;;;trn_pass_road;trn_pass;S1S;0.1305;0.06525;0.06265;0.03263;0.03263
-SSP1;USA;;;;Bus;trn_pass_road;trn_pass;S2S1;0.0872;0.1635;0.1635;0.1852;0.1852
+SSP1;USA;;;;;trn_pass_road;trn_pass;S1S;0.1305;0.1436;0.06265;0.03263;0.03263
+SSP1;USA;;;;Bus;trn_pass_road;trn_pass;S2S1;0.0872;0.109;0.1635;0.1852;0.1852
 SSP1;USA;;;;trn_pass_road_LDV;trn_pass_road;trn_pass;S2S1;1;1;1;1;1
 SSP1;USA;;;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;0.06;0.06;0.06;0.05;0.05
 SSP1;USA;;;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;1;1;1;1;1
-SSP1;USA;;Compact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.3784;0.5676;0.7568;1;1
+SSP1;USA;;Compact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.3784;0.3784;0.7568;1;1
 SSP1;USA;;Large Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.2661;0.2661;0.2661;0.2344;0.2344
 SSP1;USA;;Large Car and SUV;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;1;1;1;0.8809;0.8809
 SSP1;USA;;Midsize Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.3745;0.3745;0.3745;0.3299;0.3299
@@ -7048,22 +7048,22 @@ SSP1;USA;;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subs
 SSP1;USA;;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.9;1;1;1;1
 SSP1;USA;;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.9;1;1;1;1
 SSP1;USA;;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.6263;0.6263;0.6263;0.6263;0.6263
-SSP1;USA;BEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.2244;1;1;1
-SSP1;USA;BEV;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.088;0.432;0.756;0.756
-SSP1;USA;BEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.03252;0.4646;1;1
-SSP1;USA;BEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.01294;0.2498;1;1
-SSP1;USA;BEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.03547;0.2728;0.929;1;1
-SSP1;USA;BEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.03547;0.2728;0.929;1;1
-SSP1;USA;BEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.03252;0.4646;1;1
-SSP1;USA;Electric;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;0;0.25;0.75;1;1
+SSP1;USA;BEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.1122;1;1;1
+SSP1;USA;BEV;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.044;0.432;0.756;0.756
+SSP1;USA;BEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.01626;0.4646;1;1
+SSP1;USA;BEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.00647;0.2498;1;1
+SSP1;USA;BEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.03547;0.1364;0.929;1;1
+SSP1;USA;BEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.03547;0.1364;0.929;1;1
+SSP1;USA;BEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.01626;0.4646;1;1
+SSP1;USA;Electric;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;0;0.125;0.75;1;1
 SSP1;USA;Electric;HSR_tmp_vehicletype;HSR_tmp_subsectorL3;HSR_tmp_subsectorL2;HSR;trn_pass;FV;1;1;1;1;1
 SSP1;USA;Electric;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;1;1;1;1;1
 SSP1;USA;FCEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.02436;0.0152;0.03888;0.03888
-SSP1;USA;FCEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.003654;0.03606;0.217;0.217
-SSP1;USA;FCEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.001349;0.01367;0.1531;0.1531
-SSP1;USA;FCEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.05912;0.5457;0.7602;0.2915;0.2915
-SSP1;USA;FCEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.05912;0.5457;0.7602;0.2915;0.2915
-SSP1;USA;FCEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.003654;0.03606;0.217;0.217
+SSP1;USA;FCEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.001218;0.03606;0.217;0.217
+SSP1;USA;FCEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.0004498;0.01367;0.1531;0.1531
+SSP1;USA;FCEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.05912;0.1819;0.7602;0.2915;0.2915
+SSP1;USA;FCEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.05912;0.1819;0.7602;0.2915;0.2915
+SSP1;USA;FCEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.001218;0.03606;0.217;0.217
 SSP1;USA;Gases;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0.08478;0.09072;0.1122;0.0833;0.0833
 SSP1;USA;Gases;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.004049;0.02256;0.04406;0.04406
 SSP1;USA;Gases;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.004049;0.02256;0.04543;0.04543
@@ -7078,7 +7078,7 @@ SSP1;USA;Liquids;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freig
 SSP1;USA;Liquids;International Aviation_tmp_vehicletype;International Aviation_tmp_subsectorL3;International Aviation_tmp_subsectorL2;International Aviation;trn_aviation_intl;FV;1;1;1;1;1
 SSP1;USA;Liquids;International Ship_tmp_vehicletype;International Ship_tmp_subsectorL3;International Ship_tmp_subsectorL2;International Ship;trn_shipping_intl;FV;1;1;1;1;1
 SSP1;USA;Liquids;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;1;1;1;1;1
-SSP1;USA;Liquids;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;0.4393;0.2929;0.2197;0.1464;0.1464
+SSP1;USA;Liquids;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;0.4393;0.4393;0.2197;0.1464;0.1464
 SSP1;USA;Liquids;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;0.7177;0.7177
 SSP1;USA;Liquids;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;0.7399;0.7399
 SSP1;USA;Liquids;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;0.7047;0.7047


### PR DESCRIPTION
## Purpose of this PR
I mistakenly put SS1 values for ALL years to SSP2 values. WIth [this ](https://github.com/pik-piam/edgeTransport/pull/322) PR I intended to ONLY do it for 2020 and 2030. This PR corrects this. 