### PR TITLE
Update SSP1_3 2.0

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '43678875'
+ValidationKey: '43701216'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'edgeTransport: Prepare EDGE Transport Data for the REMIND model'
-version: 2.16.5
-date-released: '2025-03-28'
+version: 2.16.6
+date-released: '2025-03-29'
 abstract: EDGE-T is a fork of the GCAM transport module https://jgcri.github.io/gcam-doc/energy.html#transportation
   with a high level of detail in its representation of technological and modal options.
   It is a partial equilibrium model with a nested multinomial logit structure and

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: edgeTransport
 Title: Prepare EDGE Transport Data for the REMIND model
-Version: 2.16.5
+Version: 2.16.6
 Authors@R: c(
     person("Johanna", "Hoppe", email = "johanna.hoppe@pik-potsdam.de", role = c("aut", "cre"),
            comment = c(ORCID = "0009-0004-6753-5090")),
@@ -20,7 +20,7 @@ Encoding: UTF-8
 LazyData: true
 RoxygenNote: 7.3.2
 VignetteBuilder: knitr
-Date: 2025-03-28
+Date: 2025-03-29
 Config/testthat/edition: 3
 Imports:
     rmndt,

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Prepare EDGE Transport Data for the REMIND model
 
-R package **edgeTransport**, version **2.16.5**
+R package **edgeTransport**, version **2.16.6**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/edgeTransport)](https://cran.r-project.org/package=edgeTransport) [![R build status](https://github.com/pik-piam/edgeTransport/workflows/check/badge.svg)](https://github.com/pik-piam/edgeTransport/actions) [![codecov](https://codecov.io/gh/pik-piam/edgeTransport/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/edgeTransport) [![r-universe](https://pik-piam.r-universe.dev/badges/edgeTransport)](https://pik-piam.r-universe.dev/builds)
 
@@ -46,15 +46,15 @@ In case of questions / problems please contact Johanna Hoppe <johanna.hoppe@pik-
 
 To cite package **edgeTransport** in publications use:
 
-Hoppe J, Dirnaichner A, Rottoli M, Muessel J, Hagen A (2025). "edgeTransport: Prepare EDGE Transport Data for the REMIND model - Version 2.16.5."
+Hoppe J, Dirnaichner A, Rottoli M, Muessel J, Hagen A (2025). "edgeTransport: Prepare EDGE Transport Data for the REMIND model - Version 2.16.6."
 
 A BibTeX entry for LaTeX users is
 
  ```latex
 @Misc{,
-  title = {edgeTransport: Prepare EDGE Transport Data for the REMIND model - Version 2.16.5},
+  title = {edgeTransport: Prepare EDGE Transport Data for the REMIND model - Version 2.16.6},
   author = {Johanna Hoppe and Alois Dirnaichner and Marianna Rottoli and Jarusch Muessel and Alex K. Hagen},
-  date = {2025-03-28},
+  date = {2025-03-29},
   year = {2025},
 }
 ```

--- a/inst/extdata/genParBaselinePrefTrends.csv
+++ b/inst/extdata/genParBaselinePrefTrends.csv
@@ -5764,15 +5764,15 @@ SSP1;CHA;;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subs
 SSP1;CHA;;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.4022;0.3352;0.3016;0.3352;0.3352
 SSP1;CHA;;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.4022;0.3352;0.3016;0.3352;0.3352
 SSP1;CHA;;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.1657;0.1657;0.1657;0.1657;0.1657
-SSP1;CHA;BEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0;0.3019;1;1;1
+SSP1;CHA;BEV;Bus_tmp_vehicletype;Bus_tmp_subsectorL3;Bus;trn_pass_road;trn_pass;FV;0.15;0.81513;1.8;1.8;1.8
 SSP1;CHA;BEV;Moped;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.6;1;1;1
 SSP1;CHA;BEV;Motorcycle (50-250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0.06;0.6;1;1;1
 SSP1;CHA;BEV;Motorcycle (>250cc);trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;FV;0;0.6;0;0;0
-SSP1;CHA;BEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.04002;0.745;1;1
-SSP1;CHA;BEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.01592;0.4008;1;1
-SSP1;CHA;BEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.0992;0.3358;1;1;1
-SSP1;CHA;BEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.0992;0.3358;1;1;1
-SSP1;CHA;BEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.04002;0.745;1;1
+SSP1;CHA;BEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.162081;1.00575;2.36736;2.36736
+SSP1;CHA;BEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.064476;0.54108;2.29635;2.29635
+SSP1;CHA;BEV;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.40176;1.35999;2.0115;2.41056;2.41056
+SSP1;CHA;BEV;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.40176;1.35999;2.0115;2.41056;2.41056
+SSP1;CHA;BEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0;0.162081;1.00575;2.36736;2.36736
 SSP1;CHA;Electric;Freight Rail_tmp_vehicletype;Freight Rail_tmp_subsectorL3;Freight Rail_tmp_subsectorL2;Freight Rail;trn_freight;FV;0.4553;0.5234;1;1;1
 SSP1;CHA;Electric;HSR_tmp_vehicletype;HSR_tmp_subsectorL3;HSR_tmp_subsectorL2;HSR;trn_pass;FV;1;1;1;1;1
 SSP1;CHA;Electric;Passenger Rail_tmp_vehicletype;Passenger Rail_tmp_subsectorL3;Passenger Rail_tmp_subsectorL2;Passenger Rail;trn_pass;FV;0.4158;0.4888;1;1;1

--- a/inst/extdata/genParBaselinePrefTrends.csv
+++ b/inst/extdata/genParBaselinePrefTrends.csv
@@ -5750,8 +5750,8 @@ SSP1;CHA;;;;;trn_freight_road;trn_freight;S1S;1;1;1;1;1
 SSP1;CHA;;;;;trn_pass_road;trn_pass;S1S;0.6711;0.2684;0.0671;0.02007;0.02007
 SSP1;CHA;;;;Bus;trn_pass_road;trn_pass;S2S1;0.6609;0.2927;0.4168;0.2895;0.2895
 SSP1;CHA;;;;trn_pass_road_LDV;trn_pass_road;trn_pass;S2S1;1;1;1;1;1
-SSP1;CHA;;;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;0.54;0.36;0.27;0.27;0.27
-SSP1;CHA;;;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;1.1;1.1;1.1;1.1;1.1
+SSP1;CHA;;;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;0.27;0.18;0.135;0.135;0.135
+SSP1;CHA;;;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;1.98;1.98;1.98;1.98;1.98
 SSP1;CHA;;Compact Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.8035;0.7232;1;1;1
 SSP1;CHA;;Large Car and SUV;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;1;1;0.7606;0.5992;0.5992
 SSP1;CHA;;Mini Car;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;VS3;0.01783;0.01605;0.02219;0.02218;0.02218

--- a/inst/extdata/scenParPrefTrends.csv
+++ b/inst/extdata/scenParPrefTrends.csv
@@ -1769,7 +1769,7 @@ SSP2,Mix3,above GDP cutoff,FCEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn
 SSP2,Mix3,above GDP cutoff,Liquids,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,10
 SSP2,Mix3,above GDP cutoff,BEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,20,2035,10
 SSP2,Mix3,above GDP cutoff,FCEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,7,2035,10
-SSP2,Mix3,above GDP cutoff,Liquids,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,10
+SSP2,Mix3,above GDP cutoff,Liquids,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,3
 SSP2,Mix3,below GDP cutoff,BEV,Bus,Bus,trn_pass_road,FV,3.5,2035,10
 SSP2,Mix3,below GDP cutoff,FCEV,Bus,Bus,trn_pass_road,FV,3.5,2035,10
 SSP2,Mix3,below GDP cutoff,Liquids,Bus,Bus,trn_pass_road,FV,1,2050,10
@@ -1787,10 +1787,10 @@ SSP2,Mix3,below GDP cutoff,Electric,Rail,Passenger Rail_tmp_subsectorL2,Passenge
 SSP2,Mix3,below GDP cutoff,Liquids,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
 SSP2,Mix4,below GDP cutoff,BEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,70,2045,15
 SSP2,Mix3,below GDP cutoff,FCEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,3,2035,10
-SSP2,Mix3,below GDP cutoff,Liquids,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,10
+SSP2,Mix3,below GDP cutoff,Liquids,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,3
 SSP2,Mix2,below GDP cutoff,BEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,6,2040,10
 SSP2,Mix3,below GDP cutoff,FCEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,7,2035,10
-SSP2,Mix3,below GDP cutoff,Liquids,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,10
+SSP2,Mix3,below GDP cutoff,Liquids,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,3
 SSP2,Mix4,above GDP cutoff,,,,Cycle,S1S,1,2050,10
 SSP2,Mix4,above GDP cutoff,,,,Domestic Aviation,S1S,0.25,2035,10
 SSP2,Mix4,above GDP cutoff,,,,Domestic Ship,S1S,1,2050,10

--- a/inst/extdata/scenParPrefTrends.csv
+++ b/inst/extdata/scenParPrefTrends.csv
@@ -804,10 +804,10 @@ SSP1,Mix2,above GDP cutoff,BEV,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,
 SSP1,Mix2,above GDP cutoff,Liquids,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
 SSP1,Mix2,above GDP cutoff,Electric,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
 SSP1,Mix2,above GDP cutoff,Liquids,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
-SSP1,Mix2,above GDP cutoff,BEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,2,2035,10
+SSP1,Mix2,above GDP cutoff,BEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,10,2035,10
 SSP1,Mix2,above GDP cutoff,FCEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,2,2035,10
 SSP1,Mix2,above GDP cutoff,Liquids,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,10
-SSP1,Mix2,above GDP cutoff,BEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,2,2035,10
+SSP1,Mix2,above GDP cutoff,BEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,10,2035,10
 SSP1,Mix2,above GDP cutoff,FCEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,2,2035,10
 SSP1,Mix2,above GDP cutoff,Liquids,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,10
 SSP1,Mix2,below GDP cutoff,BEV,Bus,Bus,trn_pass_road,FV,1.5,2035,10
@@ -825,10 +825,10 @@ SSP1,Mix2,below GDP cutoff,BEV,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,
 SSP1,Mix2,below GDP cutoff,Liquids,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
 SSP1,Mix2,below GDP cutoff,Electric,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
 SSP1,Mix2,below GDP cutoff,Liquids,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
-SSP1,Mix2,below GDP cutoff,BEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1.5,2035,10
+SSP1,Mix2,below GDP cutoff,BEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,6,2040,10
 SSP1,Mix2,below GDP cutoff,FCEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1.5,2035,10
 SSP1,Mix2,below GDP cutoff,Liquids,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,10
-SSP1,Mix2,below GDP cutoff,BEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1.5,2035,10
+SSP1,Mix2,below GDP cutoff,BEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,6,2040,10
 SSP1,Mix2,below GDP cutoff,FCEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1.5,2035,10
 SSP1,Mix2,below GDP cutoff,Liquids,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,10
 SSP1,Mix3,above GDP cutoff,,,,Cycle,S1S,1,2050,10
@@ -868,10 +868,10 @@ SSP1,Mix3,above GDP cutoff,BEV,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,
 SSP1,Mix3,above GDP cutoff,Liquids,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
 SSP1,Mix3,above GDP cutoff,Electric,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
 SSP1,Mix3,above GDP cutoff,Liquids,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
-SSP1,Mix3,above GDP cutoff,BEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,4,2035,10
+SSP1,Mix3,above GDP cutoff,BEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,20,2035,10
 SSP1,Mix3,above GDP cutoff,FCEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,4,2035,10
 SSP1,Mix3,above GDP cutoff,Liquids,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,10
-SSP1,Mix3,above GDP cutoff,BEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,7,2035,10
+SSP1,Mix3,above GDP cutoff,BEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,20,2035,10
 SSP1,Mix3,above GDP cutoff,FCEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,20,2035,10
 SSP1,Mix3,above GDP cutoff,Liquids,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,10
 SSP1,Mix3,below GDP cutoff,BEV,Bus,Bus,trn_pass_road,FV,3.5,2035,10
@@ -889,10 +889,10 @@ SSP1,Mix3,below GDP cutoff,BEV,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,
 SSP1,Mix3,below GDP cutoff,Liquids,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
 SSP1,Mix3,below GDP cutoff,Electric,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
 SSP1,Mix3,below GDP cutoff,Liquids,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
-SSP1,Mix3,below GDP cutoff,BEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,3.5,2035,10
+SSP1,Mix3,below GDP cutoff,BEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,10,2040,10
 SSP1,Mix3,below GDP cutoff,FCEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,3.5,2035,10
 SSP1,Mix3,below GDP cutoff,Liquids,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,10
-SSP1,Mix3,below GDP cutoff,BEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,5,2035,10
+SSP1,Mix3,below GDP cutoff,BEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,10,2040,10
 SSP1,Mix3,below GDP cutoff,FCEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,17,2035,10
 SSP1,Mix3,below GDP cutoff,Liquids,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,10
 SSP1,Mix4,above GDP cutoff,,,,Cycle,S1S,1,2050,10
@@ -953,10 +953,10 @@ SSP1,Mix4,below GDP cutoff,BEV,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,
 SSP1,Mix4,below GDP cutoff,Liquids,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
 SSP1,Mix4,below GDP cutoff,Electric,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
 SSP1,Mix4,below GDP cutoff,Liquids,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
-SSP1,Mix4,below GDP cutoff,BEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,19.5,2040,5
+SSP1,Mix4,below GDP cutoff,BEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,90,2045,15
 SSP1,Mix4,below GDP cutoff,FCEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,5,2035,10
 SSP1,Mix4,below GDP cutoff,Liquids,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,10
-SSP1,Mix4,below GDP cutoff,BEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,19.5,2040,8
+SSP1,Mix4,below GDP cutoff,BEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,90,2045,15
 SSP1,Mix4,below GDP cutoff,FCEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,85,2035,10
 SSP1,Mix4,below GDP cutoff,Liquids,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,10
 SSP2,CAMP_lscStrong,CAZ,,,,Cycle,S1S,2.5,2040,10
@@ -1721,10 +1721,10 @@ SSP2,Mix2,below GDP cutoff,BEV,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,
 SSP2,Mix2,below GDP cutoff,Liquids,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
 SSP2,Mix2,below GDP cutoff,Electric,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
 SSP2,Mix2,below GDP cutoff,Liquids,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
-SSP2,Mix2,below GDP cutoff,BEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,3,2035,10
+SSP2,Mix2,below GDP cutoff,BEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,6,2040,10
 SSP2,Mix2,below GDP cutoff,FCEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1.5,2035,10
 SSP2,Mix2,below GDP cutoff,Liquids,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,10
-SSP2,Mix3,below GDP cutoff,BEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,5,2035,10
+SSP2,Mix3,below GDP cutoff,BEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,10,2040,10
 SSP2,Mix2,below GDP cutoff,FCEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1.5,2035,10
 SSP2,Mix2,below GDP cutoff,Liquids,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,10
 SSP2,Mix3,above GDP cutoff,,,,Cycle,S1S,1,2050,10
@@ -1785,10 +1785,10 @@ SSP2,Mix3,below GDP cutoff,BEV,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,
 SSP2,Mix3,below GDP cutoff,Liquids,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
 SSP2,Mix3,below GDP cutoff,Electric,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1.5,2050,10
 SSP2,Mix3,below GDP cutoff,Liquids,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
-SSP2,Mix4,below GDP cutoff,BEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,19.5,2040,8
+SSP2,Mix4,below GDP cutoff,BEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,70,2045,15
 SSP2,Mix3,below GDP cutoff,FCEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,3,2035,10
 SSP2,Mix3,below GDP cutoff,Liquids,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,10
-SSP2,Mix2,below GDP cutoff,BEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,3,2035,10
+SSP2,Mix2,below GDP cutoff,BEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,6,2040,10
 SSP2,Mix3,below GDP cutoff,FCEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,7,2035,10
 SSP2,Mix3,below GDP cutoff,Liquids,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,10
 SSP2,Mix4,above GDP cutoff,,,,Cycle,S1S,1,2050,10
@@ -1849,10 +1849,10 @@ SSP2,Mix4,below GDP cutoff,BEV,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,
 SSP2,Mix4,below GDP cutoff,Liquids,LDV|2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,10
 SSP2,Mix4,below GDP cutoff,Electric,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,2,2050,10
 SSP2,Mix4,below GDP cutoff,Liquids,Rail,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,1,2050,10
-SSP2,Mix3,below GDP cutoff,BEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,6,2035,10
+SSP2,Mix3,below GDP cutoff,BEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,10,2040,10
 SSP2,Mix4,below GDP cutoff,FCEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,10,2040,3
 SSP2,Mix4,below GDP cutoff,Liquids,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,3
-SSP2,Mix4,below GDP cutoff,BEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,19.5,2040,5
+SSP2,Mix4,below GDP cutoff,BEV,Truck|light,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,70,2045,15
 SSP2,Mix4,below GDP cutoff,FCEV,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,7,2035,3
 SSP2,Mix4,below GDP cutoff,Liquids,Truck|heavy,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,3
 SSP2,NAV_act,CAZ,,,,Cycle,S1S,2.5,2040,10


### PR DESCRIPTION
## Purpose of this PR
2.0 of this PR https://github.com/pik-piam/edgeTransport/pull/339

Changes: 
- 2W-4W changes from SSP2 to SSP1,3
- more Truck/Bus electrification in Mix4 

## Checklist:

- [x] I used ./test-standard-runs to compare and archive the changes introduced by this PR in /p/projects/edget/PRchangeLog/

* Test runs are here: 
* Comparison of results (what changes by this PR?): 
New - reduced - compScens are in `/p/projects/edget/PRchangeLog/20250328_SSP3Update`
