### PR TITLE
update SSP3 based on SSP2

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '43658700'
+ValidationKey: '43678875'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,7 +2,7 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'edgeTransport: Prepare EDGE Transport Data for the REMIND model'
-version: 2.16.4
+version: 2.16.5
 date-released: '2025-03-28'
 abstract: EDGE-T is a fork of the GCAM transport module https://jgcri.github.io/gcam-doc/energy.html#transportation
   with a high level of detail in its representation of technological and modal options.

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: edgeTransport
 Title: Prepare EDGE Transport Data for the REMIND model
-Version: 2.16.4
+Version: 2.16.5
 Authors@R: c(
     person("Johanna", "Hoppe", email = "johanna.hoppe@pik-potsdam.de", role = c("aut", "cre"),
            comment = c(ORCID = "0009-0004-6753-5090")),

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Prepare EDGE Transport Data for the REMIND model
 
-R package **edgeTransport**, version **2.16.4**
+R package **edgeTransport**, version **2.16.5**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/edgeTransport)](https://cran.r-project.org/package=edgeTransport) [![R build status](https://github.com/pik-piam/edgeTransport/workflows/check/badge.svg)](https://github.com/pik-piam/edgeTransport/actions) [![codecov](https://codecov.io/gh/pik-piam/edgeTransport/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/edgeTransport) [![r-universe](https://pik-piam.r-universe.dev/badges/edgeTransport)](https://pik-piam.r-universe.dev/builds)
 
@@ -46,13 +46,13 @@ In case of questions / problems please contact Johanna Hoppe <johanna.hoppe@pik-
 
 To cite package **edgeTransport** in publications use:
 
-Hoppe J, Dirnaichner A, Rottoli M, Muessel J, Hagen A (2025). "edgeTransport: Prepare EDGE Transport Data for the REMIND model - Version 2.16.4."
+Hoppe J, Dirnaichner A, Rottoli M, Muessel J, Hagen A (2025). "edgeTransport: Prepare EDGE Transport Data for the REMIND model - Version 2.16.5."
 
 A BibTeX entry for LaTeX users is
 
  ```latex
 @Misc{,
-  title = {edgeTransport: Prepare EDGE Transport Data for the REMIND model - Version 2.16.4},
+  title = {edgeTransport: Prepare EDGE Transport Data for the REMIND model - Version 2.16.5},
   author = {Johanna Hoppe and Alois Dirnaichner and Marianna Rottoli and Jarusch Muessel and Alex K. Hagen},
   date = {2025-03-28},
   year = {2025},

--- a/inst/extdata/genParBaselinePrefTrends.csv
+++ b/inst/extdata/genParBaselinePrefTrends.csv
@@ -8584,8 +8584,8 @@ SSP3;CHA;;;;;trn_freight_road;trn_freight;S1S;1;1;1;1;1
 SSP3;CHA;;;;;trn_pass_road;trn_pass;S1S;0.6711;0.2684;0.1342;0.04015;0.04015
 SSP3;CHA;;;;Bus;trn_pass_road;trn_pass;S2S1;0.6609;0.2927;0.2084;0.09649;0.09649
 SSP3;CHA;;;;trn_pass_road_LDV;trn_pass_road;trn_pass;S2S1;1;1;1;1;1
-SSP3;CHA;;;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;0.54;0.36;0.27;0.27;0.27
-SSP3;CHA;;;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;1.1;1.1;1.1;1.1;1.1
+SSP3;CHA;;;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;0.27;0.18;0.135;0.135;0.135
+SSP3;CHA;;;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;1.98;1.98;1.98;1.98;1.98
 SSP3;CHA;;Compact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.8035;0.7232;0.6574;0.5563;0.5563
 SSP3;CHA;;Large Car and SUV;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;1;1;1;1;1
 SSP3;CHA;;Mini Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.01783;0.01605;0.01459;0.01234;0.01234
@@ -8598,15 +8598,15 @@ SSP3;CHA;;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subs
 SSP3;CHA;;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.4022;0.3352;0.3016;0.3352;0.3352
 SSP3;CHA;;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.4022;0.3352;0.3016;0.3352;0.3352
 SSP3;CHA;;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.1657;0.1657;0.1657;0.1657;0.1657
-SSP3;CHA;BEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.36228;1.2;1.2;1.2
+SSP3;CHA;BEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0.15;0.81513;1.8;1.8;1.8
 SSP3;CHA;BEV;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.6;1;1;1
 SSP3;CHA;BEV;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0.06;0.6;1;1;1
 SSP3;CHA;BEV;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.6;1;1;1
-SSP3;CHA;BEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.048024;0.447;1.05216;1.05216
-SSP3;CHA;BEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.019104;0.24048;1.0206;1.0206
-SSP3;CHA;BEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.11904;0.40296;0.894;1.07136;1.07136
-SSP3;CHA;BEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.11904;0.40296;0.894;1.07136;1.07136
-SSP3;CHA;BEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.048024;0.447;1.05216;1.05216
+SSP3;CHA;BEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.162081;1.00575;2.36736;2.36736
+SSP3;CHA;BEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.064476;0.54108;2.29635;2.29635
+SSP3;CHA;BEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.40176;1.35999;2.0115;2.41056;2.41056
+SSP3;CHA;BEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.40176;1.35999;2.0115;2.41056;2.41056
+SSP3;CHA;BEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.162081;1.00575;2.36736;2.36736
 SSP3;CHA;Electric;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;0.4553;0.5234;0.6595;0.9319;0.9319
 SSP3;CHA;Electric;HSR_tmp_vehicletype;HSR_tmp_subsectorL3;HSR_tmp_subsectorL2;HSR;trn_pass;FV;1;1;1;1;1
 SSP3;CHA;Electric;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;0.4158;0.4888;0.6349;0.927;0.927

--- a/inst/extdata/scenParIncoCost.csv
+++ b/inst/extdata/scenParIncoCost.csv
@@ -413,36 +413,36 @@ SSP3;HydrHype4;LDV|4W;Liquids;targetYear;2027
 SSP3;HydrHype4;LDV|4W;Liquids;targetValue;0.25
 SSP3;HydrHype4;LDV|4W;Hybrid electric;ratioPHEV;0.5
 SSP3;Mix1;LDV|4W;BEV;startYear;2025
-SSP3;Mix1;LDV|4W;BEV;startValue;1.48
-SSP3;Mix1;LDV|4W;BEV;targetYear;2035
-SSP3;Mix1;LDV|4W;BEV;targetValue;0
-SSP3;Mix1;LDV|4W;Liquids;startYear;2022
-SSP3;Mix1;LDV|4W;Liquids;targetYear;2030
-SSP3;Mix1;LDV|4W;Liquids;targetValue;0
+SSP3;Mix1;LDV|4W;BEV;startValue;0.8
+SSP3;Mix1;LDV|4W;BEV;targetYear;2060
+SSP3;Mix1;LDV|4W;BEV;targetValue;0.8
+SSP3;Mix1;LDV|4W;Liquids;startYear;2025
+SSP3;Mix1;LDV|4W;Liquids;targetYear;2080
+SSP3;Mix1;LDV|4W;Liquids;targetValue;0.25
 SSP3;Mix1;LDV|4W;Hybrid electric;ratioPHEV;0.5
 SSP3;Mix2;LDV|4W;BEV;startYear;2025
-SSP3;Mix2;LDV|4W;BEV;startValue;0.99
-SSP3;Mix2;LDV|4W;BEV;targetYear;2035
-SSP3;Mix2;LDV|4W;BEV;targetValue;0.18
-SSP3;Mix2;LDV|4W;Liquids;startYear;2022
-SSP3;Mix2;LDV|4W;Liquids;targetYear;2030
-SSP3;Mix2;LDV|4W;Liquids;targetValue;0.12
+SSP3;Mix2;LDV|4W;BEV;startValue;0.8
+SSP3;Mix2;LDV|4W;BEV;targetYear;2060
+SSP3;Mix2;LDV|4W;BEV;targetValue;0.8
+SSP3;Mix2;LDV|4W;Liquids;startYear;2025
+SSP3;Mix2;LDV|4W;Liquids;targetYear;2080
+SSP3;Mix2;LDV|4W;Liquids;targetValue;0.25
 SSP3;Mix2;LDV|4W;Hybrid electric;ratioPHEV;0.5
 SSP3;Mix3;LDV|4W;BEV;startYear;2025
-SSP3;Mix3;LDV|4W;BEV;startValue;0.49
-SSP3;Mix3;LDV|4W;BEV;targetYear;2035
-SSP3;Mix3;LDV|4W;BEV;targetValue;0
-SSP3;Mix3;LDV|4W;Liquids;startYear;2022
-SSP3;Mix3;LDV|4W;Liquids;targetYear;2055
-SSP3;Mix3;LDV|4W;Liquids;targetValue;0.62
+SSP3;Mix3;LDV|4W;BEV;startValue;0.8
+SSP3;Mix3;LDV|4W;BEV;targetYear;2060
+SSP3;Mix3;LDV|4W;BEV;targetValue;0.8
+SSP3;Mix3;LDV|4W;Liquids;startYear;2025
+SSP3;Mix3;LDV|4W;Liquids;targetYear;2080
+SSP3;Mix3;LDV|4W;Liquids;targetValue;0.3
 SSP3;Mix3;LDV|4W;Hybrid electric;ratioPHEV;1
 SSP3;Mix4;LDV|4W;BEV;startYear;2025
-SSP3;Mix4;LDV|4W;BEV;startValue;0.12
-SSP3;Mix4;LDV|4W;BEV;targetYear;2045
-SSP3;Mix4;LDV|4W;BEV;targetValue;0
-SSP3;Mix4;LDV|4W;Liquids;startYear;2022
-SSP3;Mix4;LDV|4W;Liquids;targetYear;2055
-SSP3;Mix4;LDV|4W;Liquids;targetValue;0.99
+SSP3;Mix4;LDV|4W;BEV;startValue;0.8
+SSP3;Mix4;LDV|4W;BEV;targetYear;2060
+SSP3;Mix4;LDV|4W;BEV;targetValue;0.8
+SSP3;Mix4;LDV|4W;Liquids;startYear;2025
+SSP3;Mix4;LDV|4W;Liquids;targetYear;2080
+SSP3;Mix4;LDV|4W;Liquids;targetValue;0.6
 SSP3;Mix4;LDV|4W;Hybrid electric;ratioPHEV;1.5
 SSP3;NAV_act;LDV|4W;BEV;startYear;2025
 SSP3;NAV_act;LDV|4W;BEV;startValue;0.62
@@ -488,3 +488,7 @@ SSP1;Mix1;LDV|4W;Liquids;startValue;0
 SSP1;Mix2;LDV|4W;Liquids;startValue;0.16
 SSP1;Mix3;LDV|4W;Liquids;startValue;0.16
 SSP1;Mix4;LDV|4W;Liquids;startValue;0.17
+SSP3;Mix1;LDV|4W;Liquids;startValue;0
+SSP3;Mix2;LDV|4W;Liquids;startValue;0.16
+SSP3;Mix3;LDV|4W;Liquids;startValue;0.16
+SSP3;Mix4;LDV|4W;Liquids;startValue;0.17

--- a/inst/extdata/scenParIncoCost.csv
+++ b/inst/extdata/scenParIncoCost.csv
@@ -129,37 +129,37 @@ SDP_RC;Mix4;LDV|4W;Liquids;targetYear;2040
 SDP_RC;Mix4;LDV|4W;Liquids;targetValue;1.23
 SDP_RC;Mix4;LDV|4W;Hybrid electric;ratioPHEV;0.5
 SSP1;Mix1;LDV|4W;BEV;startYear;2025
-SSP1;Mix1;LDV|4W;BEV;startValue;0.62
-SSP1;Mix1;LDV|4W;BEV;targetYear;2035
-SSP1;Mix1;LDV|4W;BEV;targetValue;0
-SSP1;Mix1;LDV|4W;Liquids;startYear;2020
-SSP1;Mix1;LDV|4W;Liquids;targetYear;2027
-SSP1;Mix1;LDV|4W;Liquids;targetValue;0
+SSP1;Mix1;LDV|4W;BEV;startValue;0.8
+SSP1;Mix1;LDV|4W;BEV;targetYear;2060
+SSP1;Mix1;LDV|4W;BEV;targetValue;0.8
+SSP1;Mix1;LDV|4W;Liquids;startYear;2025
+SSP1;Mix1;LDV|4W;Liquids;targetYear;2080
+SSP1;Mix1;LDV|4W;Liquids;targetValue;0.25
 SSP1;Mix1;LDV|4W;Hybrid electric;ratioPHEV;0.5
 SSP1;Mix2;LDV|4W;BEV;startYear;2025
-SSP1;Mix2;LDV|4W;BEV;startValue;0.62
-SSP1;Mix2;LDV|4W;BEV;targetYear;2035
-SSP1;Mix2;LDV|4W;BEV;targetValue;0.18
-SSP1;Mix2;LDV|4W;Liquids;startYear;2020
-SSP1;Mix2;LDV|4W;Liquids;targetYear;2027
-SSP1;Mix2;LDV|4W;Liquids;targetValue;0.06
+SSP1;Mix2;LDV|4W;BEV;startValue;0.8
+SSP1;Mix2;LDV|4W;BEV;targetYear;2060
+SSP1;Mix2;LDV|4W;BEV;targetValue;0.8
+SSP1;Mix2;LDV|4W;Liquids;startYear;2025
+SSP1;Mix2;LDV|4W;Liquids;targetYear;2080
+SSP1;Mix2;LDV|4W;Liquids;targetValue;0.25
 SSP1;Mix2;LDV|4W;Hybrid electric;ratioPHEV;0.5
 SSP1;Mix3;LDV|4W;BEV;startYear;2025
-SSP1;Mix3;LDV|4W;BEV;startValue;0.62
-SSP1;Mix3;LDV|4W;BEV;targetYear;2035
-SSP1;Mix3;LDV|4W;BEV;targetValue;0.12
-SSP1;Mix3;LDV|4W;Liquids;startYear;2020
-SSP1;Mix3;LDV|4W;Liquids;targetYear;2040
-SSP1;Mix3;LDV|4W;Liquids;targetValue;1.23
-SSP1;Mix3;LDV|4W;Hybrid electric;ratioPHEV;0.5
+SSP1;Mix3;LDV|4W;BEV;startValue;0.8
+SSP1;Mix3;LDV|4W;BEV;targetYear;2060
+SSP1;Mix3;LDV|4W;BEV;targetValue;0.8
+SSP1;Mix3;LDV|4W;Liquids;startYear;2025
+SSP1;Mix3;LDV|4W;Liquids;targetYear;2080
+SSP1;Mix3;LDV|4W;Liquids;targetValue;0.3
+SSP1;Mix3;LDV|4W;Hybrid electric;ratioPHEV;1
 SSP1;Mix4;LDV|4W;BEV;startYear;2025
-SSP1;Mix4;LDV|4W;BEV;startValue;0.62
-SSP1;Mix4;LDV|4W;BEV;targetYear;2035
-SSP1;Mix4;LDV|4W;BEV;targetValue;0
-SSP1;Mix4;LDV|4W;Liquids;startYear;2020
-SSP1;Mix4;LDV|4W;Liquids;targetYear;2040
-SSP1;Mix4;LDV|4W;Liquids;targetValue;1.48
-SSP1;Mix4;LDV|4W;Hybrid electric;ratioPHEV;0.5
+SSP1;Mix4;LDV|4W;BEV;startValue;0.8
+SSP1;Mix4;LDV|4W;BEV;targetYear;2060
+SSP1;Mix4;LDV|4W;BEV;targetValue;0.8
+SSP1;Mix4;LDV|4W;Liquids;startYear;2025
+SSP1;Mix4;LDV|4W;Liquids;targetYear;2080
+SSP1;Mix4;LDV|4W;Liquids;targetValue;0.6
+SSP1;Mix4;LDV|4W;Hybrid electric;ratioPHEV;1.5
 SSP2;CAMP_lscStrong;LDV|4W;BEV;startYear;2025
 SSP2;CAMP_lscStrong;LDV|4W;BEV;startValue;0.62
 SSP2;CAMP_lscStrong;LDV|4W;BEV;targetYear;2030
@@ -484,3 +484,7 @@ SSP3;NAV_tec;LDV|4W;Liquids;startYear;2020
 SSP3;NAV_tec;LDV|4W;Liquids;targetYear;2027
 SSP3;NAV_tec;LDV|4W;Liquids;targetValue;0
 SSP3;NAV_tec;LDV|4W;Hybrid electric;ratioPHEV;0.5
+SSP1;Mix1;LDV|4W;Liquids;startValue;0
+SSP1;Mix2;LDV|4W;Liquids;startValue;0.16
+SSP1;Mix3;LDV|4W;Liquids;startValue;0.16
+SSP1;Mix4;LDV|4W;Liquids;startValue;0.17

--- a/inst/extdata/scenParPrefTrends.csv
+++ b/inst/extdata/scenParPrefTrends.csv
@@ -917,7 +917,7 @@ SSP1,Mix4,above GDP cutoff,,,Bus,trn_pass_road,S2S1,1,2050,10
 SSP1,Mix4,above GDP cutoff,,,trn_pass_road_LDV,trn_pass_road,S2S1,0.5,2035,10
 SSP1,Mix4,below GDP cutoff,,,Bus,trn_pass_road,S2S1,1,2050,10
 SSP1,Mix4,below GDP cutoff,,,trn_pass_road_LDV,trn_pass_road,S2S1,0.5,2035,10
-SSP1,Mix4,above GDP cutoff,BEV,Bus,Bus,trn_pass_road,FV,6,2035,10
+SSP1,Mix4,above GDP cutoff,BEV,Bus,Bus,trn_pass_road,FV,19.5,2050,10
 SSP1,Mix4,above GDP cutoff,FCEV,Bus,Bus,trn_pass_road,FV,6,2035,10
 SSP1,Mix4,above GDP cutoff,Liquids,Bus,Bus,trn_pass_road,FV,1,2050,10
 SSP1,Mix4,above GDP cutoff,Hydrogen,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
@@ -932,13 +932,13 @@ SSP1,Mix4,above GDP cutoff,BEV,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,
 SSP1,Mix4,above GDP cutoff,Liquids,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
 SSP1,Mix4,above GDP cutoff,Electric,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
 SSP1,Mix4,above GDP cutoff,Liquids,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
-SSP1,Mix4,above GDP cutoff,BEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,6,2035,10
+SSP1,Mix4,above GDP cutoff,BEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,91,2040,15
 SSP1,Mix4,above GDP cutoff,FCEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,6,2035,10
 SSP1,Mix4,above GDP cutoff,Liquids,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,10
-SSP1,Mix4,above GDP cutoff,BEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,20,2035,10
+SSP1,Mix4,above GDP cutoff,BEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,91,2040,15
 SSP1,Mix4,above GDP cutoff,FCEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,100,2035,10
 SSP1,Mix4,above GDP cutoff,Liquids,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,10
-SSP1,Mix4,below GDP cutoff,BEV,Bus,Bus,trn_pass_road,FV,5,2035,10
+SSP1,Mix4,below GDP cutoff,BEV,Bus,Bus,trn_pass_road,FV,13,2040,12
 SSP1,Mix4,below GDP cutoff,FCEV,Bus,Bus,trn_pass_road,FV,5,2035,10
 SSP1,Mix4,below GDP cutoff,Liquids,Bus,Bus,trn_pass_road,FV,1,2050,10
 SSP1,Mix4,below GDP cutoff,Hydrogen,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
@@ -953,10 +953,10 @@ SSP1,Mix4,below GDP cutoff,BEV,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,
 SSP1,Mix4,below GDP cutoff,Liquids,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
 SSP1,Mix4,below GDP cutoff,Electric,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
 SSP1,Mix4,below GDP cutoff,Liquids,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
-SSP1,Mix4,below GDP cutoff,BEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,5,2035,10
+SSP1,Mix4,below GDP cutoff,BEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,19.5,2040,5
 SSP1,Mix4,below GDP cutoff,FCEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,5,2035,10
 SSP1,Mix4,below GDP cutoff,Liquids,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,10
-SSP1,Mix4,below GDP cutoff,BEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,17,2035,10
+SSP1,Mix4,below GDP cutoff,BEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,19.5,2040,8
 SSP1,Mix4,below GDP cutoff,FCEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,85,2035,10
 SSP1,Mix4,below GDP cutoff,Liquids,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,10
 SSP2,CAMP_lscStrong,CAZ,,,,Cycle,S1S,2.5,2040,10
@@ -3307,7 +3307,7 @@ SSP3,Mix4,above GDP cutoff,,,Bus,trn_pass_road,S2S1,1,2050,10
 SSP3,Mix4,above GDP cutoff,,,trn_pass_road_LDV,trn_pass_road,S2S1,0.7,2035,10
 SSP3,Mix4,below GDP cutoff,,,Bus,trn_pass_road,S2S1,1,2050,10
 SSP3,Mix4,below GDP cutoff,,,trn_pass_road_LDV,trn_pass_road,S2S1,0.7,2035,10
-SSP3,Mix4,above GDP cutoff,BEV,Bus,Bus,trn_pass_road,FV,6,2035,10
+SSP3,Mix4,above GDP cutoff,BEV,Bus,Bus,trn_pass_road,FV,19.5,2050,10
 SSP3,Mix4,above GDP cutoff,FCEV,Bus,Bus,trn_pass_road,FV,6,2035,10
 SSP3,Mix4,above GDP cutoff,Liquids,Bus,Bus,trn_pass_road,FV,1,2050,10
 SSP3,Mix4,above GDP cutoff,Hydrogen,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
@@ -3322,13 +3322,13 @@ SSP3,Mix4,above GDP cutoff,BEV,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,
 SSP3,Mix4,above GDP cutoff,Liquids,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
 SSP3,Mix4,above GDP cutoff,Electric,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,2,2050,10
 SSP3,Mix4,above GDP cutoff,Liquids,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
-SSP3,Mix4,above GDP cutoff,BEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,40,2040,3
+SSP3,Mix4,above GDP cutoff,BEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,91,2040,15
 SSP3,Mix4,above GDP cutoff,FCEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,10,2040,3
 SSP3,Mix4,above GDP cutoff,Liquids,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,3
-SSP3,Mix4,above GDP cutoff,BEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,50,2040,5
+SSP3,Mix4,above GDP cutoff,BEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,91,2040,15
 SSP3,Mix4,above GDP cutoff,FCEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,60,2040,3
 SSP3,Mix4,above GDP cutoff,Liquids,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,3
-SSP3,Mix4,below GDP cutoff,BEV,Bus,Bus,trn_pass_road,FV,5,2035,10
+SSP3,Mix4,below GDP cutoff,BEV,Bus,Bus,trn_pass_road,FV,13,2040,12
 SSP3,Mix4,below GDP cutoff,FCEV,Bus,Bus,trn_pass_road,FV,5,2035,10
 SSP3,Mix4,below GDP cutoff,Liquids,Bus,Bus,trn_pass_road,FV,1,2050,10
 SSP3,Mix4,below GDP cutoff,Hydrogen,Aviation,Domestic Aviation_tmp_subsectorL2,Domestic Aviation,FV,1,2050,10
@@ -3343,10 +3343,10 @@ SSP3,Mix4,below GDP cutoff,BEV,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,
 SSP3,Mix4,below GDP cutoff,Liquids,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
 SSP3,Mix4,below GDP cutoff,Electric,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,2,2050,10
 SSP3,Mix4,below GDP cutoff,Liquids,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
-SSP3,Mix4,below GDP cutoff,BEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,10,2040,3
+SSP3,Mix4,below GDP cutoff,BEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,19.5,2040,5
 SSP3,Mix4,below GDP cutoff,FCEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,10,2040,3
 SSP3,Mix4,below GDP cutoff,Liquids,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,3
-SSP3,Mix4,below GDP cutoff,BEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,5,2035,5
+SSP3,Mix4,below GDP cutoff,BEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,19.5,2040,8
 SSP3,Mix4,below GDP cutoff,FCEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,7,2035,3
 SSP3,Mix4,below GDP cutoff,Liquids,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,3
 SSP3,NAV_act,CAZ,,,,Cycle,S1S,2.5,2040,10


### PR DESCRIPTION
## Purpose of this PR
Update of SSP3 based on the SSP2 baseline - I think we should automatise this in the future or create an SSP3 with intensions behind it.

## Checklist:

- [x] I used ./test-standard-runs to compare and archive the changes introduced by this PR in /p/projects/edget/PRchangeLog/

## Further information (optional):

* Test runs are here: 
* Comparison of results (what changes by this PR?): 
`/p/projects/edget/PRchangeLog/20250328_SSP3Update`

**I also added multiple compScens for the other SSPs!**
