### PR TITLE
bugfix: don't differentiate historic SW by polScen

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '44103580'
+ValidationKey: '44125992'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'edgeTransport: Prepare EDGE Transport Data for the REMIND model'
-version: 2.18.0
-date-released: '2025-05-23'
+version: 2.18.1
+date-released: '2025-05-24'
 abstract: EDGE-T is a fork of the GCAM transport module https://jgcri.github.io/gcam-doc/energy.html#transportation
   with a high level of detail in its representation of technological and modal options.
   It is a partial equilibrium model with a nested multinomial logit structure and

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: edgeTransport
 Title: Prepare EDGE Transport Data for the REMIND model
-Version: 2.18.0
+Version: 2.18.1
 Authors@R: c(
     person("Johanna", "Hoppe", email = "johanna.hoppe@pik-potsdam.de", role = c("aut", "cre"),
            comment = c(ORCID = "0009-0004-6753-5090")),
@@ -20,7 +20,7 @@ Encoding: UTF-8
 LazyData: true
 RoxygenNote: 7.3.2
 VignetteBuilder: knitr
-Date: 2025-05-23
+Date: 2025-05-24
 Config/testthat/edition: 3
 Imports:
     rmndt,

--- a/R/toolEdgeTransportSA.R
+++ b/R/toolEdgeTransportSA.R
@@ -88,9 +88,9 @@ toolEdgeTransportSA <- function(SSPscen,
                                       genModelPar$lambdasDiscreteChoice,
                                       helpers)
   ##########################
-  # The following lines are supposed to be deleted: 
-  # overwrite historical preferences for trucks in MEA 
-  pathMEA <- paste0("extdata/SWsToBeDeleted/historicalPreferences", transportPolScen, ".RDS")
+  # The following lines are supposed to be deleted:
+  # overwrite historical preferences for trucks in MEA
+  pathMEA <- paste0("extdata/SWsToBeDeleted/historicalPreferencesMix2.RDS")
   paste(pathMEA)
   paste(system.file(pathMEA, package = "edgeTransport", mustWork = TRUE))
   pathIND_CHA_USA <- "extdata/SWsToBeDeleted/value2010.csv"
@@ -102,7 +102,7 @@ toolEdgeTransportSA <- function(SSPscen,
   overwriteMEA <- readRDS(system.file(pathMEA, package = "edgeTransport", mustWork = TRUE))
   histPrefs$historicalPreferences[region == "MEA" & grepl("Truck", vehicleType)] <- overwriteMEA[region == "MEA" & grepl("Truck", vehicleType)]
   histPrefs$historicalPreferences[region %in% unique(overwriteIND_CHA_USA$region) & grepl("Truck", vehicleType) & technology == "" & period %in% unique(overwriteIND_CHA_USA$period) ] <- overwriteIND_CHA_USA[region %in% unique(overwriteIND_CHA_USA$region) & grepl("Truck", vehicleType)]
-  
+
   # end of temporary solution
   ##########################
   scenSpecPrefTrends <- rbind(histPrefs$historicalPreferences,

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Prepare EDGE Transport Data for the REMIND model
 
-R package **edgeTransport**, version **2.18.0**
+R package **edgeTransport**, version **2.18.1**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/edgeTransport)](https://cran.r-project.org/package=edgeTransport) [![R build status](https://github.com/pik-piam/edgeTransport/workflows/check/badge.svg)](https://github.com/pik-piam/edgeTransport/actions) [![codecov](https://codecov.io/gh/pik-piam/edgeTransport/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/edgeTransport) [![r-universe](https://pik-piam.r-universe.dev/badges/edgeTransport)](https://pik-piam.r-universe.dev/builds)
 
@@ -46,15 +46,17 @@ In case of questions / problems please contact Johanna Hoppe <johanna.hoppe@pik-
 
 To cite package **edgeTransport** in publications use:
 
-Hoppe J, Dirnaichner A, Rottoli M, Muessel J, Hagen A (2025). "edgeTransport: Prepare EDGE Transport Data for the REMIND model - Version 2.18.0."
+Hoppe J, Dirnaichner A, Rottoli M, Muessel J, Hagen A (2025). "edgeTransport: Prepare EDGE Transport Data for the REMIND model." Version: 2.18.1, <https://github.com/pik-piam/edgeTransport>.
 
 A BibTeX entry for LaTeX users is
 
  ```latex
 @Misc{,
-  title = {edgeTransport: Prepare EDGE Transport Data for the REMIND model - Version 2.18.0},
+  title = {edgeTransport: Prepare EDGE Transport Data for the REMIND model},
   author = {Johanna Hoppe and Alois Dirnaichner and Marianna Rottoli and Jarusch Muessel and Alex K. Hagen},
-  date = {2025-05-23},
+  date = {2025-05-24},
   year = {2025},
+  url = {https://github.com/pik-piam/edgeTransport},
+  note = {Version: 2.18.1},
 }
 ```


### PR DESCRIPTION
## Purpose of this PR

ensure that the overwriting of MEA historic SW is done in all polScens - historic values anyway shouldn't be differentiated between polScens

## Checklist:

- [ ] I used ./test-standard-runs to compare and archive the changes introduced by this PR in /p/projects/edget/PRchangeLog/

## Further information (optional):

* Test runs are here: 
* Comparison of results (what changes by this PR?): 

