### PR TITLE
Add option for relative reference path

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '6107591'
+ValidationKey: '6128486'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'edgeTransport: Prepare EDGE Transport Data for the REMIND model'
-version: 3.0.1
-date-released: '2025-07-22'
+version: 3.0.2
+date-released: '2025-07-24'
 abstract: EDGE-T is a fork of the GCAM transport module https://jgcri.github.io/gcam-doc/energy.html#transportation
   with a high level of detail in its representation of technological and modal options.
   It is a partial equilibrium model with a nested multinomial logit structure and

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: edgeTransport
 Title: Prepare EDGE Transport Data for the REMIND model
-Version: 3.0.1
+Version: 3.0.2
 Authors@R: c(
     person("Johanna", "Hoppe", email = "johanna.hoppe@pik-potsdam.de", role = c("aut", "cre"),
            comment = c(ORCID = "0009-0004-6753-5090")),
@@ -21,7 +21,7 @@ Encoding: UTF-8
 LazyData: true
 RoxygenNote: 7.3.2
 VignetteBuilder: knitr
-Date: 2025-07-22
+Date: 2025-07-24
 Config/testthat/edition: 3
 Imports:
     rmndt,

--- a/R/iterativeEDGETransport.R
+++ b/R/iterativeEDGETransport.R
@@ -49,8 +49,16 @@ iterativeEdgeTransport <- function() {
 
   # If there is a reference run, load config of REMIND reference run for fixing before startyear
   # if not: duplicate scenario from current config in analogy of solution in standalone
-  if (!is.na(cfgCurrentRun$files2export$start["input_ref.gdx"])) {
-    load(file.path(dirname(cfgCurrentRun$files2export$start["input_ref.gdx"]), "config.Rdata"))
+  reference <- cfgCurrentRun$files2export$start["input_ref.gdx"]
+  if (!is.na(reference)) {
+    isAbsolutePath <- grepl("^(?:/|~)", reference)
+    if (isAbsolutePath) {
+      referenceCfgPath <- file.path(dirname(reference), "config.Rdata")
+    } else {
+      # go back to remind folder and take relative path from there
+      referenceCfgPath <- file.path("../..", dirname(reference), "config.Rdata")
+    }
+    load(referenceCfgPath)
     cfgReferenceRun <- copy(cfg)
     cfg <- NULL
     SSPscen[1] <- cfgReferenceRun$gms$cm_GDPpopScen

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Prepare EDGE Transport Data for the REMIND model
 
-R package **edgeTransport**, version **3.0.1**
+R package **edgeTransport**, version **3.0.2**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/edgeTransport)](https://cran.r-project.org/package=edgeTransport) [![R build status](https://github.com/pik-piam/edgeTransport/workflows/check/badge.svg)](https://github.com/pik-piam/edgeTransport/actions) [![codecov](https://codecov.io/gh/pik-piam/edgeTransport/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/edgeTransport) [![r-universe](https://pik-piam.r-universe.dev/badges/edgeTransport)](https://pik-piam.r-universe.dev/builds)
 
@@ -46,7 +46,7 @@ In case of questions / problems please contact Johanna Hoppe <johanna.hoppe@pik-
 
 To cite package **edgeTransport** in publications use:
 
-Hoppe J, Dirnaichner A, Rottoli M, Muessel J, Hagen A, Pietzcker R (2025). "edgeTransport: Prepare EDGE Transport Data for the REMIND model." Version: 3.0.1, <https://github.com/pik-piam/edgeTransport>.
+Hoppe J, Dirnaichner A, Rottoli M, Muessel J, Hagen A, Pietzcker R (2025). "edgeTransport: Prepare EDGE Transport Data for the REMIND model." Version: 3.0.2, <https://github.com/pik-piam/edgeTransport>.
 
 A BibTeX entry for LaTeX users is
 
@@ -54,9 +54,9 @@ A BibTeX entry for LaTeX users is
 @Misc{,
   title = {edgeTransport: Prepare EDGE Transport Data for the REMIND model},
   author = {Johanna Hoppe and Alois Dirnaichner and Marianna Rottoli and Jarusch Muessel and Alex K. Hagen and Robert P. Pietzcker},
-  date = {2025-07-22},
+  date = {2025-07-24},
   year = {2025},
   url = {https://github.com/pik-piam/edgeTransport},
-  note = {Version: 3.0.1},
+  note = {Version: 3.0.2},
 }
 ```


### PR DESCRIPTION
## Purpose of this PR
We experienced a situation where in a cascade REMIND run, config.Rdata only held a relative path to the reference gdx like "output/runFolder". This case is now also supported by iterativeEdgeTransport().


