### PR TITLE
2026 06 update US and CAZ passenger demands

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '649684091619'
+ValidationKey: '65156040'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '64940400'
+ValidationKey: '649684091619'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,7 +2,7 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'edgeTransport: Prepare EDGE Transport Data for the REMIND model'
-version: 3.15.0.9001
+version: 3.16.0
 date-released: '2026-06-15'
 abstract: EDGE-T is a fork of the GCAM transport module https://jgcri.github.io/gcam-doc/energy.html#transportation
   with a high level of detail in its representation of technological and modal options.

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'edgeTransport: Prepare EDGE Transport Data for the REMIND model'
-version: 3.15.0
-date-released: '2026-06-12'
+version: 3.15.0.9001
+date-released: '2026-06-15'
 abstract: EDGE-T is a fork of the GCAM transport module https://jgcri.github.io/gcam-doc/energy.html#transportation
   with a high level of detail in its representation of technological and modal options.
   It is a partial equilibrium model with a nested multinomial logit structure and

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: edgeTransport
 Title: Prepare EDGE Transport Data for the REMIND model
-Version: 3.15.0.9001
+Version: 3.16.0
 Authors@R: c(
     person("Johanna", "Hoppe", email = "johanna.hoppe@pik-potsdam.de", role = c("aut", "cre"),
            comment = c(ORCID = "0009-0004-6753-5090")),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: edgeTransport
 Title: Prepare EDGE Transport Data for the REMIND model
-Version: 3.15.0
+Version: 3.15.0.9001
 Authors@R: c(
     person("Johanna", "Hoppe", email = "johanna.hoppe@pik-potsdam.de", role = c("aut", "cre"),
            comment = c(ORCID = "0009-0004-6753-5090")),
@@ -21,7 +21,7 @@ Encoding: UTF-8
 LazyData: true
 RoxygenNote: 7.3.3
 VignetteBuilder: knitr
-Date: 2026-06-12
+Date: 2026-06-15
 Config/testthat/edition: 3
 Imports:
     rmndt,

--- a/R/toolEdgeTransportSA.R
+++ b/R/toolEdgeTransportSA.R
@@ -40,7 +40,7 @@ toolEdgeTransportSA <- function(SSPscen,
   level <- subsectorL3 <- variable <- version <- region <- vehicleType <- technology <- period <- NULL
 
   #To trigger the madrat caching even if changes are only applied to the csv files, we include here the version number of edget
-  version <- "3.15.0"
+  version <- "3.16.0"
 
   commonParams <- toolGetCommonParameters(startyear, isICEban[1], isICEban[2])
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Prepare EDGE Transport Data for the REMIND model
 
-R package **edgeTransport**, version **3.15.0.9001**
+R package **edgeTransport**, version **3.16.0**
 
    [![R build status](https://github.com/pik-piam/edgeTransport/workflows/check/badge.svg)](https://github.com/pik-piam/edgeTransport/actions) [![codecov](https://codecov.io/gh/pik-piam/edgeTransport/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/edgeTransport) [![r-universe](https://pik-piam.r-universe.dev/badges/edgeTransport)](https://pik-piam.r-universe.dev/builds)
 
@@ -46,7 +46,7 @@ In case of questions / problems please contact Johanna Hoppe <johanna.hoppe@pik-
 
 To cite package **edgeTransport** in publications use:
 
-Hoppe J, Dirnaichner A, Rottoli M, Muessel J, Hagen A, Pietzcker R (2026). "edgeTransport: Prepare EDGE Transport Data for the REMIND model." Version: 3.15.0.9001, <https://github.com/pik-piam/edgeTransport>.
+Hoppe J, Dirnaichner A, Rottoli M, Muessel J, Hagen A, Pietzcker R (2026). "edgeTransport: Prepare EDGE Transport Data for the REMIND model." Version: 3.16.0, <https://github.com/pik-piam/edgeTransport>.
 
 A BibTeX entry for LaTeX users is
 
@@ -57,6 +57,6 @@ A BibTeX entry for LaTeX users is
   date = {2026-06-15},
   year = {2026},
   url = {https://github.com/pik-piam/edgeTransport},
-  note = {Version: 3.15.0.9001},
+  note = {Version: 3.16.0},
 }
 ```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Prepare EDGE Transport Data for the REMIND model
 
-R package **edgeTransport**, version **3.15.0**
+R package **edgeTransport**, version **3.15.0.9001**
 
    [![R build status](https://github.com/pik-piam/edgeTransport/workflows/check/badge.svg)](https://github.com/pik-piam/edgeTransport/actions) [![codecov](https://codecov.io/gh/pik-piam/edgeTransport/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/edgeTransport) [![r-universe](https://pik-piam.r-universe.dev/badges/edgeTransport)](https://pik-piam.r-universe.dev/builds)
 
@@ -46,7 +46,7 @@ In case of questions / problems please contact Johanna Hoppe <johanna.hoppe@pik-
 
 To cite package **edgeTransport** in publications use:
 
-Hoppe J, Dirnaichner A, Rottoli M, Muessel J, Hagen A, Pietzcker R (2026). "edgeTransport: Prepare EDGE Transport Data for the REMIND model." Version: 3.15.0, <https://github.com/pik-piam/edgeTransport>.
+Hoppe J, Dirnaichner A, Rottoli M, Muessel J, Hagen A, Pietzcker R (2026). "edgeTransport: Prepare EDGE Transport Data for the REMIND model." Version: 3.15.0.9001, <https://github.com/pik-piam/edgeTransport>.
 
 A BibTeX entry for LaTeX users is
 
@@ -54,9 +54,9 @@ A BibTeX entry for LaTeX users is
 @Misc{,
   title = {edgeTransport: Prepare EDGE Transport Data for the REMIND model},
   author = {Johanna Hoppe and Alois Dirnaichner and Marianna Rottoli and Jarusch Muessel and Alex K. Hagen and Robert P. Pietzcker},
-  date = {2026-06-12},
+  date = {2026-06-15},
   year = {2026},
   url = {https://github.com/pik-piam/edgeTransport},
-  note = {Version: 3.15.0},
+  note = {Version: 3.15.0.9001},
 }
 ```

--- a/inst/extdata/scenParRegionalDemRegression.csv
+++ b/inst/extdata/scenParRegionalDemRegression.csv
@@ -148,7 +148,7 @@ SSP1;REF;trn_freight;-0.8;-0.9;-0.2;0
 SSP1;SSA;trn_freight;0;0;-0.2;0
 SSP1;UKI;trn_freight;0;0.2;0.1;0
 SSP1;USA;trn_freight;0;0.1;0.1;0.2
-SSP1;CAZ;trn_pass;-0.1;-0.1;-0.15;0
+SSP1;CAZ;trn_pass;0.5;0.15;-0.1;-0.2
 SSP1;CHA;trn_pass;0;-0.2;0.3;0.25
 SSP1;DEU;trn_pass;0.3;0;0;0.2
 SSP1;ECE;trn_pass;0;0.3;0.3;0.2
@@ -168,7 +168,7 @@ SSP1;OAS;trn_pass;0;0;-0.2;0.4
 SSP1;REF;trn_pass;0;0;0.3;0.45
 SSP1;SSA;trn_pass;0;0;-0.3;0.2
 SSP1;UKI;trn_pass;0;0.1;0.1;0.05
-SSP1;USA;trn_pass;-0.1;-0.1;-0.25;0.05
+SSP1;USA;trn_pass;0.2;0.15;-0.15;-0.3
 SSP1;CAZ;trn_shipping_intl;0;0.5;0.3;0
 SSP1;CHA;trn_shipping_intl;-0.4;0;-0.3;-2
 SSP1;EWN;trn_shipping_intl;0;-0.3;-0.4;-0.3
@@ -217,7 +217,7 @@ SSP2;REF;trn_freight;-0.8;-0.9;-0.2;0
 SSP2;SSA;trn_freight;0;0;-0.3;-0.5
 SSP2;UKI;trn_freight;0;0.5;0.4;0.3
 SSP2;USA;trn_freight;0;0.3;0.3;0.2
-SSP2;CAZ;trn_pass;-0.1;-0.1;-0.15;0
+SSP2;CAZ;trn_pass;0.5;0.15;-0.05;-0.15
 SSP2;CHA;trn_pass;0;-0.2;0.3;0.18
 SSP2;DEU;trn_pass;0.3;0;0;0.1
 SSP2;ECE;trn_pass;0;0.3;0.3;0.2
@@ -237,7 +237,7 @@ SSP2;OAS;trn_pass;0;0;-0.1;0
 SSP2;REF;trn_pass;0;0;0.3;0.45
 SSP2;SSA;trn_pass;0;0;-0.3;-0.4
 SSP2;UKI;trn_pass;0;0.1;0.1;0.05
-SSP2;USA;trn_pass;-0.1;-0.1;-0.25;0.05
+SSP2;USA;trn_pass;0.2;0.15;0;-0.1
 SSP2;CAZ;trn_shipping_intl;0;0.5;0.3;0
 SSP2;CHA;trn_shipping_intl;-0.4;0;-0.3;-2
 SSP2;EWN;trn_shipping_intl;0;-0.3;-0.4;-0.3
@@ -286,7 +286,7 @@ SSP3;REF;trn_freight;-0.8;-0.9;-0.2;0
 SSP3;SSA;trn_freight;0;0;-0.3;-0.5
 SSP3;UKI;trn_freight;0;0.5;0.4;0.3
 SSP3;USA;trn_freight;0;0.3;0.3;0.2
-SSP3;CAZ;trn_pass;-0.1;-0.1;-0.15;0
+SSP3;CAZ;trn_pass;0.5;0.15;-0.05;-0.15
 SSP3;CHA;trn_pass;0;-0.2;0.3;0.18
 SSP3;DEU;trn_pass;0.3;0;0;0.1
 SSP3;ECE;trn_pass;0;0.3;0.3;0.2
@@ -306,7 +306,7 @@ SSP3;OAS;trn_pass;0;0;-0.1;0
 SSP3;REF;trn_pass;0;0;0.3;0.45
 SSP3;SSA;trn_pass;0;0;-0.3;-0.4
 SSP3;UKI;trn_pass;0;0.1;0.1;0.05
-SSP3;USA;trn_pass;-0.1;-0.1;-0.25;0.05
+SSP3;USA;trn_pass;0.2;0.15;0;-0.1
 SSP3;CAZ;trn_shipping_intl;0;0.5;0.3;0
 SSP3;CHA;trn_shipping_intl;-0.4;0;-0.3;-2
 SSP3;EWN;trn_shipping_intl;0;-0.3;-0.4;-0.3
@@ -343,7 +343,7 @@ SSP5;REF;trn_freight;-0.8;-0.9;-0.2;0
 SSP5;SSA;trn_freight;0;0;0;0.2
 SSP5;UKI;trn_freight;0;0.2;0.1;0
 SSP5;USA;trn_freight;0;0.2;0.3;0.8
-SSP5;CAZ;trn_pass;-0.1;-0.1;-0.1;0.2
+SSP5;CAZ;trn_pass;0.5;0.15;-0.05;0
 SSP5;CHA;trn_pass;0;-0.2;0.3;-0.5
 SSP5;DEU;trn_pass;0.3;0.2;0.1;0
 SSP5;IND;trn_pass;0;-0.3;-0.3;0.3
@@ -353,7 +353,7 @@ SSP5;NES;trn_pass;0;0.6;0.5;0
 SSP5;OAS;trn_pass;0;0;-0.2;0.2
 SSP5;REF;trn_pass;0;-0.2;-0.1;0
 SSP5;SSA;trn_pass;0;0;-0.2;0.2
-SSP5;USA;trn_pass;-0.1;-0.1;-0.2;0.2
+SSP5;USA;trn_pass;0.2;0.15;0;0
 SSP5;CAZ;trn_shipping_intl;0;0.5;0.3;0
 SSP5;CHA;trn_shipping_intl;-0.4;0;-0.3;-2
 SSP5;EWN;trn_shipping_intl;0;-0.3;-0.4;-0.3


### PR DESCRIPTION
## Purpose of this PR

Reaction to issue [740](https://github.com/remindmodel/development_issues/issues/740): implement a continuous growth of passenger ES demand in US and CAZ in SSP2 as the regions get richer. Previously, per-capita passenger ES demand showed very low growth, almost stagnating at 2010 levels. 
We now assume that saturation is reached later, so as these regions grow richer until 2050, average ES demand per capita will still increase. This mirrors the perception that change towards more sustainable city/transport patterns is progressing slower than was maybe expected a few years back.

## Checklist:

- [x] I used ./test-standard-runs to compare and archive the changes introduced by this PR in /p/projects/edget/PRchangeLog/

Instructions for PIK internal testing of transport packages:

  1.  Navigate to this folder on the cluster `/p/projects/edget/PRchangeLog/`
  2.  Run the following command in the folder: `./test-standard-runs "FolderName" "ReferenceFolder"`, where "FolderName" is a name you can choose which identifies your changes or PR, i.e. the PR number plus a keyword. "ReferenceFolder" is an optional argument and should be a folder that already exists in the directory "/p/projects/edget/PRchangeLog/". If not set this defaults to the last stored run. 
      Running this command submits five sbatch jobs. these are four standalone runs and one run that simulates an iterative run, using REMIND information from the latest NPi2025 AMT. You can optionally find a help page by running ./test-standard-runs -h
  3.  You are now interactively asked if repositories should be installed from source. Here, name one after another all the repositories in which you introduced changes. You can for example use your GitHub branch for that. An example of how to do that is prompted in your console.
  4.  For verification: Wait until the submitted jobs have finished and check if the folders "ChangeLogMix[1-4]" and "ChangeLogIterative" have been generated and hold a compScen each. You can check the `testScen[1-4]_edgetPR*.out` and `testIter*.out` files in case of errors.
  5.  Check the compScen if you wish to review changes of the results compared to the reference run.


## Further information (optional):

* Test runs are here: 
/p/projects/edget/PRchangeLog/20260615_PR407_USCAZpassDem

* Comparison of results (what changes by this PR?):  
CAZ (orange) and USA (red) now show a continuous growth pass ES demand in SSP2 (SSP1 and SSP3 are also pulled up, with SSP3 completely mirroring SSP2, and SSP1 decreasing after 2050), although slower than observed in the past.

Important: for unknown reasons, the runs are wrongly labeled "before" is actually the new runs, and "after" is the old head revision. 

<img width="1157" height="803" alt="image" src="https://github.com/user-attachments/assets/e88d1bef-678d-44aa-a488-ce90a486e648" />

