### PR TITLE
Update scenParRegionalDemRegression.csv

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '65397100'
+ValidationKey: '65625660'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'edgeTransport: Prepare EDGE Transport Data for the REMIND model'
-version: 3.17.0
-date-released: '2026-06-26'
+version: 3.18.0
+date-released: '2026-07-03'
 abstract: EDGE-T is a fork of the GCAM transport module https://jgcri.github.io/gcam-doc/energy.html#transportation
   with a high level of detail in its representation of technological and modal options.
   It is a partial equilibrium model with a nested multinomial logit structure and

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: edgeTransport
 Title: Prepare EDGE Transport Data for the REMIND model
-Version: 3.17.0
+Version: 3.18.0
 Authors@R: c(
     person("Johanna", "Hoppe", email = "johanna.hoppe@pik-potsdam.de", role = c("aut", "cre"),
            comment = c(ORCID = "0009-0004-6753-5090")),
@@ -21,7 +21,7 @@ Encoding: UTF-8
 LazyData: true
 RoxygenNote: 7.3.3
 VignetteBuilder: knitr
-Date: 2026-06-26
+Date: 2026-07-03
 Config/testthat/edition: 3
 Imports:
     rmndt,

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Prepare EDGE Transport Data for the REMIND model
 
-R package **edgeTransport**, version **3.17.0**
+R package **edgeTransport**, version **3.18.0**
 
    [![R build status](https://github.com/pik-piam/edgeTransport/workflows/check/badge.svg)](https://github.com/pik-piam/edgeTransport/actions) [![codecov](https://codecov.io/gh/pik-piam/edgeTransport/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/edgeTransport) [![r-universe](https://pik-piam.r-universe.dev/badges/edgeTransport)](https://pik-piam.r-universe.dev/builds)
 
@@ -46,17 +46,15 @@ In case of questions / problems please contact Johanna Hoppe <johanna.hoppe@pik-
 
 To cite package **edgeTransport** in publications use:
 
-Hoppe J, Dirnaichner A, Rottoli M, Muessel J, Hagen A, Pietzcker R (2026). "edgeTransport: Prepare EDGE Transport Data for the REMIND model." Version: 3.17.0, <https://github.com/pik-piam/edgeTransport>.
+Hoppe J, Dirnaichner A, Rottoli M, Muessel J, Hagen A, Pietzcker R (2026). "edgeTransport: Prepare EDGE Transport Data for the REMIND model - Version 3.18.0."
 
 A BibTeX entry for LaTeX users is
 
  ```latex
 @Misc{,
-  title = {edgeTransport: Prepare EDGE Transport Data for the REMIND model},
+  title = {edgeTransport: Prepare EDGE Transport Data for the REMIND model - Version 3.18.0},
   author = {Johanna Hoppe and Alois Dirnaichner and Marianna Rottoli and Jarusch Muessel and Alex K. Hagen and Robert P. Pietzcker},
-  date = {2026-06-26},
+  date = {2026-07-03},
   year = {2026},
-  url = {https://github.com/pik-piam/edgeTransport},
-  note = {Version: 3.17.0},
 }
 ```

--- a/inst/extdata/scenParRegionalDemRegression.csv
+++ b/inst/extdata/scenParRegionalDemRegression.csv
@@ -208,7 +208,7 @@ SSP2;ECE;trn_freight;0;0;-0.4;-0.2
 SSP2;ECS;trn_freight;0;0;-0.2;0
 SSP2;ESW;trn_freight;0;-0.5;-0.2;0
 SSP2;FRA;trn_freight;0;0.2;0.4;0.2
-SSP2;IND;trn_freight;-0.9;-0.2;-0.2;0.4
+SSP2;IND;trn_freight;-1.15;-1.15;-0.45;0.4
 SSP2;LAM;trn_freight;0;0;-0.1;-0.2
 SSP2;MEA;trn_freight;0;0.2;0.2;0.2
 SSP2;NES;trn_freight;0;0.1;0.2;0.1
@@ -227,7 +227,7 @@ SSP2;ESC;trn_pass;0;0.1;0.1;0.05
 SSP2;ESW;trn_pass;0;0.1;0.1;0.05
 SSP2;EWN;trn_pass;0;0.1;0.1;0.02
 SSP2;FRA;trn_pass;0;0.1;0.1;0.02
-SSP2;IND;trn_pass;-0.7;-0.4;0.4;0.05
+SSP2;IND;trn_pass;-1;-0.68;0.4;0.05
 SSP2;JPN;trn_pass;0;0.2;0.2;0
 SSP2;LAM;trn_pass;0;0;0;0.15
 SSP2;MEA;trn_pass;0;-0.3;-0.2;0.1


### PR DESCRIPTION
## Purpose of this PR
Emissions and FE-Liquids in India are too https://github.com/remindmodel/development_issues/issues/777#event-27473032225, though ES is a bit too low --> In a https://github.com/pik-piam/mrtransport/pull/55PR, I increased ES-2010 to get more efficient modes out of the IEA harmonization. This leads to higher ES demands beyond 2010, which is why I do this PR to limit the ES growth.

## Checklist:

- [ ] I used ./test-standard-runs to compare and archive the changes introduced by this PR in /p/projects/edget/PRchangeLog/

Instructions for PIK internal testing of transport packages:

  1.  Navigate to this folder on the cluster `/p/projects/edget/PRchangeLog/`
  2.  Run the following command in the folder: `./test-standard-runs "FolderName" "ReferenceFolder"`, where "FolderName" is a name you can choose which identifies your changes or PR, i.e. the PR number plus a keyword. "ReferenceFolder" is an optional argument and should be a folder that already exists in the directory "/p/projects/edget/PRchangeLog/". If not set this defaults to the last stored run. 
      Running this command submits five sbatch jobs. these are four standalone runs and one run that simulates an iterative run, using REMIND information from the latest NPi2025 AMT. You can optionally find a help page by running ./test-standard-runs -h
  3.  You are now interactively asked if repositories should be installed from source. Here, name one after another all the repositories in which you introduced changes. You can for example use your GitHub branch for that. An example of how to do that is prompted in your console.
  4.  For verification: Wait until the submitted jobs have finished and check if the folders "ChangeLogMix[1-4]" and "ChangeLogIterative" have been generated and hold a compScen each. You can check the `testScen[1-4]_edgetPR*.out` and `testIter*.out` files in case of errors.
  5.  Check the compScen if you wish to review changes of the results compared to the reference run.


## Further information (optional):

* Test runs are here: 
* Comparison of results (what changes by this PR?): 

`/p/projects/edget/PRchangeLog/20260703_India_lowerEnInt`