### PR TITLE
electric truck (BET) sales shares adjustments

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '645820769601'
+ValidationKey: '64587270'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '64359824'
+ValidationKey: '645820769601'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '64545840'
+ValidationKey: '64940400'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -11,37 +11,22 @@ jobs:
   check:
     runs-on: ubuntu-latest
     if: github.event.pull_request.draft == false
+    container:
+      image: ghcr.io/pik-piam/ci-image:latest
 
     steps:
       - uses: actions/checkout@v4
 
-      - uses: r-lib/actions/setup-pandoc@v2
-
-      - uses: r-lib/actions/setup-r@v2
-        with:
-          use-public-rspm: true
-          extra-repositories: "https://rse.pik-potsdam.de/r/packages"
-
-      - uses: r-lib/actions/setup-r-dependencies@v2
-        with:
-          extra-packages: |
-            lucode2
-            covr
-            madrat
-            magclass
-            citation
-            gms
-            goxygen
-            GDPuc
-          # piam packages also available on CRAN (madrat, magclass, citation,
-          # gms, goxygen, GDPuc) will usually have an outdated binary version
-          # available; by using extra-packages we get the newest version
+      - name: Install package and dependencies
+        shell: Rscript {0}
+        run: |
+          options(repos = c(pikpiam = 'https://pik-piam.r-universe.dev',
+                            CRAN = Sys.getenv('RSPM')))
+          pak::pak()
 
       - name: Run pre-commit checks
         shell: bash
         run: |
-          python -m pip install pre-commit
-          python -m pip freeze --local
           pre-commit run --show-diff-on-failure --color=always --all-files
 
       - name: Verify validation key

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
     -   id: mixed-line-ending
 
 -   repo: https://github.com/lorenzwalthert/precommit
-    rev: 3b70240796cdccbe1474b0176560281aaded97e6  # frozen: v0.4.3.9003
+    rev: v0.4.3.9021
     hooks:
     -   id: parsable-R
     -   id: deps-in-desc

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'edgeTransport: Prepare EDGE Transport Data for the REMIND model'
-version: 3.14.0
-date-released: '2026-04-13'
+version: 3.15.0
+date-released: '2026-06-12'
 abstract: EDGE-T is a fork of the GCAM transport module https://jgcri.github.io/gcam-doc/energy.html#transportation
   with a high level of detail in its representation of technological and modal options.
   It is a partial equilibrium model with a nested multinomial logit structure and

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'edgeTransport: Prepare EDGE Transport Data for the REMIND model'
-version: 3.13.4.9001
-date-released: '2026-05-28'
+version: 3.13.5
+date-released: '2026-05-29'
 abstract: EDGE-T is a fork of the GCAM transport module https://jgcri.github.io/gcam-doc/energy.html#transportation
   with a high level of detail in its representation of technological and modal options.
   It is a partial equilibrium model with a nested multinomial logit structure and

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'edgeTransport: Prepare EDGE Transport Data for the REMIND model'
-version: 3.13.4
-date-released: '2026-03-24'
+version: 3.13.4.9001
+date-released: '2026-05-28'
 abstract: EDGE-T is a fork of the GCAM transport module https://jgcri.github.io/gcam-doc/energy.html#transportation
   with a high level of detail in its representation of technological and modal options.
   It is a partial equilibrium model with a nested multinomial logit structure and

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: edgeTransport
 Title: Prepare EDGE Transport Data for the REMIND model
-Version: 3.13.4
+Version: 3.13.4.9001
 Authors@R: c(
     person("Johanna", "Hoppe", email = "johanna.hoppe@pik-potsdam.de", role = c("aut", "cre"),
            comment = c(ORCID = "0009-0004-6753-5090")),
@@ -21,7 +21,7 @@ Encoding: UTF-8
 LazyData: true
 RoxygenNote: 7.3.3
 VignetteBuilder: knitr
-Date: 2026-03-24
+Date: 2026-05-28
 Config/testthat/edition: 3
 Imports:
     rmndt,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: edgeTransport
 Title: Prepare EDGE Transport Data for the REMIND model
-Version: 3.14.0
+Version: 3.15.0
 Authors@R: c(
     person("Johanna", "Hoppe", email = "johanna.hoppe@pik-potsdam.de", role = c("aut", "cre"),
            comment = c(ORCID = "0009-0004-6753-5090")),
@@ -21,7 +21,7 @@ Encoding: UTF-8
 LazyData: true
 RoxygenNote: 7.3.3
 VignetteBuilder: knitr
-Date: 2026-04-13
+Date: 2026-06-12
 Config/testthat/edition: 3
 Imports:
     rmndt,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: edgeTransport
 Title: Prepare EDGE Transport Data for the REMIND model
-Version: 3.13.4.9001
+Version: 3.13.5
 Authors@R: c(
     person("Johanna", "Hoppe", email = "johanna.hoppe@pik-potsdam.de", role = c("aut", "cre"),
            comment = c(ORCID = "0009-0004-6753-5090")),
@@ -21,7 +21,7 @@ Encoding: UTF-8
 LazyData: true
 RoxygenNote: 7.3.3
 VignetteBuilder: knitr
-Date: 2026-05-28
+Date: 2026-05-29
 Config/testthat/edition: 3
 Imports:
     rmndt,

--- a/R/toolEdgeTransportSA.R
+++ b/R/toolEdgeTransportSA.R
@@ -40,7 +40,7 @@ toolEdgeTransportSA <- function(SSPscen,
   level <- subsectorL3 <- variable <- version <- region <- vehicleType <- technology <- period <- NULL
 
   #To trigger the madrat caching even if changes are only applied to the csv files, we include here the version number of edget
-  version <- "3.13.5"
+  version <- "3.15.0"
 
   commonParams <- toolGetCommonParameters(startyear, isICEban[1], isICEban[2])
 

--- a/R/toolEdgeTransportSA.R
+++ b/R/toolEdgeTransportSA.R
@@ -40,7 +40,7 @@ toolEdgeTransportSA <- function(SSPscen,
   level <- subsectorL3 <- variable <- version <- region <- vehicleType <- technology <- period <- NULL
 
   #To trigger the madrat caching even if changes are only applied to the csv files, we include here the version number of edget
-  version <- "3.13.1"
+  version <- "3.13.4.dev"
 
   commonParams <- toolGetCommonParameters(startyear, isICEban[1], isICEban[2])
 

--- a/R/toolEdgeTransportSA.R
+++ b/R/toolEdgeTransportSA.R
@@ -40,7 +40,7 @@ toolEdgeTransportSA <- function(SSPscen,
   level <- subsectorL3 <- variable <- version <- region <- vehicleType <- technology <- period <- NULL
 
   #To trigger the madrat caching even if changes are only applied to the csv files, we include here the version number of edget
-  version <- "3.13.4.dev"
+  version <- "3.13.5"
 
   commonParams <- toolGetCommonParameters(startyear, isICEban[1], isICEban[2])
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Prepare EDGE Transport Data for the REMIND model
 
-R package **edgeTransport**, version **3.13.4.9001**
+R package **edgeTransport**, version **3.13.5**
 
    [![R build status](https://github.com/pik-piam/edgeTransport/workflows/check/badge.svg)](https://github.com/pik-piam/edgeTransport/actions) [![codecov](https://codecov.io/gh/pik-piam/edgeTransport/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/edgeTransport) [![r-universe](https://pik-piam.r-universe.dev/badges/edgeTransport)](https://pik-piam.r-universe.dev/builds)
 
@@ -46,7 +46,7 @@ In case of questions / problems please contact Johanna Hoppe <johanna.hoppe@pik-
 
 To cite package **edgeTransport** in publications use:
 
-Hoppe J, Dirnaichner A, Rottoli M, Muessel J, Hagen A, Pietzcker R (2026). "edgeTransport: Prepare EDGE Transport Data for the REMIND model." Version: 3.13.4.9001, <https://github.com/pik-piam/edgeTransport>.
+Hoppe J, Dirnaichner A, Rottoli M, Muessel J, Hagen A, Pietzcker R (2026). "edgeTransport: Prepare EDGE Transport Data for the REMIND model." Version: 3.13.5, <https://github.com/pik-piam/edgeTransport>.
 
 A BibTeX entry for LaTeX users is
 
@@ -54,9 +54,9 @@ A BibTeX entry for LaTeX users is
 @Misc{,
   title = {edgeTransport: Prepare EDGE Transport Data for the REMIND model},
   author = {Johanna Hoppe and Alois Dirnaichner and Marianna Rottoli and Jarusch Muessel and Alex K. Hagen and Robert P. Pietzcker},
-  date = {2026-05-28},
+  date = {2026-05-29},
   year = {2026},
   url = {https://github.com/pik-piam/edgeTransport},
-  note = {Version: 3.13.4.9001},
+  note = {Version: 3.13.5},
 }
 ```

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Prepare EDGE Transport Data for the REMIND model
 
-R package **edgeTransport**, version **3.13.4**
+R package **edgeTransport**, version **3.13.4.9001**
 
-[![CRAN status](https://www.r-pkg.org/badges/version/edgeTransport)](https://cran.r-project.org/package=edgeTransport) [![R build status](https://github.com/pik-piam/edgeTransport/workflows/check/badge.svg)](https://github.com/pik-piam/edgeTransport/actions) [![codecov](https://codecov.io/gh/pik-piam/edgeTransport/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/edgeTransport) [![r-universe](https://pik-piam.r-universe.dev/badges/edgeTransport)](https://pik-piam.r-universe.dev/builds)
+   [![R build status](https://github.com/pik-piam/edgeTransport/workflows/check/badge.svg)](https://github.com/pik-piam/edgeTransport/actions) [![codecov](https://codecov.io/gh/pik-piam/edgeTransport/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/edgeTransport) [![r-universe](https://pik-piam.r-universe.dev/badges/edgeTransport)](https://pik-piam.r-universe.dev/builds)
 
 ## Purpose and Functionality
 
@@ -20,13 +20,13 @@ The additional repository can be made available permanently by adding the line a
 
 After that the most recent version of the package can be installed using `install.packages`:
 
-```r 
+```r
 install.packages("edgeTransport")
 ```
 
 Package updates can be installed using `update.packages` (make sure that the additional repository has been added before running that command):
 
-```r 
+```r
 update.packages()
 ```
 
@@ -46,15 +46,17 @@ In case of questions / problems please contact Johanna Hoppe <johanna.hoppe@pik-
 
 To cite package **edgeTransport** in publications use:
 
-Hoppe J, Dirnaichner A, Rottoli M, Muessel J, Hagen A, Pietzcker R (2026). "edgeTransport: Prepare EDGE Transport Data for the REMIND model - Version 3.13.4."
+Hoppe J, Dirnaichner A, Rottoli M, Muessel J, Hagen A, Pietzcker R (2026). "edgeTransport: Prepare EDGE Transport Data for the REMIND model." Version: 3.13.4.9001, <https://github.com/pik-piam/edgeTransport>.
 
 A BibTeX entry for LaTeX users is
 
  ```latex
 @Misc{,
-  title = {edgeTransport: Prepare EDGE Transport Data for the REMIND model - Version 3.13.4},
+  title = {edgeTransport: Prepare EDGE Transport Data for the REMIND model},
   author = {Johanna Hoppe and Alois Dirnaichner and Marianna Rottoli and Jarusch Muessel and Alex K. Hagen and Robert P. Pietzcker},
-  date = {2026-03-24},
+  date = {2026-05-28},
   year = {2026},
+  url = {https://github.com/pik-piam/edgeTransport},
+  note = {Version: 3.13.4.9001},
 }
 ```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Prepare EDGE Transport Data for the REMIND model
 
-R package **edgeTransport**, version **3.14.0**
+R package **edgeTransport**, version **3.15.0**
 
    [![R build status](https://github.com/pik-piam/edgeTransport/workflows/check/badge.svg)](https://github.com/pik-piam/edgeTransport/actions) [![codecov](https://codecov.io/gh/pik-piam/edgeTransport/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/edgeTransport) [![r-universe](https://pik-piam.r-universe.dev/badges/edgeTransport)](https://pik-piam.r-universe.dev/builds)
 
@@ -46,17 +46,17 @@ In case of questions / problems please contact Johanna Hoppe <johanna.hoppe@pik-
 
 To cite package **edgeTransport** in publications use:
 
-Hoppe J, Dirnaichner A, Rottoli M, Muessel J, Hagen A, Pietzcker R (2026). "edgeTransport: Prepare EDGE Transport Data for the REMIND model - Version 3.14.0."
+Hoppe J, Dirnaichner A, Rottoli M, Muessel J, Hagen A, Pietzcker R (2026). "edgeTransport: Prepare EDGE Transport Data for the REMIND model." Version: 3.15.0, <https://github.com/pik-piam/edgeTransport>.
 
 A BibTeX entry for LaTeX users is
 
  ```latex
 @Misc{,
-  title = {edgeTransport: Prepare EDGE Transport Data for the REMIND model - Version 3.14.0},
+  title = {edgeTransport: Prepare EDGE Transport Data for the REMIND model},
   author = {Johanna Hoppe and Alois Dirnaichner and Marianna Rottoli and Jarusch Muessel and Alex K. Hagen and Robert P. Pietzcker},
-  date = {2026-04-13},
+  date = {2026-06-12},
   year = {2026},
   url = {https://github.com/pik-piam/edgeTransport},
-  note = {Version: 3.13.5},
+  note = {Version: 3.15.0},
 }
 ```

--- a/inst/extdata/genParBaselinePrefTrends.csv
+++ b/inst/extdata/genParBaselinePrefTrends.csv
@@ -746,7 +746,7 @@ SSP1;SSA;BEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tm
 SSP1;UKI;BEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.00E+00;2.82E-01;6.41E-01;1.00E+00;1.00E+00;1.00E+00
 SSP1;USA;BEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.00E+00;1.63E-02;2.40E-01;4.65E-01;1.00E+00;1.00E+00
 SSP2;CAZ;BEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.00E+00;1.41E-01;2.36E-01;3.31E-01;4.35E-01;4.35E-01
-SSP2;CHA;BEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.00E+00;1.62E-01;5.84E-01;1.01E+00;2.37E+00;2.37E+00
+SSP2;CHA;BEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.00E+00;7.00E-01;8.50E-01;1.01E+00;2.41E+00;2.37E+00
 SSP2;DEU;BEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.00E+00;3.52E-01;5.15E-01;6.78E-01;8.71E-01;8.71E-01
 SSP2;ECE;BEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.00E+00;6.50E-02;1.05E-01;1.45E-01;2.79E-01;2.79E-01
 SSP2;ECS;BEV;Truck (0-3_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.00E+00;1.04E-01;1.61E-01;2.18E-01;2.89E-01;2.89E-01
@@ -914,7 +914,7 @@ SSP1;SSA;BEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_s
 SSP1;UKI;BEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.00E+00;1.12E-01;3.71E-01;6.30E-01;1.00E+00;1.00E+00
 SSP1;USA;BEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.00E+00;6.47E-03;1.28E-01;2.50E-01;1.00E+00;1.00E+00
 SSP2;CAZ;BEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.00E+00;5.61E-02;1.17E-01;1.78E-01;4.22E-01;4.22E-01
-SSP2;CHA;BEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.00E+00;6.45E-02;3.03E-01;5.41E-01;2.30E+00;2.30E+00
+SSP2;CHA;BEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.00E+00;1.00E+00;1.40E+00;1.90E+00;2.41E+00;2.30E+00
 SSP2;DEU;BEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.00E+00;1.40E-01;2.53E-01;3.65E-01;8.45E-01;8.45E-01
 SSP2;ECE;BEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.00E+00;2.59E-02;5.21E-02;7.83E-02;2.70E-01;2.70E-01
 SSP2;ECS;BEV;Truck (18t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.00E+00;4.14E-02;7.94E-02;1.17E-01;2.81E-01;2.81E-01
@@ -1418,7 +1418,7 @@ SSP1;SSA;BEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_
 SSP1;UKI;BEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.00E+00;2.82E-01;6.41E-01;1.00E+00;1.00E+00;1.00E+00
 SSP1;USA;BEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.00E+00;1.63E-02;2.40E-01;4.65E-01;1.00E+00;1.00E+00
 SSP2;CAZ;BEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.00E+00;1.41E-01;2.36E-01;3.31E-01;4.35E-01;4.35E-01
-SSP2;CHA;BEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.00E+00;1.62E-01;5.84E-01;1.01E+00;2.37E+00;2.37E+00
+SSP2;CHA;BEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.00E+00;1.00E+00;1.40E+00;1.90E+00;2.41E+00;2.37E+00
 SSP2;DEU;BEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.00E+00;3.52E-01;5.15E-01;6.78E-01;8.71E-01;8.71E-01
 SSP2;ECE;BEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.00E+00;6.50E-02;1.05E-01;1.45E-01;2.79E-01;2.79E-01
 SSP2;ECS;BEV;Truck (7_5t);trn_freight_road_tmp_subsectorL3;trn_freight_road_tmp_subsectorL2;trn_freight_road;trn_freight;FV;0.00E+00;1.04E-01;1.61E-01;2.18E-01;2.89E-01;2.89E-01
@@ -10077,11 +10077,11 @@ SSP1;CAZ;;;;;trn_freight_road;trn_freight;S1S;1.00E+00;1.00E+00;1.05E+00;1.10E+0
 SSP1;CAZ;;;;;trn_pass_road;trn_pass;S1S;1.50E-01;1.10E-01;9.25E-02;7.50E-02;7.55E-02;7.55E-02
 SSP1;CAZ;;;;;Walk;trn_pass;S1S;1.00E+00;1.00E+00;1.00E+00;1.00E+00;1.00E+00;1.00E+00
 SSP1;CHA;;;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;2.70E-01;1.20E-01;1.10E-01;1.00E-01;1.00E-01;1.00E-01
-SSP1;CHA;;;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;2.70E+0;3.50E+0;3.00E+0;3.00E+0;2.50E+0;2.50E+0
+SSP1;CHA;;;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;2.70E+00;3.50E+00;3.00E+00;3.00E+00;2.50E+00;2.50E+00
 SSP1;CHA;;;;Bus;trn_pass_road;trn_pass;S2S1;6.61E-01;3.00E-01;2.40E-01;1.80E-01;6.50E-02;6.50E-02
 SSP1;CHA;;;;trn_pass_road_LDV;trn_pass_road;trn_pass;S2S1;1.10E+00;1.10E+00;1.15E+00;1.15E+00;1.00E+00;1.00E+00
 SSP1;CHA;;;;;Cycle;trn_pass;S1S;9.45E-02;4.80E-02;4.40E-02;4.00E-02;6.50E-02;6.50E-02
-SSP1;CHA;;;;;Domestic Aviation;trn_pass;S1S;0.50E-01;1.20E-02;1.00E-02;0.70E-02;4.00E-03;5.00E-03
+SSP1;CHA;;;;;Domestic Aviation;trn_pass;S1S;5.00E-02;1.20E-02;1.00E-02;7.00E-03;4.00E-03;5.00E-03
 SSP1;CHA;;;;;Domestic Ship;trn_freight;S1S;3.00E-02;3.00E-02;3.00E-02;3.00E-02;3.00E-02;3.00E-02
 SSP1;CHA;;;;;Freight Rail;trn_freight;S1S;9.00E-02;6.00E-02;5.00E-02;4.00E-02;2.00E-02;2.00E-02
 SSP1;CHA;;;;;HSR;trn_pass;S1S;2.40E-01;4.00E-02;2.50E-02;1.00E-02;4.00E-03;4.00E-03
@@ -10211,9 +10211,9 @@ SSP1;FRA;;;;;Passenger Rail;trn_pass;S1S;3.97E-03;2.98E-03;2.68E-03;2.38E-03;3.0
 SSP1;FRA;;;;;trn_freight_road;trn_freight;S1S;1.00E+00;1.00E+00;1.00E+00;1.00E+00;1.10E+00;1.10E+00
 SSP1;FRA;;;;;trn_pass_road;trn_pass;S1S;9.06E-02;6.00E-02;5.00E-02;4.00E-02;4.00E-02;4.00E-02
 SSP1;FRA;;;;;Walk;trn_pass;S1S;1.00E+00;1.00E+00;1.00E+00;1.00E+00;1.00E+00;1.00E+00
-SSP1;IND;;;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;0.1;8E-02;8E-02;0.09;0.25;0.25
-SSP1;IND;;;trn_pass_road_LDV_3W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;0.022;0.0075;0.01;0.008;0.005;0.005
-SSP1;IND;;;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;1.35;1.44;1.32;1.5;0.64;0.64
+SSP1;IND;;;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;1.00E-01;8.00E-02;8.00E-02;9.00E-02;2.50E-01;2.50E-01
+SSP1;IND;;;trn_pass_road_LDV_3W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;2.20E-02;7.50E-03;1.00E-02;8.00E-03;5.00E-03;5.00E-03
+SSP1;IND;;;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;1.35E+00;1.44E+00;1.32E+00;1.50E+00;6.40E-01;6.40E-01
 SSP1;IND;;;;Bus;trn_pass_road;trn_pass;S2S1;1.00E+00;3.64E-01;2.62E-01;1.60E-01;3.00E-02;3.00E-02
 SSP1;IND;;;;trn_pass_road_LDV;trn_pass_road;trn_pass;S2S1;7.34E-01;1.00E+00;1.00E+00;1.00E+00;1.00E+00;1.00E+00
 SSP1;IND;;;;;Cycle;trn_pass;S1S;1.92E-02;3.18E-02;5.34E-02;7.50E-02;1.30E-01;1.30E-01
@@ -10393,11 +10393,11 @@ SSP2;CAZ;;;;;trn_freight_road;trn_freight;S1S;1.00E+00;1.00E+00;1.05E+00;1.10E+0
 SSP2;CAZ;;;;;trn_pass_road;trn_pass;S1S;1.50E-01;1.10E-01;9.25E-02;7.50E-02;7.55E-02;7.55E-02
 SSP2;CAZ;;;;;Walk;trn_pass;S1S;1.00E+00;1.00E+00;1.00E+00;1.00E+00;1.00E+00;1.00E+00
 SSP2;CHA;;;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;2.70E-01;1.20E-01;1.10E-01;1.00E-01;1.00E-01;1.00E-01
-SSP2;CHA;;;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;2.70E+0;3.50E+0;3.00E+0;3.00E+0;2.50E+0;2.50E+0
+SSP2;CHA;;;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;2.70E+00;3.50E+00;3.00E+00;3.00E+00;2.50E+00;2.50E+00
 SSP2;CHA;;;;Bus;trn_pass_road;trn_pass;S2S1;6.61E-01;3.00E-01;2.40E-01;1.80E-01;6.50E-02;6.50E-02
 SSP2;CHA;;;;trn_pass_road_LDV;trn_pass_road;trn_pass;S2S1;1.10E+00;1.10E+00;1.15E+00;1.15E+00;1.00E+00;1.00E+00
 SSP2;CHA;;;;;Cycle;trn_pass;S1S;9.45E-02;4.80E-02;4.40E-02;4.00E-02;6.50E-02;6.50E-02
-SSP2;CHA;;;;;Domestic Aviation;trn_pass;S1S;0.50E-01;1.20E-02;1.00E-02;0.70E-02;4.00E-03;5.00E-03
+SSP2;CHA;;;;;Domestic Aviation;trn_pass;S1S;5.00E-02;1.20E-02;1.00E-02;7.00E-03;4.00E-03;5.00E-03
 SSP2;CHA;;;;;Domestic Ship;trn_freight;S1S;3.00E-02;3.00E-02;3.00E-02;3.00E-02;3.00E-02;3.00E-02
 SSP2;CHA;;;;;Freight Rail;trn_freight;S1S;9.00E-02;6.00E-02;5.00E-02;4.00E-02;2.00E-02;2.00E-02
 SSP2;CHA;;;;;HSR;trn_pass;S1S;2.40E-01;4.00E-02;2.50E-02;1.00E-02;4.00E-03;4.00E-03
@@ -10527,21 +10527,21 @@ SSP2;FRA;;;;;Passenger Rail;trn_pass;S1S;3.97E-03;2.98E-03;2.68E-03;2.38E-03;3.0
 SSP2;FRA;;;;;trn_freight_road;trn_freight;S1S;1.00E+00;1.00E+00;1.00E+00;1.00E+00;1.10E+00;1.10E+00
 SSP2;FRA;;;;;trn_pass_road;trn_pass;S1S;9.06E-02;6.00E-02;5.00E-02;4.00E-02;4.00E-02;4.00E-02
 SSP2;FRA;;;;;Walk;trn_pass;S1S;1.00E+00;1.00E+00;1.00E+00;1.00E+00;1.00E+00;1.00E+00
-SSP2;IND;;;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;0.1;8E-02;8E-02;0.09;0.25;0.25
-SSP2;IND;;;trn_pass_road_LDV_3W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;0.022;0.0075;0.007;0.004;0.002;0.002
-SSP2;IND;;;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;1.35;1.44;1.32;1.425;0.64;0.64
-SSP2;IND;;;;Bus;trn_pass_road;trn_pass;S2S1;0.4;0.2;2.62E-01;1.60E-01;3.00E-02;3.00E-02
+SSP2;IND;;;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;1.00E-01;8.00E-02;8.00E-02;9.00E-02;2.50E-01;2.50E-01
+SSP2;IND;;;trn_pass_road_LDV_3W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;2.20E-02;7.50E-03;7.00E-03;4.00E-03;2.00E-03;2.00E-03
+SSP2;IND;;;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;1.35E+00;1.44E+00;1.32E+00;1.43E+00;6.40E-01;6.40E-01
+SSP2;IND;;;;Bus;trn_pass_road;trn_pass;S2S1;4.00E-01;2.00E-01;2.62E-01;1.60E-01;3.00E-02;3.00E-02
 SSP2;IND;;;;trn_pass_road_LDV;trn_pass_road;trn_pass;S2S1;7.34E-01;1.00E+00;1.00E+00;1.00E+00;1.00E+00;1.00E+00
 SSP2;IND;;;;;Cycle;trn_pass;S1S;1.92E-02;3.18E-02;5.34E-02;7.50E-02;1.30E-01;1.30E-01
 SSP2;IND;;;;;Domestic Aviation;trn_pass;S1S;1.40E+00;7.57E-01;5.79E-01;4.00E-01;2.50E-01;2.50E-01
 SSP2;IND;;;;;Domestic Ship;trn_freight;S1S;2.20E-02;1.00E-02;1.00E-02;1.00E-02;1.00E-02;1.00E-02
-SSP2;IND;;;;;Freight Rail;trn_freight;S1S;0.09;0.06;0.015;0.015;0.0007;0.0004
-SSP2;IND;;;;;HSR;trn_pass;S1S;0;2E-04;2E-04;2.00E-04;2.00E-04;2.00E-04
+SSP2;IND;;;;;Freight Rail;trn_freight;S1S;9.00E-02;6.00E-02;1.50E-02;1.50E-02;7.00E-04;4.00E-04
+SSP2;IND;;;;;HSR;trn_pass;S1S;0.00E+00;2.00E-04;2.00E-04;2.00E-04;2.00E-04;2.00E-04
 SSP2;IND;;;;;International Aviation;trn_aviation_intl;S1S;1.00E+00;1.00E+00;1.00E+00;1.00E+00;1.00E+00;1.00E+00
 SSP2;IND;;;;;International Ship;trn_shipping_intl;S1S;1.00E+00;1.00E+00;1.00E+00;1.00E+00;1.00E+00;1.00E+00
-SSP2;IND;;;;;Passenger Rail;trn_pass;S1S;5.5E-03;3E-03;2E-03;1.2E-03;1.2E-03;1.2E-03
-SSP2;IND;;;;;trn_freight_road;trn_freight;S1S;1.5;1.5;1.5;1.3;1.3;1.3
-SSP2;IND;;;;;trn_pass_road;trn_pass;S1S;1.5;1.5;1.5;1.5;1.2;1.2
+SSP2;IND;;;;;Passenger Rail;trn_pass;S1S;5.50E-03;3.00E-03;2.00E-03;1.20E-03;1.20E-03;1.20E-03
+SSP2;IND;;;;;trn_freight_road;trn_freight;S1S;1.50E+00;1.50E+00;1.50E+00;1.30E+00;1.30E+00;1.30E+00
+SSP2;IND;;;;;trn_pass_road;trn_pass;S1S;1.50E+00;1.50E+00;1.50E+00;1.50E+00;1.20E+00;1.20E+00
 SSP2;IND;;;;;Walk;trn_pass;S1S;1.05E+00;9.00E-01;1.05E+00;1.20E+00;1.20E+00;1.20E+00
 SSP2;JPN;;;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;7.00E-02;6.00E-02;5.75E-02;5.49E-02;5.49E-02;5.49E-02
 SSP2;JPN;;;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;1.00E+00;1.00E+00;1.00E+00;1.00E+00;1.00E+00;1.00E+00
@@ -10709,11 +10709,11 @@ SSP3;CAZ;;;;;trn_freight_road;trn_freight;S1S;1.00E+00;1.00E+00;1.05E+00;1.10E+0
 SSP3;CAZ;;;;;trn_pass_road;trn_pass;S1S;1.50E-01;1.10E-01;9.25E-02;7.50E-02;7.55E-02;7.55E-02
 SSP3;CAZ;;;;;Walk;trn_pass;S1S;1.00E+00;1.00E+00;1.00E+00;1.00E+00;1.00E+00;1.00E+00
 SSP3;CHA;;;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;2.70E-01;1.20E-01;1.10E-01;1.00E-01;1.00E-01;1.00E-01
-SSP3;CHA;;;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;2.70E+0;3.50E+0;3.00E+0;3.00E+0;2.50E+0;2.50E+0
+SSP3;CHA;;;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;2.70E+00;3.50E+00;3.00E+00;3.00E+00;2.50E+00;2.50E+00
 SSP3;CHA;;;;Bus;trn_pass_road;trn_pass;S2S1;6.61E-01;3.00E-01;2.40E-01;1.80E-01;6.50E-02;6.50E-02
 SSP3;CHA;;;;trn_pass_road_LDV;trn_pass_road;trn_pass;S2S1;1.10E+00;1.10E+00;1.15E+00;1.15E+00;1.00E+00;1.00E+00
 SSP3;CHA;;;;;Cycle;trn_pass;S1S;9.45E-02;4.80E-02;4.40E-02;4.00E-02;6.50E-02;6.50E-02
-SSP3;CHA;;;;;Domestic Aviation;trn_pass;S1S;0.50E-01;1.20E-02;1.00E-02;0.70E-02;4.00E-03;5.00E-03
+SSP3;CHA;;;;;Domestic Aviation;trn_pass;S1S;5.00E-02;1.20E-02;1.00E-02;7.00E-03;4.00E-03;5.00E-03
 SSP3;CHA;;;;;Domestic Ship;trn_freight;S1S;3.00E-02;3.00E-02;3.00E-02;3.00E-02;3.00E-02;3.00E-02
 SSP3;CHA;;;;;Freight Rail;trn_freight;S1S;9.00E-02;6.00E-02;5.00E-02;4.00E-02;2.00E-02;2.00E-02
 SSP3;CHA;;;;;HSR;trn_pass;S1S;2.40E-01;4.00E-02;2.50E-02;1.00E-02;4.00E-03;4.00E-03
@@ -10843,9 +10843,9 @@ SSP3;FRA;;;;;Passenger Rail;trn_pass;S1S;3.97E-03;2.98E-03;2.68E-03;2.38E-03;3.0
 SSP3;FRA;;;;;trn_freight_road;trn_freight;S1S;1.00E+00;1.00E+00;1.00E+00;1.00E+00;1.10E+00;1.10E+00
 SSP3;FRA;;;;;trn_pass_road;trn_pass;S1S;9.06E-02;6.00E-02;5.00E-02;4.00E-02;4.00E-02;4.00E-02
 SSP3;FRA;;;;;Walk;trn_pass;S1S;1.00E+00;1.00E+00;1.00E+00;1.00E+00;1.00E+00;1.00E+00
-SSP3;IND;;;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;0.1;8E-02;8E-02;0.09;0.25;0.25
-SSP3;IND;;;trn_pass_road_LDV_3W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;0.022;0.0075;0.005;0.002;0.001;0.001
-SSP3;IND;;;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;1.35;1.44;1.32;1.43;0.65;0.65
+SSP3;IND;;;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;1.00E-01;8.00E-02;8.00E-02;9.00E-02;2.50E-01;2.50E-01
+SSP3;IND;;;trn_pass_road_LDV_3W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;2.20E-02;7.50E-03;5.00E-03;2.00E-03;1.00E-03;1.00E-03
+SSP3;IND;;;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;1.35E+00;1.44E+00;1.32E+00;1.43E+00;6.50E-01;6.50E-01
 SSP3;IND;;;;Bus;trn_pass_road;trn_pass;S2S1;1.00E+00;3.64E-01;2.62E-01;1.60E-01;3.00E-02;3.00E-02
 SSP3;IND;;;;trn_pass_road_LDV;trn_pass_road;trn_pass;S2S1;7.34E-01;1.00E+00;1.00E+00;1.00E+00;1.00E+00;1.00E+00
 SSP3;IND;;;;;Cycle;trn_pass;S1S;1.92E-02;3.18E-02;5.34E-02;7.50E-02;1.30E-01;1.30E-01
@@ -11159,9 +11159,9 @@ SSP5;FRA;;;;;Passenger Rail;trn_pass;S1S;3.97E-03;2.98E-03;2.28E-03;1.59E-03;1.3
 SSP5;FRA;;;;;trn_freight_road;trn_freight;S1S;1.00E+00;1.00E+00;1.00E+00;1.00E+00;1.00E+00;1.00E+00
 SSP5;FRA;;;;;trn_pass_road;trn_pass;S1S;9.06E-02;7.13E-02;6.11E-02;5.09E-02;4.62E-02;4.62E-02
 SSP5;FRA;;;;;Walk;trn_pass;S1S;1.00E+00;1.00E+00;1.00E+00;1.00E+00;1.00E+00;1.00E+00
-SSP5;IND;;;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;0.1;8E-02;8E-02;0.09;0.25;0.25
-SSP5;IND;;;trn_pass_road_LDV_3W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;0.022;0.0075;0.005;0.002;0.001;0.001
-SSP5;IND;;;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;1.35;1.44;1.32;1.43;0.65;0.65
+SSP5;IND;;;trn_pass_road_LDV_2W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;1.00E-01;8.00E-02;8.00E-02;9.00E-02;2.50E-01;2.50E-01
+SSP5;IND;;;trn_pass_road_LDV_3W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;2.20E-02;7.50E-03;5.00E-03;2.00E-03;1.00E-03;1.00E-03
+SSP5;IND;;;trn_pass_road_LDV_4W;trn_pass_road_LDV;trn_pass_road;trn_pass;S3S2;1.35E+00;1.44E+00;1.32E+00;1.43E+00;6.50E-01;6.50E-01
 SSP5;IND;;;;Bus;trn_pass_road;trn_pass;S2S1;1.00E+00;1.82E-01;1.32E-01;8.23E-02;3.95E-02;3.95E-02
 SSP5;IND;;;;trn_pass_road_LDV;trn_pass_road;trn_pass;S2S1;9.18E-01;1.00E+00;1.00E+00;1.00E+00;1.00E+00;1.00E+00
 SSP5;IND;;;;;Cycle;trn_pass;S1S;1.92E-02;2.27E-02;2.68E-02;3.09E-02;1.00E-01;1.00E-01

--- a/inst/extdata/scenParPrefTrends.csv
+++ b/inst/extdata/scenParPrefTrends.csv
@@ -1841,10 +1841,10 @@ SSP2,Mix4,above GDP cutoff,BEV,LDV|2W,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn
 SSP2,Mix4,above GDP cutoff,Liquids,LDV|2W,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,25
 SSP2,Mix4,above GDP cutoff,Electric,Rail,Passenger Rail_tmp_subsectorL3,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,8,2050,25
 SSP2,Mix4,above GDP cutoff,Liquids,Rail,Passenger Rail_tmp_subsectorL3,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,0.3,2050,25
-SSP2,Mix4,above GDP cutoff,BEV,Truck|light,trn_freight_road_tmp_subsectorL3,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,75,2050,10
+SSP2,Mix4,above GDP cutoff,BEV,Truck|light,trn_freight_road_tmp_subsectorL3,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,85,2051,5
 SSP2,Mix4,above GDP cutoff,FCEV,Truck|light,trn_freight_road_tmp_subsectorL3,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,6,2050,15
 SSP2,Mix4,above GDP cutoff,Liquids,Truck|light,trn_freight_road_tmp_subsectorL3,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,25
-SSP2,Mix4,above GDP cutoff,BEV,Truck|heavy,trn_freight_road_tmp_subsectorL3,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,75,2050,10
+SSP2,Mix4,above GDP cutoff,BEV,Truck|heavy,trn_freight_road_tmp_subsectorL3,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,85,2051,5
 SSP2,Mix4,above GDP cutoff,FCEV,Truck|heavy,trn_freight_road_tmp_subsectorL3,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,40,2050,15
 SSP2,Mix4,above GDP cutoff,Liquids,Truck|heavy,trn_freight_road_tmp_subsectorL3,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,25
 SSP2,Mix4,below GDP cutoff,BEV,Bus,Bus_tmp_subsectorL3,Bus,trn_pass_road,FV,13,2050,25

--- a/inst/extdata/scenParPrefTrends.csv
+++ b/inst/extdata/scenParPrefTrends.csv
@@ -1777,10 +1777,10 @@ SSP2,Mix3,above GDP cutoff,BEV,LDV|2W,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn
 SSP2,Mix3,above GDP cutoff,Liquids,LDV|2W,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,25
 SSP2,Mix3,above GDP cutoff,Electric,Rail,Passenger Rail_tmp_subsectorL3,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,4,2050,25
 SSP2,Mix3,above GDP cutoff,Liquids,Rail,Passenger Rail_tmp_subsectorL3,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,0.5,2050,25
-SSP2,Mix3,above GDP cutoff,BEV,Truck|light,trn_freight_road_tmp_subsectorL3,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,20,2050,25
+SSP2,Mix3,above GDP cutoff,BEV,Truck|light,trn_freight_road_tmp_subsectorL3,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,40,2065,10
 SSP2,Mix3,above GDP cutoff,FCEV,Truck|light,trn_freight_road_tmp_subsectorL3,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,4,2050,25
 SSP2,Mix3,above GDP cutoff,Liquids,Truck|light,trn_freight_road_tmp_subsectorL3,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,25
-SSP2,Mix3,above GDP cutoff,BEV,Truck|heavy,trn_freight_road_tmp_subsectorL3,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,20,2050,25
+SSP2,Mix3,above GDP cutoff,BEV,Truck|heavy,trn_freight_road_tmp_subsectorL3,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,40,2065,10
 SSP2,Mix3,above GDP cutoff,FCEV,Truck|heavy,trn_freight_road_tmp_subsectorL3,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,10,2050,25
 SSP2,Mix3,above GDP cutoff,Liquids,Truck|heavy,trn_freight_road_tmp_subsectorL3,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,25
 SSP2,Mix3,below GDP cutoff,BEV,Bus,Bus_tmp_subsectorL3,Bus,trn_pass_road,FV,3.5,2050,25
@@ -1798,10 +1798,10 @@ SSP2,Mix3,below GDP cutoff,BEV,LDV|2W,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn
 SSP2,Mix3,below GDP cutoff,Liquids,LDV|2W,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,25
 SSP2,Mix3,below GDP cutoff,Electric,Rail,Passenger Rail_tmp_subsectorL3,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,2,2050,25
 SSP2,Mix3,below GDP cutoff,Liquids,Rail,Passenger Rail_tmp_subsectorL3,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,0.6,2050,25
-SSP2,Mix3,below GDP cutoff,BEV,Truck|light,trn_freight_road_tmp_subsectorL3,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,10,2050,25
+SSP2,Mix3,below GDP cutoff,BEV,Truck|light,trn_freight_road_tmp_subsectorL3,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,10,2050,17
 SSP2,Mix3,below GDP cutoff,FCEV,Truck|light,trn_freight_road_tmp_subsectorL3,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,3.5,2050,25
 SSP2,Mix3,below GDP cutoff,Liquids,Truck|light,trn_freight_road_tmp_subsectorL3,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,25
-SSP2,Mix3,below GDP cutoff,BEV,Truck|heavy,trn_freight_road_tmp_subsectorL3,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,10,2050,25
+SSP2,Mix3,below GDP cutoff,BEV,Truck|heavy,trn_freight_road_tmp_subsectorL3,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,10,2050,17
 SSP2,Mix3,below GDP cutoff,FCEV,Truck|heavy,trn_freight_road_tmp_subsectorL3,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,5,2050,25
 SSP2,Mix3,below GDP cutoff,Liquids,Truck|heavy,trn_freight_road_tmp_subsectorL3,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,25
 SSP2,Mix4,above GDP cutoff,,,,,Cycle,S1S,1,2050,25

--- a/inst/extdata/scenParPrefTrends.csv
+++ b/inst/extdata/scenParPrefTrends.csv
@@ -1862,10 +1862,10 @@ SSP2,Mix4,below GDP cutoff,BEV,LDV|2W,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn
 SSP2,Mix4,below GDP cutoff,Liquids,LDV|2W,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,25
 SSP2,Mix4,below GDP cutoff,Electric,Rail,Passenger Rail_tmp_subsectorL3,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,5,2050,25
 SSP2,Mix4,below GDP cutoff,Liquids,Rail,Passenger Rail_tmp_subsectorL3,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,0.4,2050,25
-SSP2,Mix4,below GDP cutoff,BEV,Truck|light,trn_freight_road_tmp_subsectorL3,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,75,2050,10
+SSP2,Mix4,below GDP cutoff,BEV,Truck|light,trn_freight_road_tmp_subsectorL3,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,77,2050,6
 SSP2,Mix4,below GDP cutoff,FCEV,Truck|light,trn_freight_road_tmp_subsectorL3,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,5,2050,15
 SSP2,Mix4,below GDP cutoff,Liquids,Truck|light,trn_freight_road_tmp_subsectorL3,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,25
-SSP2,Mix4,below GDP cutoff,BEV,Truck|heavy,trn_freight_road_tmp_subsectorL3,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,75,2050,10
+SSP2,Mix4,below GDP cutoff,BEV,Truck|heavy,trn_freight_road_tmp_subsectorL3,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,77,2050,6
 SSP2,Mix4,below GDP cutoff,FCEV,Truck|heavy,trn_freight_road_tmp_subsectorL3,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,45,2050,15
 SSP2,Mix4,below GDP cutoff,Liquids,Truck|heavy,trn_freight_road_tmp_subsectorL3,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,25
 SSP2,NAV_act,CAZ,,,,,Cycle,S1S,2.5,2040,10
@@ -3887,9 +3887,9 @@ SSP2,Mix4,IND,BEV,LDV|2W,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,FV
 SSP2,Mix4,IND,Liquids,LDV|2W,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,25
 SSP2,Mix4,IND,Electric,Rail,Passenger Rail_tmp_subsectorL3,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,5,2050,25
 SSP2,Mix4,IND,Liquids,Rail,Passenger Rail_tmp_subsectorL3,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,0.4,2050,25
-SSP2,Mix4,IND,BEV,Truck|light,trn_freight_road_tmp_subsectorL3,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,90,2050,25
+SSP2,Mix4,IND,BEV,Truck|light,trn_freight_road_tmp_subsectorL3,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,75,2048,6
 SSP2,Mix4,IND,FCEV,Truck|light,trn_freight_road_tmp_subsectorL3,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,5,2050,25
 SSP2,Mix4,IND,Liquids,Truck|light,trn_freight_road_tmp_subsectorL3,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,25
-SSP2,Mix4,IND,BEV,Truck|heavy,trn_freight_road_tmp_subsectorL3,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,90,2050,25
+SSP2,Mix4,IND,BEV,Truck|heavy,trn_freight_road_tmp_subsectorL3,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,75,2048,6
 SSP2,Mix4,IND,FCEV,Truck|heavy,trn_freight_road_tmp_subsectorL3,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,45,2050,25
 SSP2,Mix4,IND,Liquids,Truck|heavy,trn_freight_road_tmp_subsectorL3,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,25

--- a/inst/extdata/scenParPrefTrends.csv
+++ b/inst/extdata/scenParPrefTrends.csv
@@ -1711,11 +1711,11 @@ SSP2,Mix2,above GDP cutoff,BEV,LDV|3W,trn_pass_road_LDV_3W,trn_pass_road_LDV,trn
 SSP2,Mix2,above GDP cutoff,Liquids,LDV|3W,trn_pass_road_LDV_3W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,25
 SSP2,Mix2,above GDP cutoff,Electric,Rail,Passenger Rail_tmp_subsectorL3,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,2,2050,25
 SSP2,Mix2,above GDP cutoff,Liquids,Rail,Passenger Rail_tmp_subsectorL3,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,0.7,2050,25
-SSP2,Mix2,above GDP cutoff,BEV,Truck|light,trn_freight_road_tmp_subsectorL3,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,8,2050,10
-SSP2,Mix2,above GDP cutoff,FCEV,Truck|light,trn_freight_road_tmp_subsectorL3,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,2,2050,25
+SSP2,Mix2,above GDP cutoff,BEV,Truck|light,trn_freight_road_tmp_subsectorL3,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,6,2050,10
+SSP2,Mix2,above GDP cutoff,FCEV,Truck|light,trn_freight_road_tmp_subsectorL3,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1.5,2050,25
 SSP2,Mix2,above GDP cutoff,Liquids,Truck|light,trn_freight_road_tmp_subsectorL3,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,25
-SSP2,Mix2,above GDP cutoff,BEV,Truck|heavy,trn_freight_road_tmp_subsectorL3,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,8,2050,10
-SSP2,Mix2,above GDP cutoff,FCEV,Truck|heavy,trn_freight_road_tmp_subsectorL3,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,2,2050,25
+SSP2,Mix2,above GDP cutoff,BEV,Truck|heavy,trn_freight_road_tmp_subsectorL3,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,6,2050,10
+SSP2,Mix2,above GDP cutoff,FCEV,Truck|heavy,trn_freight_road_tmp_subsectorL3,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1.5,2050,25
 SSP2,Mix2,above GDP cutoff,Liquids,Truck|heavy,trn_freight_road_tmp_subsectorL3,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,25
 SSP2,Mix2,below GDP cutoff,BEV,Bus,Bus_tmp_subsectorL3,Bus,trn_pass_road,FV,1.5,2050,25
 SSP2,Mix2,below GDP cutoff,FCEV,Bus,Bus_tmp_subsectorL3,Bus,trn_pass_road,FV,1,2050,25

--- a/inst/extdata/scenParPrefTrends.csv
+++ b/inst/extdata/scenParPrefTrends.csv
@@ -1711,10 +1711,10 @@ SSP2,Mix2,above GDP cutoff,BEV,LDV|3W,trn_pass_road_LDV_3W,trn_pass_road_LDV,trn
 SSP2,Mix2,above GDP cutoff,Liquids,LDV|3W,trn_pass_road_LDV_3W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,25
 SSP2,Mix2,above GDP cutoff,Electric,Rail,Passenger Rail_tmp_subsectorL3,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,2,2050,25
 SSP2,Mix2,above GDP cutoff,Liquids,Rail,Passenger Rail_tmp_subsectorL3,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,0.7,2050,25
-SSP2,Mix2,above GDP cutoff,BEV,Truck|light,trn_freight_road_tmp_subsectorL3,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,10,2050,25
+SSP2,Mix2,above GDP cutoff,BEV,Truck|light,trn_freight_road_tmp_subsectorL3,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,8,2050,10
 SSP2,Mix2,above GDP cutoff,FCEV,Truck|light,trn_freight_road_tmp_subsectorL3,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,2,2050,25
 SSP2,Mix2,above GDP cutoff,Liquids,Truck|light,trn_freight_road_tmp_subsectorL3,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,25
-SSP2,Mix2,above GDP cutoff,BEV,Truck|heavy,trn_freight_road_tmp_subsectorL3,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,10,2050,25
+SSP2,Mix2,above GDP cutoff,BEV,Truck|heavy,trn_freight_road_tmp_subsectorL3,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,8,2050,10
 SSP2,Mix2,above GDP cutoff,FCEV,Truck|heavy,trn_freight_road_tmp_subsectorL3,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,2,2050,25
 SSP2,Mix2,above GDP cutoff,Liquids,Truck|heavy,trn_freight_road_tmp_subsectorL3,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,25
 SSP2,Mix2,below GDP cutoff,BEV,Bus,Bus_tmp_subsectorL3,Bus,trn_pass_road,FV,1.5,2050,25
@@ -1841,11 +1841,11 @@ SSP2,Mix4,above GDP cutoff,BEV,LDV|2W,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn
 SSP2,Mix4,above GDP cutoff,Liquids,LDV|2W,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,25
 SSP2,Mix4,above GDP cutoff,Electric,Rail,Passenger Rail_tmp_subsectorL3,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,8,2050,25
 SSP2,Mix4,above GDP cutoff,Liquids,Rail,Passenger Rail_tmp_subsectorL3,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,0.3,2050,25
-SSP2,Mix4,above GDP cutoff,BEV,Truck|light,trn_freight_road_tmp_subsectorL3,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,91,2050,25
-SSP2,Mix4,above GDP cutoff,FCEV,Truck|light,trn_freight_road_tmp_subsectorL3,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,6,2050,25
+SSP2,Mix4,above GDP cutoff,BEV,Truck|light,trn_freight_road_tmp_subsectorL3,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,75,2050,10
+SSP2,Mix4,above GDP cutoff,FCEV,Truck|light,trn_freight_road_tmp_subsectorL3,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,6,2050,15
 SSP2,Mix4,above GDP cutoff,Liquids,Truck|light,trn_freight_road_tmp_subsectorL3,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,25
-SSP2,Mix4,above GDP cutoff,BEV,Truck|heavy,trn_freight_road_tmp_subsectorL3,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,91,2050,25
-SSP2,Mix4,above GDP cutoff,FCEV,Truck|heavy,trn_freight_road_tmp_subsectorL3,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,40,2050,25
+SSP2,Mix4,above GDP cutoff,BEV,Truck|heavy,trn_freight_road_tmp_subsectorL3,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,75,2050,10
+SSP2,Mix4,above GDP cutoff,FCEV,Truck|heavy,trn_freight_road_tmp_subsectorL3,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,40,2050,15
 SSP2,Mix4,above GDP cutoff,Liquids,Truck|heavy,trn_freight_road_tmp_subsectorL3,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,25
 SSP2,Mix4,below GDP cutoff,BEV,Bus,Bus_tmp_subsectorL3,Bus,trn_pass_road,FV,13,2050,25
 SSP2,Mix4,below GDP cutoff,FCEV,Bus,Bus_tmp_subsectorL3,Bus,trn_pass_road,FV,1,2050,25
@@ -1862,11 +1862,11 @@ SSP2,Mix4,below GDP cutoff,BEV,LDV|2W,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn
 SSP2,Mix4,below GDP cutoff,Liquids,LDV|2W,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,25
 SSP2,Mix4,below GDP cutoff,Electric,Rail,Passenger Rail_tmp_subsectorL3,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,5,2050,25
 SSP2,Mix4,below GDP cutoff,Liquids,Rail,Passenger Rail_tmp_subsectorL3,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,0.4,2050,25
-SSP2,Mix4,below GDP cutoff,BEV,Truck|light,trn_freight_road_tmp_subsectorL3,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,90,2050,25
-SSP2,Mix4,below GDP cutoff,FCEV,Truck|light,trn_freight_road_tmp_subsectorL3,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,5,2050,25
+SSP2,Mix4,below GDP cutoff,BEV,Truck|light,trn_freight_road_tmp_subsectorL3,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,75,2050,10
+SSP2,Mix4,below GDP cutoff,FCEV,Truck|light,trn_freight_road_tmp_subsectorL3,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,5,2050,15
 SSP2,Mix4,below GDP cutoff,Liquids,Truck|light,trn_freight_road_tmp_subsectorL3,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,25
-SSP2,Mix4,below GDP cutoff,BEV,Truck|heavy,trn_freight_road_tmp_subsectorL3,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,90,2050,25
-SSP2,Mix4,below GDP cutoff,FCEV,Truck|heavy,trn_freight_road_tmp_subsectorL3,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,45,2050,25
+SSP2,Mix4,below GDP cutoff,BEV,Truck|heavy,trn_freight_road_tmp_subsectorL3,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,75,2050,10
+SSP2,Mix4,below GDP cutoff,FCEV,Truck|heavy,trn_freight_road_tmp_subsectorL3,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,45,2050,15
 SSP2,Mix4,below GDP cutoff,Liquids,Truck|heavy,trn_freight_road_tmp_subsectorL3,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,25
 SSP2,NAV_act,CAZ,,,,,Cycle,S1S,2.5,2040,10
 SSP2,NAV_act,CAZ,,,,,Domestic Aviation,S1S,0.3,2040,10

--- a/inst/extdata/scenParPrefTrends.csv
+++ b/inst/extdata/scenParPrefTrends.csv
@@ -3887,9 +3887,9 @@ SSP2,Mix4,IND,BEV,LDV|2W,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,FV
 SSP2,Mix4,IND,Liquids,LDV|2W,trn_pass_road_LDV_2W,trn_pass_road_LDV,trn_pass_road,FV,1,2050,25
 SSP2,Mix4,IND,Electric,Rail,Passenger Rail_tmp_subsectorL3,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,5,2050,25
 SSP2,Mix4,IND,Liquids,Rail,Passenger Rail_tmp_subsectorL3,Passenger Rail_tmp_subsectorL2,Passenger Rail,FV,0.4,2050,25
-SSP2,Mix4,IND,BEV,Truck|light,trn_freight_road_tmp_subsectorL3,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,75,2048,6
+SSP2,Mix4,IND,BEV,Truck|light,trn_freight_road_tmp_subsectorL3,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,75,2045,10
 SSP2,Mix4,IND,FCEV,Truck|light,trn_freight_road_tmp_subsectorL3,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,5,2050,25
 SSP2,Mix4,IND,Liquids,Truck|light,trn_freight_road_tmp_subsectorL3,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,25
-SSP2,Mix4,IND,BEV,Truck|heavy,trn_freight_road_tmp_subsectorL3,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,75,2048,6
+SSP2,Mix4,IND,BEV,Truck|heavy,trn_freight_road_tmp_subsectorL3,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,75,2045,10
 SSP2,Mix4,IND,FCEV,Truck|heavy,trn_freight_road_tmp_subsectorL3,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,45,2050,25
 SSP2,Mix4,IND,Liquids,Truck|heavy,trn_freight_road_tmp_subsectorL3,trn_freight_road_tmp_subsectorL2,trn_freight_road,FV,1,2050,25

--- a/tests/PRtest/PRtestEDGET.R
+++ b/tests/PRtest/PRtestEDGET.R
@@ -96,18 +96,30 @@ plotStandardScenarios <- function(folderNameD, defScenN, refFolderD = NULL){
 
   sec <- c("00_info", "01_energy_demand","02_energy_services","03_energy_intensity", "04_stock_and_sales", "05_emissions", "06_input_parameters", "08_transportRemindInputfiles")
 
+
+  #H12
+  piamPlotComparison::compareScenarios(
+    projectLibrary = "reporttransport",
+    mifs,
+    mifHist,
+    outDir,
+    outputFile = paste0(format(Sys.time(), "%Y-%m-%d_%H.%M.%S"), "_", filename, "H12.pdf"),
+    outputFormat = "pdf",
+    mifScenNames = scenNames,
+    sections = sec,
+    reg = c("OAS","MEA","SSA","LAM","REF","CAZ","CHA","IND","JPN","USA","NEU","EUR","World"),
+    mainReg = "World"
+  )
+
   #EU21
   piamPlotComparison::compareScenarios(
     projectLibrary = "reporttransport",
     mifs,
     mifHist,
     outDir,
-    outputFile = paste0(format(Sys.time(), "%Y-%m-%d_%H.%M.%S"), "_", filename, "EUR-short.pdf"),
+    outputFile = paste0(format(Sys.time(), "%Y-%m-%d_%H.%M.%S"), "_", filename, "EUR.pdf"),
     outputFormat = "pdf",
     mifScenNames = scenNames,
-    yearsScen = c(seq(2005, 2050, 5)),
-    yearsHist = c(seq(1990, 2030, 1)),
-    yearsBarPlot = c(2020, 2030, 2040, 2050),
     sections = sec,
     reg = c("ENC","EWN","ECS","ESC","ECE","FRA","DEU","UKI","ESW","EUR"),
     mainReg = "EUR"
@@ -136,27 +148,18 @@ plotStandardScenarios <- function(folderNameD, defScenN, refFolderD = NULL){
     mifs,
     mifHist,
     outDir,
-    outputFile = paste0(format(Sys.time(), "%Y-%m-%d_%H.%M.%S"), "_", filename, "EUR.pdf"),
+    outputFile = paste0(format(Sys.time(), "%Y-%m-%d_%H.%M.%S"), "_", filename, "EUR-short.pdf"),
     outputFormat = "pdf",
     mifScenNames = scenNames,
+    yearsScen = c(seq(2005, 2050, 5)),
+    yearsHist = c(seq(1990, 2030, 1)),
+    yearsBarPlot = c(2020, 2030, 2040, 2050),
     sections = sec,
     reg = c("ENC","EWN","ECS","ESC","ECE","FRA","DEU","UKI","ESW","EUR"),
     mainReg = "EUR"
   )
 
-  #H12
-  piamPlotComparison::compareScenarios(
-    projectLibrary = "reporttransport",
-    mifs,
-    mifHist,
-    outDir,
-    outputFile = paste0(format(Sys.time(), "%Y-%m-%d_%H.%M.%S"), "_", filename, "H12.pdf"),
-    outputFormat = "pdf",
-    mifScenNames = scenNames,
-    sections = sec,
-    reg = c("OAS","MEA","SSA","LAM","REF","CAZ","CHA","IND","JPN","USA","NEU","EUR","World"),
-    mainReg = "World"
-  )
+
 }
 
 


### PR DESCRIPTION
## Purpose of this PR

This PR addresses this issue: https://github.com/remindmodel/development_issues/issues/723

This PR adjusts electric truck sales shares to better reflect real-world near-term trends in the regions, special emphasis on:

- **BET sales share is lowered in EUR, CAZ, JPN, NEU, USA in NPi2025 (esp. in 2030)**
- **BET sales share is strongly increased in CHA esp. in 2030 (from originally <25% to now ~55%)**

This reflects a strong increase in BET sales shares seen in CHA in 2025 (as can be seen in the [EV outlook 2026](https://www.iea.org/reports/global-ev-outlook-2026)) and CHA as the region with highest BET sales shares globally.
<img width="594" height="344" alt="Image" src="https://github.com/user-attachments/assets/a5d170b7-6b59-453e-bce8-25051c556b45" />

For EUR the shares are still rather too high (now ~40% in 2030, NPi2025) compared with current shares and ACEA projections. This could possibly be further checked/validated and addressed in a subsequent step since a stronger adjustment needs a different methodology. Maybe the ICEban is too strong?

In addition:

- **BET sales share is globally reduced in PkBudg750 (especially in 2030) to decrease the jump from Mix2 to Mix4 that was unplausible and present before in 2030**
This was also due to a unfavorable behavior of the function that is used to adjust the transportPolScen in EDGET from 2021 onward, and introduced a huge jump from 2020 to 2021 for some scenarios (esp. Mix4):
<img width="217" height="397" alt="image" src="https://github.com/user-attachments/assets/0985025b-2495-4eb4-9e99-ca654766c87d" />

more context on that is in the issue linked above.

_This was corrected in this PR by choosing different parameter sets for the function values for trucks, that prevent a huge jump._

However, the general behavior of the function is unchanged and setting new parameters needs still to be handled with care, and this problem may still be present for other modes or levels.

## Checklist:

- [x] I used ./test-standard-runs to compare and archive the changes introduced by this PR in /p/projects/edget/PRchangeLog/

## Further information (optional):

* Test runs are here: 

   - ChangeLog EDGE-T old vs. new: `/p/projects/edget/PRchangeLog/20260612_PR405_adjBETsales_final/`
   _EDIT:_ updated to final version here, see conversation, NOTE: 'before' and 'after' are switched in the plot legends of the ChangeLog pdfs

   - REMIND runs with the adjustments included: `/p/tmp/ahagen/remindRuns/202605_BETsales_remind_V04/`
     (no new calibration, _EDIT:_ this was just an intermediate status, final one is V08, see conversation)

* Comparison of results (what changes by this PR?): 

    - compScen for REMIND runs NPi2025 & PKBudg750 before/after 
`/p/projects/edget/PRchangeLog/20260529_PR405_adjBETsales/2026-05-29_10.26.03_BETsales_V04_REMINDH12.pdf`

<img width="1101" height="819" alt="image" src="https://github.com/user-attachments/assets/4dc089a6-4238-473c-b70f-90a5005a7d47" />
<img width="1106" height="743" alt="image" src="https://github.com/user-attachments/assets/1f37869f-cb62-475f-91af-1ffbc98251d1" />




   - cross comparison Mix1-4 EDGET standalone: 
`/p/projects/edget/PRchangeLog/20260529_PR405_adjBETsales/2026-05-28_15.54.53_BETsales_V04H12.pdf`

<img width="1408" height="939" alt="image" src="https://github.com/user-attachments/assets/b3b31fd0-186c-40bf-bfb6-e15ee5c93d30" />

<img width="1408" height="939" alt="image" src="https://github.com/user-attachments/assets/a80e4ae0-25ce-4de9-87ee-4e76c5f0fd26" />


