### PR TITLE
enInt

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '43616188'
+ValidationKey: '43636362'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,7 +2,7 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'edgeTransport: Prepare EDGE Transport Data for the REMIND model'
-version: 2.16.2
+version: 2.16.3
 date-released: '2025-03-27'
 abstract: EDGE-T is a fork of the GCAM transport module https://jgcri.github.io/gcam-doc/energy.html#transportation
   with a high level of detail in its representation of technological and modal options.

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: edgeTransport
 Title: Prepare EDGE Transport Data for the REMIND model
-Version: 2.16.2
+Version: 2.16.3
 Authors@R: c(
     person("Johanna", "Hoppe", email = "johanna.hoppe@pik-potsdam.de", role = c("aut", "cre"),
            comment = c(ORCID = "0009-0004-6753-5090")),

--- a/R/toolCalculateFleetComposition.R
+++ b/R/toolCalculateFleetComposition.R
@@ -35,7 +35,7 @@ toolCalculateFleetComposition <- function(ESdemandFVsalesLevel,
   # calculate total energy service demand for modes with tracked fleets ---------------------------------
   fleetESdemand <- copy(ESdemandFVsalesLevel)
   fleetESdemand <- fleetESdemand[grepl("Bus.*|.*4W|.*freight_road.*", subsectorL3)]
-  fleetESdemand <- fleetESdemand[, .(totalESdemand = sum(value)), by = c("region", "period", "subsectorL3")]
+  fleetESdemand <- fleetESdemand[period >= 2005, .(totalESdemand = sum(value)), by = c("region", "period", "subsectorL3")]
 
   # calculate distribution of total demand on construction years -----------------------------------------
   # change to yearly resolution

--- a/R/toolCalculateFleetComposition.R
+++ b/R/toolCalculateFleetComposition.R
@@ -35,7 +35,7 @@ toolCalculateFleetComposition <- function(ESdemandFVsalesLevel,
   # calculate total energy service demand for modes with tracked fleets ---------------------------------
   fleetESdemand <- copy(ESdemandFVsalesLevel)
   fleetESdemand <- fleetESdemand[grepl("Bus.*|.*4W|.*freight_road.*", subsectorL3)]
-  fleetESdemand <- fleetESdemand[period >= 2005, .(totalESdemand = sum(value)), by = c("region", "period", "subsectorL3")]
+  fleetESdemand <- fleetESdemand[, .(totalESdemand = sum(value[period >= 2005])), by = c("region", "period", "subsectorL3")]
 
   # calculate distribution of total demand on construction years -----------------------------------------
   # change to yearly resolution

--- a/R/toolUpdateEndogenousCosts.R
+++ b/R/toolUpdateEndogenousCosts.R
@@ -32,7 +32,7 @@ toolUpdateEndogenousCosts <- function(dataEndoCosts,
   # bind variables locally to prevent NSE notes in R CMD CHECK
   totVeh <- technology <- startValue <- period <- startYear <- targetYear <- targetValue <- NULL
   FVvehvar <- regionCode12 <- region <- type <- endoCostRaw <- value <- indexUsagePeriod <- NULL
-  depreciationFactor <- FS3share <- variable <- FS3shareUpdate <- unit <- NULL
+  depreciationFactor <- FS3share <- variable <- FS3shareUpdate <- unit <- lateStart <- NULL
 
   # parameters of endogenous cost trends
   bfuelav <- -5    ## value based on Greene 2001 the original value was "-20"
@@ -97,6 +97,12 @@ toolUpdateEndogenousCosts <- function(dataEndoCosts,
   policyMask[, lateStart := FALSE]
   policyMask[technology == "Liquids", startValue := ifelse(!is.na(startValue), startValue, 0)]
   policyMask[technology == "Liquids" & startValue >0 , lateStart := TRUE]
+  policyMask[, `:=`(
+    startYear = as.numeric(startYear),
+    startValue = as.numeric(startValue),
+    targetYear = as.numeric(targetYear),
+    targetValue = as.numeric(targetValue)
+  )]
   policyMask[, policyMask := linFunc(period, startYear, startValue, targetYear, targetValue, lateStart), by = c("region", "period", "technology")]
   policyMask <- policyMask[, c("region", "period", "FVvehvar", "technology", "policyMask")]
   policyMask <- rbind(policyMask, policyMaskPHEV)
@@ -202,7 +208,7 @@ toolUpdateEndogenousCosts <- function(dataEndoCosts,
     # and should be reworked)
     dataEndoCosts[variable == "Range anxiety" & period == t,
                    value := pmax(value[period == (policyStartYear - 1)] * policyMask, endoCostRaw),
-                     by = c("region", "technology", "vehicleType", "univocalName")] 
+                     by = c("region", "technology", "vehicleType", "univocalName")]
 
     ratioPhev <- unique(policyMaskPHEV$policyMask)
     # Model availability for Hybrid electric

--- a/R/toolUpdateEndogenousCosts.R
+++ b/R/toolUpdateEndogenousCosts.R
@@ -124,6 +124,7 @@ toolUpdateEndogenousCosts <- function(dataEndoCosts,
     policyMask[technology %in% c("Liquids", "Gases", "Hybrid electric") & region %in% affectedRegions,
                policyMask := max(policyMask, applyICEban(period, policyMask)), by = c("period")]
   }
+  policyMask[, policyMask := as.numeric(policyMask)]
 
   # check whether policy mask is calculated correctly for respective technologys
   if (anyNA(policyMask)) {
@@ -143,6 +144,7 @@ toolUpdateEndogenousCosts <- function(dataEndoCosts,
     # to get a proxy for total vehicles of one technology in the fleet
     dataEndoCosts[!is.na(depreciationFactor), techFleetProxy := sum(FS3share * totVeh * depreciationFactor) / sum(totVeh * depreciationFactor),
                   by = c("region", "univocalName", "technology", "variable")]
+
 
     # update raw endogenous costs-------------------------------------------------------------------
     ## Stations availability featured by BEV, FCEV, Hybrid electric, Gases
@@ -210,7 +212,7 @@ toolUpdateEndogenousCosts <- function(dataEndoCosts,
                    value := pmax(value[period == (policyStartYear - 1)] * policyMask, endoCostRaw),
                      by = c("region", "technology", "vehicleType", "univocalName")]
 
-    ratioPhev <- unique(policyMaskPHEV$policyMask)
+    ratioPhev <- as.numeric(unique(policyMaskPHEV$policyMask))
     # Model availability for Hybrid electric
     if (isICEban) dataEndoCosts[variable == "Model availability" & technology == "Hybrid electric" & period == t & period >= 2030 &
                       region %in% affectedRegions, endoCostRaw := pmax(policyMask, endoCostRaw),

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Prepare EDGE Transport Data for the REMIND model
 
-R package **edgeTransport**, version **2.16.2**
+R package **edgeTransport**, version **2.16.3**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/edgeTransport)](https://cran.r-project.org/package=edgeTransport) [![R build status](https://github.com/pik-piam/edgeTransport/workflows/check/badge.svg)](https://github.com/pik-piam/edgeTransport/actions) [![codecov](https://codecov.io/gh/pik-piam/edgeTransport/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/edgeTransport) [![r-universe](https://pik-piam.r-universe.dev/badges/edgeTransport)](https://pik-piam.r-universe.dev/builds)
 
@@ -46,13 +46,13 @@ In case of questions / problems please contact Johanna Hoppe <johanna.hoppe@pik-
 
 To cite package **edgeTransport** in publications use:
 
-Hoppe J, Dirnaichner A, Rottoli M, Muessel J, Hagen A (2025). "edgeTransport: Prepare EDGE Transport Data for the REMIND model - Version 2.16.2."
+Hoppe J, Dirnaichner A, Rottoli M, Muessel J, Hagen A (2025). "edgeTransport: Prepare EDGE Transport Data for the REMIND model - Version 2.16.3."
 
 A BibTeX entry for LaTeX users is
 
  ```latex
 @Misc{,
-  title = {edgeTransport: Prepare EDGE Transport Data for the REMIND model - Version 2.16.2},
+  title = {edgeTransport: Prepare EDGE Transport Data for the REMIND model - Version 2.16.3},
   author = {Johanna Hoppe and Alois Dirnaichner and Marianna Rottoli and Jarusch Muessel and Alex K. Hagen},
   date = {2025-03-27},
   year = {2025},


### PR DESCRIPTION
## Purpose of this PR
varying enInt before 2005 leads to changes in fleet enInt when changing a vehicles lifetime. Now I this should be fixed with excluding values before 2005 in the fleetESdemand and fixing enInt to before 2005 (see [this ](https://github.com/pik-piam/mrtransport/pull/41)mrtransport PR) 

## Checklist:

- [x] I used ./test-standard-runs to compare and archive the changes introduced by this PR in /p/projects/edget/PRchangeLog/

## Further information (optional):

* Test runs are here: 
`/p/projects/edget/PRchangeLog/20250327_edgeTenInt`

