### PR TITLE
update preferences for Trucks fleet composition in India

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '64359824'
+ValidationKey: '64545840'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'edgeTransport: Prepare EDGE Transport Data for the REMIND model'
-version: 3.13.4
-date-released: '2026-03-24'
+version: 3.14.0
+date-released: '2026-04-13'
 abstract: EDGE-T is a fork of the GCAM transport module https://jgcri.github.io/gcam-doc/energy.html#transportation
   with a high level of detail in its representation of technological and modal options.
   It is a partial equilibrium model with a nested multinomial logit structure and

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: edgeTransport
 Title: Prepare EDGE Transport Data for the REMIND model
-Version: 3.13.4
+Version: 3.14.0
 Authors@R: c(
     person("Johanna", "Hoppe", email = "johanna.hoppe@pik-potsdam.de", role = c("aut", "cre"),
            comment = c(ORCID = "0009-0004-6753-5090")),
@@ -21,7 +21,7 @@ Encoding: UTF-8
 LazyData: true
 RoxygenNote: 7.3.3
 VignetteBuilder: knitr
-Date: 2026-03-24
+Date: 2026-04-13
 Config/testthat/edition: 3
 Imports:
     rmndt,

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Prepare EDGE Transport Data for the REMIND model
 
-R package **edgeTransport**, version **3.13.4**
+R package **edgeTransport**, version **3.14.0**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/edgeTransport)](https://cran.r-project.org/package=edgeTransport) [![R build status](https://github.com/pik-piam/edgeTransport/workflows/check/badge.svg)](https://github.com/pik-piam/edgeTransport/actions) [![codecov](https://codecov.io/gh/pik-piam/edgeTransport/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/edgeTransport) [![r-universe](https://pik-piam.r-universe.dev/badges/edgeTransport)](https://pik-piam.r-universe.dev/builds)
 
@@ -46,15 +46,15 @@ In case of questions / problems please contact Johanna Hoppe <johanna.hoppe@pik-
 
 To cite package **edgeTransport** in publications use:
 
-Hoppe J, Dirnaichner A, Rottoli M, Muessel J, Hagen A, Pietzcker R (2026). "edgeTransport: Prepare EDGE Transport Data for the REMIND model - Version 3.13.4."
+Hoppe J, Dirnaichner A, Rottoli M, Muessel J, Hagen A, Pietzcker R (2026). "edgeTransport: Prepare EDGE Transport Data for the REMIND model - Version 3.14.0."
 
 A BibTeX entry for LaTeX users is
 
  ```latex
 @Misc{,
-  title = {edgeTransport: Prepare EDGE Transport Data for the REMIND model - Version 3.13.4},
+  title = {edgeTransport: Prepare EDGE Transport Data for the REMIND model - Version 3.14.0},
   author = {Johanna Hoppe and Alois Dirnaichner and Marianna Rottoli and Jarusch Muessel and Alex K. Hagen and Robert P. Pietzcker},
-  date = {2026-03-24},
+  date = {2026-04-13},
   year = {2026},
 }
 ```

--- a/inst/extdata/genParBaselinePrefTrends.csv
+++ b/inst/extdata/genParBaselinePrefTrends.csv
@@ -8012,7 +8012,7 @@ SSP2;ESC;;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_s
 SSP2;ESW;;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;2.85E-01;2.85E-01;2.85E-01;2.85E-01;2.85E-01;2.85E-01
 SSP2;EWN;;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;1.00E+00;1.00E+00;1.00E+00;1.00E+00;1.00E+00;1.00E+00
 SSP2;FRA;;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;1.00E+00;1.00E+00;1.00E+00;1.00E+00;1.00E+00;1.00E+00
-SSP2;IND;;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;1.50E-01;2.50E-01;3.25E-01;0.2592;0.2592;0.2592
+SSP2;IND;;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;1.50E-01;2.50E-01;3.25E-01;0.23328;0.23328;0.23328
 SSP2;JPN;;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;1.00E+00;1.00E+00;1.00E+00;1.00E+00;1.00E+00;1.00E+00
 SSP2;LAM;;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;3.85E-01;3.85E-01;3.85E-01;3.85E-01;3.85E-01;3.85E-01
 SSP2;MEA;;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;1.30E-01;1.30E-01;1.30E-01;1.30E-01;1.30E-01;1.30E-01
@@ -8684,7 +8684,7 @@ SSP2;ESC;;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_sub
 SSP2;ESW;;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;1.00E+00;1.00E+00;1.00E+00;1.00E+00;1.00E+00;1.00E+00
 SSP2;EWN;;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;5.65E-01;5.65E-01;5.65E-01;5.65E-01;5.65E-01;5.65E-01
 SSP2;FRA;;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;3.76E-01;3.76E-01;3.76E-01;3.76E-01;3.76E-01;3.76E-01
-SSP2;IND;;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;1.20E+00;7.00E-01;6.00E-01;0.45;0.45;0.45
+SSP2;IND;;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;1.20E+00;7.00E-01;6.00E-01;0.405;0.405;0.405
 SSP2;JPN;;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;5.90E-01;5.90E-01;5.90E-01;5.90E-01;5.90E-01;5.90E-01
 SSP2;LAM;;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;1.89E-01;1.89E-01;1.89E-01;1.89E-01;1.89E-01;1.89E-01
 SSP2;MEA;;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;1.00E+00;1.00E+00;1.00E+00;1.00E+00;1.00E+00;1.00E+00

--- a/inst/extdata/genParBaselinePrefTrends.csv
+++ b/inst/extdata/genParBaselinePrefTrends.csv
@@ -8012,7 +8012,7 @@ SSP2;ESC;;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_s
 SSP2;ESW;;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;2.85E-01;2.85E-01;2.85E-01;2.85E-01;2.85E-01;2.85E-01
 SSP2;EWN;;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;1.00E+00;1.00E+00;1.00E+00;1.00E+00;1.00E+00;1.00E+00
 SSP2;FRA;;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;1.00E+00;1.00E+00;1.00E+00;1.00E+00;1.00E+00;1.00E+00
-SSP2;IND;;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;1.70E-01;2.50E-01;3.25E-01;1.7E-01;1.7E-01;1.7E-01
+SSP2;IND;;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;1.75E-01;3E-01;3.2E-01;0.14;0.15;0.15
 SSP2;JPN;;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;1.00E+00;1.00E+00;1.00E+00;1.00E+00;1.00E+00;1.00E+00
 SSP2;LAM;;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;3.85E-01;3.85E-01;3.85E-01;3.85E-01;3.85E-01;3.85E-01
 SSP2;MEA;;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;1.30E-01;1.30E-01;1.30E-01;1.30E-01;1.30E-01;1.30E-01
@@ -8180,7 +8180,7 @@ SSP2;ESC;;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subs
 SSP2;ESW;;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;6.04E-02;6.04E-02;6.04E-02;6.04E-02;6.04E-02;6.04E-02
 SSP2;EWN;;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;1.16E-01;1.16E-01;1.16E-01;1.16E-01;1.16E-01;1.16E-01
 SSP2;FRA;;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;1.41E-01;1.41E-01;1.41E-01;1.41E-01;1.41E-01;1.41E-01
-SSP2;IND;;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;5.00E-02;1.00E-01;1.00E-01;1.00E-01;1.00E-01;1.00E-01
+SSP2;IND;;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;5.50E-02;1.50E-01;1.50E-01;1.50E-01;1.50E-01;1.50E-01
 SSP2;JPN;;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.00E+00;0.00E+00;0.00E+00;0.00E+00;0.00E+00;0.00E+00
 SSP2;LAM;;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;2.65E-02;2.65E-02;2.65E-02;2.65E-02;2.65E-02;2.65E-02
 SSP2;MEA;;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;2.01E-01;2.01E-01;2.01E-01;2.01E-01;2.01E-01;2.01E-01
@@ -8348,7 +8348,7 @@ SSP2;ESC;;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subs
 SSP2;ESW;;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;8.42E-02;8.42E-02;8.42E-02;8.42E-02;8.42E-02;8.42E-02
 SSP2;EWN;;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;5.22E-01;5.22E-01;5.22E-01;5.22E-01;5.22E-01;5.22E-01
 SSP2;FRA;;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;1.60E-01;1.60E-01;1.60E-01;1.60E-01;1.60E-01;1.60E-01
-SSP2;IND;;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;4.00E-01;3.00E-01;2.50E-01;2.00E-01;2.00E-01;2.00E-01
+SSP2;IND;;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;4.00E-01;3.00E-01;2.50E-01;2.10E-01;2.10E-01;2.10E-01
 SSP2;JPN;;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.00E+00;0.00E+00;0.00E+00;0.00E+00;0.00E+00;0.00E+00
 SSP2;LAM;;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;1.00E+00;1.00E+00;1.00E+00;1.00E+00;1.00E+00;1.00E+00
 SSP2;MEA;;Truck (26t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.00E+00;0.00E+00;0.00E+00;0.00E+00;0.00E+00;0.00E+00
@@ -8516,7 +8516,7 @@ SSP2;ESC;;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subs
 SSP2;ESW;;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;4.04E-01;4.04E-01;4.04E-01;4.04E-01;4.04E-01;4.04E-01
 SSP2;EWN;;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;4.06E-01;4.06E-01;4.06E-01;4.06E-01;4.06E-01;4.06E-01
 SSP2;FRA;;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;4.01E-01;4.01E-01;4.01E-01;4.01E-01;4.01E-01;4.01E-01
-SSP2;IND;;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;1.00E-01;1.00E-01;1.00E-01;0.105;0.105;0.105
+SSP2;IND;;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;1.00E-01;1.00E-01;1.00E-01;0.1125;0.1125;0.1125
 SSP2;JPN;;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.00E+00;0.00E+00;0.00E+00;0.00E+00;0.00E+00;0.00E+00
 SSP2;LAM;;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;5.08E-04;5.08E-04;5.08E-04;5.08E-04;5.08E-04;5.08E-04
 SSP2;MEA;;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.00E+00;0.00E+00;0.00E+00;0.00E+00;0.00E+00;0.00E+00
@@ -8684,7 +8684,7 @@ SSP2;ESC;;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_sub
 SSP2;ESW;;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;1.00E+00;1.00E+00;1.00E+00;1.00E+00;1.00E+00;1.00E+00
 SSP2;EWN;;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;5.65E-01;5.65E-01;5.65E-01;5.65E-01;5.65E-01;5.65E-01
 SSP2;FRA;;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;3.76E-01;3.76E-01;3.76E-01;3.76E-01;3.76E-01;3.76E-01
-SSP2;IND;;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;1.20E+00;7.00E-01;6.00E-01;0.405;0.405;0.405
+SSP2;IND;;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.82E+00;5E-01;4.50E-01;0.306;0.306;0.306
 SSP2;JPN;;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;5.90E-01;5.90E-01;5.90E-01;5.90E-01;5.90E-01;5.90E-01
 SSP2;LAM;;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;1.89E-01;1.89E-01;1.89E-01;1.89E-01;1.89E-01;1.89E-01
 SSP2;MEA;;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;1.00E+00;1.00E+00;1.00E+00;1.00E+00;1.00E+00;1.00E+00
@@ -10529,8 +10529,8 @@ SSP2;FRA;;;;;trn_pass_road;trn_pass;S1S;9.06E-02;6.00E-02;5.00E-02;4.00E-02;4.00
 SSP2;FRA;;;;;Walk;trn_pass;S1S;1.00E+00;1.00E+00;1.00E+00;1.00E+00;1.00E+00;1.00E+00
 SSP2;IND;;;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;0.1;8E-02;8E-02;0.09;0.25;0.25
 SSP2;IND;;;trn_pass_road_LDV_3W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;0.022;0.0075;0.007;0.004;0.002;0.002
-SSP2;IND;;;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;1.35;1.44;1.32;1.425;0.64;0.64
-SSP2;IND;;;;Bus;trn_pass_road;trn_pass;S2S1;0.4;0.2;2.62E-01;1.60E-01;3.00E-02;3.00E-02
+SSP2;IND;;;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;1.35;1.44;1.32;1.425;0.448;0.448
+SSP2;IND;;;;Bus;trn_pass_road;trn_pass;S2S1;0.32;0.2;2.62E-01;1.60E-01;3.00E-02;3.00E-02
 SSP2;IND;;;;trn_pass_road_LDV;trn_pass_road;trn_pass;S2S1;7.34E-01;1.00E+00;1.00E+00;1.00E+00;1.00E+00;1.00E+00
 SSP2;IND;;;;;Cycle;trn_pass;S1S;1.92E-02;3.18E-02;5.34E-02;7.50E-02;1.30E-01;1.30E-01
 SSP2;IND;;;;;Domestic Aviation;trn_pass;S1S;1.40E+00;7.57E-01;5.79E-01;4.00E-01;2.50E-01;2.50E-01
@@ -10540,8 +10540,8 @@ SSP2;IND;;;;;HSR;trn_pass;S1S;0;2E-04;2E-04;2.00E-04;2.00E-04;2.00E-04
 SSP2;IND;;;;;International Aviation;trn_aviation_intl;S1S;1.00E+00;1.00E+00;1.00E+00;1.00E+00;1.00E+00;1.00E+00
 SSP2;IND;;;;;International Ship;trn_shipping_intl;S1S;1.00E+00;1.00E+00;1.00E+00;1.00E+00;1.00E+00;1.00E+00
 SSP2;IND;;;;;Passenger Rail;trn_pass;S1S;5.5E-03;3E-03;2E-03;1.2E-03;1.2E-03;1.2E-03
-SSP2;IND;;;;;trn_freight_road;trn_freight;S1S;1.5;1.5;1.5;1.3;1.3;1.3
-SSP2;IND;;;;;trn_pass_road;trn_pass;S1S;1.5;1.5;1.5;1.5;1.2;1.2
+SSP2;IND;;;;;trn_freight_road;trn_freight;S1S;1.8;1.5;1.5;1.3;1.3;1.3
+SSP2;IND;;;;;trn_pass_road;trn_pass;S1S;1.8;1.5;1.5;1.5;1.2;1.2
 SSP2;IND;;;;;Walk;trn_pass;S1S;1.05E+00;9.00E-01;1.05E+00;1.20E+00;1.20E+00;1.20E+00
 SSP2;JPN;;;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;7.00E-02;6.00E-02;5.75E-02;5.49E-02;5.49E-02;5.49E-02
 SSP2;JPN;;;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;1.00E+00;1.00E+00;1.00E+00;1.00E+00;1.00E+00;1.00E+00

--- a/inst/extdata/genParBaselinePrefTrends.csv
+++ b/inst/extdata/genParBaselinePrefTrends.csv
@@ -8012,7 +8012,7 @@ SSP2;ESC;;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_s
 SSP2;ESW;;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;2.85E-01;2.85E-01;2.85E-01;2.85E-01;2.85E-01;2.85E-01
 SSP2;EWN;;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;1.00E+00;1.00E+00;1.00E+00;1.00E+00;1.00E+00;1.00E+00
 SSP2;FRA;;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;1.00E+00;1.00E+00;1.00E+00;1.00E+00;1.00E+00;1.00E+00
-SSP2;IND;;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;1.50E-01;2.50E-01;3.25E-01;0.23328;0.23328;0.23328
+SSP2;IND;;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;1.70E-01;2.50E-01;3.25E-01;1.7E-01;1.7E-01;1.7E-01
 SSP2;JPN;;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;1.00E+00;1.00E+00;1.00E+00;1.00E+00;1.00E+00;1.00E+00
 SSP2;LAM;;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;3.85E-01;3.85E-01;3.85E-01;3.85E-01;3.85E-01;3.85E-01
 SSP2;MEA;;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;1.30E-01;1.30E-01;1.30E-01;1.30E-01;1.30E-01;1.30E-01

--- a/inst/extdata/genParBaselinePrefTrends.csv
+++ b/inst/extdata/genParBaselinePrefTrends.csv
@@ -8012,7 +8012,7 @@ SSP2;ESC;;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_s
 SSP2;ESW;;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;2.85E-01;2.85E-01;2.85E-01;2.85E-01;2.85E-01;2.85E-01
 SSP2;EWN;;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;1.00E+00;1.00E+00;1.00E+00;1.00E+00;1.00E+00;1.00E+00
 SSP2;FRA;;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;1.00E+00;1.00E+00;1.00E+00;1.00E+00;1.00E+00;1.00E+00
-SSP2;IND;;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;1.75E-01;3E-01;3.2E-01;0.14;0.15;0.15
+SSP2;IND;;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;1.75E-01;3E-01;3.2E-01;1.4E-01;1.5E-01;1.5E-01
 SSP2;JPN;;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;1.00E+00;1.00E+00;1.00E+00;1.00E+00;1.00E+00;1.00E+00
 SSP2;LAM;;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;3.85E-01;3.85E-01;3.85E-01;3.85E-01;3.85E-01;3.85E-01
 SSP2;MEA;;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;1.30E-01;1.30E-01;1.30E-01;1.30E-01;1.30E-01;1.30E-01
@@ -8516,7 +8516,7 @@ SSP2;ESC;;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subs
 SSP2;ESW;;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;4.04E-01;4.04E-01;4.04E-01;4.04E-01;4.04E-01;4.04E-01
 SSP2;EWN;;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;4.06E-01;4.06E-01;4.06E-01;4.06E-01;4.06E-01;4.06E-01
 SSP2;FRA;;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;4.01E-01;4.01E-01;4.01E-01;4.01E-01;4.01E-01;4.01E-01
-SSP2;IND;;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;1.00E-01;1.00E-01;1.00E-01;0.1125;0.1125;0.1125
+SSP2;IND;;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;1.00E-01;1.00E-01;1.00E-01;1.125E-01;1.125E-01;1.125E-01
 SSP2;JPN;;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.00E+00;0.00E+00;0.00E+00;0.00E+00;0.00E+00;0.00E+00
 SSP2;LAM;;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;5.08E-04;5.08E-04;5.08E-04;5.08E-04;5.08E-04;5.08E-04
 SSP2;MEA;;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.00E+00;0.00E+00;0.00E+00;0.00E+00;0.00E+00;0.00E+00
@@ -8684,7 +8684,7 @@ SSP2;ESC;;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_sub
 SSP2;ESW;;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;1.00E+00;1.00E+00;1.00E+00;1.00E+00;1.00E+00;1.00E+00
 SSP2;EWN;;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;5.65E-01;5.65E-01;5.65E-01;5.65E-01;5.65E-01;5.65E-01
 SSP2;FRA;;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;3.76E-01;3.76E-01;3.76E-01;3.76E-01;3.76E-01;3.76E-01
-SSP2;IND;;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.82E+00;5E-01;4.50E-01;0.306;0.306;0.306
+SSP2;IND;;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.82E+00;5E-01;4.50E-01;3.06E-01;3.06E-01;3.06E-01
 SSP2;JPN;;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;5.90E-01;5.90E-01;5.90E-01;5.90E-01;5.90E-01;5.90E-01
 SSP2;LAM;;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;1.89E-01;1.89E-01;1.89E-01;1.89E-01;1.89E-01;1.89E-01
 SSP2;MEA;;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;1.00E+00;1.00E+00;1.00E+00;1.00E+00;1.00E+00;1.00E+00

--- a/inst/extdata/genParBaselinePrefTrends.csv
+++ b/inst/extdata/genParBaselinePrefTrends.csv
@@ -8012,7 +8012,7 @@ SSP2;ESC;;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_s
 SSP2;ESW;;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;2.85E-01;2.85E-01;2.85E-01;2.85E-01;2.85E-01;2.85E-01
 SSP2;EWN;;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;1.00E+00;1.00E+00;1.00E+00;1.00E+00;1.00E+00;1.00E+00
 SSP2;FRA;;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;1.00E+00;1.00E+00;1.00E+00;1.00E+00;1.00E+00;1.00E+00
-SSP2;IND;;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;1.50E-01;2.50E-01;3.25E-01;4.00E-01;4.00E-01;4.00E-01
+SSP2;IND;;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;1.50E-01;2.50E-01;3.25E-01;0.2592;0.2592;0.2592
 SSP2;JPN;;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;1.00E+00;1.00E+00;1.00E+00;1.00E+00;1.00E+00;1.00E+00
 SSP2;LAM;;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;3.85E-01;3.85E-01;3.85E-01;3.85E-01;3.85E-01;3.85E-01
 SSP2;MEA;;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;1.30E-01;1.30E-01;1.30E-01;1.30E-01;1.30E-01;1.30E-01
@@ -8516,7 +8516,7 @@ SSP2;ESC;;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subs
 SSP2;ESW;;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;4.04E-01;4.04E-01;4.04E-01;4.04E-01;4.04E-01;4.04E-01
 SSP2;EWN;;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;4.06E-01;4.06E-01;4.06E-01;4.06E-01;4.06E-01;4.06E-01
 SSP2;FRA;;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;4.01E-01;4.01E-01;4.01E-01;4.01E-01;4.01E-01;4.01E-01
-SSP2;IND;;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;1.00E-01;1.00E-01;1.00E-01;1.00E-01;1.00E-01;1.00E-01
+SSP2;IND;;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;1.00E-01;1.00E-01;1.00E-01;0.105;0.105;0.105
 SSP2;JPN;;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.00E+00;0.00E+00;0.00E+00;0.00E+00;0.00E+00;0.00E+00
 SSP2;LAM;;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;5.08E-04;5.08E-04;5.08E-04;5.08E-04;5.08E-04;5.08E-04
 SSP2;MEA;;Truck (40t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;0.00E+00;0.00E+00;0.00E+00;0.00E+00;0.00E+00;0.00E+00
@@ -8684,7 +8684,7 @@ SSP2;ESC;;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_sub
 SSP2;ESW;;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;1.00E+00;1.00E+00;1.00E+00;1.00E+00;1.00E+00;1.00E+00
 SSP2;EWN;;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;5.65E-01;5.65E-01;5.65E-01;5.65E-01;5.65E-01;5.65E-01
 SSP2;FRA;;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;3.76E-01;3.76E-01;3.76E-01;3.76E-01;3.76E-01;3.76E-01
-SSP2;IND;;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;1.20E+00;7.00E-01;6.00E-01;5.00E-01;5.00E-01;5.00E-01
+SSP2;IND;;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;1.20E+00;7.00E-01;6.00E-01;0.45;0.45;0.45
 SSP2;JPN;;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;5.90E-01;5.90E-01;5.90E-01;5.90E-01;5.90E-01;5.90E-01
 SSP2;LAM;;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;1.89E-01;1.89E-01;1.89E-01;1.89E-01;1.89E-01;1.89E-01
 SSP2;MEA;;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;VS3;1.00E+00;1.00E+00;1.00E+00;1.00E+00;1.00E+00;1.00E+00

--- a/inst/extdata/scenParPrefTrends.csv
+++ b/inst/extdata/scenParPrefTrends.csv
@@ -3893,9 +3893,9 @@ SSP2,Mix4,IND,Liquids,Truck|light,trn_freight_road_tmp_subsectorL3,trn_freight_r
 SSP2,Mix4,IND,BEV,Truck|heavy,trn_freight_road_tmp_subsectorL3,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,90,2050,25
 SSP2,Mix4,IND,FCEV,Truck|heavy,trn_freight_road_tmp_subsectorL3,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,45,2050,25
 SSP2,Mix4,IND,Liquids,Truck|heavy,trn_freight_road_tmp_subsectorL3,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,25
-SSP2,Mix2,IND,,Truck|light,trn_freight_road_tmp_subsectorL3,trn_freight_road_tmp_subsectorL2,trn_freight_road,VS3,9,2050,25
+SSP2,Mix2,IND,,Truck|light,trn_freight_road_tmp_subsectorL3,trn_freight_road_tmp_subsectorL2,trn_freight_road,VS3,6.5,2050,25
 SSP2,Mix2,IND,,Truck|heavy,trn_freight_road_tmp_subsectorL3,trn_freight_road_tmp_subsectorL2,trn_freight_road,VS3,10,2050,25
-SSP2,Mix3,IND,,Truck|light,trn_freight_road_tmp_subsectorL3,trn_freight_road_tmp_subsectorL2,trn_freight_road,VS3,8,2050,25
+SSP2,Mix3,IND,,Truck|light,trn_freight_road_tmp_subsectorL3,trn_freight_road_tmp_subsectorL2,trn_freight_road,VS3,5.5,2050,25
 SSP2,Mix3,IND,,Truck|heavy,trn_freight_road_tmp_subsectorL3,trn_freight_road_tmp_subsectorL2,trn_freight_road,VS3,10,2050,25
-SSP2,Mix4,IND,,Truck|light,trn_freight_road_tmp_subsectorL3,trn_freight_road_tmp_subsectorL2,trn_freight_road,VS3,7,2050,25
+SSP2,Mix4,IND,,Truck|light,trn_freight_road_tmp_subsectorL3,trn_freight_road_tmp_subsectorL2,trn_freight_road,VS3,4.5,2050,25
 SSP2,Mix4,IND,,Truck|heavy,trn_freight_road_tmp_subsectorL3,trn_freight_road_tmp_subsectorL2,trn_freight_road,VS3,10,2050,25

--- a/inst/extdata/scenParPrefTrends.csv
+++ b/inst/extdata/scenParPrefTrends.csv
@@ -3893,3 +3893,9 @@ SSP2,Mix4,IND,Liquids,Truck|light,trn_freight_road_tmp_subsectorL3,trn_freight_r
 SSP2,Mix4,IND,BEV,Truck|heavy,trn_freight_road_tmp_subsectorL3,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,90,2050,25
 SSP2,Mix4,IND,FCEV,Truck|heavy,trn_freight_road_tmp_subsectorL3,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,45,2050,25
 SSP2,Mix4,IND,Liquids,Truck|heavy,trn_freight_road_tmp_subsectorL3,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,25
+SSP2,Mix2,IND,,Truck|light,trn_freight_road_tmp_subsectorL3,trn_freight_road_tmp_subsectorL2,trn_freight_road,VS3,10,2050,25
+SSP2,Mix2,IND,,Truck|heavy,trn_freight_road_tmp_subsectorL3,trn_freight_road_tmp_subsectorL2,trn_freight_road,VS3,10,2050,25
+SSP2,Mix3,IND,,Truck|light,trn_freight_road_tmp_subsectorL3,trn_freight_road_tmp_subsectorL2,trn_freight_road,VS3,10,2050,25
+SSP2,Mix3,IND,,Truck|heavy,trn_freight_road_tmp_subsectorL3,trn_freight_road_tmp_subsectorL2,trn_freight_road,VS3,10,2050,25
+SSP2,Mix4,IND,,Truck|light,trn_freight_road_tmp_subsectorL3,trn_freight_road_tmp_subsectorL2,trn_freight_road,VS3,10,2050,25
+SSP2,Mix4,IND,,Truck|heavy,trn_freight_road_tmp_subsectorL3,trn_freight_road_tmp_subsectorL2,trn_freight_road,VS3,10,2050,25

--- a/inst/extdata/scenParPrefTrends.csv
+++ b/inst/extdata/scenParPrefTrends.csv
@@ -3893,9 +3893,9 @@ SSP2,Mix4,IND,Liquids,Truck|light,trn_freight_road_tmp_subsectorL3,trn_freight_r
 SSP2,Mix4,IND,BEV,Truck|heavy,trn_freight_road_tmp_subsectorL3,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,90,2050,25
 SSP2,Mix4,IND,FCEV,Truck|heavy,trn_freight_road_tmp_subsectorL3,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,45,2050,25
 SSP2,Mix4,IND,Liquids,Truck|heavy,trn_freight_road_tmp_subsectorL3,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,25
-SSP2,Mix2,IND,,Truck|light,trn_freight_road_tmp_subsectorL3,trn_freight_road_tmp_subsectorL2,trn_freight_road,VS3,10,2050,25
+SSP2,Mix2,IND,,Truck|light,trn_freight_road_tmp_subsectorL3,trn_freight_road_tmp_subsectorL2,trn_freight_road,VS3,9,2050,25
 SSP2,Mix2,IND,,Truck|heavy,trn_freight_road_tmp_subsectorL3,trn_freight_road_tmp_subsectorL2,trn_freight_road,VS3,10,2050,25
-SSP2,Mix3,IND,,Truck|light,trn_freight_road_tmp_subsectorL3,trn_freight_road_tmp_subsectorL2,trn_freight_road,VS3,10,2050,25
+SSP2,Mix3,IND,,Truck|light,trn_freight_road_tmp_subsectorL3,trn_freight_road_tmp_subsectorL2,trn_freight_road,VS3,8,2050,25
 SSP2,Mix3,IND,,Truck|heavy,trn_freight_road_tmp_subsectorL3,trn_freight_road_tmp_subsectorL2,trn_freight_road,VS3,10,2050,25
-SSP2,Mix4,IND,,Truck|light,trn_freight_road_tmp_subsectorL3,trn_freight_road_tmp_subsectorL2,trn_freight_road,VS3,10,2050,25
+SSP2,Mix4,IND,,Truck|light,trn_freight_road_tmp_subsectorL3,trn_freight_road_tmp_subsectorL2,trn_freight_road,VS3,7,2050,25
 SSP2,Mix4,IND,,Truck|heavy,trn_freight_road_tmp_subsectorL3,trn_freight_road_tmp_subsectorL2,trn_freight_road,VS3,10,2050,25


### PR DESCRIPTION
Reduce the truck fleet size in IND by increasing the share of larger trucks in mrtransport and edgeTransport (corresponding [PR](https://github.com/pik-piam/mrtransport/pull/51)). Increased share of heavier trucks (18-40t) through time and Mix-scenario --> higher logistic efficiency in the freight road sector.

MrTransport: Adjustment of Annual Mileage and Historical Energy Service Demand. 
EdgeTransport: Adjustment of preference factors

EdgeTransport: Adjustment of preference factors (Mix1-4)

Sources: Sources used for the adjustments can be found here:
`/p/projects/edget/adjustmentDataFiles/IND_validation/` specifically in
`..ValidationSheets/TrucksValidation.xlsx` maps: TruckFleetComposition
and `..ValidationSheets/validationSheet.xlsx`

Though for future timesteps, the literature is very scarce. This is why I reached out to my contact at CEEW and ICCT to include also their estimates (noted as source in the Excel file)

Checklist:
I used ./test-standard-runs, compScens can be found here: `/p/projects/edget/PRchangeLog/20260410_trucksIND_mrTransAndEdgeT`
    
    
  Legend: 
<img width="468" height="146" alt="image" src="https://github.com/user-attachments/assets/d2346229-b170-4c89-8f9a-8c73593ff92f" />

Stock relative: 
<img width="644" height="441" alt="image" src="https://github.com/user-attachments/assets/7790ff4f-5910-4c0e-b759-48c7b11b59e0" />


Stock absolute:
<img width="637" height="421" alt="image" src="https://github.com/user-attachments/assets/f3196be5-67ae-4228-89b5-be5c3de4c337" />


The impact of the changes in edgeT to the version with only mrTransport changes is significant but not huge: 
left: oldMix2, right: newMix2
<img width="518" height="673" alt="image" src="https://github.com/user-attachments/assets/eaed8dad-e87a-42a4-9929-9585772c1d4a" />

