### PR TITLE
remove access to gdx path using madrat function

### DIFF
--- a/R/toolEdgeTransportSA.R
+++ b/R/toolEdgeTransportSA.R
@@ -38,6 +38,8 @@ toolEdgeTransportSA <- function(SSPscen,
                                 isAnalyticsReported = FALSE,
                                 testIterative = FALSE){
 
+  browser()
+
   # bind variables locally to prevent NSE notes in R CMD CHECK
   variable <- version <- region <- vehicleType <- technology <- period <- NULL
 
@@ -67,9 +69,9 @@ toolEdgeTransportSA <- function(SSPscen,
 
   inputs <- toolLoadInputs(SSPscen, transportPolScen, demScen, hybridElecShare, allEqYear)
 
-  if (is.null(gdxPath)) {gdxPath <- file.path(getConfig("sourcefolder"),
-                                              "REMINDinputForTransportStandalone", "v1.2", "fulldata.gdx")}
-  if (!file.exists(gdxPath)) stop("Please provide valid path to REMIND fulldata.gdx as input for fuel costs")
+  if (!is.null(gdxPath) && !file.exists(gdxPath)) {
+    stop("Please provide valid path to REMIND fulldata.gdx as input for fuel costs")
+  }
 
   ## Load fuel costs from REMIND
   REMINDfuelCosts <- toolLoadREMINDfuelCosts(gdxPath = gdxPath,
@@ -111,9 +113,9 @@ toolEdgeTransportSA <- function(SSPscen,
   paste(system.file(pathMEA, package = "edgeTransport", mustWork = TRUE))
   pathIND_CHA_USA <- "extdata/SWsToBeDeleted/value2010.csv"
   overwriteIND_CHA_USA <- fread(system.file(pathIND_CHA_USA, package = "edgeTransport", mustWork = TRUE),
-            header = TRUE,
-            na.strings = "NA",
-            colClasses = list(character = "technology"))
+                                header = TRUE,
+                                na.strings = "NA",
+                                colClasses = list(character = "technology"))
 
   overwriteMEA <- readRDS(system.file(pathMEA, package = "edgeTransport", mustWork = TRUE))
   histPrefs$historicalPreferences[region == "MEA" & grepl("Truck", vehicleType)] <- overwriteMEA[region == "MEA" & grepl("Truck", vehicleType)]
@@ -126,7 +128,7 @@ toolEdgeTransportSA <- function(SSPscen,
   scenSpecPrefTrends <- toolApplyMixedTimeRes(scenSpecPrefTrends,
                                               helpers)
   if (isICEban[1] | isICEban[2]) {
-   scenSpecPrefTrends <- toolApplyICEbanOnPreferences(scenSpecPrefTrends, helpers, ICEbanYears)
+    scenSpecPrefTrends <- toolApplyICEbanOnPreferences(scenSpecPrefTrends, helpers, ICEbanYears)
   }
   scenSpecPrefTrends <- toolNormalizePreferences(scenSpecPrefTrends)
 
@@ -163,15 +165,15 @@ toolEdgeTransportSA <- function(SSPscen,
   #################################################
   ## demand in million km
   sectorESdemand <- toolDemandRegression(inputData$histESdemand,
-                                           inputData$GDPpcPPP,
-                                           inputData$population,
-                                           genModelPar$genParDemRegression,
-                                           scenModelPar$scenParDemRegression,
-                                           scenModelPar$scenParRegionalDemRegression,
-                                           scenModelPar$scenParDemFactors,
-                                           baseYear,
-                                           allEqYear,
-                                           helpers)
+                                         inputData$GDPpcPPP,
+                                         inputData$population,
+                                         genModelPar$genParDemRegression,
+                                         scenModelPar$scenParDemRegression,
+                                         scenModelPar$scenParRegionalDemRegression,
+                                         scenModelPar$scenParDemFactors,
+                                         baseYear,
+                                         allEqYear,
+                                         helpers)
 
   if (testIterative) {
     # development setting:
@@ -235,7 +237,7 @@ toolEdgeTransportSA <- function(SSPscen,
                                                 helpers)
     if (isAnalyticsReported) {
       costsDiscreteChoiceIterations[[i]] <- lapply(copy(vehSalesAndModeShares$costsDiscreteChoice),
-                                               function(x){ x[, variable := paste0(variable, "|Iteration ", i)]})
+                                                   function(x){ x[, variable := paste0(variable, "|Iteration ", i)]})
     }
 
     ESdemandFVsalesLevel <- toolCalculateFVdemand(sectorESdemand,
@@ -286,7 +288,7 @@ toolEdgeTransportSA <- function(SSPscen,
   if (testIterative) {
     print("EDGET was running in development mode to enable comparison of results to the iterative script.")
     otputFolder <- file.path(outputFolder, paste0(format(Sys.time(), "%Y-%m-%d_%H.%M.%S"),
-                                                 "-sy", startyear, "-", SSPscen[2], "-", transportPolScen[2], "-", demScen[2], "-develop"))
+                                                  "-sy", startyear, "-", SSPscen[2], "-", transportPolScen[2], "-", demScen[2], "-develop"))
   }
 
   outputRaw <- list(
@@ -322,5 +324,5 @@ toolEdgeTransportSA <- function(SSPscen,
                                 isREMINDinputReported,
                                 isStored)
 
-return(output)
+  return(output)
 }

--- a/R/toolLoadREMINDesDemand.R
+++ b/R/toolLoadREMINDesDemand.R
@@ -17,7 +17,11 @@ toolLoadREMINDesDemand <- function(gdxPath, helpers) {
   mapEdgeToREMIND <- mapEdgeToREMIND[!is.na(all_in)]
   mapEdgeToREMIND <- unique(mapEdgeToREMIND[, c("all_in", "sector")])
 
-  ESdemand <- gdx::readGDX(gdxPath, c("vm_cesIO"), field = "l", restore_zeros = FALSE)
+  if (!is.null(gdxPath)){
+    ESdemand <- gdx::readGDX(gdxPath, c("vm_cesIO"), field = "l", restore_zeros = FALSE)
+  } else {
+    ESdemand <- readSource("REMINDinputForTransportStandalone", subtype = "esDemand", convert = FALSE)
+  }
   ESdemand <- ESdemand[, , c("entrp_pass_sm", "entrp_pass_lo", "entrp_frgt_sm", "entrp_frgt_lo")]
   ESdemand <- magpie2dt(ESdemand, regioncol = "region",
                    yearcol = "period", datacols = "all_in")

--- a/R/toolLoadREMINDfuelCosts.R
+++ b/R/toolLoadREMINDfuelCosts.R
@@ -26,7 +26,8 @@ toolLoadREMINDfuelCosts <- function(gdxPath, hybridElecShare, helpers, transport
 
    # load prices from REMIND gdx
    if (is.null(gdxPath)) {
-     fuelCosts <- readSource("REMINDinputForTransportStandalone", convert = FALSE)
+     fuelCosts <- readSource("REMINDinputForTransportStandalone", subtype = "fuelCosts",
+                             convert = FALSE)
    } else {
      fuelCosts <- gdx::readGDX(gdxPath,
                                "pm_FEPrice",


### PR DESCRIPTION
## Purpose of this PR

## Checklist:

- [ ] I used ./test-standard-runs to compare and archive the changes introduced by this PR in /p/projects/edget/PRchangeLog/

Instructions for PIK internal testing of transport packages:

  1.  Navigate to this folder on the cluster `/p/projects/edget/PRchangeLog/`
  2.  Run the following command in the folder: `./test-standard-runs "FolderName" "ReferenceFolder"`, where "FolderName" is a name you can choose which identifies your changes or PR, i.e. the PR number plus a keyword. "ReferenceFolder" is an optional argument and should be a folder that already exists in the directory "/p/projects/edget/PRchangeLog/". If not set this defaults to the last stored run. 
      Running this command submits four sbatch jobs. You can optionally find a help page by running ./test-standard-runs -h
  3.  You are now interactively asked if repositories should be installed from source. Here, name one after another all the repositories in which you introduced changes. You can for example use your GitHub branch for that.
  4.  Wait until the submitted jobs have finished and check if the folders "ChangeLogMix[1-4]" have been generated and hold a compScen each.  You can check the `testScen[1-4]_edgetPR*.out` files in case of errors.
  5.  Check the compScen if you wish to review changes of the results compared to the reference run.


## Further information (optional):

* Test runs are here: 
* Comparison of results (what changes by this PR?): 

