### PR TITLE
revert last commit

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '44521400'
+ValidationKey: '44557044'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'edgeTransport: Prepare EDGE Transport Data for the REMIND model'
-version: 2.20.0
-date-released: '2025-05-29'
+version: 2.20.1
+date-released: '2025-06-05'
 abstract: EDGE-T is a fork of the GCAM transport module https://jgcri.github.io/gcam-doc/energy.html#transportation
   with a high level of detail in its representation of technological and modal options.
   It is a partial equilibrium model with a nested multinomial logit structure and

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: edgeTransport
 Title: Prepare EDGE Transport Data for the REMIND model
-Version: 2.20.0
+Version: 2.20.1
 Authors@R: c(
     person("Johanna", "Hoppe", email = "johanna.hoppe@pik-potsdam.de", role = c("aut", "cre"),
            comment = c(ORCID = "0009-0004-6753-5090")),
@@ -21,7 +21,7 @@ Encoding: UTF-8
 LazyData: true
 RoxygenNote: 7.3.2
 VignetteBuilder: knitr
-Date: 2025-05-29
+Date: 2025-06-05
 Config/testthat/edition: 3
 Imports:
     rmndt,

--- a/R/toolEdgeTransportSA.R
+++ b/R/toolEdgeTransportSA.R
@@ -38,7 +38,7 @@ toolEdgeTransportSA <- function(SSPscen,
   variable <- version <- NULL
 
   #To trigger the madrat caching even if changes are only applied to the csv files, we include here the version number of edget
-  version <- "2.17.1"
+  version <- "2.20.1"
 
   # set GDP cutoff to differentiate between regions
   GDPcutoff <- 30800 # [constant 2017 US$MER]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Prepare EDGE Transport Data for the REMIND model
 
-R package **edgeTransport**, version **2.20.0**
+R package **edgeTransport**, version **2.20.1**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/edgeTransport)](https://cran.r-project.org/package=edgeTransport) [![R build status](https://github.com/pik-piam/edgeTransport/workflows/check/badge.svg)](https://github.com/pik-piam/edgeTransport/actions) [![codecov](https://codecov.io/gh/pik-piam/edgeTransport/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/edgeTransport) [![r-universe](https://pik-piam.r-universe.dev/badges/edgeTransport)](https://pik-piam.r-universe.dev/builds)
 
@@ -46,7 +46,7 @@ In case of questions / problems please contact Johanna Hoppe <johanna.hoppe@pik-
 
 To cite package **edgeTransport** in publications use:
 
-Hoppe J, Dirnaichner A, Rottoli M, Muessel J, Hagen A, Pietzcker R (2025). "edgeTransport: Prepare EDGE Transport Data for the REMIND model." Version: 2.20.0, <https://github.com/pik-piam/edgeTransport>.
+Hoppe J, Dirnaichner A, Rottoli M, Muessel J, Hagen A, Pietzcker R (2025). "edgeTransport: Prepare EDGE Transport Data for the REMIND model." Version: 2.20.1, <https://github.com/pik-piam/edgeTransport>.
 
 A BibTeX entry for LaTeX users is
 
@@ -54,9 +54,9 @@ A BibTeX entry for LaTeX users is
 @Misc{,
   title = {edgeTransport: Prepare EDGE Transport Data for the REMIND model},
   author = {Johanna Hoppe and Alois Dirnaichner and Marianna Rottoli and Jarusch Muessel and Alex K. Hagen and Robert P. Pietzcker},
-  date = {2025-05-29},
+  date = {2025-06-05},
   year = {2025},
   url = {https://github.com/pik-piam/edgeTransport},
-  note = {Version: 2.20.0},
+  note = {Version: 2.20.1},
 }
 ```

--- a/inst/extdata/genParBaselinePrefTrends.csv
+++ b/inst/extdata/genParBaselinePrefTrends.csv
@@ -7760,10 +7760,10 @@ SSP2;FRA;Liquids;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_t
 SSP2;FRA;Liquids;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
 SSP2;FRA;Liquids;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;1;1;1;1;1
 SSP2;IND;;;;;Cycle;trn_pass;S1S;0.01915;0.03175;0.0463;0.1;0.1
-SSP2;IND;;;;;Domestic Aviation;trn_pass;S1S;0.6;0.3;0.2;0.05;0.05
+SSP2;IND;;;;;Domestic Aviation;trn_pass;S1S;1.4;0.7575;0.4861;0.1909;0.1909
 SSP2;IND;;;;;Domestic Ship;trn_freight;S1S;0.02;0.01;0.01;0.01;0.01
 SSP2;IND;;;;;Freight Rail;trn_freight;S1S;0.35;0.2;0.15;0.1;0.1
-SSP2;IND;;;;;HSR;trn_pass;S1S;0;0.0003175;0.0005093;0.001;0.001
+SSP2;IND;;;;;HSR;trn_pass;S1S;0;0.0003175;0.0005093;0.0003;0.0003
 SSP2;IND;;;;;International Aviation;trn_aviation_intl;S1S;1;1;1;1;1
 SSP2;IND;;;;;International Ship;trn_shipping_intl;S1S;1;1;1;1;1
 SSP2;IND;;;;;Passenger Rail;trn_pass;S1S;0.004978;0.00582;0.005556;0.004;0.004

--- a/inst/extdata/scenParRegionalDemRegression.csv
+++ b/inst/extdata/scenParRegionalDemRegression.csv
@@ -209,7 +209,7 @@ SSP2;MEA;trn_shipping_intl;0.3;0;0;0
 SSP2;CHA;trn_shipping_intl;-0.4;0;-0.3;-2
 SSP2;JPN;trn_shipping_intl;0;0;-1;-2
 SSP2;REF;trn_aviation_intl;0;-0.3;0;0
-SSP2;IND;trn_aviation_intl;-1;0.3;0;1
+SSP2;IND;trn_aviation_intl;0;0.6;0;1
 SSP2;SSA;trn_aviation_intl;0;0;0.2;0.2
 SSP2;CHA;trn_aviation_intl;0;0.2;0.1;0
 SSP2;CAZ;trn_pass;-0.1;-0.1;-0.1;0.2
@@ -219,11 +219,11 @@ SSP2;MEA;trn_pass;0;-0.3;-0.3;0.1
 SSP2;REF;trn_pass;0;-0.2;-0.1;0
 SSP2;SSA;trn_pass;0;0;-0.2;0.2
 SSP2;SSA;trn_freight;0;0;0;0.2
-SSP2;IND;trn_freight;-0.7;-0.2;-0.5;0
+SSP2;IND;trn_freight;0;0;-0.5;0
 SSP2;USA;trn_freight;0;0.2;0.3;0.8
 SSP2;CAZ;trn_freight;0.3;0.1;0.2;0
 SSP2;OAS;trn_pass;0;0;-0.2;0.2
-SSP2;IND;trn_pass;-0.4;-0.45;-0.3;0.3
+SSP2;IND;trn_pass;0;-0.3;-0.3;0.3
 SSP2;CHA;trn_pass;0;-0.2;0.3;-0.5
 SSP2;OAS;trn_aviation_intl;-0.5;-0.5;-0.2;0.7
 SSP2;MEA;trn_aviation_intl;0;-0.4;-0.2;0
@@ -232,7 +232,7 @@ SSP2;MEA;trn_freight;0;0.2;0.4;1
 SSP2;REF;trn_freight;-0.8;-0.9;-0.2;0
 SSP2;CHA;trn_freight;-1;-0.4;0;-1
 SSP2;UKI;trn_freight;0;0.2;0.1;0
-SSP2;IND;trn_shipping_intl;-0.1;0.8;0.6;0.2
+SSP2;IND;trn_shipping_intl;0;1.1;0.6;0.2
 SSP2;SSA;trn_shipping_intl;0;0.3;0.4;0.2
 SSP2;REF;trn_shipping_intl;-0.3;-0.4;-0.4;-0.3
 SSP2;OAS;trn_shipping_intl;-0.3;-0.3;-0.2;-0.5


### PR DESCRIPTION
## Purpose of this PR

Reverts https://github.com/pik-piam/edgeTransport/pull/349

The changes were a super-urgent quick fix for an India project stakeholder meeting, and never made it into REMIND because I didn't increase the version number by hand (see https://github.com/pik-piam/edgeTransport/pull/343) , so the old cache was used for input data generation.

More thorough updates to India demands will follow in the next weeks

I didn't manage to revert the PR in the github interface, because it then complained that the version number was not increased, so took the head revision, copied the old csv files over, and then did lucode2::buildLibrary(). 
If there is a better, way, I can also do it differently. 

## Checklist:

- [ ] I used ./test-standard-runs to compare and archive the changes introduced by this PR in /p/projects/edget/PRchangeLog/

## Further information (optional):

* Test runs are here: 
* Comparison of results (what changes by this PR?): 

