### PR TITLE
Ldv bev

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '43593853'
+ValidationKey: '43616188'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'edgeTransport: Prepare EDGE Transport Data for the REMIND model'
-version: 2.16.1
-date-released: '2025-03-26'
+version: 2.16.2
+date-released: '2025-03-27'
 abstract: EDGE-T is a fork of the GCAM transport module https://jgcri.github.io/gcam-doc/energy.html#transportation
   with a high level of detail in its representation of technological and modal options.
   It is a partial equilibrium model with a nested multinomial logit structure and

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: edgeTransport
 Title: Prepare EDGE Transport Data for the REMIND model
-Version: 2.16.1
+Version: 2.16.2
 Authors@R: c(
     person("Johanna", "Hoppe", email = "johanna.hoppe@pik-potsdam.de", role = c("aut", "cre"),
            comment = c(ORCID = "0009-0004-6753-5090")),
@@ -20,7 +20,7 @@ Encoding: UTF-8
 LazyData: true
 RoxygenNote: 7.3.2
 VignetteBuilder: knitr
-Date: 2025-03-26
+Date: 2025-03-27
 Config/testthat/edition: 3
 Imports:
     rmndt,

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Prepare EDGE Transport Data for the REMIND model
 
-R package **edgeTransport**, version **2.16.1**
+R package **edgeTransport**, version **2.16.2**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/edgeTransport)](https://cran.r-project.org/package=edgeTransport) [![R build status](https://github.com/pik-piam/edgeTransport/workflows/check/badge.svg)](https://github.com/pik-piam/edgeTransport/actions) [![codecov](https://codecov.io/gh/pik-piam/edgeTransport/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/edgeTransport) [![r-universe](https://pik-piam.r-universe.dev/badges/edgeTransport)](https://pik-piam.r-universe.dev/builds)
 
@@ -46,15 +46,15 @@ In case of questions / problems please contact Johanna Hoppe <johanna.hoppe@pik-
 
 To cite package **edgeTransport** in publications use:
 
-Hoppe J, Dirnaichner A, Rottoli M, Muessel J, Hagen A (2025). "edgeTransport: Prepare EDGE Transport Data for the REMIND model - Version 2.16.1."
+Hoppe J, Dirnaichner A, Rottoli M, Muessel J, Hagen A (2025). "edgeTransport: Prepare EDGE Transport Data for the REMIND model - Version 2.16.2."
 
 A BibTeX entry for LaTeX users is
 
  ```latex
 @Misc{,
-  title = {edgeTransport: Prepare EDGE Transport Data for the REMIND model - Version 2.16.1},
+  title = {edgeTransport: Prepare EDGE Transport Data for the REMIND model - Version 2.16.2},
   author = {Johanna Hoppe and Alois Dirnaichner and Marianna Rottoli and Jarusch Muessel and Alex K. Hagen},
-  date = {2025-03-26},
+  date = {2025-03-27},
   year = {2025},
 }
 ```

--- a/inst/extdata/scenParIncoCost.csv
+++ b/inst/extdata/scenParIncoCost.csv
@@ -246,9 +246,9 @@ SSP2;Mix2;LDV|4W;BEV;startValue;0.8
 SSP2;Mix2;LDV|4W;BEV;targetYear;2060
 SSP2;Mix2;LDV|4W;BEV;targetValue;0.8
 SSP2;Mix2;LDV|4W;Liquids;startYear;2025
-SSP2;Mix2;LDV|4W;Liquids;startValue;0.15
+SSP2;Mix2;LDV|4W;Liquids;startValue;0.16
 SSP2;Mix2;LDV|4W;Liquids;targetYear;2080
-SSP2;Mix2;LDV|4W;Liquids;targetValue;0.4
+SSP2;Mix2;LDV|4W;Liquids;targetValue;0.25
 SSP2;Mix2;LDV|4W;Hybrid electric;ratioPHEV;0.5
 SSP2;Mix3;LDV|4W;BEV;startYear;2025
 SSP2;Mix3;LDV|4W;BEV;startValue;0.8
@@ -257,7 +257,7 @@ SSP2;Mix3;LDV|4W;BEV;targetValue;0.8
 SSP2;Mix3;LDV|4W;Liquids;startYear;2025
 SSP2;Mix3;LDV|4W;Liquids;startValue;0.17
 SSP2;Mix3;LDV|4W;Liquids;targetYear;2080
-SSP2;Mix3;LDV|4W;Liquids;targetValue;0.5
+SSP2;Mix3;LDV|4W;Liquids;targetValue;0.7
 SSP2;Mix3;LDV|4W;Hybrid electric;ratioPHEV;1
 SSP2;Mix4;LDV|4W;BEV;startYear;2025
 SSP2;Mix4;LDV|4W;BEV;startValue;0.8

--- a/inst/extdata/scenParIncoCost.csv
+++ b/inst/extdata/scenParIncoCost.csv
@@ -239,7 +239,7 @@ SSP2;Mix1;LDV|4W;BEV;targetValue;0.8
 SSP2;Mix1;LDV|4W;Liquids;startYear;2025
 SSP2;Mix1;LDV|4W;Liquids;startValue;0
 SSP2;Mix1;LDV|4W;Liquids;targetYear;2080
-SSP2;Mix1;LDV|4W;Liquids;targetValue;0.3
+SSP2;Mix1;LDV|4W;Liquids;targetValue;0.25
 SSP2;Mix1;LDV|4W;Hybrid electric;ratioPHEV;0.5
 SSP2;Mix2;LDV|4W;BEV;startYear;2025
 SSP2;Mix2;LDV|4W;BEV;startValue;0.8
@@ -255,9 +255,9 @@ SSP2;Mix3;LDV|4W;BEV;startValue;0.8
 SSP2;Mix3;LDV|4W;BEV;targetYear;2060
 SSP2;Mix3;LDV|4W;BEV;targetValue;0.8
 SSP2;Mix3;LDV|4W;Liquids;startYear;2025
-SSP2;Mix3;LDV|4W;Liquids;startValue;0.17
+SSP2;Mix3;LDV|4W;Liquids;startValue;0.16
 SSP2;Mix3;LDV|4W;Liquids;targetYear;2080
-SSP2;Mix3;LDV|4W;Liquids;targetValue;0.7
+SSP2;Mix3;LDV|4W;Liquids;targetValue;0.0.3
 SSP2;Mix3;LDV|4W;Hybrid electric;ratioPHEV;1
 SSP2;Mix4;LDV|4W;BEV;startYear;2025
 SSP2;Mix4;LDV|4W;BEV;startValue;0.8


### PR DESCRIPTION
## Purpose of this PR
BEV PhaseIn for multiple regions, especially of the global south, was too quick. I adjusted the incoCOst start values and the policy mask. This PR is a reaction to [this ](https://github.com/remindmodel/development_issues/issues/430#issuecomment-2737064395) issue.

What I did: 
- change of parameters: incoCost start values, policy mask, parameters of the ICE ban implementation, and exponent for range anxiety (bfuelav)
- introduced the option of a start year for ICEs


## Checklist:

- [x] I used ./test-standard-runs to compare and archive the changes introduced by this PR in /p/projects/edget/PRchangeLog/

## Further information (optional):

* Test runs are here: 
`/p/projects/edget/PRchangeLog/20250326_LDV_BEV_PhaseIn`


