### PR TITLE
Update renv version to 1.1.4 in PRtests

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '43792770'
+ValidationKey: '43812951'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,7 +2,7 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'edgeTransport: Prepare EDGE Transport Data for the REMIND model'
-version: 2.17.0
+version: 2.17.1
 date-released: '2025-04-03'
 abstract: EDGE-T is a fork of the GCAM transport module https://jgcri.github.io/gcam-doc/energy.html#transportation
   with a high level of detail in its representation of technological and modal options.

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: edgeTransport
 Title: Prepare EDGE Transport Data for the REMIND model
-Version: 2.17.0
+Version: 2.17.1
 Authors@R: c(
     person("Johanna", "Hoppe", email = "johanna.hoppe@pik-potsdam.de", role = c("aut", "cre"),
            comment = c(ORCID = "0009-0004-6753-5090")),

--- a/R/toolEdgeTransportSA.R
+++ b/R/toolEdgeTransportSA.R
@@ -38,7 +38,7 @@ toolEdgeTransportSA <- function(SSPscen,
   variable <- version <- NULL
 
   #To trigger the madrat caching even if changes are only applied to the csv files, we include here the version number of edget
-  version <- "2.17.0"
+  version <- "2.17.1"
 
   # set GDP cutoff to differentiate between regions
   GDPcutoff <- 30800 # [constant 2017 US$MER]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Prepare EDGE Transport Data for the REMIND model
 
-R package **edgeTransport**, version **2.17.0**
+R package **edgeTransport**, version **2.17.1**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/edgeTransport)](https://cran.r-project.org/package=edgeTransport) [![R build status](https://github.com/pik-piam/edgeTransport/workflows/check/badge.svg)](https://github.com/pik-piam/edgeTransport/actions) [![codecov](https://codecov.io/gh/pik-piam/edgeTransport/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/edgeTransport) [![r-universe](https://pik-piam.r-universe.dev/badges/edgeTransport)](https://pik-piam.r-universe.dev/builds)
 
@@ -46,7 +46,7 @@ In case of questions / problems please contact Johanna Hoppe <johanna.hoppe@pik-
 
 To cite package **edgeTransport** in publications use:
 
-Hoppe J, Dirnaichner A, Rottoli M, Muessel J, Hagen A (2025). "edgeTransport: Prepare EDGE Transport Data for the REMIND model." Version: 2.17.0, <https://github.com/pik-piam/edgeTransport>.
+Hoppe J, Dirnaichner A, Rottoli M, Muessel J, Hagen A (2025). "edgeTransport: Prepare EDGE Transport Data for the REMIND model." Version: 2.17.1, <https://github.com/pik-piam/edgeTransport>.
 
 A BibTeX entry for LaTeX users is
 
@@ -57,6 +57,6 @@ A BibTeX entry for LaTeX users is
   date = {2025-04-03},
   year = {2025},
   url = {https://github.com/pik-piam/edgeTransport},
-  note = {Version: 2.17.0},
+  note = {Version: 2.17.1},
 }
 ```

--- a/tests/PRtest/test-standard-runs
+++ b/tests/PRtest/test-standard-runs
@@ -71,7 +71,7 @@ cd ${working_path}${folder_name}
 
 # interactive set-up of renv
 Rscript -e 'renv::init()'
-Rscript -e 'renv::install("renv@1.0.7")'
+Rscript -e 'renv::install("renv@1.1.4")'
 Rscript -e '
 renv::record("renv@1.0.7")
 renv::install("madrat") 

--- a/tests/PRtest/test-standard-runs-ssp
+++ b/tests/PRtest/test-standard-runs-ssp
@@ -73,7 +73,7 @@ cd ${working_path}${folder_name}
 
 # interactive set-up of renv
 Rscript -e 'renv::init()'
-Rscript -e 'renv::install("renv@1.0.7")'
+Rscript -e 'renv::install("renv@1.1.4")'
 Rscript -e '
 renv::record("renv@1.0.7")
 renv::install("madrat") 


### PR DESCRIPTION
## Purpose of this PR

Update renv version to 1.1.4 in PRtests

This has no effect on the edgeTransport functions and calculations and only concerns the versioning of the PR test routine
