### PR TITLE
remove deprecated argument to mrdriver calc function

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '43812951'
+ValidationKey: '43835304'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'edgeTransport: Prepare EDGE Transport Data for the REMIND model'
-version: 2.17.1
-date-released: '2025-04-03'
+version: 2.17.2
+date-released: '2025-04-04'
 abstract: EDGE-T is a fork of the GCAM transport module https://jgcri.github.io/gcam-doc/energy.html#transportation
   with a high level of detail in its representation of technological and modal options.
   It is a partial equilibrium model with a nested multinomial logit structure and

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: edgeTransport
 Title: Prepare EDGE Transport Data for the REMIND model
-Version: 2.17.1
+Version: 2.17.2
 Authors@R: c(
     person("Johanna", "Hoppe", email = "johanna.hoppe@pik-potsdam.de", role = c("aut", "cre"),
            comment = c(ORCID = "0009-0004-6753-5090")),
@@ -20,7 +20,7 @@ Encoding: UTF-8
 LazyData: true
 RoxygenNote: 7.3.2
 VignetteBuilder: knitr
-Date: 2025-04-03
+Date: 2025-04-04
 Config/testthat/edition: 3
 Imports:
     rmndt,

--- a/EDGEtransport.Rproj
+++ b/EDGEtransport.Rproj
@@ -1,4 +1,5 @@
 Version: 1.0
+ProjectId: 27fb5ddf-6207-4547-a8ef-b31153a0e4fa
 
 RestoreWorkspace: Default
 SaveWorkspace: Default

--- a/R/toolLoadmrdriversData.R
+++ b/R/toolLoadmrdriversData.R
@@ -17,7 +17,6 @@ toolLoadmrdriversData <- function(SSPscen, helpers) {
 
   GDPMERmag <- calcOutput("GDP",
                           scenario = c("SSPs", "SDPs", "SSP2IndiaDEAs"),
-                          naming = "scenario",
                           regionmapping = "regionmapping_21_EU11.csv",
                           unit = mrdrivers::toolGetUnitDollar())
   unitGDP <- gsub(" unit: ", "", getComment(GDPMERmag)[2])
@@ -26,7 +25,6 @@ toolLoadmrdriversData <- function(SSPscen, helpers) {
 
   GDPpcMERmag <- calcOutput("GDPpc",
                             scenario = c("SSPs", "SDPs", "SSP2IndiaDEAs"),
-                            naming = "scenario",
                             regionmapping = "regionmapping_21_EU11.csv",
                             unit = mrdrivers::toolGetUnitDollar())
   unitGDP <- gsub(" unit: ", "", getComment(GDPpcMERmag)[2])
@@ -35,7 +33,6 @@ toolLoadmrdriversData <- function(SSPscen, helpers) {
 
   GDPpppMag <- calcOutput("GDP",
                           scenario = c("SSPs", "SDPs", "SSP2IndiaDEAs"),
-                          naming = "scenario",
                           regionmapping = "regionmapping_21_EU11.csv")
   unitGDP <- gsub(" unit: ", "", getComment(GDPpppMag)[2])
   GDPpppMag <- GDPpppMag[, , SSPscen] |> time_interpolate(years)
@@ -43,7 +40,6 @@ toolLoadmrdriversData <- function(SSPscen, helpers) {
 
   GDPpcPPPmag <- calcOutput("GDPpc",
                             scenario = c("SSPs", "SDPs", "SSP2IndiaDEAs"),
-                            naming = "scenario",
                             regionmapping = "regionmapping_21_EU11.csv")
   unitGDP <- gsub(" unit: ", "", getComment(GDPpcPPPmag)[2])
   GDPpcPPPmag <- GDPpcPPPmag[, , SSPscen] |> time_interpolate(years)
@@ -51,7 +47,6 @@ toolLoadmrdriversData <- function(SSPscen, helpers) {
 
   POPmag <- calcOutput("Population",
                        scenario = c("SSPs", "SDPs", "SSP2IndiaDEAs"),
-                       naming = "scenario",
                        regionmapping = "regionmapping_21_EU11.csv")[, , SSPscen] |> time_interpolate(years)
   POP <- magpie2dt(POPmag, yearcol = "period", regioncol = "region")[, variable := "Population"][, unit := "million"]
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Prepare EDGE Transport Data for the REMIND model
 
-R package **edgeTransport**, version **2.17.1**
+R package **edgeTransport**, version **2.17.2**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/edgeTransport)](https://cran.r-project.org/package=edgeTransport) [![R build status](https://github.com/pik-piam/edgeTransport/workflows/check/badge.svg)](https://github.com/pik-piam/edgeTransport/actions) [![codecov](https://codecov.io/gh/pik-piam/edgeTransport/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/edgeTransport) [![r-universe](https://pik-piam.r-universe.dev/badges/edgeTransport)](https://pik-piam.r-universe.dev/builds)
 
@@ -46,7 +46,7 @@ In case of questions / problems please contact Johanna Hoppe <johanna.hoppe@pik-
 
 To cite package **edgeTransport** in publications use:
 
-Hoppe J, Dirnaichner A, Rottoli M, Muessel J, Hagen A (2025). "edgeTransport: Prepare EDGE Transport Data for the REMIND model." Version: 2.17.1, <https://github.com/pik-piam/edgeTransport>.
+Hoppe J, Dirnaichner A, Rottoli M, Muessel J, Hagen A (2025). "edgeTransport: Prepare EDGE Transport Data for the REMIND model." Version: 2.17.2, <https://github.com/pik-piam/edgeTransport>.
 
 A BibTeX entry for LaTeX users is
 
@@ -54,9 +54,9 @@ A BibTeX entry for LaTeX users is
 @Misc{,
   title = {edgeTransport: Prepare EDGE Transport Data for the REMIND model},
   author = {Johanna Hoppe and Alois Dirnaichner and Marianna Rottoli and Jarusch Muessel and Alex K. Hagen},
-  date = {2025-04-03},
+  date = {2025-04-04},
   year = {2025},
   url = {https://github.com/pik-piam/edgeTransport},
-  note = {Version: 2.17.1},
+  note = {Version: 2.17.2},
 }
 ```


### PR DESCRIPTION
This PR removes a deprecated argument to mrdrivers calc functions, currently producing a warning. Removing without replacement should not change the output.