### PR TITLE
add fleet tracking for 2W & 3W

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '65156040'
+ValidationKey: '65397100'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'edgeTransport: Prepare EDGE Transport Data for the REMIND model'
-version: 3.16.0
-date-released: '2026-06-15'
+version: 3.17.0
+date-released: '2026-06-26'
 abstract: EDGE-T is a fork of the GCAM transport module https://jgcri.github.io/gcam-doc/energy.html#transportation
   with a high level of detail in its representation of technological and modal options.
   It is a partial equilibrium model with a nested multinomial logit structure and

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: edgeTransport
 Title: Prepare EDGE Transport Data for the REMIND model
-Version: 3.16.0
+Version: 3.17.0
 Authors@R: c(
     person("Johanna", "Hoppe", email = "johanna.hoppe@pik-potsdam.de", role = c("aut", "cre"),
            comment = c(ORCID = "0009-0004-6753-5090")),
@@ -21,7 +21,7 @@ Encoding: UTF-8
 LazyData: true
 RoxygenNote: 7.3.3
 VignetteBuilder: knitr
-Date: 2026-06-15
+Date: 2026-06-26
 Config/testthat/edition: 3
 Imports:
     rmndt,

--- a/R/toolCalculateFleetComposition.R
+++ b/R/toolCalculateFleetComposition.R
@@ -34,7 +34,7 @@ toolCalculateFleetComposition <- function(ESdemandFVsalesLevel,
 
   # calculate total energy service demand for modes with tracked fleets ---------------------------------
   fleetESdemand <- copy(ESdemandFVsalesLevel)
-  fleetESdemand <- fleetESdemand[grepl("Bus.*|.*4W|.*freight_road.*", subsectorL3)]
+  fleetESdemand <- fleetESdemand[grepl("Bus.*|.*4W|.*2W|.*3W|.*freight_road.*", subsectorL3)]
   fleetESdemand <- fleetESdemand[, .(totalESdemand = sum(value[period >= 2005])), by = c("region", "period", "subsectorL3")]
 
   # calculate distribution of total demand on construction years -----------------------------------------

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Prepare EDGE Transport Data for the REMIND model
 
-R package **edgeTransport**, version **3.16.0**
+R package **edgeTransport**, version **3.17.0**
 
    [![R build status](https://github.com/pik-piam/edgeTransport/workflows/check/badge.svg)](https://github.com/pik-piam/edgeTransport/actions) [![codecov](https://codecov.io/gh/pik-piam/edgeTransport/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/edgeTransport) [![r-universe](https://pik-piam.r-universe.dev/badges/edgeTransport)](https://pik-piam.r-universe.dev/builds)
 
@@ -46,7 +46,7 @@ In case of questions / problems please contact Johanna Hoppe <johanna.hoppe@pik-
 
 To cite package **edgeTransport** in publications use:
 
-Hoppe J, Dirnaichner A, Rottoli M, Muessel J, Hagen A, Pietzcker R (2026). "edgeTransport: Prepare EDGE Transport Data for the REMIND model." Version: 3.16.0, <https://github.com/pik-piam/edgeTransport>.
+Hoppe J, Dirnaichner A, Rottoli M, Muessel J, Hagen A, Pietzcker R (2026). "edgeTransport: Prepare EDGE Transport Data for the REMIND model." Version: 3.17.0, <https://github.com/pik-piam/edgeTransport>.
 
 A BibTeX entry for LaTeX users is
 
@@ -54,9 +54,9 @@ A BibTeX entry for LaTeX users is
 @Misc{,
   title = {edgeTransport: Prepare EDGE Transport Data for the REMIND model},
   author = {Johanna Hoppe and Alois Dirnaichner and Marianna Rottoli and Jarusch Muessel and Alex K. Hagen and Robert P. Pietzcker},
-  date = {2026-06-15},
+  date = {2026-06-26},
   year = {2026},
   url = {https://github.com/pik-piam/edgeTransport},
-  note = {Version: 3.16.0},
+  note = {Version: 3.17.0},
 }
 ```

--- a/inst/extdata/genParAnnuityCalc.csv
+++ b/inst/extdata/genParAnnuityCalc.csv
@@ -1,5 +1,7 @@
 transportPolScen;FVvehvar;interestRate;serviceLife
 default;LDV|4W;0.1;20
+default;LDV|2W;0.1;20
+default;LDV|3W;0.1;20
 default;Bus;0.05;15
 default;Truck|light;0.05;15
 default;Truck|heavy;0.05;15

--- a/inst/extdata/genParAnnuityCalc.csv
+++ b/inst/extdata/genParAnnuityCalc.csv
@@ -1,7 +1,7 @@
 transportPolScen;FVvehvar;interestRate;serviceLife
 default;LDV|4W;0.1;20
-default;LDV|2W;0.1;20
-default;LDV|3W;0.1;20
+default;LDV|2W;0.1;15
+default;LDV|3W;0.1;8
 default;Bus;0.05;15
 default;Truck|light;0.05;15
 default;Truck|heavy;0.05;15


### PR DESCRIPTION
## Purpose of this PR

This adds fleet tracking for 2W and 3W, analogous to the 2W tracking.

This PR is related to [PR48 in reporttransport](https://github.com/pik-piam/reporttransport/pull/48)

Service life was roughly estimated in this first version and is adjusted later. For 3W (only present in IND so far) it was set as the common ground between real service life estimates (~3-8yrs also depending on technology) and to lead to realistic technology fleet shares in 2025 (~18%).

## Checklist:

- [x] I used ./test-standard-runs to compare and archive the changes introduced by this PR in /p/projects/edget/PRchangeLog/

## Further information (optional):

* Test runs are here: `20260626_PR_409_add23Wfleet`

* Comparison of results (what changes by this PR?): 

Total node ES demand stays the same, however, technology share is changed conservatively by the introduction of fleet tracking, i.e. ICE vehicles stay longer in the fleet. Before this PR, there was no inter-temporal correlation of decisions regarding technology reflected for 2Ws and 3Ws.
