### PR TITLE
add CHANGELOG

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,3 +1,4 @@
+^CHANGELOG.md
 ^pull_request_template.md
 ^renv$
 ^renv\.locks$

--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '66166400'
+ValidationKey: '66389220'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,8 +30,8 @@ edgeTransport and accompanying packages use versioning reflecting MAJOR.MINOR.PA
 
 ## [[REMIND 3.7.0](https://github.com/remindmodel/remind/releases/tag/v3.7.0)] - 2026-07-15
 #### `edgeTransport 3.18.0`
-#### `mrtransport 1.4.1`
-#### `reporttransport 0.16.4`
+#### `mrtransport 0.16.4`
+#### `reporttransport 1.4.1`
 
 ### changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ edgeTransport and accompanying packages use versioning reflecting MAJOR.MINOR.PA
 
 ### added
 
+- **CHANGELOG.md** [edgeTransport #414](https://github.com/pik-piam/edgeTransport/pull/414)
+
 ### removed
 
 - **deprecated `gdxrrw` dependency** switched to read/write gdx functions based on `gamstransfer`[edgeTransport #413](https://github.com/pik-piam/edgeTransport/pull/413) [reporttransport #55](https://github.com/pik-piam/reporttransport/pull/55) [rmndt #9](https://github.com/pik-piam/rmndt/pull/9)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,87 @@
+
+# Changelog
+
+All notable changes to the [edgeTransport](https://github.com/pik-piam/edgeTransport) model, incl. [mrtransport](https://github.com/pik-piam/mrtransport) and [reporttransport](https://github.com/pik-piam/reporttransport) packages, will be documented in this file.
+The sections in this file correspond to release versions of the [remindmodel](https://github.com/remindmodel/remind/releases).
+All respective package versions for a REMIND release can be found [here](https://github.com/remindmodel/remind/tree/master/renv/archive).
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+edgeTransport and accompanying packages use versioning reflecting MAJOR.MINOR.PATCH notation.
+
+## [Unreleased]
+#### `edgeTransport`
+#### `mrtransport`
+#### `reporttransport`
+
+### changed
+
+### added
+
+### removed
+
+- **deprecated `gdxrrw` dependency** switched to read/write gdx functions based on `gamstransfer`[edgeTransport #413](https://github.com/pik-piam/edgeTransport/pull/413) [reporttransport #55](https://github.com/pik-piam/reporttransport/pull/55) [rmndt #9](https://github.com/pik-piam/rmndt/pull/9)
+
+### fixed
+
+### validated
+
+
+
+## [[REMIND 3.7.0](https://github.com/remindmodel/remind/releases/tag/v3.7.0)] - 2026-07-15
+#### `edgeTransport 3.18.0`
+#### `mrtransport 1.4.1`
+#### `reporttransport 0.16.4`
+
+### changed
+
+- **BET sales shares** 
+  improved near-term representation [edgeTransport #405](https://github.com/pik-piam/edgeTransport/pull/405)
+
+- **US and CAZ passenger demands** 
+  added continuous growth to reflect later saturation [edgeTransport #407](https://github.com/pik-piam/edgeTransport/pull/407)
+
+- **IND historical ES** 
+  improved representation [mrtransport #55](https://github.com/pik-piam/mrtransport/pull/55) [edgeTransport #411](https://github.com/pik-piam/edgeTransport/pull/411)
+
+- **IND truck fleet composition** improved representation of truck fleet and sizes [edgeTransport #401](https://github.com/pik-piam/edgeTransport/pull/401) [mrtransport #51](https://github.com/pik-piam/mrtransport/pull/51) [mrtransport #54](https://github.com/pik-piam/mrtransport/pull/54)
+
+
+### added
+
+- **fleet tracking 2-& 3-Wheeler**
+  added technology-resolved tracking of vintages for 2W, 3W, analogous to LDVs, Busses and Trucks [edgeTransport #409](https://github.com/pik-piam/edgeTransport/pull/409) [reporttransport #50](https://github.com/pik-piam/reporttransport/pull/50)
+
+- **iterativeEdgeTransport reloading of input data** 
+  added functionality: starting from the second call in a REMIND run, unchanged edgeT input data is reloaded from the output folder [edgeTransport #408](https://github.com/pik-piam/edgeTransport/pull/408)
+
+
+### removed
+
+- **`mrcommons` dependency** was replaced by more clearly defined `mrcommonsenergy` in a larger restructuring effort in pik-piam packages [mrtransport #52](https://github.com/pik-piam/mrtransport/pull/52)
+
+
+### validated
+
+- **SSP2 NPi2025 / Mix2ICEban** 
+  in-depth validation with regards to near-term realism and IEA projections
+  
+
+## [[REMIND 3.6.0](https://github.com/remindmodel/remind/releases/tag/v3.6.0)] - 2026-03-27
+#### `edgeTransport 3.13.4`
+#### `mrtransport 0.14.0`
+#### `reporttransport 1.2.1`
+
+
+## [[REMIND x.y.z](link to release tag)] - yyyy-mm-dd
+#### `edgeTransport x.y.z`
+#### `mrtransport x.y.z`
+#### `reporttransport x.y.z`
+
+### changed
+
+### added
+
+### removed
+
+### fixed
+
+### validated

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'edgeTransport: Prepare EDGE Transport Data for the REMIND model'
-version: 3.20.0
-date-released: '2026-08-12'
+version: 3.21.0
+date-released: '2026-08-17'
 abstract: EDGE-T is a fork of the GCAM transport module https://jgcri.github.io/gcam-doc/energy.html#transportation
   with a high level of detail in its representation of technological and modal options.
   It is a partial equilibrium model with a nested multinomial logit structure and

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: edgeTransport
 Title: Prepare EDGE Transport Data for the REMIND model
-Version: 3.20.0
+Version: 3.21.0
 Authors@R: c(
     person("Johanna", "Hoppe", email = "johanna.hoppe@pik-potsdam.de", role = c("aut", "cre"),
            comment = c(ORCID = "0009-0004-6753-5090")),
@@ -20,7 +20,7 @@ URL: https://github.com/pik-piam/edgeTransport
 Encoding: UTF-8
 LazyData: true
 VignetteBuilder: knitr
-Date: 2026-08-12
+Date: 2026-08-17
 Config/testthat/edition: 3
 Imports:
     rmndt,

--- a/README.md
+++ b/README.md
@@ -60,3 +60,6 @@ A BibTeX entry for LaTeX users is
   note = {Version: 3.20.0},
 }
 ```
+
+## CHANGELOG
+See [CHANGELOG.md](CHANGELOG.md) on GitHub for notable changes of the model corresponding to each release of the [remindmodel](https://github.com/remindmodel/remind/releases).

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Prepare EDGE Transport Data for the REMIND model
 
-R package **edgeTransport**, version **3.20.0**
+R package **edgeTransport**, version **3.21.0**
 
    [![R build status](https://github.com/pik-piam/edgeTransport/workflows/check/badge.svg)](https://github.com/pik-piam/edgeTransport/actions) [![codecov](https://codecov.io/gh/pik-piam/edgeTransport/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/edgeTransport) [![r-universe](https://pik-piam.r-universe.dev/badges/edgeTransport)](https://pik-piam.r-universe.dev/builds)
 
@@ -46,7 +46,7 @@ In case of questions / problems please contact Johanna Hoppe <johanna.hoppe@pik-
 
 To cite package **edgeTransport** in publications use:
 
-Hoppe J, Dirnaichner A, Rottoli M, Muessel J, Hagen A, Pietzcker R (2026). "edgeTransport: Prepare EDGE Transport Data for the REMIND model." Version: 3.20.0, <https://github.com/pik-piam/edgeTransport>.
+Hoppe J, Dirnaichner A, Rottoli M, Muessel J, Hagen A, Pietzcker R (2026). "edgeTransport: Prepare EDGE Transport Data for the REMIND model." Version: 3.21.0, <https://github.com/pik-piam/edgeTransport>.
 
 A BibTeX entry for LaTeX users is
 
@@ -54,12 +54,9 @@ A BibTeX entry for LaTeX users is
 @Misc{,
   title = {edgeTransport: Prepare EDGE Transport Data for the REMIND model},
   author = {Johanna Hoppe and Alois Dirnaichner and Marianna Rottoli and Jarusch Muessel and Alex K. Hagen and Robert P. Pietzcker},
-  date = {2026-08-12},
+  date = {2026-08-17},
   year = {2026},
   url = {https://github.com/pik-piam/edgeTransport},
-  note = {Version: 3.20.0},
+  note = {Version: 3.21.0},
 }
 ```
-
-## CHANGELOG
-See [CHANGELOG.md](CHANGELOG.md) on GitHub for notable changes of the model corresponding to each release of the [remindmodel](https://github.com/remindmodel/remind/releases).


### PR DESCRIPTION
## Purpose of this PR

It adds a CHANGELOG.md to the repository, following the one used in REMIND. 

This CHANGELOG should be updated **after** every REMIND release to reflect the notable changes in `edgeTransport`, `mrtransport` and `reporttransport` since the last release. 

`edgeTransport` has no individual validation cycle but is, as a bidirectionally coupled model, closely related to the REMIND release workflow. This is why the CHANGELOG structure relates to REMIND release versions. For a more easy overview `edgeTransport`, `mrtransport` and `reporttransport` packages all share this CHANGELOG.

#### Additional Notes:

- Changes in other packages and dependencies might be added if they result in a notable change in the transport model

- The most up-to-date section is always on top of the document

- This document should help humans to understand the status and development progress of the transport model

- Transport package version numbers that correspond to the respective REMIND release should be noted 

- It is structured in categories: changed, added, removed, fixed, validated (up for debate)

- Changes can also be added to the UNRELEASED section prior to a release, however this section is not supposed to be complete

- Main PRs should be linked for each added item

- This CHANGELOG startes with REMIND v3.7.0, however sections for prior releases might be added later

- The CHANGELOG can subsequently be changed, if needed, also for already filled sections
